### PR TITLE
fixed all parsed numbers

### DIFF
--- a/buildings/academy.json
+++ b/buildings/academy.json
@@ -25,11 +25,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 8596
+            "value": 8596560000
           }
         ]
       },
-      "build_time": 11170,
+      "build_time": 11170080,
       "increased_power": 3000,
       "level": 40,
       "requirements": [
@@ -72,11 +72,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 8772
+            "value": 8772000000
           }
         ]
       },
-      "build_time": 10468,
+      "build_time": 10468800,
       "increased_power": 3000,
       "level": 41,
       "requirements": [
@@ -115,11 +115,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1156
+            "value": 1156680000
           }
         ]
       },
-      "build_time": 4741,
+      "build_time": 4741920,
       "increased_power": 2500,
       "level": 38,
       "requirements": [
@@ -158,11 +158,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 13066
+            "value": 13066200000
           }
         ]
       },
-      "build_time": 16090,
+      "build_time": 16090560,
       "increased_power": 3500,
       "level": 42,
       "requirements": [
@@ -205,11 +205,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 18666
+            "value": 18666000000
           }
         ]
       },
-      "build_time": 21260,
+      "build_time": 21260160,
       "increased_power": 3500,
       "level": 43,
       "requirements": [
@@ -248,11 +248,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 27999
+            "value": 27999000000
           }
         ]
       },
-      "build_time": 27748,
+      "build_time": 27748800,
       "increased_power": 3500,
       "level": 44,
       "requirements": [
@@ -295,11 +295,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 54697
+            "value": 54697500000
           }
         ]
       },
-      "build_time": 45792,
+      "build_time": 45792000,
       "increased_power": 4000,
       "level": 46,
       "requirements": [
@@ -342,11 +342,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 483786
+            "value": 483786000
           }
         ]
       },
-      "build_time": 2829,
+      "build_time": 2829600,
       "increased_power": 2000,
       "level": 36,
       "requirements": [
@@ -385,11 +385,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 743580
+            "value": 743580000
           }
         ]
       },
-      "build_time": 2923,
+      "build_time": 2923200,
       "increased_power": 2500,
       "level": 37,
       "requirements": [
@@ -1068,11 +1068,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 79560
+            "value": 79560000000
           }
         ]
       },
-      "build_time": 58008,
+      "build_time": 58008960,
       "increased_power": 4000,
       "level": 47,
       "requirements": [
@@ -1111,11 +1111,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 128520
+            "value": 128520000000
           }
         ]
       },
-      "build_time": 72881,
+      "build_time": 72881280,
       "increased_power": 5000,
       "level": 48,
       "requirements": [
@@ -1158,11 +1158,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1973
+            "value": 1973700000
           }
         ]
       },
-      "build_time": 6294,
+      "build_time": 6294240,
       "increased_power": 2500,
       "level": 39,
       "requirements": [
@@ -1199,7 +1199,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 2943
+            "value": 2943720
           }
         ]
       },
@@ -1242,7 +1242,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 4773
+            "value": 4773600
           }
         ]
       },
@@ -1289,7 +1289,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 7458
+            "value": 7458750
           }
         ]
       },
@@ -1326,7 +1326,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 11383
+            "value": 11383200
           }
         ]
       },
@@ -1373,7 +1373,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 17074
+            "value": 17074800
           }
         ]
       },
@@ -1416,7 +1416,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 27183
+            "value": 27183000
           }
         ]
       },
@@ -1457,7 +1457,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 39780
+            "value": 39780000
           }
         ]
       },
@@ -1500,7 +1500,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 62883
+            "value": 62883000
           }
         ]
       },
@@ -1547,7 +1547,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 90831
+            "value": 90831000
           }
         ]
       },
@@ -1590,11 +1590,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 140505
+            "value": 140505000
           }
         ]
       },
-      "build_time": 1268,
+      "build_time": 1268640,
       "increased_power": 1750,
       "level": 33,
       "requirements": [
@@ -1631,11 +1631,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 221850
+            "value": 221850000
           }
         ]
       },
-      "build_time": 1680,
+      "build_time": 1680480,
       "increased_power": 2250,
       "level": 34,
       "requirements": [
@@ -1674,11 +1674,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 343332
+            "value": 343332000
           }
         ]
       },
-      "build_time": 2213,
+      "build_time": 2213280,
       "increased_power": 2000,
       "level": 35,
       "requirements": [
@@ -1708,7 +1708,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1135
+            "value": 1135260
           }
         ]
       },
@@ -1738,7 +1738,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1868
+            "value": 1868130
           }
         ]
       },
@@ -1785,11 +1785,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 39780
+            "value": 39780000000
           }
         ]
       },
-      "build_time": 35824,
+      "build_time": 35824320,
       "increased_power": 3500,
       "level": 45,
       "requirements": [
@@ -1828,11 +1828,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 214200
+            "value": 214200000000
           }
         ]
       },
-      "build_time": 90869,
+      "build_time": 90869760,
       "increased_power": 4000,
       "level": 49,
       "requirements": [
@@ -1858,11 +1858,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 374850
+            "value": 374850000000
           }
         ]
       },
-      "build_time": 112502,
+      "build_time": 112502880,
       "increased_power": 5000,
       "level": 50,
       "requirements": [

--- a/buildings/armada_control_center.json
+++ b/buildings/armada_control_center.json
@@ -28,19 +28,19 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 328950
+            "value": 328950000
           },
           {
             "type": "tritanium",
-            "value": 193500
+            "value": 193500000
           },
           {
             "type": "dilithium",
-            "value": 19350
+            "value": 19350000
           }
         ]
       },
-      "build_time": 2360,
+      "build_time": 2360160,
       "increased_power": 2500,
       "level": 39,
       "requirements": [
@@ -76,19 +76,19 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 560000
+            "value": 560000000
           },
           {
             "type": "tritanium",
-            "value": 24200
+            "value": 24200000
           },
           {
             "type": "dilithium",
-            "value": 10875
+            "value": 10875000
           }
         ]
       },
-      "build_time": 3925,
+      "build_time": 3925440,
       "increased_power": 3000,
       "level": 41,
       "requirements": [
@@ -124,19 +124,19 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1432
+            "value": 1432760000
           },
           {
             "type": "tritanium",
-            "value": 301000
+            "value": 301000000
           },
           {
             "type": "dilithium",
-            "value": 30100
+            "value": 30100000
           }
         ]
       },
-      "build_time": 4188,
+      "build_time": 4188960,
       "increased_power": 3000,
       "level": 40,
       "requirements": [
@@ -175,19 +175,19 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 123930
+            "value": 123930000
           },
           {
             "type": "tritanium",
-            "value": 72900
+            "value": 72900000
           },
           {
             "type": "dilithium",
-            "value": 7290
+            "value": 7290000
           }
         ]
       },
-      "build_time": 1095,
+      "build_time": 1095840,
       "increased_power": 2500,
       "level": 37,
       "requirements": [
@@ -226,19 +226,19 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 192780
+            "value": 192780000
           },
           {
             "type": "tritanium",
-            "value": 113400
+            "value": 113400000
           },
           {
             "type": "dilithium",
-            "value": 11340
+            "value": 11340000
           }
         ]
       },
-      "build_time": 1778,
+      "build_time": 1778400,
       "increased_power": 2500,
       "level": 38,
       "requirements": [
@@ -277,19 +277,19 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 80631
+            "value": 80631000
           },
           {
             "type": "tritanium",
-            "value": 47430
+            "value": 47430000
           },
           {
             "type": "dilithium",
-            "value": 4743
+            "value": 4743000
           }
         ]
       },
-      "build_time": 1061,
+      "build_time": 1061280,
       "increased_power": 2000,
       "level": 36,
       "requirements": [
@@ -328,15 +328,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 23417
+            "value": 23417500
           },
           {
             "type": "tritanium",
-            "value": 13775
+            "value": 13775000
           },
           {
             "type": "dilithium",
-            "value": 1377
+            "value": 1377500
           }
         ]
       },
@@ -423,11 +423,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 4530
+            "value": 4530500
           },
           {
             "type": "tritanium",
-            "value": 2665
+            "value": 2665000
           },
           {
             "type": "dilithium",
@@ -474,11 +474,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 6630
+            "value": 6630000
           },
           {
             "type": "tritanium",
-            "value": 3900
+            "value": 3900000
           },
           {
             "type": "dilithium",
@@ -522,19 +522,19 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 840000
+            "value": 840000000
           },
           {
             "type": "tritanium",
-            "value": 36300
+            "value": 36300000
           },
           {
             "type": "dilithium",
-            "value": 12687
+            "value": 12687500
           }
         ]
       },
-      "build_time": 6033,
+      "build_time": 6033600,
       "increased_power": 3500,
       "level": 42,
       "requirements": [
@@ -570,19 +570,19 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1190
+            "value": 1190000000
           },
           {
             "type": "tritanium",
-            "value": 51425
+            "value": 51425000
           },
           {
             "type": "dilithium",
-            "value": 14500
+            "value": 14500000
           }
         ]
       },
-      "build_time": 7971,
+      "build_time": 7971840,
       "increased_power": 3500,
       "level": 43,
       "requirements": [
@@ -618,19 +618,19 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1750
+            "value": 1750000000
           },
           {
             "type": "tritanium",
-            "value": 75625
+            "value": 75625000
           },
           {
             "type": "dilithium",
-            "value": 16312
+            "value": 16312500
           }
         ]
       },
-      "build_time": 10405,
+      "build_time": 10405440,
       "increased_power": 3500,
       "level": 44,
       "requirements": [
@@ -666,19 +666,19 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 2660
+            "value": 2660000000
           },
           {
             "type": "tritanium",
-            "value": 114950
+            "value": 114950000
           },
           {
             "type": "dilithium",
-            "value": 18125
+            "value": 18125000
           }
         ]
       },
-      "build_time": 13433,
+      "build_time": 13433760,
       "increased_power": 3500,
       "level": 45,
       "requirements": [
@@ -714,19 +714,19 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 8000
+            "value": 8000000000
           },
           {
             "type": "tritanium",
-            "value": 185600
+            "value": 185600000
           },
           {
             "type": "dilithium",
-            "value": 32880
+            "value": 32880000
           }
         ]
       },
-      "build_time": 17172,
+      "build_time": 17172000,
       "increased_power": 4000,
       "level": 46,
       "requirements": [
@@ -762,19 +762,19 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 12000
+            "value": 12000000000
           },
           {
             "type": "tritanium",
-            "value": 278400
+            "value": 278400000
           },
           {
             "type": "dilithium",
-            "value": 49320
+            "value": 49320000
           }
         ]
       },
-      "build_time": 21754,
+      "build_time": 21754080,
       "increased_power": 4000,
       "level": 47,
       "requirements": [
@@ -810,19 +810,19 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 17000
+            "value": 17000000000
           },
           {
             "type": "tritanium",
-            "value": 394400
+            "value": 394400000
           },
           {
             "type": "dilithium",
-            "value": 69870
+            "value": 69870000
           }
         ]
       },
-      "build_time": 27329,
+      "build_time": 27329760,
       "increased_power": 5000,
       "level": 48,
       "requirements": [
@@ -848,7 +848,7 @@
         "others": [
           {
             "type": "Armada\u00a0Tactical\u00a0Core",
-            "value": 1035
+            "value": 1035000
           },
           {
             "type": "Rare\u00a0Armada\u00a0Tactical\u00a0Core",
@@ -858,19 +858,19 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 25000
+            "value": 25000000000
           },
           {
             "type": "tritanium",
-            "value": 580000
+            "value": 580000000
           },
           {
             "type": "dilithium",
-            "value": 102750
+            "value": 102750000
           }
         ]
       },
-      "build_time": 34076,
+      "build_time": 34076160,
       "increased_power": 4000,
       "level": 49,
       "requirements": [
@@ -896,7 +896,7 @@
         "others": [
           {
             "type": "Armada\u00a0Tactical\u00a0Core",
-            "value": 1150
+            "value": 1150000
           },
           {
             "type": "Rare\u00a0Armada\u00a0Tactical\u00a0Core",
@@ -906,19 +906,19 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 38000
+            "value": 38000000000
           },
           {
             "type": "tritanium",
-            "value": 881600
+            "value": 881600000
           },
           {
             "type": "dilithium",
-            "value": 156180
+            "value": 156180000
           }
         ]
       },
-      "build_time": 42189,
+      "build_time": 42189120,
       "increased_power": 5000,
       "level": 50,
       "requirements": [
@@ -957,11 +957,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 15138
+            "value": 15138500
           },
           {
             "type": "tritanium",
-            "value": 8905
+            "value": 8905000
           },
           {
             "type": "dilithium",
@@ -2030,7 +2030,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1243
+            "value": 1243125
           },
           {
             "type": "tritanium",
@@ -2081,11 +2081,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1897
+            "value": 1897200
           },
           {
             "type": "tritanium",
-            "value": 1116
+            "value": 1116000
           },
           {
             "type": "dilithium",
@@ -2132,11 +2132,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 2845
+            "value": 2845800
           },
           {
             "type": "tritanium",
-            "value": 1674
+            "value": 1674000
           },
           {
             "type": "dilithium",
@@ -2183,11 +2183,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 10480
+            "value": 10480500
           },
           {
             "type": "tritanium",
-            "value": 6165
+            "value": 6165000
           },
           {
             "type": "dilithium",
@@ -2234,15 +2234,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 36975
+            "value": 36975000
           },
           {
             "type": "tritanium",
-            "value": 21750
+            "value": 21750000
           },
           {
             "type": "dilithium",
-            "value": 2175
+            "value": 2175000
           }
         ]
       },
@@ -2285,15 +2285,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 57222
+            "value": 57222000
           },
           {
             "type": "tritanium",
-            "value": 33660
+            "value": 33660000
           },
           {
             "type": "dilithium",
-            "value": 3366
+            "value": 3366000
           }
         ]
       },

--- a/buildings/armory.json
+++ b/buildings/armory.json
@@ -23,15 +23,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 15912
+            "value": 15912000000
           },
           {
             "type": "dilithium",
-            "value": 117000
+            "value": 117000000
           }
         ]
       },
-      "build_time": 17912,
+      "build_time": 17912160,
       "increased_power": 3500,
       "level": 45,
       "requirements": [
@@ -88,15 +88,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 137332
+            "value": 137332800
           },
           {
             "type": "dilithium",
-            "value": 2019
+            "value": 2019600
           }
         ]
       },
-      "build_time": 1107,
+      "build_time": 1107360,
       "increased_power": 2000,
       "level": 35,
       "requirements": [
@@ -122,11 +122,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 88740
+            "value": 88740000
           },
           {
             "type": "dilithium",
-            "value": 1305
+            "value": 1305000
           }
         ]
       },

--- a/buildings/astronautics_studio.json
+++ b/buildings/astronautics_studio.json
@@ -31,15 +31,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 347004
+            "value": 347004000
           },
           {
             "type": "tritanium",
-            "value": 14580
+            "value": 14580000
           }
         ]
       },
-      "build_time": 1461,
+      "build_time": 1461600,
       "increased_power": 2500,
       "level": 37,
       "requirements": [
@@ -71,15 +71,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 160221
+            "value": 160221600
           },
           {
             "type": "tritanium",
-            "value": 6732
+            "value": 6732000
           }
         ]
       },
-      "build_time": 1107,
+      "build_time": 1107360,
       "increased_power": 2000,
       "level": 35,
       "requirements": [
@@ -117,11 +117,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 103530
+            "value": 103530000
           },
           {
             "type": "tritanium",
-            "value": 4350
+            "value": 4350000
           }
         ]
       },
@@ -163,15 +163,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 6097
+            "value": 6097560000
           },
           {
             "type": "tritanium",
-            "value": 128100
+            "value": 128100000
           }
         ]
       },
-      "build_time": 8045,
+      "build_time": 8045280,
       "increased_power": 3500,
       "level": 42,
       "requirements": [
@@ -213,15 +213,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 8710
+            "value": 8710800000
           },
           {
             "type": "tritanium",
-            "value": 183000
+            "value": 183000000
           }
         ]
       },
-      "build_time": 10630,
+      "build_time": 10630080,
       "increased_power": 3500,
       "level": 43,
       "requirements": [
@@ -259,15 +259,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 13066
+            "value": 13066200000
           },
           {
             "type": "tritanium",
-            "value": 274500
+            "value": 274500000
           }
         ]
       },
-      "build_time": 13874,
+      "build_time": 13874400,
       "increased_power": 3500,
       "level": 44,
       "requirements": [
@@ -305,15 +305,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 921060
+            "value": 921060000
           },
           {
             "type": "tritanium",
-            "value": 38700
+            "value": 38700000
           }
         ]
       },
-      "build_time": 3146,
+      "build_time": 3146400,
       "increased_power": 2500,
       "level": 39,
       "requirements": [
@@ -345,15 +345,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 99960
+            "value": 99960000000
           },
           {
             "type": "tritanium",
-            "value": 2100
+            "value": 2100000000
           }
         ]
       },
-      "build_time": 45434,
+      "build_time": 45434880,
       "increased_power": 4000,
       "level": 49,
       "requirements": [
@@ -389,15 +389,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 59976
+            "value": 59976000000
           },
           {
             "type": "tritanium",
-            "value": 1260
+            "value": 1260000000
           }
         ]
       },
-      "build_time": 36440,
+      "build_time": 36440640,
       "increased_power": 5000,
       "level": 48,
       "requirements": [
@@ -433,15 +433,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 37128
+            "value": 37128000000
           },
           {
             "type": "tritanium",
-            "value": 780000
+            "value": 780000000
           }
         ]
       },
-      "build_time": 29004,
+      "build_time": 29004480,
       "increased_power": 4000,
       "level": 47,
       "requirements": [
@@ -477,15 +477,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 25525
+            "value": 25525500000
           },
           {
             "type": "tritanium",
-            "value": 536250
+            "value": 536250000
           }
         ]
       },
-      "build_time": 22896,
+      "build_time": 22896000,
       "increased_power": 4000,
       "level": 46,
       "requirements": [
@@ -517,15 +517,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 18564
+            "value": 18564000000
           },
           {
             "type": "tritanium",
-            "value": 390000
+            "value": 390000000
           }
         ]
       },
-      "build_time": 17912,
+      "build_time": 17912160,
       "increased_power": 3500,
       "level": 45,
       "requirements": [
@@ -563,11 +563,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 29345
+            "value": 29345400
           },
           {
             "type": "tritanium",
-            "value": 1233
+            "value": 1233000
           }
         ]
       },
@@ -609,15 +609,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 4093
+            "value": 4093600000
           },
           {
             "type": "tritanium",
-            "value": 86000
+            "value": 86000000
           }
         ]
       },
-      "build_time": 5234,
+      "build_time": 5234400,
       "increased_power": 3000,
       "level": 41,
       "requirements": [
@@ -1401,7 +1401,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1373
+            "value": 1373736
           },
           {
             "type": "tritanium",
@@ -1447,7 +1447,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 2227
+            "value": 2227680
           },
           {
             "type": "tritanium",
@@ -1487,7 +1487,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 3480
+            "value": 3480750
           },
           {
             "type": "tritanium",
@@ -1533,7 +1533,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 5312
+            "value": 5312160
           },
           {
             "type": "tritanium",
@@ -1579,7 +1579,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 7968
+            "value": 7968240
           },
           {
             "type": "tritanium",
@@ -1625,7 +1625,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 12685
+            "value": 12685400
           },
           {
             "type": "tritanium",
@@ -1665,7 +1665,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 18564
+            "value": 18564000
           },
           {
             "type": "tritanium",
@@ -1715,11 +1715,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 42387
+            "value": 42387800
           },
           {
             "type": "tritanium",
-            "value": 1781
+            "value": 1781000
           }
         ]
       },
@@ -1759,11 +1759,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 65569
+            "value": 65569000
           },
           {
             "type": "tritanium",
-            "value": 2755
+            "value": 2755000
           }
         ]
       },
@@ -1799,15 +1799,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 225766
+            "value": 225766800
           },
           {
             "type": "tritanium",
-            "value": 9486
+            "value": 9486000
           }
         ]
       },
-      "build_time": 1414,
+      "build_time": 1414080,
       "increased_power": 2000,
       "level": 36,
       "requirements": [
@@ -1849,15 +1849,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 539784
+            "value": 539784000
           },
           {
             "type": "tritanium",
-            "value": 22680
+            "value": 22680000
           }
         ]
       },
-      "build_time": 2370,
+      "build_time": 2370240,
       "increased_power": 2500,
       "level": 38,
       "requirements": [
@@ -1895,15 +1895,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 4011
+            "value": 4011728000
           },
           {
             "type": "tritanium",
-            "value": 60200
+            "value": 60200000
           }
         ]
       },
-      "build_time": 5584,
+      "build_time": 5584320,
       "increased_power": 3000,
       "level": 40,
       "requirements": [
@@ -1928,15 +1928,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 174930
+            "value": 174930000000
           },
           {
             "type": "tritanium",
-            "value": 3675
+            "value": 3675000000
           }
         ]
       },
-      "build_time": 56250,
+      "build_time": 56250720,
       "increased_power": 5000,
       "level": 50,
       "requirements": [

--- a/buildings/defense_platform_a.json
+++ b/buildings/defense_platform_a.json
@@ -25,7 +25,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1962
+            "value": 1962480
           },
           {
             "type": "tritanium",
@@ -58,7 +58,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1245
+            "value": 1245420
           },
           {
             "type": "tritanium",
@@ -131,11 +131,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 93670
+            "value": 93670000
           },
           {
             "type": "tritanium",
-            "value": 2755
+            "value": 2755000
           },
           {
             "type": "dilithium",
@@ -143,7 +143,7 @@
           }
         ]
       },
-      "build_time": 1110,
+      "build_time": 1110240,
       "increased_power": 100954,
       "level": 33,
       "requirements": [
@@ -168,19 +168,19 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1315
+            "value": 1315800000
           },
           {
             "type": "tritanium",
-            "value": 38700
+            "value": 38700000
           },
           {
             "type": "dilithium",
-            "value": 3870
+            "value": 3870000
           }
         ]
       },
-      "build_time": 5506,
+      "build_time": 5506560,
       "increased_power": 282851,
       "level": 39,
       "requirements": [
@@ -914,7 +914,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 3182
+            "value": 3182400
           },
           {
             "type": "tritanium",
@@ -964,7 +964,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 4972
+            "value": 4972500
           },
           {
             "type": "tritanium",
@@ -1004,7 +1004,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 7588
+            "value": 7588800
           },
           {
             "type": "tritanium",
@@ -1050,19 +1050,19 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 771120
+            "value": 771120000
           },
           {
             "type": "tritanium",
-            "value": 22680
+            "value": 22680000
           },
           {
             "type": "dilithium",
-            "value": 2268
+            "value": 2268000
           }
         ]
       },
-      "build_time": 4148,
+      "build_time": 4148640,
       "increased_power": 228653,
       "level": 38,
       "requirements": [
@@ -1096,7 +1096,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 11383
+            "value": 11383200
           },
           {
             "type": "tritanium",
@@ -1136,7 +1136,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 18122
+            "value": 18122000
           },
           {
             "type": "tritanium",
@@ -1176,7 +1176,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 26520
+            "value": 26520000
           },
           {
             "type": "tritanium",
@@ -1226,11 +1226,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 41922
+            "value": 41922000
           },
           {
             "type": "tritanium",
-            "value": 1233
+            "value": 1233000
           },
           {
             "type": "dilithium",
@@ -1266,11 +1266,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 60554
+            "value": 60554000
           },
           {
             "type": "tritanium",
-            "value": 1781
+            "value": 1781000
           },
           {
             "type": "dilithium",
@@ -1312,11 +1312,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 147900
+            "value": 147900000
           },
           {
             "type": "tritanium",
-            "value": 4350
+            "value": 4350000
           },
           {
             "type": "dilithium",
@@ -1324,7 +1324,7 @@
           }
         ]
       },
-      "build_time": 1470,
+      "build_time": 1470240,
       "increased_power": 108576,
       "level": 34,
       "requirements": [
@@ -1352,11 +1352,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 228888
+            "value": 228888000
           },
           {
             "type": "tritanium",
-            "value": 6732
+            "value": 6732000
           },
           {
             "type": "dilithium",
@@ -1364,7 +1364,7 @@
           }
         ]
       },
-      "build_time": 1936,
+      "build_time": 1936800,
       "increased_power": 205049,
       "level": 35,
       "requirements": [
@@ -1402,11 +1402,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 322524
+            "value": 322524000
           },
           {
             "type": "tritanium",
-            "value": 9486
+            "value": 9486000
           },
           {
             "type": "dilithium",
@@ -1414,7 +1414,7 @@
           }
         ]
       },
-      "build_time": 2475,
+      "build_time": 2475360,
       "increased_power": 188295,
       "level": 36,
       "requirements": [
@@ -1448,19 +1448,19 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 495720
+            "value": 495720000
           },
           {
             "type": "tritanium",
-            "value": 14580
+            "value": 14580000
           },
           {
             "type": "dilithium",
-            "value": 1458
+            "value": 1458000
           }
         ]
       },
-      "build_time": 2558,
+      "build_time": 2558880,
       "increased_power": 135959,
       "level": 37,
       "requirements": [
@@ -1494,20 +1494,20 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 5731
+            "value": 5731040000
           },
           {
             "type": "tritanium",
-            "value": 60200
+            "value": 60200000
           },
           {
             "type": "dilithium",
-            "value": 6020
+            "value": 6020000
           }
         ]
       },
-      "build_time": 9773,
-      "increased_power": 1145,
+      "build_time": 9773280,
+      "increased_power": 1145609,
       "level": 40,
       "requirements": [
         {
@@ -1540,19 +1540,19 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 5848
+            "value": 5848000000
           },
           {
             "type": "tritanium",
-            "value": 86000
+            "value": 86000000
           },
           {
             "type": "dilithium",
-            "value": 8600
+            "value": 8600000
           }
         ]
       },
-      "build_time": 9159,
+      "build_time": 9159840,
       "increased_power": 287514,
       "level": 41,
       "requirements": [
@@ -1586,19 +1586,19 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 8710
+            "value": 8710800000
           },
           {
             "type": "tritanium",
-            "value": 128100
+            "value": 128100000
           },
           {
             "type": "dilithium",
-            "value": 12810
+            "value": 12810000
           }
         ]
       },
-      "build_time": 14080,
+      "build_time": 14080320,
       "increased_power": 312176,
       "level": 42,
       "requirements": [
@@ -1632,19 +1632,19 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 12444
+            "value": 12444000000
           },
           {
             "type": "tritanium",
-            "value": 183000
+            "value": 183000000
           },
           {
             "type": "dilithium",
-            "value": 18300
+            "value": 18300000
           }
         ]
       },
-      "build_time": 18601,
+      "build_time": 18601920,
       "increased_power": 338944,
       "level": 43,
       "requirements": [
@@ -1672,19 +1672,19 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 18666
+            "value": 18666000000
           },
           {
             "type": "tritanium",
-            "value": 274500
+            "value": 274500000
           },
           {
             "type": "dilithium",
-            "value": 27450
+            "value": 27450000
           }
         ]
       },
-      "build_time": 24279,
+      "build_time": 24279840,
       "increased_power": 368048,
       "level": 44,
       "requirements": [
@@ -1722,19 +1722,19 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 26520
+            "value": 26520000000
           },
           {
             "type": "tritanium",
-            "value": 390000
+            "value": 390000000
           },
           {
             "type": "dilithium",
-            "value": 39000
+            "value": 39000000
           }
         ]
       },
-      "build_time": 31345,
+      "build_time": 31345920,
       "increased_power": 399658,
       "level": 45,
       "requirements": [
@@ -1772,19 +1772,19 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 36465
+            "value": 36465000000
           },
           {
             "type": "tritanium",
-            "value": 536250
+            "value": 536250000
           },
           {
             "type": "dilithium",
-            "value": 53625
+            "value": 53625000
           }
         ]
       },
-      "build_time": 40068,
+      "build_time": 40068000,
       "increased_power": 434003,
       "level": 46,
       "requirements": [
@@ -1822,19 +1822,19 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 53040
+            "value": 53040000000
           },
           {
             "type": "tritanium",
-            "value": 780000
+            "value": 780000000
           },
           {
             "type": "dilithium",
-            "value": 78000
+            "value": 78000000
           }
         ]
       },
-      "build_time": 50758,
+      "build_time": 50758560,
       "increased_power": 471309,
       "level": 47,
       "requirements": [
@@ -1868,19 +1868,19 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 85680
+            "value": 85680000000
           },
           {
             "type": "tritanium",
-            "value": 1260
+            "value": 1260000000
           },
           {
             "type": "dilithium",
-            "value": 126000
+            "value": 126000000
           }
         ]
       },
-      "build_time": 63770,
+      "build_time": 63770400,
       "increased_power": 511850,
       "level": 48,
       "requirements": [
@@ -1914,19 +1914,19 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 142800
+            "value": 142800000000
           },
           {
             "type": "tritanium",
-            "value": 2100
+            "value": 2100000000
           },
           {
             "type": "dilithium",
-            "value": 210000
+            "value": 210000000
           }
         ]
       },
-      "build_time": 79511,
+      "build_time": 79511040,
       "increased_power": 555899,
       "level": 49,
       "requirements": [
@@ -1951,19 +1951,19 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 249900
+            "value": 249900000000
           },
           {
             "type": "tritanium",
-            "value": 3675
+            "value": 3675000000
           },
           {
             "type": "dilithium",
-            "value": 367500
+            "value": 367500000
           }
         ]
       },
-      "build_time": 98439,
+      "build_time": 98439840,
       "increased_power": 603739,
       "level": 50,
       "requirements": [

--- a/buildings/defense_platform_b.json
+++ b/buildings/defense_platform_b.json
@@ -18,19 +18,19 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1315
+            "value": 1315800000
           },
           {
             "type": "tritanium",
-            "value": 38700
+            "value": 38700000
           },
           {
             "type": "dilithium",
-            "value": 3870
+            "value": 3870000
           }
         ]
       },
-      "build_time": 5506,
+      "build_time": 5506560,
       "increased_power": 282851,
       "level": 39,
       "requirements": [
@@ -68,19 +68,19 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 771120
+            "value": 771120000
           },
           {
             "type": "tritanium",
-            "value": 22680
+            "value": 22680000
           },
           {
             "type": "dilithium",
-            "value": 2268
+            "value": 2268000
           }
         ]
       },
-      "build_time": 4148,
+      "build_time": 4148640,
       "increased_power": 228653,
       "level": 38,
       "requirements": [
@@ -118,11 +118,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 228888
+            "value": 228888000
           },
           {
             "type": "tritanium",
-            "value": 6732
+            "value": 6732000
           },
           {
             "type": "dilithium",
@@ -130,7 +130,7 @@
           }
         ]
       },
-      "build_time": 1936,
+      "build_time": 1936800,
       "increased_power": 205049,
       "level": 35,
       "requirements": [
@@ -168,19 +168,19 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 8710
+            "value": 8710800000
           },
           {
             "type": "tritanium",
-            "value": 128100
+            "value": 128100000
           },
           {
             "type": "dilithium",
-            "value": 12810
+            "value": 12810000
           }
         ]
       },
-      "build_time": 14080,
+      "build_time": 14080320,
       "increased_power": 312176,
       "level": 42,
       "requirements": [
@@ -214,19 +214,19 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 12444
+            "value": 12444000000
           },
           {
             "type": "tritanium",
-            "value": 183000
+            "value": 183000000
           },
           {
             "type": "dilithium",
-            "value": 18300
+            "value": 18300000
           }
         ]
       },
-      "build_time": 18601,
+      "build_time": 18601920,
       "increased_power": 338944,
       "level": 43,
       "requirements": [
@@ -254,19 +254,19 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 18666
+            "value": 18666000000
           },
           {
             "type": "tritanium",
-            "value": 274500
+            "value": 274500000
           },
           {
             "type": "dilithium",
-            "value": 27450
+            "value": 27450000
           }
         ]
       },
-      "build_time": 24279,
+      "build_time": 24279840,
       "increased_power": 368048,
       "level": 44,
       "requirements": [
@@ -304,19 +304,19 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 5848
+            "value": 5848000000
           },
           {
             "type": "tritanium",
-            "value": 86000
+            "value": 86000000
           },
           {
             "type": "dilithium",
-            "value": 8600
+            "value": 8600000
           }
         ]
       },
-      "build_time": 9159,
+      "build_time": 9159840,
       "increased_power": 287514,
       "level": 41,
       "requirements": [
@@ -354,20 +354,20 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 5731
+            "value": 5731040000
           },
           {
             "type": "tritanium",
-            "value": 60200
+            "value": 60200000
           },
           {
             "type": "dilithium",
-            "value": 6020
+            "value": 6020000
           }
         ]
       },
-      "build_time": 9773,
-      "increased_power": 1145,
+      "build_time": 9773280,
+      "increased_power": 1145609,
       "level": 40,
       "requirements": [
         {
@@ -394,11 +394,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 322524
+            "value": 322524000
           },
           {
             "type": "tritanium",
-            "value": 9486
+            "value": 9486000
           },
           {
             "type": "dilithium",
@@ -406,7 +406,7 @@
           }
         ]
       },
-      "build_time": 2475,
+      "build_time": 2475360,
       "increased_power": 188295,
       "level": 36,
       "requirements": [
@@ -440,19 +440,19 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 36465
+            "value": 36465000000
           },
           {
             "type": "tritanium",
-            "value": 536250
+            "value": 536250000
           },
           {
             "type": "dilithium",
-            "value": 53625
+            "value": 53625000
           }
         ]
       },
-      "build_time": 40068,
+      "build_time": 40068000,
       "increased_power": 434003,
       "level": 46,
       "requirements": [
@@ -490,7 +490,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 18122
+            "value": 18122000
           },
           {
             "type": "tritanium",
@@ -530,7 +530,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 26520
+            "value": 26520000
           },
           {
             "type": "tritanium",
@@ -1322,7 +1322,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1245
+            "value": 1245420
           },
           {
             "type": "tritanium",
@@ -1362,7 +1362,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1962
+            "value": 1962480
           },
           {
             "type": "tritanium",
@@ -1408,7 +1408,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 3182
+            "value": 3182400
           },
           {
             "type": "tritanium",
@@ -1458,7 +1458,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 4972
+            "value": 4972500
           },
           {
             "type": "tritanium",
@@ -1498,7 +1498,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 7588
+            "value": 7588800
           },
           {
             "type": "tritanium",
@@ -1538,7 +1538,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 11383
+            "value": 11383200
           },
           {
             "type": "tritanium",
@@ -1584,11 +1584,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 41922
+            "value": 41922000
           },
           {
             "type": "tritanium",
-            "value": 1233
+            "value": 1233000
           },
           {
             "type": "dilithium",
@@ -1624,11 +1624,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 60554
+            "value": 60554000
           },
           {
             "type": "tritanium",
-            "value": 1781
+            "value": 1781000
           },
           {
             "type": "dilithium",
@@ -1664,11 +1664,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 93670
+            "value": 93670000
           },
           {
             "type": "tritanium",
-            "value": 2755
+            "value": 2755000
           },
           {
             "type": "dilithium",
@@ -1676,7 +1676,7 @@
           }
         ]
       },
-      "build_time": 1110,
+      "build_time": 1110240,
       "increased_power": 100954,
       "level": 33,
       "requirements": [
@@ -1714,11 +1714,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 147900
+            "value": 147900000
           },
           {
             "type": "tritanium",
-            "value": 4350
+            "value": 4350000
           },
           {
             "type": "dilithium",
@@ -1726,7 +1726,7 @@
           }
         ]
       },
-      "build_time": 1470,
+      "build_time": 1470240,
       "increased_power": 108576,
       "level": 34,
       "requirements": [
@@ -1760,19 +1760,19 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 495720
+            "value": 495720000
           },
           {
             "type": "tritanium",
-            "value": 14580
+            "value": 14580000
           },
           {
             "type": "dilithium",
-            "value": 1458
+            "value": 1458000
           }
         ]
       },
-      "build_time": 2558,
+      "build_time": 2558880,
       "increased_power": 135959,
       "level": 37,
       "requirements": [
@@ -1806,19 +1806,19 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 26520
+            "value": 26520000000
           },
           {
             "type": "tritanium",
-            "value": 390000
+            "value": 390000000
           },
           {
             "type": "dilithium",
-            "value": 39000
+            "value": 39000000
           }
         ]
       },
-      "build_time": 31345,
+      "build_time": 31345920,
       "increased_power": 399658,
       "level": 45,
       "requirements": [
@@ -1856,19 +1856,19 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 53040
+            "value": 53040000000
           },
           {
             "type": "tritanium",
-            "value": 780000
+            "value": 780000000
           },
           {
             "type": "dilithium",
-            "value": 78000
+            "value": 78000000
           }
         ]
       },
-      "build_time": 50758,
+      "build_time": 50758560,
       "increased_power": 471309,
       "level": 47,
       "requirements": [
@@ -1902,19 +1902,19 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 85680
+            "value": 85680000000
           },
           {
             "type": "tritanium",
-            "value": 1260
+            "value": 1260000000
           },
           {
             "type": "dilithium",
-            "value": 126000
+            "value": 126000000
           }
         ]
       },
-      "build_time": 63770,
+      "build_time": 63770400,
       "increased_power": 511850,
       "level": 48,
       "requirements": [
@@ -1948,19 +1948,19 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 142800
+            "value": 142800000000
           },
           {
             "type": "tritanium",
-            "value": 2100
+            "value": 2100000000
           },
           {
             "type": "dilithium",
-            "value": 210000
+            "value": 210000000
           }
         ]
       },
-      "build_time": 79511,
+      "build_time": 79511040,
       "increased_power": 555899,
       "level": 49,
       "requirements": [
@@ -1985,19 +1985,19 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 249900
+            "value": 249900000000
           },
           {
             "type": "tritanium",
-            "value": 3675
+            "value": 3675000000
           },
           {
             "type": "dilithium",
-            "value": 367500
+            "value": 367500000
           }
         ]
       },
-      "build_time": 98439,
+      "build_time": 98439840,
       "increased_power": 603739,
       "level": 50,
       "requirements": [

--- a/buildings/defense_platform_c.json
+++ b/buildings/defense_platform_c.json
@@ -18,19 +18,19 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1315
+            "value": 1315800000
           },
           {
             "type": "tritanium",
-            "value": 38700
+            "value": 38700000
           },
           {
             "type": "dilithium",
-            "value": 3870
+            "value": 3870000
           }
         ]
       },
-      "build_time": 5506,
+      "build_time": 5506560,
       "increased_power": 282851,
       "level": 39,
       "requirements": [
@@ -68,19 +68,19 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 771120
+            "value": 771120000
           },
           {
             "type": "tritanium",
-            "value": 22680
+            "value": 22680000
           },
           {
             "type": "dilithium",
-            "value": 2268
+            "value": 2268000
           }
         ]
       },
-      "build_time": 4148,
+      "build_time": 4148640,
       "increased_power": 228653,
       "level": 38,
       "requirements": [
@@ -118,11 +118,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 228888
+            "value": 228888000
           },
           {
             "type": "tritanium",
-            "value": 6732
+            "value": 6732000
           },
           {
             "type": "dilithium",
@@ -130,7 +130,7 @@
           }
         ]
       },
-      "build_time": 1936,
+      "build_time": 1936800,
       "increased_power": 205049,
       "level": 35,
       "requirements": [
@@ -168,19 +168,19 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 8710
+            "value": 8710800000
           },
           {
             "type": "tritanium",
-            "value": 128100
+            "value": 128100000
           },
           {
             "type": "dilithium",
-            "value": 12810
+            "value": 12810000
           }
         ]
       },
-      "build_time": 14080,
+      "build_time": 14080320,
       "increased_power": 312176,
       "level": 42,
       "requirements": [
@@ -214,19 +214,19 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 12444
+            "value": 12444000000
           },
           {
             "type": "tritanium",
-            "value": 183000
+            "value": 183000000
           },
           {
             "type": "dilithium",
-            "value": 18300
+            "value": 18300000
           }
         ]
       },
-      "build_time": 18601,
+      "build_time": 18601920,
       "increased_power": 338944,
       "level": 43,
       "requirements": [
@@ -254,19 +254,19 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 18666
+            "value": 18666000000
           },
           {
             "type": "tritanium",
-            "value": 274500
+            "value": 274500000
           },
           {
             "type": "dilithium",
-            "value": 27450
+            "value": 27450000
           }
         ]
       },
-      "build_time": 24279,
+      "build_time": 24279840,
       "increased_power": 368048,
       "level": 44,
       "requirements": [
@@ -370,19 +370,19 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 5848
+            "value": 5848000000
           },
           {
             "type": "tritanium",
-            "value": 86000
+            "value": 86000000
           },
           {
             "type": "dilithium",
-            "value": 8600
+            "value": 8600000
           }
         ]
       },
-      "build_time": 9159,
+      "build_time": 9159840,
       "increased_power": 287514,
       "level": 41,
       "requirements": [
@@ -420,20 +420,20 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 5731
+            "value": 5731040000
           },
           {
             "type": "tritanium",
-            "value": 60200
+            "value": 60200000
           },
           {
             "type": "dilithium",
-            "value": 6020
+            "value": 6020000
           }
         ]
       },
-      "build_time": 9773,
-      "increased_power": 1145,
+      "build_time": 9773280,
+      "increased_power": 1145609,
       "level": 40,
       "requirements": [
         {
@@ -460,11 +460,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 322524
+            "value": 322524000
           },
           {
             "type": "tritanium",
-            "value": 9486
+            "value": 9486000
           },
           {
             "type": "dilithium",
@@ -472,7 +472,7 @@
           }
         ]
       },
-      "build_time": 2475,
+      "build_time": 2475360,
       "increased_power": 188295,
       "level": 36,
       "requirements": [
@@ -500,11 +500,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 41922
+            "value": 41922000
           },
           {
             "type": "tritanium",
-            "value": 1233
+            "value": 1233000
           },
           {
             "type": "dilithium",
@@ -546,19 +546,19 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 36465
+            "value": 36465000000
           },
           {
             "type": "tritanium",
-            "value": 536250
+            "value": 536250000
           },
           {
             "type": "dilithium",
-            "value": 53625
+            "value": 53625000
           }
         ]
       },
-      "build_time": 40068,
+      "build_time": 40068000,
       "increased_power": 434003,
       "level": 46,
       "requirements": [
@@ -596,7 +596,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 18122
+            "value": 18122000
           },
           {
             "type": "tritanium",
@@ -642,7 +642,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 26520
+            "value": 26520000
           },
           {
             "type": "tritanium",
@@ -725,19 +725,19 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 495720
+            "value": 495720000
           },
           {
             "type": "tritanium",
-            "value": 14580
+            "value": 14580000
           },
           {
             "type": "dilithium",
-            "value": 1458
+            "value": 1458000
           }
         ]
       },
-      "build_time": 2558,
+      "build_time": 2558880,
       "increased_power": 135959,
       "level": 37,
       "requirements": [
@@ -1389,7 +1389,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1245
+            "value": 1245420
           },
           {
             "type": "tritanium",
@@ -1422,7 +1422,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1962
+            "value": 1962480
           },
           {
             "type": "tritanium",
@@ -1468,7 +1468,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 3182
+            "value": 3182400
           },
           {
             "type": "tritanium",
@@ -1518,7 +1518,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 4972
+            "value": 4972500
           },
           {
             "type": "tritanium",
@@ -1558,7 +1558,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 7588
+            "value": 7588800
           },
           {
             "type": "tritanium",
@@ -1598,7 +1598,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 11383
+            "value": 11383200
           },
           {
             "type": "tritanium",
@@ -1644,11 +1644,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 60554
+            "value": 60554000
           },
           {
             "type": "tritanium",
-            "value": 1781
+            "value": 1781000
           },
           {
             "type": "dilithium",
@@ -1684,11 +1684,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 93670
+            "value": 93670000
           },
           {
             "type": "tritanium",
-            "value": 2755
+            "value": 2755000
           },
           {
             "type": "dilithium",
@@ -1696,7 +1696,7 @@
           }
         ]
       },
-      "build_time": 1110,
+      "build_time": 1110240,
       "increased_power": 100954,
       "level": 33,
       "requirements": [
@@ -1728,11 +1728,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 147900
+            "value": 147900000
           },
           {
             "type": "tritanium",
-            "value": 4350
+            "value": 4350000
           },
           {
             "type": "dilithium",
@@ -1740,7 +1740,7 @@
           }
         ]
       },
-      "build_time": 1470,
+      "build_time": 1470240,
       "increased_power": 108576,
       "level": 34,
       "requirements": [
@@ -1774,19 +1774,19 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 26520
+            "value": 26520000000
           },
           {
             "type": "tritanium",
-            "value": 390000
+            "value": 390000000
           },
           {
             "type": "dilithium",
-            "value": 39000
+            "value": 39000000
           }
         ]
       },
-      "build_time": 31345,
+      "build_time": 31345920,
       "increased_power": 399658,
       "level": 45,
       "requirements": [
@@ -1824,19 +1824,19 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 53040
+            "value": 53040000000
           },
           {
             "type": "tritanium",
-            "value": 780000
+            "value": 780000000
           },
           {
             "type": "dilithium",
-            "value": 78000
+            "value": 78000000
           }
         ]
       },
-      "build_time": 50758,
+      "build_time": 50758560,
       "increased_power": 471309,
       "level": 47,
       "requirements": [
@@ -1870,19 +1870,19 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 85680
+            "value": 85680000000
           },
           {
             "type": "tritanium",
-            "value": 1260
+            "value": 1260000000
           },
           {
             "type": "dilithium",
-            "value": 126000
+            "value": 126000000
           }
         ]
       },
-      "build_time": 63770,
+      "build_time": 63770400,
       "increased_power": 511850,
       "level": 48,
       "requirements": [
@@ -1916,19 +1916,19 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 142800
+            "value": 142800000000
           },
           {
             "type": "tritanium",
-            "value": 2100
+            "value": 2100000000
           },
           {
             "type": "dilithium",
-            "value": 210000
+            "value": 210000000
           }
         ]
       },
-      "build_time": 79511,
+      "build_time": 79511040,
       "increased_power": 555899,
       "level": 49,
       "requirements": [
@@ -1953,19 +1953,19 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 249900
+            "value": 249900000000
           },
           {
             "type": "tritanium",
-            "value": 3675
+            "value": 3675000000
           },
           {
             "type": "dilithium",
-            "value": 367500
+            "value": 367500000
           }
         ]
       },
-      "build_time": 98439,
+      "build_time": 98439840,
       "increased_power": 603739,
       "level": 50,
       "requirements": [

--- a/buildings/defense_platform_d.json
+++ b/buildings/defense_platform_d.json
@@ -18,19 +18,19 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1315
+            "value": 1315800000
           },
           {
             "type": "tritanium",
-            "value": 38700
+            "value": 38700000
           },
           {
             "type": "dilithium",
-            "value": 3870
+            "value": 3870000
           }
         ]
       },
-      "build_time": 5506,
+      "build_time": 5506560,
       "increased_power": 282851,
       "level": 39,
       "requirements": [
@@ -68,20 +68,20 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 5731
+            "value": 5731040000
           },
           {
             "type": "tritanium",
-            "value": 60200
+            "value": 60200000
           },
           {
             "type": "dilithium",
-            "value": 6020
+            "value": 6020000
           }
         ]
       },
-      "build_time": 9773,
-      "increased_power": 1145,
+      "build_time": 9773280,
+      "increased_power": 1145609,
       "level": 40,
       "requirements": [
         {
@@ -114,19 +114,19 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 5848
+            "value": 5848000000
           },
           {
             "type": "tritanium",
-            "value": 86000
+            "value": 86000000
           },
           {
             "type": "dilithium",
-            "value": 8600
+            "value": 8600000
           }
         ]
       },
-      "build_time": 9159,
+      "build_time": 9159840,
       "increased_power": 287514,
       "level": 41,
       "requirements": [
@@ -164,19 +164,19 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 771120
+            "value": 771120000
           },
           {
             "type": "tritanium",
-            "value": 22680
+            "value": 22680000
           },
           {
             "type": "dilithium",
-            "value": 2268
+            "value": 2268000
           }
         ]
       },
-      "build_time": 4148,
+      "build_time": 4148640,
       "increased_power": 228653,
       "level": 38,
       "requirements": [
@@ -214,11 +214,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 228888
+            "value": 228888000
           },
           {
             "type": "tritanium",
-            "value": 6732
+            "value": 6732000
           },
           {
             "type": "dilithium",
@@ -226,7 +226,7 @@
           }
         ]
       },
-      "build_time": 1936,
+      "build_time": 1936800,
       "increased_power": 205049,
       "level": 35,
       "requirements": [
@@ -264,19 +264,19 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 8710
+            "value": 8710800000
           },
           {
             "type": "tritanium",
-            "value": 128100
+            "value": 128100000
           },
           {
             "type": "dilithium",
-            "value": 12810
+            "value": 12810000
           }
         ]
       },
-      "build_time": 14080,
+      "build_time": 14080320,
       "increased_power": 312176,
       "level": 42,
       "requirements": [
@@ -310,19 +310,19 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 12444
+            "value": 12444000000
           },
           {
             "type": "tritanium",
-            "value": 183000
+            "value": 183000000
           },
           {
             "type": "dilithium",
-            "value": 18300
+            "value": 18300000
           }
         ]
       },
-      "build_time": 18601,
+      "build_time": 18601920,
       "increased_power": 338944,
       "level": 43,
       "requirements": [
@@ -350,19 +350,19 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 18666
+            "value": 18666000000
           },
           {
             "type": "tritanium",
-            "value": 274500
+            "value": 274500000
           },
           {
             "type": "dilithium",
-            "value": 27450
+            "value": 27450000
           }
         ]
       },
-      "build_time": 24279,
+      "build_time": 24279840,
       "increased_power": 368048,
       "level": 44,
       "requirements": [
@@ -400,19 +400,19 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 85680
+            "value": 85680000000
           },
           {
             "type": "tritanium",
-            "value": 1260
+            "value": 1260000000
           },
           {
             "type": "dilithium",
-            "value": 126000
+            "value": 126000000
           }
         ]
       },
-      "build_time": 63770,
+      "build_time": 63770400,
       "increased_power": 511850,
       "level": 48,
       "requirements": [
@@ -446,19 +446,19 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 26520
+            "value": 26520000000
           },
           {
             "type": "tritanium",
-            "value": 390000
+            "value": 390000000
           },
           {
             "type": "dilithium",
-            "value": 39000
+            "value": 39000000
           }
         ]
       },
-      "build_time": 31345,
+      "build_time": 31345920,
       "increased_power": 399658,
       "level": 45,
       "requirements": [
@@ -496,19 +496,19 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 36465
+            "value": 36465000000
           },
           {
             "type": "tritanium",
-            "value": 536250
+            "value": 536250000
           },
           {
             "type": "dilithium",
-            "value": 53625
+            "value": 53625000
           }
         ]
       },
-      "build_time": 40068,
+      "build_time": 40068000,
       "increased_power": 434003,
       "level": 46,
       "requirements": [
@@ -546,19 +546,19 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 142800
+            "value": 142800000000
           },
           {
             "type": "tritanium",
-            "value": 2100
+            "value": 2100000000
           },
           {
             "type": "dilithium",
-            "value": 210000
+            "value": 210000000
           }
         ]
       },
-      "build_time": 79511,
+      "build_time": 79511040,
       "increased_power": 555899,
       "level": 49,
       "requirements": [
@@ -590,11 +590,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 322524
+            "value": 322524000
           },
           {
             "type": "tritanium",
-            "value": 9486
+            "value": 9486000
           },
           {
             "type": "dilithium",
@@ -602,7 +602,7 @@
           }
         ]
       },
-      "build_time": 2475,
+      "build_time": 2475360,
       "increased_power": 188295,
       "level": 36,
       "requirements": [
@@ -636,11 +636,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 93670
+            "value": 93670000
           },
           {
             "type": "tritanium",
-            "value": 2755
+            "value": 2755000
           },
           {
             "type": "dilithium",
@@ -648,7 +648,7 @@
           }
         ]
       },
-      "build_time": 1110,
+      "build_time": 1110240,
       "increased_power": 100954,
       "level": 33,
       "requirements": [
@@ -680,11 +680,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 41922
+            "value": 41922000
           },
           {
             "type": "tritanium",
-            "value": 1233
+            "value": 1233000
           },
           {
             "type": "dilithium",
@@ -726,7 +726,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 18122
+            "value": 18122000
           },
           {
             "type": "tritanium",
@@ -772,7 +772,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 26520
+            "value": 26520000
           },
           {
             "type": "tritanium",
@@ -822,19 +822,19 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 495720
+            "value": 495720000
           },
           {
             "type": "tritanium",
-            "value": 14580
+            "value": 14580000
           },
           {
             "type": "dilithium",
-            "value": 1458
+            "value": 1458000
           }
         ]
       },
-      "build_time": 2558,
+      "build_time": 2558880,
       "increased_power": 135959,
       "level": 37,
       "requirements": [
@@ -1519,7 +1519,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1245
+            "value": 1245420
           },
           {
             "type": "tritanium",
@@ -1552,7 +1552,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1962
+            "value": 1962480
           },
           {
             "type": "tritanium",
@@ -1592,7 +1592,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 3182
+            "value": 3182400
           },
           {
             "type": "tritanium",
@@ -1636,7 +1636,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 4972
+            "value": 4972500
           },
           {
             "type": "tritanium",
@@ -1676,7 +1676,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 7588
+            "value": 7588800
           },
           {
             "type": "tritanium",
@@ -1716,7 +1716,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 11383
+            "value": 11383200
           },
           {
             "type": "tritanium",
@@ -1756,11 +1756,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 60554
+            "value": 60554000
           },
           {
             "type": "tritanium",
-            "value": 1781
+            "value": 1781000
           },
           {
             "type": "dilithium",
@@ -1796,11 +1796,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 147900
+            "value": 147900000
           },
           {
             "type": "tritanium",
-            "value": 4350
+            "value": 4350000
           },
           {
             "type": "dilithium",
@@ -1808,7 +1808,7 @@
           }
         ]
       },
-      "build_time": 1470,
+      "build_time": 1470240,
       "increased_power": 108576,
       "level": 34,
       "requirements": [
@@ -1842,19 +1842,19 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 53040
+            "value": 53040000000
           },
           {
             "type": "tritanium",
-            "value": 780000
+            "value": 780000000
           },
           {
             "type": "dilithium",
-            "value": 78000
+            "value": 78000000
           }
         ]
       },
-      "build_time": 50758,
+      "build_time": 50758560,
       "increased_power": 471309,
       "level": 47,
       "requirements": [
@@ -1875,19 +1875,19 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 249900
+            "value": 249900000000
           },
           {
             "type": "tritanium",
-            "value": 3675
+            "value": 3675000000
           },
           {
             "type": "dilithium",
-            "value": 367500
+            "value": 367500000
           }
         ]
       },
-      "build_time": 98439,
+      "build_time": 98439840,
       "increased_power": 603739,
       "level": 50,
       "requirements": [

--- a/buildings/defense_platform_e.json
+++ b/buildings/defense_platform_e.json
@@ -51,19 +51,19 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1315
+            "value": 1315800000
           },
           {
             "type": "tritanium",
-            "value": 38700
+            "value": 38700000
           },
           {
             "type": "dilithium",
-            "value": 3870
+            "value": 3870000
           }
         ]
       },
-      "build_time": 5506,
+      "build_time": 5506560,
       "increased_power": 282851,
       "level": 39,
       "requirements": [
@@ -84,19 +84,19 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 771120
+            "value": 771120000
           },
           {
             "type": "tritanium",
-            "value": 22680
+            "value": 22680000
           },
           {
             "type": "dilithium",
-            "value": 2268
+            "value": 2268000
           }
         ]
       },
-      "build_time": 4148,
+      "build_time": 4148640,
       "increased_power": 228653,
       "level": 38,
       "requirements": [
@@ -117,11 +117,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 228888
+            "value": 228888000
           },
           {
             "type": "tritanium",
-            "value": 6732
+            "value": 6732000
           },
           {
             "type": "dilithium",
@@ -129,7 +129,7 @@
           }
         ]
       },
-      "build_time": 1936,
+      "build_time": 1936800,
       "increased_power": 205049,
       "level": 35,
       "requirements": [
@@ -163,19 +163,19 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 8710
+            "value": 8710800000
           },
           {
             "type": "tritanium",
-            "value": 128100
+            "value": 128100000
           },
           {
             "type": "dilithium",
-            "value": 12810
+            "value": 12810000
           }
         ]
       },
-      "build_time": 14080,
+      "build_time": 14080320,
       "increased_power": 312176,
       "level": 42,
       "requirements": [
@@ -209,19 +209,19 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 12444
+            "value": 12444000000
           },
           {
             "type": "tritanium",
-            "value": 183000
+            "value": 183000000
           },
           {
             "type": "dilithium",
-            "value": 18300
+            "value": 18300000
           }
         ]
       },
-      "build_time": 18601,
+      "build_time": 18601920,
       "increased_power": 338944,
       "level": 43,
       "requirements": [
@@ -255,19 +255,19 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 18666
+            "value": 18666000000
           },
           {
             "type": "tritanium",
-            "value": 274500
+            "value": 274500000
           },
           {
             "type": "dilithium",
-            "value": 27450
+            "value": 27450000
           }
         ]
       },
-      "build_time": 24279,
+      "build_time": 24279840,
       "increased_power": 368048,
       "level": 44,
       "requirements": [
@@ -301,19 +301,19 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 142800
+            "value": 142800000000
           },
           {
             "type": "tritanium",
-            "value": 2100
+            "value": 2100000000
           },
           {
             "type": "dilithium",
-            "value": 210000
+            "value": 210000000
           }
         ]
       },
-      "build_time": 79511,
+      "build_time": 79511040,
       "increased_power": 555899,
       "level": 49,
       "requirements": [
@@ -351,19 +351,19 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 85680
+            "value": 85680000000
           },
           {
             "type": "tritanium",
-            "value": 1260
+            "value": 1260000000
           },
           {
             "type": "dilithium",
-            "value": 126000
+            "value": 126000000
           }
         ]
       },
-      "build_time": 63770,
+      "build_time": 63770400,
       "increased_power": 511850,
       "level": 48,
       "requirements": [
@@ -397,19 +397,19 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 53040
+            "value": 53040000000
           },
           {
             "type": "tritanium",
-            "value": 780000
+            "value": 780000000
           },
           {
             "type": "dilithium",
-            "value": 78000
+            "value": 78000000
           }
         ]
       },
-      "build_time": 50758,
+      "build_time": 50758560,
       "increased_power": 471309,
       "level": 47,
       "requirements": [
@@ -443,19 +443,19 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 36465
+            "value": 36465000000
           },
           {
             "type": "tritanium",
-            "value": 536250
+            "value": 536250000
           },
           {
             "type": "dilithium",
-            "value": 53625
+            "value": 53625000
           }
         ]
       },
-      "build_time": 40068,
+      "build_time": 40068000,
       "increased_power": 434003,
       "level": 46,
       "requirements": [
@@ -493,19 +493,19 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 26520
+            "value": 26520000000
           },
           {
             "type": "tritanium",
-            "value": 390000
+            "value": 390000000
           },
           {
             "type": "dilithium",
-            "value": 39000
+            "value": 39000000
           }
         ]
       },
-      "build_time": 31345,
+      "build_time": 31345920,
       "increased_power": 399658,
       "level": 45,
       "requirements": [
@@ -543,19 +543,19 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 5848
+            "value": 5848000000
           },
           {
             "type": "tritanium",
-            "value": 86000
+            "value": 86000000
           },
           {
             "type": "dilithium",
-            "value": 8600
+            "value": 8600000
           }
         ]
       },
-      "build_time": 9159,
+      "build_time": 9159840,
       "increased_power": 287514,
       "level": 41,
       "requirements": [
@@ -613,11 +613,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 322524
+            "value": 322524000
           },
           {
             "type": "tritanium",
-            "value": 9486
+            "value": 9486000
           },
           {
             "type": "dilithium",
@@ -625,7 +625,7 @@
           }
         ]
       },
-      "build_time": 2475,
+      "build_time": 2475360,
       "increased_power": 188295,
       "level": 36,
       "requirements": [
@@ -659,20 +659,20 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 5731
+            "value": 5731040000
           },
           {
             "type": "tritanium",
-            "value": 60200
+            "value": 60200000
           },
           {
             "type": "dilithium",
-            "value": 6020
+            "value": 6020000
           }
         ]
       },
-      "build_time": 9773,
-      "increased_power": 1145,
+      "build_time": 9773280,
+      "increased_power": 1145609,
       "level": 40,
       "requirements": [
         {
@@ -692,7 +692,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 18122
+            "value": 18122000
           },
           {
             "type": "tritanium",
@@ -725,7 +725,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 26520
+            "value": 26520000
           },
           {
             "type": "tritanium",
@@ -791,19 +791,19 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 495720
+            "value": 495720000
           },
           {
             "type": "tritanium",
-            "value": 14580
+            "value": 14580000
           },
           {
             "type": "dilithium",
-            "value": 1458
+            "value": 1458000
           }
         ]
       },
-      "build_time": 2558,
+      "build_time": 2558880,
       "increased_power": 135959,
       "level": 37,
       "requirements": [
@@ -824,7 +824,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 3182
+            "value": 3182400
           },
           {
             "type": "tritanium",
@@ -890,7 +890,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1245
+            "value": 1245420
           },
           {
             "type": "tritanium",
@@ -956,11 +956,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 41922
+            "value": 41922000
           },
           {
             "type": "tritanium",
-            "value": 1233
+            "value": 1233000
           },
           {
             "type": "dilithium",
@@ -1517,7 +1517,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1962
+            "value": 1962480
           },
           {
             "type": "tritanium",
@@ -1550,7 +1550,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 4972
+            "value": 4972500
           },
           {
             "type": "tritanium",
@@ -1583,7 +1583,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 7588
+            "value": 7588800
           },
           {
             "type": "tritanium",
@@ -1616,7 +1616,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 11383
+            "value": 11383200
           },
           {
             "type": "tritanium",
@@ -1649,11 +1649,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 60554
+            "value": 60554000
           },
           {
             "type": "tritanium",
-            "value": 1781
+            "value": 1781000
           },
           {
             "type": "dilithium",
@@ -1682,11 +1682,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 93670
+            "value": 93670000
           },
           {
             "type": "tritanium",
-            "value": 2755
+            "value": 2755000
           },
           {
             "type": "dilithium",
@@ -1694,7 +1694,7 @@
           }
         ]
       },
-      "build_time": 1110,
+      "build_time": 1110240,
       "increased_power": 100954,
       "level": 33,
       "requirements": [
@@ -1715,11 +1715,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 147900
+            "value": 147900000
           },
           {
             "type": "tritanium",
-            "value": 4350
+            "value": 4350000
           },
           {
             "type": "dilithium",
@@ -1727,7 +1727,7 @@
           }
         ]
       },
-      "build_time": 1470,
+      "build_time": 1470240,
       "increased_power": 108576,
       "level": 34,
       "requirements": [
@@ -1748,19 +1748,19 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 249900
+            "value": 249900000000
           },
           {
             "type": "tritanium",
-            "value": 3675
+            "value": 3675000000
           },
           {
             "type": "dilithium",
-            "value": 367500
+            "value": 367500000
           }
         ]
       },
-      "build_time": 98439,
+      "build_time": 98439840,
       "increased_power": 603739,
       "level": 50,
       "requirements": [

--- a/buildings/defense_platform_f.json
+++ b/buildings/defense_platform_f.json
@@ -18,19 +18,19 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1315
+            "value": 1315800000
           },
           {
             "type": "tritanium",
-            "value": 38700
+            "value": 38700000
           },
           {
             "type": "dilithium",
-            "value": 3870
+            "value": 3870000
           }
         ]
       },
-      "build_time": 5506,
+      "build_time": 5506560,
       "increased_power": 282851,
       "level": 39,
       "requirements": [
@@ -51,19 +51,19 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 771120
+            "value": 771120000
           },
           {
             "type": "tritanium",
-            "value": 22680
+            "value": 22680000
           },
           {
             "type": "dilithium",
-            "value": 2268
+            "value": 2268000
           }
         ]
       },
-      "build_time": 4148,
+      "build_time": 4148640,
       "increased_power": 228653,
       "level": 38,
       "requirements": [
@@ -84,11 +84,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 228888
+            "value": 228888000
           },
           {
             "type": "tritanium",
-            "value": 6732
+            "value": 6732000
           },
           {
             "type": "dilithium",
@@ -96,7 +96,7 @@
           }
         ]
       },
-      "build_time": 1936,
+      "build_time": 1936800,
       "increased_power": 205049,
       "level": 35,
       "requirements": [
@@ -130,19 +130,19 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 5848
+            "value": 5848000000
           },
           {
             "type": "tritanium",
-            "value": 86000
+            "value": 86000000
           },
           {
             "type": "dilithium",
-            "value": 8600
+            "value": 8600000
           }
         ]
       },
-      "build_time": 9159,
+      "build_time": 9159840,
       "increased_power": 287514,
       "level": 41,
       "requirements": [
@@ -176,20 +176,20 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 5731
+            "value": 5731040000
           },
           {
             "type": "tritanium",
-            "value": 60200
+            "value": 60200000
           },
           {
             "type": "dilithium",
-            "value": 6020
+            "value": 6020000
           }
         ]
       },
-      "build_time": 9773,
-      "increased_power": 1145,
+      "build_time": 9773280,
+      "increased_power": 1145609,
       "level": 40,
       "requirements": [
         {
@@ -209,11 +209,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 322524
+            "value": 322524000
           },
           {
             "type": "tritanium",
-            "value": 9486
+            "value": 9486000
           },
           {
             "type": "dilithium",
@@ -221,7 +221,7 @@
           }
         ]
       },
-      "build_time": 2475,
+      "build_time": 2475360,
       "increased_power": 188295,
       "level": 36,
       "requirements": [
@@ -255,19 +255,19 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 36465
+            "value": 36465000000
           },
           {
             "type": "tritanium",
-            "value": 536250
+            "value": 536250000
           },
           {
             "type": "dilithium",
-            "value": 53625
+            "value": 53625000
           }
         ]
       },
-      "build_time": 40068,
+      "build_time": 40068000,
       "increased_power": 434003,
       "level": 46,
       "requirements": [
@@ -288,7 +288,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 18122
+            "value": 18122000
           },
           {
             "type": "tritanium",
@@ -321,7 +321,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 26520
+            "value": 26520000
           },
           {
             "type": "tritanium",
@@ -367,19 +367,19 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 8710
+            "value": 8710800000
           },
           {
             "type": "tritanium",
-            "value": 128100
+            "value": 128100000
           },
           {
             "type": "dilithium",
-            "value": 12810
+            "value": 12810000
           }
         ]
       },
-      "build_time": 14080,
+      "build_time": 14080320,
       "increased_power": 312176,
       "level": 42,
       "requirements": [
@@ -400,11 +400,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 41922
+            "value": 41922000
           },
           {
             "type": "tritanium",
-            "value": 1233
+            "value": 1233000
           },
           {
             "type": "dilithium",
@@ -466,19 +466,19 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 495720
+            "value": 495720000
           },
           {
             "type": "tritanium",
-            "value": 14580
+            "value": 14580000
           },
           {
             "type": "dilithium",
-            "value": 1458
+            "value": 1458000
           }
         ]
       },
-      "build_time": 2558,
+      "build_time": 2558880,
       "increased_power": 135959,
       "level": 37,
       "requirements": [
@@ -1060,7 +1060,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1245
+            "value": 1245420
           },
           {
             "type": "tritanium",
@@ -1093,7 +1093,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1962
+            "value": 1962480
           },
           {
             "type": "tritanium",
@@ -1126,7 +1126,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 3182
+            "value": 3182400
           },
           {
             "type": "tritanium",
@@ -1159,7 +1159,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 4972
+            "value": 4972500
           },
           {
             "type": "tritanium",
@@ -1192,7 +1192,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 7588
+            "value": 7588800
           },
           {
             "type": "tritanium",
@@ -1225,7 +1225,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 11383
+            "value": 11383200
           },
           {
             "type": "tritanium",
@@ -1258,11 +1258,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 60554
+            "value": 60554000
           },
           {
             "type": "tritanium",
-            "value": 1781
+            "value": 1781000
           },
           {
             "type": "dilithium",
@@ -1291,11 +1291,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 93670
+            "value": 93670000
           },
           {
             "type": "tritanium",
-            "value": 2755
+            "value": 2755000
           },
           {
             "type": "dilithium",
@@ -1303,7 +1303,7 @@
           }
         ]
       },
-      "build_time": 1110,
+      "build_time": 1110240,
       "increased_power": 100954,
       "level": 33,
       "requirements": [
@@ -1324,11 +1324,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 147900
+            "value": 147900000
           },
           {
             "type": "tritanium",
-            "value": 4350
+            "value": 4350000
           },
           {
             "type": "dilithium",
@@ -1336,7 +1336,7 @@
           }
         ]
       },
-      "build_time": 1470,
+      "build_time": 1470240,
       "increased_power": 108576,
       "level": 34,
       "requirements": [
@@ -1370,19 +1370,19 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 12444
+            "value": 12444000000
           },
           {
             "type": "tritanium",
-            "value": 183000
+            "value": 183000000
           },
           {
             "type": "dilithium",
-            "value": 18300
+            "value": 18300000
           }
         ]
       },
-      "build_time": 18601,
+      "build_time": 18601920,
       "increased_power": 338944,
       "level": 43,
       "requirements": [
@@ -1416,19 +1416,19 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 18666
+            "value": 18666000000
           },
           {
             "type": "tritanium",
-            "value": 274500
+            "value": 274500000
           },
           {
             "type": "dilithium",
-            "value": 27450
+            "value": 27450000
           }
         ]
       },
-      "build_time": 24279,
+      "build_time": 24279840,
       "increased_power": 368048,
       "level": 44,
       "requirements": [
@@ -1462,19 +1462,19 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 26520
+            "value": 26520000000
           },
           {
             "type": "tritanium",
-            "value": 390000
+            "value": 390000000
           },
           {
             "type": "dilithium",
-            "value": 39000
+            "value": 39000000
           }
         ]
       },
-      "build_time": 31345,
+      "build_time": 31345920,
       "increased_power": 399658,
       "level": 45,
       "requirements": [
@@ -1512,19 +1512,19 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 53040
+            "value": 53040000000
           },
           {
             "type": "tritanium",
-            "value": 780000
+            "value": 780000000
           },
           {
             "type": "dilithium",
-            "value": 78000
+            "value": 78000000
           }
         ]
       },
-      "build_time": 50758,
+      "build_time": 50758560,
       "increased_power": 471309,
       "level": 47,
       "requirements": [
@@ -1558,19 +1558,19 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 85680
+            "value": 85680000000
           },
           {
             "type": "tritanium",
-            "value": 1260
+            "value": 1260000000
           },
           {
             "type": "dilithium",
-            "value": 126000
+            "value": 126000000
           }
         ]
       },
-      "build_time": 63770,
+      "build_time": 63770400,
       "increased_power": 511850,
       "level": 48,
       "requirements": [
@@ -1604,19 +1604,19 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 142800
+            "value": 142800000000
           },
           {
             "type": "tritanium",
-            "value": 2100
+            "value": 2100000000
           },
           {
             "type": "dilithium",
-            "value": 210000
+            "value": 210000000
           }
         ]
       },
-      "build_time": 79511,
+      "build_time": 79511040,
       "increased_power": 555899,
       "level": 49,
       "requirements": [
@@ -1637,19 +1637,19 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 249900
+            "value": 249900000000
           },
           {
             "type": "tritanium",
-            "value": 3675
+            "value": 3675000000
           },
           {
             "type": "dilithium",
-            "value": 367500
+            "value": 367500000
           }
         ]
       },
-      "build_time": 98439,
+      "build_time": 98439840,
       "increased_power": 603739,
       "level": 50,
       "requirements": [

--- a/buildings/defense_technologies.json
+++ b/buildings/defense_technologies.json
@@ -30,15 +30,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 247860
+            "value": 247860000
           },
           {
             "type": "tritanium",
-            "value": 29160
+            "value": 29160000
           }
         ]
       },
-      "build_time": 1461,
+      "build_time": 1461600,
       "increased_power": 2500,
       "level": 37,
       "requirements": [
@@ -75,15 +75,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 114444
+            "value": 114444000
           },
           {
             "type": "tritanium",
-            "value": 13464
+            "value": 13464000
           }
         ]
       },
-      "build_time": 1107,
+      "build_time": 1107360,
       "increased_power": 2000,
       "level": 35,
       "requirements": [
@@ -126,15 +126,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 4355
+            "value": 4355400000
           },
           {
             "type": "tritanium",
-            "value": 256200
+            "value": 256200000
           }
         ]
       },
-      "build_time": 8045,
+      "build_time": 8045280,
       "increased_power": 3500,
       "level": 42,
       "requirements": [
@@ -173,15 +173,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 6222
+            "value": 6222000000
           },
           {
             "type": "tritanium",
-            "value": 366000
+            "value": 366000000
           }
         ]
       },
-      "build_time": 10630,
+      "build_time": 10630080,
       "increased_power": 3500,
       "level": 43,
       "requirements": [
@@ -220,15 +220,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 9333
+            "value": 9333000000
           },
           {
             "type": "tritanium",
-            "value": 549000
+            "value": 549000000
           }
         ]
       },
-      "build_time": 13874,
+      "build_time": 13874400,
       "increased_power": 3500,
       "level": 44,
       "requirements": [
@@ -271,15 +271,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 71400
+            "value": 71400000000
           },
           {
             "type": "tritanium",
-            "value": 4200
+            "value": 4200000000
           }
         ]
       },
-      "build_time": 45434,
+      "build_time": 45434880,
       "increased_power": 4000,
       "level": 49,
       "requirements": [
@@ -322,15 +322,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 42840
+            "value": 42840000000
           },
           {
             "type": "tritanium",
-            "value": 2520
+            "value": 2520000000
           }
         ]
       },
-      "build_time": 36440,
+      "build_time": 36440640,
       "increased_power": 5000,
       "level": 48,
       "requirements": [
@@ -369,15 +369,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 26520
+            "value": 26520000000
           },
           {
             "type": "tritanium",
-            "value": 1560
+            "value": 1560000000
           }
         ]
       },
-      "build_time": 29004,
+      "build_time": 29004480,
       "increased_power": 4000,
       "level": 47,
       "requirements": [
@@ -416,15 +416,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 18232
+            "value": 18232500000
           },
           {
             "type": "tritanium",
-            "value": 1072
+            "value": 1072500000
           }
         ]
       },
-      "build_time": 22896,
+      "build_time": 22896000,
       "increased_power": 4000,
       "level": 46,
       "requirements": [
@@ -463,15 +463,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 13260
+            "value": 13260000000
           },
           {
             "type": "tritanium",
-            "value": 780000
+            "value": 780000000
           }
         ]
       },
-      "build_time": 17912,
+      "build_time": 17912160,
       "increased_power": 3500,
       "level": 45,
       "requirements": [
@@ -501,15 +501,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 657900
+            "value": 657900000
           },
           {
             "type": "tritanium",
-            "value": 77400
+            "value": 77400000
           }
         ]
       },
-      "build_time": 3146,
+      "build_time": 3146400,
       "increased_power": 2500,
       "level": 39,
       "requirements": [
@@ -546,11 +546,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 13260
+            "value": 13260000
           },
           {
             "type": "tritanium",
-            "value": 1560
+            "value": 1560000
           }
         ]
       },
@@ -597,15 +597,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 2924
+            "value": 2924000000
           },
           {
             "type": "tritanium",
-            "value": 172000
+            "value": 172000000
           }
         ]
       },
-      "build_time": 5234,
+      "build_time": 5234400,
       "increased_power": 3000,
       "level": 41,
       "requirements": [
@@ -1472,7 +1472,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1591
+            "value": 1591200
           },
           {
             "type": "tritanium",
@@ -1523,7 +1523,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 2486
+            "value": 2486250
           },
           {
             "type": "tritanium",
@@ -1570,7 +1570,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 3794
+            "value": 3794400
           },
           {
             "type": "tritanium",
@@ -1611,7 +1611,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 5691
+            "value": 5691600
           },
           {
             "type": "tritanium",
@@ -1658,11 +1658,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 9061
+            "value": 9061000
           },
           {
             "type": "tritanium",
-            "value": 1066
+            "value": 1066000
           }
         ]
       },
@@ -1699,11 +1699,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 20961
+            "value": 20961000
           },
           {
             "type": "tritanium",
-            "value": 2466
+            "value": 2466000
           }
         ]
       },
@@ -1746,11 +1746,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 30277
+            "value": 30277000
           },
           {
             "type": "tritanium",
-            "value": 3562
+            "value": 3562000
           }
         ]
       },
@@ -1791,11 +1791,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 46835
+            "value": 46835000
           },
           {
             "type": "tritanium",
-            "value": 5510
+            "value": 5510000
           }
         ]
       },
@@ -1842,11 +1842,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 73950
+            "value": 73950000
           },
           {
             "type": "tritanium",
-            "value": 8700
+            "value": 8700000
           }
         ]
       },
@@ -1893,15 +1893,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 161262
+            "value": 161262000
           },
           {
             "type": "tritanium",
-            "value": 18972
+            "value": 18972000
           }
         ]
       },
-      "build_time": 1414,
+      "build_time": 1414080,
       "increased_power": 2000,
       "level": 36,
       "requirements": [
@@ -1944,15 +1944,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 385560
+            "value": 385560000
           },
           {
             "type": "tritanium",
-            "value": 45360
+            "value": 45360000
           }
         ]
       },
-      "build_time": 2370,
+      "build_time": 2370240,
       "increased_power": 2500,
       "level": 38,
       "requirements": [
@@ -1995,15 +1995,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 2865
+            "value": 2865520000
           },
           {
             "type": "tritanium",
-            "value": 120400
+            "value": 120400000
           }
         ]
       },
-      "build_time": 5584,
+      "build_time": 5584320,
       "increased_power": 3000,
       "level": 40,
       "requirements": [
@@ -2029,15 +2029,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 124950
+            "value": 124950000000
           },
           {
             "type": "tritanium",
-            "value": 7350
+            "value": 7350000000
           }
         ]
       },
-      "build_time": 56250,
+      "build_time": 56250720,
       "increased_power": 5000,
       "level": 50,
       "requirements": [

--- a/buildings/dilithium_generator_a.json
+++ b/buildings/dilithium_generator_a.json
@@ -36,15 +36,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1146
+            "value": 1146208000
           },
           {
             "type": "tritanium",
-            "value": 301000
+            "value": 301000000
           }
         ]
       },
-      "build_time": 5584,
+      "build_time": 5584320,
       "increased_power": 1000,
       "level": 40,
       "requirements": [
@@ -73,15 +73,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1742
+            "value": 1742160000
           },
           {
             "type": "tritanium",
-            "value": 640500
+            "value": 640500000
           }
         ]
       },
-      "build_time": 8045,
+      "build_time": 8045280,
       "increased_power": 1000,
       "level": 42,
       "requirements": [
@@ -110,15 +110,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 2488
+            "value": 2488800000
           },
           {
             "type": "tritanium",
-            "value": 915000
+            "value": 915000000
           }
         ]
       },
-      "build_time": 10630,
+      "build_time": 10630080,
       "increased_power": 1250,
       "level": 43,
       "requirements": [
@@ -147,15 +147,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 3733
+            "value": 3733200000
           },
           {
             "type": "tritanium",
-            "value": 1372
+            "value": 1372500000
           }
         ]
       },
-      "build_time": 13874,
+      "build_time": 13874400,
       "increased_power": 1250,
       "level": 44,
       "requirements": [
@@ -190,15 +190,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 10608
+            "value": 10608000000
           },
           {
             "type": "tritanium",
-            "value": 3900
+            "value": 3900000000
           }
         ]
       },
-      "build_time": 29004,
+      "build_time": 29004480,
       "increased_power": 1500,
       "level": 47,
       "requirements": [
@@ -233,15 +233,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 7293
+            "value": 7293000000
           },
           {
             "type": "tritanium",
-            "value": 2681
+            "value": 2681250000
           }
         ]
       },
-      "build_time": 22896,
+      "build_time": 22896000,
       "increased_power": 1250,
       "level": 46,
       "requirements": [
@@ -276,15 +276,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 28560
+            "value": 28560000000
           },
           {
             "type": "tritanium",
-            "value": 10500
+            "value": 10500000000
           }
         ]
       },
-      "build_time": 45434,
+      "build_time": 45434880,
       "increased_power": 1500,
       "level": 49,
       "requirements": [
@@ -319,15 +319,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 17136
+            "value": 17136000000
           },
           {
             "type": "tritanium",
-            "value": 6300
+            "value": 6300000000
           }
         ]
       },
-      "build_time": 36440,
+      "build_time": 36440640,
       "increased_power": 1500,
       "level": 48,
       "requirements": [
@@ -1157,11 +1157,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1517
+            "value": 1517760
           },
           {
             "type": "tritanium",
-            "value": 1116
+            "value": 1116000
           }
         ]
       },
@@ -1187,11 +1187,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 2276
+            "value": 2276640
           },
           {
             "type": "tritanium",
-            "value": 1674
+            "value": 1674000
           }
         ]
       },
@@ -1217,11 +1217,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 3624
+            "value": 3624400
           },
           {
             "type": "tritanium",
-            "value": 2665
+            "value": 2665000
           }
         ]
       },
@@ -1247,11 +1247,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 5304
+            "value": 5304000
           },
           {
             "type": "tritanium",
-            "value": 3900
+            "value": 3900000
           }
         ]
       },
@@ -1277,11 +1277,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 8384
+            "value": 8384400
           },
           {
             "type": "tritanium",
-            "value": 6165
+            "value": 6165000
           }
         ]
       },
@@ -1307,11 +1307,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 12110
+            "value": 12110800
           },
           {
             "type": "tritanium",
-            "value": 8905
+            "value": 8905000
           }
         ]
       },
@@ -1337,11 +1337,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 18734
+            "value": 18734000
           },
           {
             "type": "tritanium",
-            "value": 13775
+            "value": 13775000
           }
         ]
       },
@@ -1367,11 +1367,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 29580
+            "value": 29580000
           },
           {
             "type": "tritanium",
-            "value": 21750
+            "value": 21750000
           }
         ]
       },
@@ -1397,15 +1397,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 45777
+            "value": 45777600
           },
           {
             "type": "tritanium",
-            "value": 33660
+            "value": 33660000
           }
         ]
       },
-      "build_time": 1107,
+      "build_time": 1107360,
       "increased_power": 750,
       "level": 35,
       "requirements": [
@@ -1427,15 +1427,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 64504
+            "value": 64504800
           },
           {
             "type": "tritanium",
-            "value": 47430
+            "value": 47430000
           }
         ]
       },
-      "build_time": 1414,
+      "build_time": 1414080,
       "increased_power": 750,
       "level": 36,
       "requirements": [
@@ -1457,15 +1457,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 99144
+            "value": 99144000
           },
           {
             "type": "tritanium",
-            "value": 72900
+            "value": 72900000
           }
         ]
       },
-      "build_time": 1461,
+      "build_time": 1461600,
       "increased_power": 750,
       "level": 37,
       "requirements": [
@@ -1487,15 +1487,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 154224
+            "value": 154224000
           },
           {
             "type": "tritanium",
-            "value": 113400
+            "value": 113400000
           }
         ]
       },
-      "build_time": 2370,
+      "build_time": 2370240,
       "increased_power": 1000,
       "level": 38,
       "requirements": [
@@ -1517,15 +1517,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 263160
+            "value": 263160000
           },
           {
             "type": "tritanium",
-            "value": 193500
+            "value": 193500000
           }
         ]
       },
-      "build_time": 3146,
+      "build_time": 3146400,
       "increased_power": 750,
       "level": 39,
       "requirements": [
@@ -1560,15 +1560,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1169
+            "value": 1169600000
           },
           {
             "type": "tritanium",
-            "value": 430000
+            "value": 430000000
           }
         ]
       },
-      "build_time": 5234,
+      "build_time": 5234400,
       "increased_power": 1000,
       "level": 41,
       "requirements": [
@@ -1597,15 +1597,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 5304
+            "value": 5304000000
           },
           {
             "type": "tritanium",
-            "value": 1950
+            "value": 1950000000
           }
         ]
       },
-      "build_time": 17912,
+      "build_time": 17912160,
       "increased_power": 1250,
       "level": 45,
       "requirements": [
@@ -1627,15 +1627,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 49980
+            "value": 49980000000
           },
           {
             "type": "tritanium",
-            "value": 18375
+            "value": 18375000000
           }
         ]
       },
-      "build_time": 56250,
+      "build_time": 56250720,
       "increased_power": 1500,
       "level": 50,
       "requirements": [

--- a/buildings/dilithium_generator_b.json
+++ b/buildings/dilithium_generator_b.json
@@ -30,15 +30,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1742
+            "value": 1742160000
           },
           {
             "type": "tritanium",
-            "value": 640500
+            "value": 640500000
           }
         ]
       },
-      "build_time": 8045,
+      "build_time": 8045280,
       "increased_power": 1000,
       "level": 42,
       "requirements": [
@@ -71,15 +71,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 2488
+            "value": 2488800000
           },
           {
             "type": "tritanium",
-            "value": 915000
+            "value": 915000000
           }
         ]
       },
-      "build_time": 10630,
+      "build_time": 10630080,
       "increased_power": 1250,
       "level": 43,
       "requirements": [
@@ -112,15 +112,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 3733
+            "value": 3733200000
           },
           {
             "type": "tritanium",
-            "value": 1372
+            "value": 1372500000
           }
         ]
       },
-      "build_time": 13874,
+      "build_time": 13874400,
       "increased_power": 1250,
       "level": 44,
       "requirements": [
@@ -159,15 +159,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 10608
+            "value": 10608000000
           },
           {
             "type": "tritanium",
-            "value": 3900
+            "value": 3900000000
           }
         ]
       },
-      "build_time": 29004,
+      "build_time": 29004480,
       "increased_power": 1500,
       "level": 47,
       "requirements": [
@@ -206,15 +206,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1169
+            "value": 1169600000
           },
           {
             "type": "tritanium",
-            "value": 430000
+            "value": 430000000
           }
         ]
       },
-      "build_time": 5234,
+      "build_time": 5234400,
       "increased_power": 1000,
       "level": 41,
       "requirements": [
@@ -240,11 +240,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1517
+            "value": 1517760
           },
           {
             "type": "tritanium",
-            "value": 1116
+            "value": 1116000
           }
         ]
       },
@@ -287,15 +287,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 7293
+            "value": 7293000000
           },
           {
             "type": "tritanium",
-            "value": 2681
+            "value": 2681250000
           }
         ]
       },
-      "build_time": 22896,
+      "build_time": 22896000,
       "increased_power": 1250,
       "level": 46,
       "requirements": [
@@ -321,11 +321,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 5304
+            "value": 5304000
           },
           {
             "type": "tritanium",
-            "value": 3900
+            "value": 3900000
           }
         ]
       },
@@ -355,11 +355,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 3624
+            "value": 3624400
           },
           {
             "type": "tritanium",
-            "value": 2665
+            "value": 2665000
           }
         ]
       },
@@ -389,11 +389,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 8384
+            "value": 8384400
           },
           {
             "type": "tritanium",
-            "value": 6165
+            "value": 6165000
           }
         ]
       },
@@ -423,11 +423,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 12110
+            "value": 12110800
           },
           {
             "type": "tritanium",
-            "value": 8905
+            "value": 8905000
           }
         ]
       },
@@ -491,15 +491,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 45777
+            "value": 45777600
           },
           {
             "type": "tritanium",
-            "value": 33660
+            "value": 33660000
           }
         ]
       },
-      "build_time": 1107,
+      "build_time": 1107360,
       "increased_power": 750,
       "level": 35,
       "requirements": [
@@ -525,11 +525,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 18734
+            "value": 18734000
           },
           {
             "type": "tritanium",
-            "value": 13775
+            "value": 13775000
           }
         ]
       },
@@ -606,15 +606,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1146
+            "value": 1146208000
           },
           {
             "type": "tritanium",
-            "value": 301000
+            "value": 301000000
           }
         ]
       },
-      "build_time": 5584,
+      "build_time": 5584320,
       "increased_power": 1000,
       "level": 40,
       "requirements": [
@@ -708,11 +708,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 29580
+            "value": 29580000
           },
           {
             "type": "tritanium",
-            "value": 21750
+            "value": 21750000
           }
         ]
       },
@@ -878,11 +878,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 2276
+            "value": 2276640
           },
           {
             "type": "tritanium",
-            "value": 1674
+            "value": 1674000
           }
         ]
       },
@@ -1048,15 +1048,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 99144
+            "value": 99144000
           },
           {
             "type": "tritanium",
-            "value": 72900
+            "value": 72900000
           }
         ]
       },
-      "build_time": 1461,
+      "build_time": 1461600,
       "increased_power": 750,
       "level": 37,
       "requirements": [
@@ -1082,15 +1082,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 64504
+            "value": 64504800
           },
           {
             "type": "tritanium",
-            "value": 47430
+            "value": 47430000
           }
         ]
       },
-      "build_time": 1414,
+      "build_time": 1414080,
       "increased_power": 750,
       "level": 36,
       "requirements": [
@@ -1150,15 +1150,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 154224
+            "value": 154224000
           },
           {
             "type": "tritanium",
-            "value": 113400
+            "value": 113400000
           }
         ]
       },
-      "build_time": 2370,
+      "build_time": 2370240,
       "increased_power": 1000,
       "level": 38,
       "requirements": [
@@ -1184,15 +1184,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 263160
+            "value": 263160000
           },
           {
             "type": "tritanium",
-            "value": 193500
+            "value": 193500000
           }
         ]
       },
-      "build_time": 3146,
+      "build_time": 3146400,
       "increased_power": 750,
       "level": 39,
       "requirements": [
@@ -1293,15 +1293,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 5304
+            "value": 5304000000
           },
           {
             "type": "tritanium",
-            "value": 1950
+            "value": 1950000000
           }
         ]
       },
-      "build_time": 17912,
+      "build_time": 17912160,
       "increased_power": 1250,
       "level": 45,
       "requirements": [
@@ -1340,15 +1340,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 17136
+            "value": 17136000000
           },
           {
             "type": "tritanium",
-            "value": 6300
+            "value": 6300000000
           }
         ]
       },
-      "build_time": 36440,
+      "build_time": 36440640,
       "increased_power": 1500,
       "level": 48,
       "requirements": [
@@ -1387,15 +1387,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 28560
+            "value": 28560000000
           },
           {
             "type": "tritanium",
-            "value": 10500
+            "value": 10500000000
           }
         ]
       },
-      "build_time": 45434,
+      "build_time": 45434880,
       "increased_power": 1500,
       "level": 49,
       "requirements": [
@@ -1421,15 +1421,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 49980
+            "value": 49980000000
           },
           {
             "type": "tritanium",
-            "value": 18375
+            "value": 18375000000
           }
         ]
       },
-      "build_time": 56250,
+      "build_time": 56250720,
       "increased_power": 1500,
       "level": 50,
       "requirements": [

--- a/buildings/dilithium_generator_c.json
+++ b/buildings/dilithium_generator_c.json
@@ -23,15 +23,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1742
+            "value": 1742160000
           },
           {
             "type": "tritanium",
-            "value": 640500
+            "value": 640500000
           }
         ]
       },
-      "build_time": 8045,
+      "build_time": 8045280,
       "increased_power": 1000,
       "level": 42,
       "requirements": [
@@ -57,15 +57,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1169
+            "value": 1169600000
           },
           {
             "type": "tritanium",
-            "value": 430000
+            "value": 430000000
           }
         ]
       },
-      "build_time": 5234,
+      "build_time": 5234400,
       "increased_power": 1000,
       "level": 41,
       "requirements": [
@@ -91,11 +91,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1517
+            "value": 1517760
           },
           {
             "type": "tritanium",
-            "value": 1116
+            "value": 1116000
           }
         ]
       },
@@ -125,11 +125,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 5304
+            "value": 5304000
           },
           {
             "type": "tritanium",
-            "value": 3900
+            "value": 3900000
           }
         ]
       },
@@ -159,11 +159,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 3624
+            "value": 3624400
           },
           {
             "type": "tritanium",
-            "value": 2665
+            "value": 2665000
           }
         ]
       },
@@ -193,11 +193,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 8384
+            "value": 8384400
           },
           {
             "type": "tritanium",
-            "value": 6165
+            "value": 6165000
           }
         ]
       },
@@ -227,11 +227,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 12110
+            "value": 12110800
           },
           {
             "type": "tritanium",
-            "value": 8905
+            "value": 8905000
           }
         ]
       },
@@ -261,15 +261,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 45777
+            "value": 45777600
           },
           {
             "type": "tritanium",
-            "value": 33660
+            "value": 33660000
           }
         ]
       },
-      "build_time": 1107,
+      "build_time": 1107360,
       "increased_power": 750,
       "level": 35,
       "requirements": [
@@ -295,15 +295,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1146
+            "value": 1146208000
           },
           {
             "type": "tritanium",
-            "value": 301000
+            "value": 301000000
           }
         ]
       },
-      "build_time": 5584,
+      "build_time": 5584320,
       "increased_power": 1000,
       "level": 40,
       "requirements": [
@@ -397,11 +397,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 29580
+            "value": 29580000
           },
           {
             "type": "tritanium",
-            "value": 21750
+            "value": 21750000
           }
         ]
       },
@@ -533,11 +533,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 2276
+            "value": 2276640
           },
           {
             "type": "tritanium",
-            "value": 1674
+            "value": 1674000
           }
         ]
       },
@@ -567,15 +567,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 99144
+            "value": 99144000
           },
           {
             "type": "tritanium",
-            "value": 72900
+            "value": 72900000
           }
         ]
       },
-      "build_time": 1461,
+      "build_time": 1461600,
       "increased_power": 750,
       "level": 37,
       "requirements": [
@@ -601,15 +601,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 154224
+            "value": 154224000
           },
           {
             "type": "tritanium",
-            "value": 113400
+            "value": 113400000
           }
         ]
       },
-      "build_time": 2370,
+      "build_time": 2370240,
       "increased_power": 1000,
       "level": 38,
       "requirements": [
@@ -635,15 +635,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 263160
+            "value": 263160000
           },
           {
             "type": "tritanium",
-            "value": 193500
+            "value": 193500000
           }
         ]
       },
-      "build_time": 3146,
+      "build_time": 3146400,
       "increased_power": 750,
       "level": 39,
       "requirements": [
@@ -669,15 +669,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 64504
+            "value": 64504800
           },
           {
             "type": "tritanium",
-            "value": 47430
+            "value": 47430000
           }
         ]
       },
-      "build_time": 1414,
+      "build_time": 1414080,
       "increased_power": 750,
       "level": 36,
       "requirements": [
@@ -703,15 +703,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 3733
+            "value": 3733200000
           },
           {
             "type": "tritanium",
-            "value": 1372
+            "value": 1372500000
           }
         ]
       },
-      "build_time": 13874,
+      "build_time": 13874400,
       "increased_power": 1250,
       "level": 44,
       "requirements": [
@@ -805,15 +805,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 5304
+            "value": 5304000000
           },
           {
             "type": "tritanium",
-            "value": 1950
+            "value": 1950000000
           }
         ]
       },
-      "build_time": 17912,
+      "build_time": 17912160,
       "increased_power": 1250,
       "level": 45,
       "requirements": [
@@ -839,11 +839,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 18734
+            "value": 18734000
           },
           {
             "type": "tritanium",
-            "value": 13775
+            "value": 13775000
           }
         ]
       },
@@ -1111,15 +1111,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 2488
+            "value": 2488800000
           },
           {
             "type": "tritanium",
-            "value": 915000
+            "value": 915000000
           }
         ]
       },
-      "build_time": 10630,
+      "build_time": 10630080,
       "increased_power": 1250,
       "level": 43,
       "requirements": [
@@ -1179,15 +1179,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 17136
+            "value": 17136000000
           },
           {
             "type": "tritanium",
-            "value": 6300
+            "value": 6300000000
           }
         ]
       },
-      "build_time": 36440,
+      "build_time": 36440640,
       "increased_power": 1500,
       "level": 48,
       "requirements": [
@@ -1213,15 +1213,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 28560
+            "value": 28560000000
           },
           {
             "type": "tritanium",
-            "value": 10500
+            "value": 10500000000
           }
         ]
       },
-      "build_time": 45434,
+      "build_time": 45434880,
       "increased_power": 1500,
       "level": 49,
       "requirements": [
@@ -1621,15 +1621,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 49980
+            "value": 49980000000
           },
           {
             "type": "tritanium",
-            "value": 18375
+            "value": 18375000000
           }
         ]
       },
-      "build_time": 56250,
+      "build_time": 56250720,
       "increased_power": 1500,
       "level": 50,
       "requirements": [
@@ -1655,15 +1655,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 10608
+            "value": 10608000000
           },
           {
             "type": "tritanium",
-            "value": 3900
+            "value": 3900000000
           }
         ]
       },
-      "build_time": 29004,
+      "build_time": 29004480,
       "increased_power": 1500,
       "level": 47,
       "requirements": [
@@ -1689,15 +1689,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 7293
+            "value": 7293000000
           },
           {
             "type": "tritanium",
-            "value": 2681
+            "value": 2681250000
           }
         ]
       },
-      "build_time": 22896,
+      "build_time": 22896000,
       "increased_power": 1250,
       "level": 46,
       "requirements": [

--- a/buildings/dilithium_generator_d.json
+++ b/buildings/dilithium_generator_d.json
@@ -23,15 +23,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1742
+            "value": 1742160000
           },
           {
             "type": "tritanium",
-            "value": 640500
+            "value": 640500000
           }
         ]
       },
-      "build_time": 8045,
+      "build_time": 8045280,
       "increased_power": 1000,
       "level": 42,
       "requirements": [
@@ -57,15 +57,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1169
+            "value": 1169600000
           },
           {
             "type": "tritanium",
-            "value": 430000
+            "value": 430000000
           }
         ]
       },
-      "build_time": 5234,
+      "build_time": 5234400,
       "increased_power": 1000,
       "level": 41,
       "requirements": [
@@ -125,11 +125,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 5304
+            "value": 5304000
           },
           {
             "type": "tritanium",
-            "value": 3900
+            "value": 3900000
           }
         ]
       },
@@ -159,11 +159,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 8384
+            "value": 8384400
           },
           {
             "type": "tritanium",
-            "value": 6165
+            "value": 6165000
           }
         ]
       },
@@ -193,11 +193,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 12110
+            "value": 12110800
           },
           {
             "type": "tritanium",
-            "value": 8905
+            "value": 8905000
           }
         ]
       },
@@ -227,15 +227,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 45777
+            "value": 45777600
           },
           {
             "type": "tritanium",
-            "value": 33660
+            "value": 33660000
           }
         ]
       },
-      "build_time": 1107,
+      "build_time": 1107360,
       "increased_power": 750,
       "level": 35,
       "requirements": [
@@ -261,11 +261,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1517
+            "value": 1517760
           },
           {
             "type": "tritanium",
-            "value": 1116
+            "value": 1116000
           }
         ]
       },
@@ -295,15 +295,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1146
+            "value": 1146208000
           },
           {
             "type": "tritanium",
-            "value": 301000
+            "value": 301000000
           }
         ]
       },
-      "build_time": 5584,
+      "build_time": 5584320,
       "increased_power": 1000,
       "level": 40,
       "requirements": [
@@ -329,11 +329,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 29580
+            "value": 29580000
           },
           {
             "type": "tritanium",
-            "value": 21750
+            "value": 21750000
           }
         ]
       },
@@ -431,15 +431,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 99144
+            "value": 99144000
           },
           {
             "type": "tritanium",
-            "value": 72900
+            "value": 72900000
           }
         ]
       },
-      "build_time": 1461,
+      "build_time": 1461600,
       "increased_power": 750,
       "level": 37,
       "requirements": [
@@ -465,15 +465,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 154224
+            "value": 154224000
           },
           {
             "type": "tritanium",
-            "value": 113400
+            "value": 113400000
           }
         ]
       },
-      "build_time": 2370,
+      "build_time": 2370240,
       "increased_power": 1000,
       "level": 38,
       "requirements": [
@@ -567,15 +567,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 263160
+            "value": 263160000
           },
           {
             "type": "tritanium",
-            "value": 193500
+            "value": 193500000
           }
         ]
       },
-      "build_time": 3146,
+      "build_time": 3146400,
       "increased_power": 750,
       "level": 39,
       "requirements": [
@@ -601,15 +601,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 64504
+            "value": 64504800
           },
           {
             "type": "tritanium",
-            "value": 47430
+            "value": 47430000
           }
         ]
       },
-      "build_time": 1414,
+      "build_time": 1414080,
       "increased_power": 750,
       "level": 36,
       "requirements": [
@@ -635,15 +635,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 3733
+            "value": 3733200000
           },
           {
             "type": "tritanium",
-            "value": 1372
+            "value": 1372500000
           }
         ]
       },
-      "build_time": 13874,
+      "build_time": 13874400,
       "increased_power": 1250,
       "level": 44,
       "requirements": [
@@ -669,15 +669,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 5304
+            "value": 5304000000
           },
           {
             "type": "tritanium",
-            "value": 1950
+            "value": 1950000000
           }
         ]
       },
-      "build_time": 17912,
+      "build_time": 17912160,
       "increased_power": 1250,
       "level": 45,
       "requirements": [
@@ -737,11 +737,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 18734
+            "value": 18734000
           },
           {
             "type": "tritanium",
-            "value": 13775
+            "value": 13775000
           }
         ]
       },
@@ -805,15 +805,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 2488
+            "value": 2488800000
           },
           {
             "type": "tritanium",
-            "value": 915000
+            "value": 915000000
           }
         ]
       },
-      "build_time": 10630,
+      "build_time": 10630080,
       "increased_power": 1250,
       "level": 43,
       "requirements": [
@@ -873,15 +873,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 17136
+            "value": 17136000000
           },
           {
             "type": "tritanium",
-            "value": 6300
+            "value": 6300000000
           }
         ]
       },
-      "build_time": 36440,
+      "build_time": 36440640,
       "increased_power": 1500,
       "level": 48,
       "requirements": [
@@ -907,15 +907,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 28560
+            "value": 28560000000
           },
           {
             "type": "tritanium",
-            "value": 10500
+            "value": 10500000000
           }
         ]
       },
-      "build_time": 45434,
+      "build_time": 45434880,
       "increased_power": 1500,
       "level": 49,
       "requirements": [
@@ -941,15 +941,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 49980
+            "value": 49980000000
           },
           {
             "type": "tritanium",
-            "value": 18375
+            "value": 18375000000
           }
         ]
       },
-      "build_time": 56250,
+      "build_time": 56250720,
       "increased_power": 1500,
       "level": 50,
       "requirements": [
@@ -975,15 +975,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 10608
+            "value": 10608000000
           },
           {
             "type": "tritanium",
-            "value": 3900
+            "value": 3900000000
           }
         ]
       },
-      "build_time": 29004,
+      "build_time": 29004480,
       "increased_power": 1500,
       "level": 47,
       "requirements": [
@@ -1077,11 +1077,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 2276
+            "value": 2276640
           },
           {
             "type": "tritanium",
-            "value": 1674
+            "value": 1674000
           }
         ]
       },
@@ -1111,11 +1111,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 3624
+            "value": 3624400
           },
           {
             "type": "tritanium",
-            "value": 2665
+            "value": 2665000
           }
         ]
       },
@@ -1247,15 +1247,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 7293
+            "value": 7293000000
           },
           {
             "type": "tritanium",
-            "value": 2681
+            "value": 2681250000
           }
         ]
       },
-      "build_time": 22896,
+      "build_time": 22896000,
       "increased_power": 1250,
       "level": 46,
       "requirements": [

--- a/buildings/dilithium_generator_e.json
+++ b/buildings/dilithium_generator_e.json
@@ -23,15 +23,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1742
+            "value": 1742160000
           },
           {
             "type": "tritanium",
-            "value": 640500
+            "value": 640500000
           }
         ]
       },
-      "build_time": 8045,
+      "build_time": 8045280,
       "increased_power": 1000,
       "level": 42,
       "requirements": [
@@ -57,15 +57,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1169
+            "value": 1169600000
           },
           {
             "type": "tritanium",
-            "value": 430000
+            "value": 430000000
           }
         ]
       },
-      "build_time": 5234,
+      "build_time": 5234400,
       "increased_power": 1000,
       "level": 41,
       "requirements": [
@@ -125,15 +125,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1146
+            "value": 1146208000
           },
           {
             "type": "tritanium",
-            "value": 301000
+            "value": 301000000
           }
         ]
       },
-      "build_time": 5584,
+      "build_time": 5584320,
       "increased_power": 1000,
       "level": 40,
       "requirements": [
@@ -159,15 +159,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 3733
+            "value": 3733200000
           },
           {
             "type": "tritanium",
-            "value": 1372
+            "value": 1372500000
           }
         ]
       },
-      "build_time": 13874,
+      "build_time": 13874400,
       "increased_power": 1250,
       "level": 44,
       "requirements": [
@@ -193,15 +193,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 5304
+            "value": 5304000000
           },
           {
             "type": "tritanium",
-            "value": 1950
+            "value": 1950000000
           }
         ]
       },
-      "build_time": 17912,
+      "build_time": 17912160,
       "increased_power": 1250,
       "level": 45,
       "requirements": [
@@ -227,15 +227,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 2488
+            "value": 2488800000
           },
           {
             "type": "tritanium",
-            "value": 915000
+            "value": 915000000
           }
         ]
       },
-      "build_time": 10630,
+      "build_time": 10630080,
       "increased_power": 1250,
       "level": 43,
       "requirements": [
@@ -261,15 +261,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 17136
+            "value": 17136000000
           },
           {
             "type": "tritanium",
-            "value": 6300
+            "value": 6300000000
           }
         ]
       },
-      "build_time": 36440,
+      "build_time": 36440640,
       "increased_power": 1500,
       "level": 48,
       "requirements": [
@@ -295,15 +295,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 28560
+            "value": 28560000000
           },
           {
             "type": "tritanium",
-            "value": 10500
+            "value": 10500000000
           }
         ]
       },
-      "build_time": 45434,
+      "build_time": 45434880,
       "increased_power": 1500,
       "level": 49,
       "requirements": [
@@ -329,15 +329,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 49980
+            "value": 49980000000
           },
           {
             "type": "tritanium",
-            "value": 18375
+            "value": 18375000000
           }
         ]
       },
-      "build_time": 56250,
+      "build_time": 56250720,
       "increased_power": 1500,
       "level": 50,
       "requirements": [
@@ -363,15 +363,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 10608
+            "value": 10608000000
           },
           {
             "type": "tritanium",
-            "value": 3900
+            "value": 3900000000
           }
         ]
       },
-      "build_time": 29004,
+      "build_time": 29004480,
       "increased_power": 1500,
       "level": 47,
       "requirements": [
@@ -397,15 +397,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 7293
+            "value": 7293000000
           },
           {
             "type": "tritanium",
-            "value": 2681
+            "value": 2681250000
           }
         ]
       },
-      "build_time": 22896,
+      "build_time": 22896000,
       "increased_power": 1250,
       "level": 46,
       "requirements": [

--- a/buildings/dilithium_generator_f.json
+++ b/buildings/dilithium_generator_f.json
@@ -57,15 +57,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 49980
+            "value": 49980000000
           },
           {
             "type": "tritanium",
-            "value": 18375
+            "value": 18375000000
           }
         ]
       },
-      "build_time": 56250,
+      "build_time": 56250720,
       "increased_power": 1500,
       "level": 50,
       "requirements": [

--- a/buildings/dilithium_generator_g.json
+++ b/buildings/dilithium_generator_g.json
@@ -57,15 +57,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 49980
+            "value": 49980000000
           },
           {
             "type": "tritanium",
-            "value": 18375
+            "value": 18375000000
           }
         ]
       },
-      "build_time": 56250,
+      "build_time": 56250720,
       "increased_power": 1500,
       "level": 50,
       "requirements": [

--- a/buildings/dilithium_generator_h.json
+++ b/buildings/dilithium_generator_h.json
@@ -57,15 +57,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 49980
+            "value": 49980000000
           },
           {
             "type": "tritanium",
-            "value": 18375
+            "value": 18375000000
           }
         ]
       },
-      "build_time": 56250,
+      "build_time": 56250720,
       "increased_power": 1500,
       "level": 50,
       "requirements": [

--- a/buildings/dilithium_vault.json
+++ b/buildings/dilithium_vault.json
@@ -10,7 +10,7 @@
   "levels": [
     {
       "bonuses": {
-        "bonus1": 1260
+        "bonus1": 1260000
       },
       "build_costs": {
         "materials": [
@@ -31,15 +31,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 17421
+            "value": 17421600000
           },
           {
             "type": "dilithium",
-            "value": 96075
+            "value": 96075000
           }
         ]
       },
-      "build_time": 16090,
+      "build_time": 16090560,
       "increased_power": 4500,
       "level": 42,
       "requirements": [
@@ -56,7 +56,7 @@
     },
     {
       "bonuses": {
-        "bonus1": 1700
+        "bonus1": 1700000
       },
       "build_costs": {
         "materials": [
@@ -77,15 +77,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 24888
+            "value": 24888000000
           },
           {
             "type": "dilithium",
-            "value": 137250
+            "value": 137250000
           }
         ]
       },
-      "build_time": 21260,
+      "build_time": 21260160,
       "increased_power": 4500,
       "level": 43,
       "requirements": [
@@ -102,7 +102,7 @@
     },
     {
       "bonuses": {
-        "bonus1": 2400
+        "bonus1": 2400000
       },
       "build_costs": {
         "materials": [
@@ -123,15 +123,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 37332
+            "value": 37332000000
           },
           {
             "type": "dilithium",
-            "value": 205875
+            "value": 205875000
           }
         ]
       },
-      "build_time": 27748,
+      "build_time": 27748800,
       "increased_power": 5000,
       "level": 44,
       "requirements": [
@@ -148,7 +148,7 @@
     },
     {
       "bonuses": {
-        "bonus1": 3000
+        "bonus1": 3000000
       },
       "build_costs": {
         "materials": [
@@ -163,15 +163,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 53040
+            "value": 53040000000
           },
           {
             "type": "dilithium",
-            "value": 292500
+            "value": 292500000
           }
         ]
       },
-      "build_time": 35824,
+      "build_time": 35824320,
       "increased_power": 5000,
       "level": 45,
       "requirements": [
@@ -192,7 +192,7 @@
     },
     {
       "bonuses": {
-        "bonus1": 5200
+        "bonus1": 5200000
       },
       "build_costs": {
         "materials": [
@@ -213,15 +213,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 106080
+            "value": 106080000000
           },
           {
             "type": "dilithium",
-            "value": 585000
+            "value": 585000000
           }
         ]
       },
-      "build_time": 58008,
+      "build_time": 58008960,
       "increased_power": 6000,
       "level": 47,
       "requirements": [
@@ -242,7 +242,7 @@
     },
     {
       "bonuses": {
-        "bonus1": 11000
+        "bonus1": 11000000
       },
       "build_costs": {
         "materials": [
@@ -263,15 +263,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 285600
+            "value": 285600000000
           },
           {
             "type": "dilithium",
-            "value": 1575
+            "value": 1575000000
           }
         ]
       },
-      "build_time": 90869,
+      "build_time": 90869760,
       "increased_power": 6000,
       "level": 49,
       "requirements": [
@@ -292,7 +292,7 @@
     },
     {
       "bonuses": {
-        "bonus1": 7200
+        "bonus1": 7200000
       },
       "build_costs": {
         "materials": [
@@ -313,15 +313,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 171360
+            "value": 171360000000
           },
           {
             "type": "dilithium",
-            "value": 945000
+            "value": 945000000
           }
         ]
       },
-      "build_time": 72881,
+      "build_time": 72881280,
       "increased_power": 6000,
       "level": 48,
       "requirements": [
@@ -359,15 +359,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 11696
+            "value": 11696000000
           },
           {
             "type": "dilithium",
-            "value": 64500
+            "value": 64500000
           }
         ]
       },
-      "build_time": 10468,
+      "build_time": 10468800,
       "increased_power": 4000,
       "level": 41,
       "requirements": [
@@ -1085,7 +1085,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1513
+            "value": 1513680
           },
           {
             "type": "dilithium",
@@ -1118,7 +1118,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 2490
+            "value": 2490840
           },
           {
             "type": "dilithium",
@@ -1151,7 +1151,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 3924
+            "value": 3924960
           },
           {
             "type": "dilithium",
@@ -1201,7 +1201,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 6364
+            "value": 6364800
           },
           {
             "type": "dilithium",
@@ -1241,7 +1241,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 9945
+            "value": 9945000
           },
           {
             "type": "dilithium",
@@ -1287,7 +1287,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 15177
+            "value": 15177600
           },
           {
             "type": "dilithium",
@@ -1333,7 +1333,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 22766
+            "value": 22766400
           },
           {
             "type": "dilithium",
@@ -1373,7 +1373,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 36244
+            "value": 36244000
           },
           {
             "type": "dilithium",
@@ -1423,7 +1423,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 53040
+            "value": 53040000
           },
           {
             "type": "dilithium",
@@ -1463,7 +1463,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 83844
+            "value": 83844000
           },
           {
             "type": "dilithium",
@@ -1503,11 +1503,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 121108
+            "value": 121108000
           },
           {
             "type": "dilithium",
-            "value": 1335
+            "value": 1335750
           }
         ]
       },
@@ -1549,15 +1549,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 187340
+            "value": 187340000
           },
           {
             "type": "dilithium",
-            "value": 2066
+            "value": 2066250
           }
         ]
       },
-      "build_time": 1268,
+      "build_time": 1268640,
       "increased_power": 2500,
       "level": 33,
       "requirements": [
@@ -1595,15 +1595,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 295800
+            "value": 295800000
           },
           {
             "type": "dilithium",
-            "value": 3262
+            "value": 3262500
           }
         ]
       },
-      "build_time": 1680,
+      "build_time": 1680480,
       "increased_power": 2500,
       "level": 34,
       "requirements": [
@@ -1635,15 +1635,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 457776
+            "value": 457776000
           },
           {
             "type": "dilithium",
-            "value": 5049
+            "value": 5049000
           }
         ]
       },
-      "build_time": 2213,
+      "build_time": 2213280,
       "increased_power": 2500,
       "level": 35,
       "requirements": [
@@ -1675,15 +1675,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 645048
+            "value": 645048000
           },
           {
             "type": "dilithium",
-            "value": 7114
+            "value": 7114500
           }
         ]
       },
-      "build_time": 2829,
+      "build_time": 2829600,
       "increased_power": 3000,
       "level": 36,
       "requirements": [
@@ -1721,15 +1721,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 991440
+            "value": 991440000
           },
           {
             "type": "dilithium",
-            "value": 10935
+            "value": 10935000
           }
         ]
       },
-      "build_time": 2923,
+      "build_time": 2923200,
       "increased_power": 3500,
       "level": 37,
       "requirements": [
@@ -1767,15 +1767,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1542
+            "value": 1542240000
           },
           {
             "type": "dilithium",
-            "value": 17010
+            "value": 17010000
           }
         ]
       },
-      "build_time": 4741,
+      "build_time": 4741920,
       "increased_power": 3000,
       "level": 38,
       "requirements": [
@@ -1804,15 +1804,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 2631
+            "value": 2631600000
           },
           {
             "type": "dilithium",
-            "value": 29025
+            "value": 29025000
           }
         ]
       },
-      "build_time": 6294,
+      "build_time": 6294240,
       "increased_power": 4000,
       "level": 39,
       "requirements": [
@@ -1844,15 +1844,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 11462
+            "value": 11462080000
           },
           {
             "type": "dilithium",
-            "value": 45150
+            "value": 45150000
           }
         ]
       },
-      "build_time": 11170,
+      "build_time": 11170080,
       "increased_power": 3500,
       "level": 40,
       "requirements": [
@@ -1869,7 +1869,7 @@
     },
     {
       "bonuses": {
-        "bonus1": 3850
+        "bonus1": 3850000
       },
       "build_costs": {
         "materials": [
@@ -1890,15 +1890,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 72930
+            "value": 72930000000
           },
           {
             "type": "dilithium",
-            "value": 402187
+            "value": 402187500
           }
         ]
       },
-      "build_time": 45792,
+      "build_time": 45792000,
       "increased_power": 5000,
       "level": 46,
       "requirements": [
@@ -1915,7 +1915,7 @@
     },
     {
       "bonuses": {
-        "bonus1": 17500
+        "bonus1": 17500000
       },
       "build_costs": {
         "materials": [],
@@ -1923,15 +1923,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 499800
+            "value": 499800000000
           },
           {
             "type": "dilithium",
-            "value": 2756
+            "value": 2756250000
           }
         ]
       },
-      "build_time": 112502,
+      "build_time": 112502880,
       "increased_power": 6000,
       "level": 50,
       "requirements": [

--- a/buildings/dilithium_warehouse.json
+++ b/buildings/dilithium_warehouse.json
@@ -10,7 +10,7 @@
   "levels": [
     {
       "bonuses": {
-        "bonus1": 3500
+        "bonus1": 3500000
       },
       "build_costs": {
         "materials": [
@@ -25,15 +25,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 3438
+            "value": 3438624000
           },
           {
             "type": "dilithium",
-            "value": 60200
+            "value": 60200000
           }
         ]
       },
-      "build_time": 8377,
+      "build_time": 8377920,
       "increased_power": 2000,
       "level": 40,
       "requirements": [
@@ -83,7 +83,7 @@
     },
     {
       "bonuses": {
-        "bonus1": 4750
+        "bonus1": 4750000
       },
       "build_costs": {
         "materials": [
@@ -104,15 +104,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 5226
+            "value": 5226480000
           },
           {
             "type": "dilithium",
-            "value": 128100
+            "value": 128100000
           }
         ]
       },
-      "build_time": 12068,
+      "build_time": 12068640,
       "increased_power": 2000,
       "level": 42,
       "requirements": [
@@ -129,7 +129,7 @@
     },
     {
       "bonuses": {
-        "bonus1": 6450
+        "bonus1": 6450000
       },
       "build_costs": {
         "materials": [
@@ -150,15 +150,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 7466
+            "value": 7466400000
           },
           {
             "type": "dilithium",
-            "value": 183000
+            "value": 183000000
           }
         ]
       },
-      "build_time": 15945,
+      "build_time": 15945120,
       "increased_power": 2500,
       "level": 43,
       "requirements": [
@@ -175,7 +175,7 @@
     },
     {
       "bonuses": {
-        "bonus1": 9150
+        "bonus1": 9150000
       },
       "build_costs": {
         "materials": [
@@ -196,15 +196,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 11199
+            "value": 11199600000
           },
           {
             "type": "dilithium",
-            "value": 274500
+            "value": 274500000
           }
         ]
       },
-      "build_time": 20812,
+      "build_time": 20812320,
       "increased_power": 2500,
       "level": 44,
       "requirements": [
@@ -221,7 +221,7 @@
     },
     {
       "bonuses": {
-        "bonus1": 11500
+        "bonus1": 11500000
       },
       "build_costs": {
         "materials": [
@@ -236,15 +236,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 15912
+            "value": 15912000000
           },
           {
             "type": "dilithium",
-            "value": 390000
+            "value": 390000000
           }
         ]
       },
-      "build_time": 26867,
+      "build_time": 26867520,
       "increased_power": 2500,
       "level": 45,
       "requirements": [
@@ -265,7 +265,7 @@
     },
     {
       "bonuses": {
-        "bonus1": 20000
+        "bonus1": 20000000
       },
       "build_costs": {
         "materials": [
@@ -286,15 +286,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 31824
+            "value": 31824000000
           },
           {
             "type": "dilithium",
-            "value": 780000
+            "value": 780000000
           }
         ]
       },
-      "build_time": 43506,
+      "build_time": 43506720,
       "increased_power": 3000,
       "level": 47,
       "requirements": [
@@ -315,7 +315,7 @@
     },
     {
       "bonuses": {
-        "bonus1": 15000
+        "bonus1": 15000000
       },
       "build_costs": {
         "materials": [
@@ -336,15 +336,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 21879
+            "value": 21879000000
           },
           {
             "type": "dilithium",
-            "value": 536250
+            "value": 536250000
           }
         ]
       },
-      "build_time": 34344,
+      "build_time": 34344000,
       "increased_power": 2500,
       "level": 46,
       "requirements": [
@@ -361,7 +361,7 @@
     },
     {
       "bonuses": {
-        "bonus1": 3650
+        "bonus1": 3650000
       },
       "build_costs": {
         "materials": [
@@ -376,15 +376,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 3508
+            "value": 3508800000
           },
           {
             "type": "dilithium",
-            "value": 86000
+            "value": 86000000
           }
         ]
       },
-      "build_time": 7850,
+      "build_time": 7850880,
       "increased_power": 2000,
       "level": 41,
       "requirements": [
@@ -401,7 +401,7 @@
     },
     {
       "bonuses": {
-        "bonus1": 43500
+        "bonus1": 43500000
       },
       "build_costs": {
         "materials": [
@@ -422,15 +422,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 85680
+            "value": 85680000000
           },
           {
             "type": "dilithium",
-            "value": 2100
+            "value": 2100000000
           }
         ]
       },
-      "build_time": 68152,
+      "build_time": 68152320,
       "increased_power": 3000,
       "level": 49,
       "requirements": [
@@ -451,7 +451,7 @@
     },
     {
       "bonuses": {
-        "bonus1": 28000
+        "bonus1": 28000000
       },
       "build_costs": {
         "materials": [
@@ -472,15 +472,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 51408
+            "value": 51408000000
           },
           {
             "type": "dilithium",
-            "value": 1260
+            "value": 1260000000
           }
         ]
       },
-      "build_time": 54660,
+      "build_time": 54660960,
       "increased_power": 3000,
       "level": 48,
       "requirements": [
@@ -497,7 +497,7 @@
     },
     {
       "bonuses": {
-        "bonus1": 1550
+        "bonus1": 1550000
       },
       "build_costs": {
         "materials": [
@@ -512,15 +512,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 88740
+            "value": 88740000
           },
           {
             "type": "dilithium",
-            "value": 4350
+            "value": 4350000
           }
         ]
       },
-      "build_time": 1260,
+      "build_time": 1260000,
       "increased_power": 1250,
       "level": 34,
       "requirements": [
@@ -1259,7 +1259,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1177
+            "value": 1177488
           },
           {
             "type": "dilithium",
@@ -1299,7 +1299,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1909
+            "value": 1909440
           },
           {
             "type": "dilithium",
@@ -1343,7 +1343,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 2983
+            "value": 2983500
           },
           {
             "type": "dilithium",
@@ -1389,7 +1389,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 4553
+            "value": 4553280
           },
           {
             "type": "dilithium",
@@ -1429,7 +1429,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 6829
+            "value": 6829920
           },
           {
             "type": "dilithium",
@@ -1469,7 +1469,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 10873
+            "value": 10873200
           },
           {
             "type": "dilithium",
@@ -1515,7 +1515,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 15912
+            "value": 15912000
           },
           {
             "type": "dilithium",
@@ -1555,11 +1555,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 25153
+            "value": 25153200
           },
           {
             "type": "dilithium",
-            "value": 1233
+            "value": 1233000
           }
         ]
       },
@@ -1601,11 +1601,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 36332
+            "value": 36332400
           },
           {
             "type": "dilithium",
-            "value": 1781
+            "value": 1781000
           }
         ]
       },
@@ -1626,7 +1626,7 @@
     },
     {
       "bonuses": {
-        "bonus1": 1100
+        "bonus1": 1100000
       },
       "build_costs": {
         "materials": [
@@ -1641,11 +1641,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 56202
+            "value": 56202000
           },
           {
             "type": "dilithium",
-            "value": 2755
+            "value": 2755000
           }
         ]
       },
@@ -1666,7 +1666,7 @@
     },
     {
       "bonuses": {
-        "bonus1": 1950
+        "bonus1": 1950000
       },
       "build_costs": {
         "materials": [
@@ -1687,15 +1687,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 137332
+            "value": 137332800
           },
           {
             "type": "dilithium",
-            "value": 6732
+            "value": 6732000
           }
         ]
       },
-      "build_time": 1660,
+      "build_time": 1660320,
       "increased_power": 1250,
       "level": 35,
       "requirements": [
@@ -1712,7 +1712,7 @@
     },
     {
       "bonuses": {
-        "bonus1": 2250
+        "bonus1": 2250000
       },
       "build_costs": {
         "materials": [
@@ -1727,15 +1727,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 193514
+            "value": 193514400
           },
           {
             "type": "dilithium",
-            "value": 9486
+            "value": 9486000
           }
         ]
       },
-      "build_time": 2121,
+      "build_time": 2121120,
       "increased_power": 1500,
       "level": 36,
       "requirements": [
@@ -1752,7 +1752,7 @@
     },
     {
       "bonuses": {
-        "bonus1": 2650
+        "bonus1": 2650000
       },
       "build_costs": {
         "materials": [
@@ -1767,15 +1767,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 297432
+            "value": 297432000
           },
           {
             "type": "dilithium",
-            "value": 14580
+            "value": 14580000
           }
         ]
       },
-      "build_time": 2193,
+      "build_time": 2193120,
       "increased_power": 1750,
       "level": 37,
       "requirements": [
@@ -1792,7 +1792,7 @@
     },
     {
       "bonuses": {
-        "bonus1": 3100
+        "bonus1": 3100000
       },
       "build_costs": {
         "materials": [
@@ -1813,15 +1813,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 462672
+            "value": 462672000
           },
           {
             "type": "dilithium",
-            "value": 22680
+            "value": 22680000
           }
         ]
       },
-      "build_time": 3556,
+      "build_time": 3556800,
       "increased_power": 1750,
       "level": 38,
       "requirements": [
@@ -1842,7 +1842,7 @@
     },
     {
       "bonuses": {
-        "bonus1": 3300
+        "bonus1": 3300000
       },
       "build_costs": {
         "materials": [],
@@ -1850,15 +1850,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 789480
+            "value": 789480000
           },
           {
             "type": "dilithium",
-            "value": 38700
+            "value": 38700000
           }
         ]
       },
-      "build_time": 4720,
+      "build_time": 4720320,
       "increased_power": 1500,
       "level": 39,
       "requirements": [
@@ -1875,7 +1875,7 @@
     },
     {
       "bonuses": {
-        "bonus1": 70000
+        "bonus1": 70000000
       },
       "build_costs": {
         "materials": [],
@@ -1883,15 +1883,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 149940
+            "value": 149940000000
           },
           {
             "type": "dilithium",
-            "value": 3675
+            "value": 3675000000
           }
         ]
       },
-      "build_time": 84376,
+      "build_time": 84376800,
       "increased_power": 3000,
       "level": 50,
       "requirements": [

--- a/buildings/drydock_a.json
+++ b/buildings/drydock_a.json
@@ -36,7 +36,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 21216
+            "value": 21216000
           },
           {
             "type": "tritanium",
@@ -66,15 +66,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1052
+            "value": 1052640000
           },
           {
             "type": "tritanium",
-            "value": 29025
+            "value": 29025000
           }
         ]
       },
-      "build_time": 3934,
+      "build_time": 3934080,
       "increased_power": 5000,
       "level": 39,
       "requirements": [
@@ -109,15 +109,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 4584
+            "value": 4584832000
           },
           {
             "type": "tritanium",
-            "value": 45150
+            "value": 45150000
           }
         ]
       },
-      "build_time": 6981,
+      "build_time": 6981120,
       "increased_power": 6000,
       "level": 40,
       "requirements": [
@@ -182,15 +182,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 183110
+            "value": 183110400
           },
           {
             "type": "tritanium",
-            "value": 5049
+            "value": 5049000
           }
         ]
       },
-      "build_time": 1383,
+      "build_time": 1383840,
       "increased_power": 4000,
       "level": 35,
       "requirements": [
@@ -225,15 +225,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 6968
+            "value": 6968640000
           },
           {
             "type": "tritanium",
-            "value": 96075
+            "value": 96075000
           }
         ]
       },
-      "build_time": 10056,
+      "build_time": 10056960,
       "increased_power": 7000,
       "level": 42,
       "requirements": [
@@ -262,15 +262,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 9955
+            "value": 9955200000
           },
           {
             "type": "tritanium",
-            "value": 137250
+            "value": 137250000
           }
         ]
       },
-      "build_time": 13286,
+      "build_time": 13286880,
       "increased_power": 7000,
       "level": 43,
       "requirements": [
@@ -305,15 +305,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 14932
+            "value": 14932800000
           },
           {
             "type": "tritanium",
-            "value": 205875
+            "value": 205875000
           }
         ]
       },
-      "build_time": 17343,
+      "build_time": 17343360,
       "increased_power": 7000,
       "level": 44,
       "requirements": [
@@ -348,15 +348,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 114240
+            "value": 114240000000
           },
           {
             "type": "tritanium",
-            "value": 1575
+            "value": 1575000000
           }
         ]
       },
-      "build_time": 56793,
+      "build_time": 56793600,
       "increased_power": 10000,
       "level": 49,
       "requirements": [
@@ -432,15 +432,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 29172
+            "value": 29172000000
           },
           {
             "type": "tritanium",
-            "value": 402187
+            "value": 402187500
           }
         ]
       },
-      "build_time": 28620,
+      "build_time": 28620000,
       "increased_power": 8000,
       "level": 46,
       "requirements": [
@@ -475,7 +475,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 2545
+            "value": 2545920
           },
           {
             "type": "tritanium",
@@ -522,15 +522,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 258019
+            "value": 258019200
           },
           {
             "type": "tritanium",
-            "value": 7114
+            "value": 7114500
           }
         ]
       },
-      "build_time": 1768,
+      "build_time": 1768320,
       "increased_power": 4500,
       "level": 36,
       "requirements": [
@@ -559,7 +559,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 9106
+            "value": 9106560
           },
           {
             "type": "tritanium",
@@ -602,15 +602,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 4678
+            "value": 4678400000
           },
           {
             "type": "tritanium",
-            "value": 64500
+            "value": 64500000
           }
         ]
       },
-      "build_time": 6543,
+      "build_time": 6543360,
       "increased_power": 6000,
       "level": 41,
       "requirements": [
@@ -645,15 +645,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 21216
+            "value": 21216000000
           },
           {
             "type": "tritanium",
-            "value": 292500
+            "value": 292500000
           }
         ]
       },
-      "build_time": 22390,
+      "build_time": 22390560,
       "increased_power": 7000,
       "level": 45,
       "requirements": [
@@ -688,15 +688,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 42432
+            "value": 42432000000
           },
           {
             "type": "tritanium",
-            "value": 585000
+            "value": 585000000
           }
         ]
       },
-      "build_time": 36256,
+      "build_time": 36256320,
       "increased_power": 9000,
       "level": 47,
       "requirements": [
@@ -731,15 +731,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 68544
+            "value": 68544000000
           },
           {
             "type": "tritanium",
-            "value": 945000
+            "value": 945000000
           }
         ]
       },
-      "build_time": 45550,
+      "build_time": 45550080,
       "increased_power": 8000,
       "level": 48,
       "requirements": [
@@ -761,15 +761,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 199920
+            "value": 199920000000
           },
           {
             "type": "tritanium",
-            "value": 2756
+            "value": 2756250000
           }
         ]
       },
-      "build_time": 70313,
+      "build_time": 70313760,
       "increased_power": 9000,
       "level": 50,
       "requirements": [
@@ -804,7 +804,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 33537
+            "value": 33537600
           },
           {
             "type": "tritanium",
@@ -841,11 +841,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 74936
+            "value": 74936000
           },
           {
             "type": "tritanium",
-            "value": 2066
+            "value": 2066250
           }
         ]
       },
@@ -878,15 +878,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 396576
+            "value": 396576000
           },
           {
             "type": "tritanium",
-            "value": 10935
+            "value": 10935000
           }
         ]
       },
-      "build_time": 1827,
+      "build_time": 1827360,
       "increased_power": 5000,
       "level": 37,
       "requirements": [
@@ -921,15 +921,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 616896
+            "value": 616896000
           },
           {
             "type": "tritanium",
-            "value": 17010
+            "value": 17010000
           }
         ]
       },
-      "build_time": 2963,
+      "build_time": 2963520,
       "increased_power": 5000,
       "level": 38,
       "requirements": [
@@ -994,15 +994,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 118320
+            "value": 118320000
           },
           {
             "type": "tritanium",
-            "value": 3262
+            "value": 3262500
           }
         ]
       },
-      "build_time": 1049,
+      "build_time": 1049760,
       "increased_power": 4000,
       "level": 34,
       "requirements": [
@@ -1615,7 +1615,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1569
+            "value": 1569984
           },
           {
             "type": "tritanium",
@@ -1658,7 +1658,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 3978
+            "value": 3978000
           },
           {
             "type": "tritanium",
@@ -1701,7 +1701,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 6071
+            "value": 6071040
           },
           {
             "type": "tritanium",
@@ -1744,7 +1744,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 14497
+            "value": 14497600
           },
           {
             "type": "tritanium",
@@ -1781,11 +1781,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 48443
+            "value": 48443200
           },
           {
             "type": "tritanium",
-            "value": 1335
+            "value": 1335750
           }
         ]
       },

--- a/buildings/drydock_b.json
+++ b/buildings/drydock_b.json
@@ -36,15 +36,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 616896
+            "value": 616896000
           },
           {
             "type": "tritanium",
-            "value": 17010
+            "value": 17010000
           }
         ]
       },
-      "build_time": 2963,
+      "build_time": 2963520,
       "increased_power": 5000,
       "level": 38,
       "requirements": [
@@ -66,15 +66,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1052
+            "value": 1052640000
           },
           {
             "type": "tritanium",
-            "value": 29025
+            "value": 29025000
           }
         ]
       },
-      "build_time": 3934,
+      "build_time": 3934080,
       "increased_power": 5000,
       "level": 39,
       "requirements": [
@@ -109,15 +109,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 4584
+            "value": 4584832000
           },
           {
             "type": "tritanium",
-            "value": 45150
+            "value": 45150000
           }
         ]
       },
-      "build_time": 6981,
+      "build_time": 6981120,
       "increased_power": 6000,
       "level": 40,
       "requirements": [
@@ -152,15 +152,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 6968
+            "value": 6968640000
           },
           {
             "type": "tritanium",
-            "value": 96075
+            "value": 96075000
           }
         ]
       },
-      "build_time": 10056,
+      "build_time": 10056960,
       "increased_power": 7000,
       "level": 42,
       "requirements": [
@@ -193,15 +193,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 9955
+            "value": 9955200000
           },
           {
             "type": "tritanium",
-            "value": 137250
+            "value": 137250000
           }
         ]
       },
-      "build_time": 13286,
+      "build_time": 13286880,
       "increased_power": 7000,
       "level": 43,
       "requirements": [
@@ -236,15 +236,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 14932
+            "value": 14932800000
           },
           {
             "type": "tritanium",
-            "value": 205875
+            "value": 205875000
           }
         ]
       },
-      "build_time": 17343,
+      "build_time": 17343360,
       "increased_power": 7000,
       "level": 44,
       "requirements": [
@@ -279,15 +279,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 114240
+            "value": 114240000000
           },
           {
             "type": "tritanium",
-            "value": 1575
+            "value": 1575000000
           }
         ]
       },
-      "build_time": 56793,
+      "build_time": 56793600,
       "increased_power": 10000,
       "level": 49,
       "requirements": [
@@ -326,15 +326,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 118320
+            "value": 118320000
           },
           {
             "type": "tritanium",
-            "value": 3262
+            "value": 3262500
           }
         ]
       },
-      "build_time": 1049,
+      "build_time": 1049760,
       "increased_power": 4000,
       "level": 34,
       "requirements": [
@@ -363,7 +363,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 2545
+            "value": 2545920
           },
           {
             "type": "tritanium",
@@ -410,15 +410,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 258019
+            "value": 258019200
           },
           {
             "type": "tritanium",
-            "value": 7114
+            "value": 7114500
           }
         ]
       },
-      "build_time": 1768,
+      "build_time": 1768320,
       "increased_power": 4500,
       "level": 36,
       "requirements": [
@@ -453,7 +453,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 9106
+            "value": 9106560
           },
           {
             "type": "tritanium",
@@ -490,7 +490,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 33537
+            "value": 33537600
           },
           {
             "type": "tritanium",
@@ -533,15 +533,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 396576
+            "value": 396576000
           },
           {
             "type": "tritanium",
-            "value": 10935
+            "value": 10935000
           }
         ]
       },
-      "build_time": 1827,
+      "build_time": 1827360,
       "increased_power": 5000,
       "level": 37,
       "requirements": [
@@ -684,15 +684,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 183110
+            "value": 183110400
           },
           {
             "type": "tritanium",
-            "value": 5049
+            "value": 5049000
           }
         ]
       },
-      "build_time": 1383,
+      "build_time": 1383840,
       "increased_power": 4000,
       "level": 35,
       "requirements": [
@@ -1300,7 +1300,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1569
+            "value": 1569984
           },
           {
             "type": "tritanium",
@@ -1343,7 +1343,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 3978
+            "value": 3978000
           },
           {
             "type": "tritanium",
@@ -1386,7 +1386,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 6071
+            "value": 6071040
           },
           {
             "type": "tritanium",
@@ -1423,7 +1423,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 14497
+            "value": 14497600
           },
           {
             "type": "tritanium",
@@ -1466,7 +1466,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 21216
+            "value": 21216000
           },
           {
             "type": "tritanium",
@@ -1503,11 +1503,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 48443
+            "value": 48443200
           },
           {
             "type": "tritanium",
-            "value": 1335
+            "value": 1335750
           }
         ]
       },
@@ -1546,11 +1546,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 74936
+            "value": 74936000
           },
           {
             "type": "tritanium",
-            "value": 2066
+            "value": 2066250
           }
         ]
       },
@@ -1589,15 +1589,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 4678
+            "value": 4678400000
           },
           {
             "type": "tritanium",
-            "value": 64500
+            "value": 64500000
           }
         ]
       },
-      "build_time": 6543,
+      "build_time": 6543360,
       "increased_power": 6000,
       "level": 41,
       "requirements": [
@@ -1632,15 +1632,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 21216
+            "value": 21216000000
           },
           {
             "type": "tritanium",
-            "value": 292500
+            "value": 292500000
           }
         ]
       },
-      "build_time": 22390,
+      "build_time": 22390560,
       "increased_power": 7000,
       "level": 45,
       "requirements": [
@@ -1675,15 +1675,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 29172
+            "value": 29172000000
           },
           {
             "type": "tritanium",
-            "value": 402187
+            "value": 402187500
           }
         ]
       },
-      "build_time": 28620,
+      "build_time": 28620000,
       "increased_power": 8000,
       "level": 46,
       "requirements": [
@@ -1722,15 +1722,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 42432
+            "value": 42432000000
           },
           {
             "type": "tritanium",
-            "value": 585000
+            "value": 585000000
           }
         ]
       },
-      "build_time": 36256,
+      "build_time": 36256320,
       "increased_power": 9000,
       "level": 47,
       "requirements": [
@@ -1765,15 +1765,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 68544
+            "value": 68544000000
           },
           {
             "type": "tritanium",
-            "value": 945000
+            "value": 945000000
           }
         ]
       },
-      "build_time": 45550,
+      "build_time": 45550080,
       "increased_power": 8000,
       "level": 48,
       "requirements": [
@@ -1795,15 +1795,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 199920
+            "value": 199920000000
           },
           {
             "type": "tritanium",
-            "value": 2756
+            "value": 2756250000
           }
         ]
       },
-      "build_time": 70313,
+      "build_time": 70313760,
       "increased_power": 9000,
       "level": 50,
       "requirements": [

--- a/buildings/drydock_c.json
+++ b/buildings/drydock_c.json
@@ -36,15 +36,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 4584
+            "value": 4584832000
           },
           {
             "type": "tritanium",
-            "value": 45150
+            "value": 45150000
           }
         ]
       },
-      "build_time": 6981,
+      "build_time": 6981120,
       "increased_power": 6000,
       "level": 40,
       "requirements": [
@@ -66,15 +66,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1052
+            "value": 1052640000
           },
           {
             "type": "tritanium",
-            "value": 29025
+            "value": 29025000
           }
         ]
       },
-      "build_time": 3934,
+      "build_time": 3934080,
       "increased_power": 5000,
       "level": 39,
       "requirements": [
@@ -109,15 +109,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 6968
+            "value": 6968640000
           },
           {
             "type": "tritanium",
-            "value": 96075
+            "value": 96075000
           }
         ]
       },
-      "build_time": 10056,
+      "build_time": 10056960,
       "increased_power": 7000,
       "level": 42,
       "requirements": [
@@ -150,15 +150,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 9955
+            "value": 9955200000
           },
           {
             "type": "tritanium",
-            "value": 137250
+            "value": 137250000
           }
         ]
       },
-      "build_time": 13286,
+      "build_time": 13286880,
       "increased_power": 7000,
       "level": 43,
       "requirements": [
@@ -193,15 +193,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 14932
+            "value": 14932800000
           },
           {
             "type": "tritanium",
-            "value": 205875
+            "value": 205875000
           }
         ]
       },
-      "build_time": 17343,
+      "build_time": 17343360,
       "increased_power": 7000,
       "level": 44,
       "requirements": [
@@ -236,15 +236,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 114240
+            "value": 114240000000
           },
           {
             "type": "tritanium",
-            "value": 1575
+            "value": 1575000000
           }
         ]
       },
-      "build_time": 56793,
+      "build_time": 56793600,
       "increased_power": 10000,
       "level": 49,
       "requirements": [
@@ -283,7 +283,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 2545
+            "value": 2545920
           },
           {
             "type": "tritanium",
@@ -330,15 +330,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 258019
+            "value": 258019200
           },
           {
             "type": "tritanium",
-            "value": 7114
+            "value": 7114500
           }
         ]
       },
-      "build_time": 1768,
+      "build_time": 1768320,
       "increased_power": 4500,
       "level": 36,
       "requirements": [
@@ -373,7 +373,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 33537
+            "value": 33537600
           },
           {
             "type": "tritanium",
@@ -416,15 +416,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 396576
+            "value": 396576000
           },
           {
             "type": "tritanium",
-            "value": 10935
+            "value": 10935000
           }
         ]
       },
-      "build_time": 1827,
+      "build_time": 1827360,
       "increased_power": 5000,
       "level": 37,
       "requirements": [
@@ -459,15 +459,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 616896
+            "value": 616896000
           },
           {
             "type": "tritanium",
-            "value": 17010
+            "value": 17010000
           }
         ]
       },
-      "build_time": 2963,
+      "build_time": 2963520,
       "increased_power": 5000,
       "level": 38,
       "requirements": [
@@ -604,15 +604,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 183110
+            "value": 183110400
           },
           {
             "type": "tritanium",
-            "value": 5049
+            "value": 5049000
           }
         ]
       },
-      "build_time": 1383,
+      "build_time": 1383840,
       "increased_power": 4000,
       "level": 35,
       "requirements": [
@@ -1192,7 +1192,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1569
+            "value": 1569984
           },
           {
             "type": "tritanium",
@@ -1235,7 +1235,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 3978
+            "value": 3978000
           },
           {
             "type": "tritanium",
@@ -1272,7 +1272,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 6071
+            "value": 6071040
           },
           {
             "type": "tritanium",
@@ -1315,7 +1315,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 9106
+            "value": 9106560
           },
           {
             "type": "tritanium",
@@ -1352,7 +1352,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 14497
+            "value": 14497600
           },
           {
             "type": "tritanium",
@@ -1395,7 +1395,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 21216
+            "value": 21216000
           },
           {
             "type": "tritanium",
@@ -1438,11 +1438,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 48443
+            "value": 48443200
           },
           {
             "type": "tritanium",
-            "value": 1335
+            "value": 1335750
           }
         ]
       },
@@ -1481,11 +1481,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 74936
+            "value": 74936000
           },
           {
             "type": "tritanium",
-            "value": 2066
+            "value": 2066250
           }
         ]
       },
@@ -1524,15 +1524,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 118320
+            "value": 118320000
           },
           {
             "type": "tritanium",
-            "value": 3262
+            "value": 3262500
           }
         ]
       },
-      "build_time": 1049,
+      "build_time": 1049760,
       "increased_power": 4000,
       "level": 34,
       "requirements": [
@@ -1567,15 +1567,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 4678
+            "value": 4678400000
           },
           {
             "type": "tritanium",
-            "value": 64500
+            "value": 64500000
           }
         ]
       },
-      "build_time": 6543,
+      "build_time": 6543360,
       "increased_power": 6000,
       "level": 41,
       "requirements": [
@@ -1610,15 +1610,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 21216
+            "value": 21216000000
           },
           {
             "type": "tritanium",
-            "value": 292500
+            "value": 292500000
           }
         ]
       },
-      "build_time": 22390,
+      "build_time": 22390560,
       "increased_power": 7000,
       "level": 45,
       "requirements": [
@@ -1653,15 +1653,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 29172
+            "value": 29172000000
           },
           {
             "type": "tritanium",
-            "value": 402187
+            "value": 402187500
           }
         ]
       },
-      "build_time": 28620,
+      "build_time": 28620000,
       "increased_power": 8000,
       "level": 46,
       "requirements": [
@@ -1700,15 +1700,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 42432
+            "value": 42432000000
           },
           {
             "type": "tritanium",
-            "value": 585000
+            "value": 585000000
           }
         ]
       },
-      "build_time": 36256,
+      "build_time": 36256320,
       "increased_power": 9000,
       "level": 47,
       "requirements": [
@@ -1743,15 +1743,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 68544
+            "value": 68544000000
           },
           {
             "type": "tritanium",
-            "value": 945000
+            "value": 945000000
           }
         ]
       },
-      "build_time": 45550,
+      "build_time": 45550080,
       "increased_power": 8000,
       "level": 48,
       "requirements": [
@@ -1773,15 +1773,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 199920
+            "value": 199920000000
           },
           {
             "type": "tritanium",
-            "value": 2756
+            "value": 2756250000
           }
         ]
       },
-      "build_time": 70313,
+      "build_time": 70313760,
       "increased_power": 9000,
       "level": 50,
       "requirements": [

--- a/buildings/drydock_d.json
+++ b/buildings/drydock_d.json
@@ -36,15 +36,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 4584
+            "value": 4584832000
           },
           {
             "type": "tritanium",
-            "value": 45150
+            "value": 45150000
           }
         ]
       },
-      "build_time": 6981,
+      "build_time": 6981120,
       "increased_power": 6000,
       "level": 40,
       "requirements": [
@@ -79,15 +79,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 4678
+            "value": 4678400000
           },
           {
             "type": "tritanium",
-            "value": 64500
+            "value": 64500000
           }
         ]
       },
-      "build_time": 6543,
+      "build_time": 6543360,
       "increased_power": 6000,
       "level": 41,
       "requirements": [
@@ -109,15 +109,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1052
+            "value": 1052640000
           },
           {
             "type": "tritanium",
-            "value": 29025
+            "value": 29025000
           }
         ]
       },
-      "build_time": 3934,
+      "build_time": 3934080,
       "increased_power": 5000,
       "level": 39,
       "requirements": [
@@ -152,15 +152,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 183110
+            "value": 183110400
           },
           {
             "type": "tritanium",
-            "value": 5049
+            "value": 5049000
           }
         ]
       },
-      "build_time": 1383,
+      "build_time": 1383840,
       "increased_power": 4000,
       "level": 35,
       "requirements": [
@@ -195,15 +195,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 258019
+            "value": 258019200
           },
           {
             "type": "tritanium",
-            "value": 7114
+            "value": 7114500
           }
         ]
       },
-      "build_time": 1768,
+      "build_time": 1768320,
       "increased_power": 4500,
       "level": 36,
       "requirements": [
@@ -232,15 +232,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 396576
+            "value": 396576000
           },
           {
             "type": "tritanium",
-            "value": 10935
+            "value": 10935000
           }
         ]
       },
-      "build_time": 1827,
+      "build_time": 1827360,
       "increased_power": 5000,
       "level": 37,
       "requirements": [
@@ -275,15 +275,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 616896
+            "value": 616896000
           },
           {
             "type": "tritanium",
-            "value": 17010
+            "value": 17010000
           }
         ]
       },
-      "build_time": 2963,
+      "build_time": 2963520,
       "increased_power": 5000,
       "level": 38,
       "requirements": [
@@ -318,15 +318,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 6968
+            "value": 6968640000
           },
           {
             "type": "tritanium",
-            "value": 96075
+            "value": 96075000
           }
         ]
       },
-      "build_time": 10056,
+      "build_time": 10056960,
       "increased_power": 7000,
       "level": 42,
       "requirements": [
@@ -359,15 +359,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 9955
+            "value": 9955200000
           },
           {
             "type": "tritanium",
-            "value": 137250
+            "value": 137250000
           }
         ]
       },
-      "build_time": 13286,
+      "build_time": 13286880,
       "increased_power": 7000,
       "level": 43,
       "requirements": [
@@ -402,15 +402,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 14932
+            "value": 14932800000
           },
           {
             "type": "tritanium",
-            "value": 205875
+            "value": 205875000
           }
         ]
       },
-      "build_time": 17343,
+      "build_time": 17343360,
       "increased_power": 7000,
       "level": 44,
       "requirements": [
@@ -445,15 +445,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 114240
+            "value": 114240000000
           },
           {
             "type": "tritanium",
-            "value": 1575
+            "value": 1575000000
           }
         ]
       },
-      "build_time": 56793,
+      "build_time": 56793600,
       "increased_power": 10000,
       "level": 49,
       "requirements": [
@@ -492,15 +492,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 68544
+            "value": 68544000000
           },
           {
             "type": "tritanium",
-            "value": 945000
+            "value": 945000000
           }
         ]
       },
-      "build_time": 45550,
+      "build_time": 45550080,
       "increased_power": 8000,
       "level": 48,
       "requirements": [
@@ -535,15 +535,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 42432
+            "value": 42432000000
           },
           {
             "type": "tritanium",
-            "value": 585000
+            "value": 585000000
           }
         ]
       },
-      "build_time": 36256,
+      "build_time": 36256320,
       "increased_power": 9000,
       "level": 47,
       "requirements": [
@@ -578,15 +578,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 29172
+            "value": 29172000000
           },
           {
             "type": "tritanium",
-            "value": 402187
+            "value": 402187500
           }
         ]
       },
-      "build_time": 28620,
+      "build_time": 28620000,
       "increased_power": 8000,
       "level": 46,
       "requirements": [
@@ -625,11 +625,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 74936
+            "value": 74936000
           },
           {
             "type": "tritanium",
-            "value": 2066
+            "value": 2066250
           }
         ]
       },
@@ -668,7 +668,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 14497
+            "value": 14497600
           },
           {
             "type": "tritanium",
@@ -705,7 +705,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 21216
+            "value": 21216000
           },
           {
             "type": "tritanium",
@@ -748,7 +748,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 33537
+            "value": 33537600
           },
           {
             "type": "tritanium",
@@ -1451,7 +1451,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1569
+            "value": 1569984
           },
           {
             "type": "tritanium",
@@ -1488,7 +1488,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 2545
+            "value": 2545920
           },
           {
             "type": "tritanium",
@@ -1525,7 +1525,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 3978
+            "value": 3978000
           },
           {
             "type": "tritanium",
@@ -1562,7 +1562,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 6071
+            "value": 6071040
           },
           {
             "type": "tritanium",
@@ -1599,7 +1599,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 9106
+            "value": 9106560
           },
           {
             "type": "tritanium",
@@ -1642,11 +1642,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 48443
+            "value": 48443200
           },
           {
             "type": "tritanium",
-            "value": 1335
+            "value": 1335750
           }
         ]
       },
@@ -1679,15 +1679,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 118320
+            "value": 118320000
           },
           {
             "type": "tritanium",
-            "value": 3262
+            "value": 3262500
           }
         ]
       },
-      "build_time": 1049,
+      "build_time": 1049760,
       "increased_power": 4000,
       "level": 34,
       "requirements": [
@@ -1722,15 +1722,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 21216
+            "value": 21216000000
           },
           {
             "type": "tritanium",
-            "value": 292500
+            "value": 292500000
           }
         ]
       },
-      "build_time": 22390,
+      "build_time": 22390560,
       "increased_power": 7000,
       "level": 45,
       "requirements": [
@@ -1752,15 +1752,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 199920
+            "value": 199920000000
           },
           {
             "type": "tritanium",
-            "value": 2756
+            "value": 2756250000
           }
         ]
       },
-      "build_time": 70313,
+      "build_time": 70313760,
       "increased_power": 9000,
       "level": 50,
       "requirements": [

--- a/buildings/drydock_e.json
+++ b/buildings/drydock_e.json
@@ -23,15 +23,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1052
+            "value": 1052640000
           },
           {
             "type": "tritanium",
-            "value": 29025
+            "value": 29025000
           }
         ]
       },
-      "build_time": 3934,
+      "build_time": 3934080,
       "increased_power": 5000,
       "level": 39,
       "requirements": [
@@ -60,15 +60,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 4584
+            "value": 4584832000
           },
           {
             "type": "tritanium",
-            "value": 45150
+            "value": 45150000
           }
         ]
       },
-      "build_time": 6981,
+      "build_time": 6981120,
       "increased_power": 6000,
       "level": 40,
       "requirements": [
@@ -97,15 +97,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 6968
+            "value": 6968640000
           },
           {
             "type": "tritanium",
-            "value": 96075
+            "value": 96075000
           }
         ]
       },
-      "build_time": 10056,
+      "build_time": 10056960,
       "increased_power": 7000,
       "level": 42,
       "requirements": [
@@ -138,15 +138,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 9955
+            "value": 9955200000
           },
           {
             "type": "tritanium",
-            "value": 137250
+            "value": 137250000
           }
         ]
       },
-      "build_time": 13286,
+      "build_time": 13286880,
       "increased_power": 7000,
       "level": 43,
       "requirements": [
@@ -181,15 +181,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 14932
+            "value": 14932800000
           },
           {
             "type": "tritanium",
-            "value": 205875
+            "value": 205875000
           }
         ]
       },
-      "build_time": 17343,
+      "build_time": 17343360,
       "increased_power": 7000,
       "level": 44,
       "requirements": [
@@ -224,15 +224,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 114240
+            "value": 114240000000
           },
           {
             "type": "tritanium",
-            "value": 1575
+            "value": 1575000000
           }
         ]
       },
-      "build_time": 56793,
+      "build_time": 56793600,
       "increased_power": 10000,
       "level": 49,
       "requirements": [
@@ -271,15 +271,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 68544
+            "value": 68544000000
           },
           {
             "type": "tritanium",
-            "value": 945000
+            "value": 945000000
           }
         ]
       },
-      "build_time": 45550,
+      "build_time": 45550080,
       "increased_power": 8000,
       "level": 48,
       "requirements": [
@@ -314,15 +314,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 42432
+            "value": 42432000000
           },
           {
             "type": "tritanium",
-            "value": 585000
+            "value": 585000000
           }
         ]
       },
-      "build_time": 36256,
+      "build_time": 36256320,
       "increased_power": 9000,
       "level": 47,
       "requirements": [
@@ -351,15 +351,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 29172
+            "value": 29172000000
           },
           {
             "type": "tritanium",
-            "value": 402187
+            "value": 402187500
           }
         ]
       },
-      "build_time": 28620,
+      "build_time": 28620000,
       "increased_power": 8000,
       "level": 46,
       "requirements": [
@@ -398,15 +398,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 21216
+            "value": 21216000000
           },
           {
             "type": "tritanium",
-            "value": 292500
+            "value": 292500000
           }
         ]
       },
-      "build_time": 22390,
+      "build_time": 22390560,
       "increased_power": 7000,
       "level": 45,
       "requirements": [
@@ -435,15 +435,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 4678
+            "value": 4678400000
           },
           {
             "type": "tritanium",
-            "value": 64500
+            "value": 64500000
           }
         ]
       },
-      "build_time": 6543,
+      "build_time": 6543360,
       "increased_power": 6000,
       "level": 41,
       "requirements": [
@@ -472,11 +472,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 6000
+            "value": 6000000
           }
         ]
       },
-      "build_time": 1036,
+      "build_time": 1036800,
       "increased_power": 60,
       "level": 1,
       "requirements": [
@@ -498,15 +498,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 616896
+            "value": 616896000
           },
           {
             "type": "tritanium",
-            "value": 17010
+            "value": 17010000
           }
         ]
       },
-      "build_time": 2963,
+      "build_time": 2963520,
       "increased_power": 5000,
       "level": 38,
       "requirements": [
@@ -644,15 +644,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 258019
+            "value": 258019200
           },
           {
             "type": "tritanium",
-            "value": 7114
+            "value": 7114500
           }
         ]
       },
-      "build_time": 1768,
+      "build_time": 1768320,
       "increased_power": 4500,
       "level": 36,
       "requirements": [
@@ -674,7 +674,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 33537
+            "value": 33537600
           },
           {
             "type": "tritanium",
@@ -704,15 +704,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 396576
+            "value": 396576000
           },
           {
             "type": "tritanium",
-            "value": 10935
+            "value": 10935000
           }
         ]
       },
-      "build_time": 1827,
+      "build_time": 1827360,
       "increased_power": 5000,
       "level": 37,
       "requirements": [
@@ -764,15 +764,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 183110
+            "value": 183110400
           },
           {
             "type": "tritanium",
-            "value": 5049
+            "value": 5049000
           }
         ]
       },
-      "build_time": 1383,
+      "build_time": 1383840,
       "increased_power": 4000,
       "level": 35,
       "requirements": [
@@ -1288,7 +1288,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1569
+            "value": 1569984
           },
           {
             "type": "tritanium",
@@ -1318,7 +1318,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 2545
+            "value": 2545920
           },
           {
             "type": "tritanium",
@@ -1348,7 +1348,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 3978
+            "value": 3978000
           },
           {
             "type": "tritanium",
@@ -1378,7 +1378,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 6071
+            "value": 6071040
           },
           {
             "type": "tritanium",
@@ -1408,7 +1408,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 9106
+            "value": 9106560
           },
           {
             "type": "tritanium",
@@ -1438,7 +1438,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 14497
+            "value": 14497600
           },
           {
             "type": "tritanium",
@@ -1468,7 +1468,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 21216
+            "value": 21216000
           },
           {
             "type": "tritanium",
@@ -1498,11 +1498,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 48443
+            "value": 48443200
           },
           {
             "type": "tritanium",
-            "value": 1335
+            "value": 1335750
           }
         ]
       },
@@ -1528,11 +1528,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 74936
+            "value": 74936000
           },
           {
             "type": "tritanium",
-            "value": 2066
+            "value": 2066250
           }
         ]
       },
@@ -1558,15 +1558,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 118320
+            "value": 118320000
           },
           {
             "type": "tritanium",
-            "value": 3262
+            "value": 3262500
           }
         ]
       },
-      "build_time": 1049,
+      "build_time": 1049760,
       "increased_power": 4000,
       "level": 34,
       "requirements": [
@@ -1588,15 +1588,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 199920
+            "value": 199920000000
           },
           {
             "type": "tritanium",
-            "value": 2756
+            "value": 2756250000
           }
         ]
       },
-      "build_time": 70313,
+      "build_time": 70313760,
       "increased_power": 9000,
       "level": 50,
       "requirements": [

--- a/buildings/drydock_f.json
+++ b/buildings/drydock_f.json
@@ -23,15 +23,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1052
+            "value": 1052640000
           },
           {
             "type": "tritanium",
-            "value": 29025
+            "value": 29025000
           }
         ]
       },
-      "build_time": 3934,
+      "build_time": 3934080,
       "increased_power": 5000,
       "level": 39,
       "requirements": [
@@ -66,15 +66,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 4584
+            "value": 4584832000
           },
           {
             "type": "tritanium",
-            "value": 45150
+            "value": 45150000
           }
         ]
       },
-      "build_time": 6981,
+      "build_time": 6981120,
       "increased_power": 6000,
       "level": 40,
       "requirements": [
@@ -96,7 +96,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 100000
+            "value": 100000000000
           }
         ]
       },
@@ -135,15 +135,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 6968
+            "value": 6968640000
           },
           {
             "type": "tritanium",
-            "value": 96075
+            "value": 96075000
           }
         ]
       },
-      "build_time": 10056,
+      "build_time": 10056960,
       "increased_power": 7000,
       "level": 42,
       "requirements": [
@@ -165,15 +165,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 258019
+            "value": 258019200
           },
           {
             "type": "tritanium",
-            "value": 7114
+            "value": 7114500
           }
         ]
       },
-      "build_time": 1768,
+      "build_time": 1768320,
       "increased_power": 4500,
       "level": 36,
       "requirements": [
@@ -195,7 +195,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 33537
+            "value": 33537600
           },
           {
             "type": "tritanium",
@@ -225,15 +225,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 396576
+            "value": 396576000
           },
           {
             "type": "tritanium",
-            "value": 10935
+            "value": 10935000
           }
         ]
       },
-      "build_time": 1827,
+      "build_time": 1827360,
       "increased_power": 5000,
       "level": 37,
       "requirements": [
@@ -255,15 +255,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 616896
+            "value": 616896000
           },
           {
             "type": "tritanium",
-            "value": 17010
+            "value": 17010000
           }
         ]
       },
-      "build_time": 2963,
+      "build_time": 2963520,
       "increased_power": 5000,
       "level": 38,
       "requirements": [
@@ -315,15 +315,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 183110
+            "value": 183110400
           },
           {
             "type": "tritanium",
-            "value": 5049
+            "value": 5049000
           }
         ]
       },
-      "build_time": 1383,
+      "build_time": 1383840,
       "increased_power": 4000,
       "level": 35,
       "requirements": [
@@ -955,7 +955,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1569
+            "value": 1569984
           },
           {
             "type": "tritanium",
@@ -985,7 +985,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 2545
+            "value": 2545920
           },
           {
             "type": "tritanium",
@@ -1015,7 +1015,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 3978
+            "value": 3978000
           },
           {
             "type": "tritanium",
@@ -1045,7 +1045,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 6071
+            "value": 6071040
           },
           {
             "type": "tritanium",
@@ -1075,7 +1075,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 9106
+            "value": 9106560
           },
           {
             "type": "tritanium",
@@ -1105,7 +1105,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 14497
+            "value": 14497600
           },
           {
             "type": "tritanium",
@@ -1135,7 +1135,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 21216
+            "value": 21216000
           },
           {
             "type": "tritanium",
@@ -1165,11 +1165,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 48443
+            "value": 48443200
           },
           {
             "type": "tritanium",
-            "value": 1335
+            "value": 1335750
           }
         ]
       },
@@ -1195,11 +1195,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 74936
+            "value": 74936000
           },
           {
             "type": "tritanium",
-            "value": 2066
+            "value": 2066250
           }
         ]
       },
@@ -1225,15 +1225,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 118320
+            "value": 118320000
           },
           {
             "type": "tritanium",
-            "value": 3262
+            "value": 3262500
           }
         ]
       },
-      "build_time": 1049,
+      "build_time": 1049760,
       "increased_power": 4000,
       "level": 34,
       "requirements": [
@@ -1268,15 +1268,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 4678
+            "value": 4678400000
           },
           {
             "type": "tritanium",
-            "value": 64500
+            "value": 64500000
           }
         ]
       },
-      "build_time": 6543,
+      "build_time": 6543360,
       "increased_power": 6000,
       "level": 41,
       "requirements": [
@@ -1305,15 +1305,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 9955
+            "value": 9955200000
           },
           {
             "type": "tritanium",
-            "value": 137250
+            "value": 137250000
           }
         ]
       },
-      "build_time": 13286,
+      "build_time": 13286880,
       "increased_power": 7000,
       "level": 43,
       "requirements": [
@@ -1348,15 +1348,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 14932
+            "value": 14932800000
           },
           {
             "type": "tritanium",
-            "value": 205875
+            "value": 205875000
           }
         ]
       },
-      "build_time": 17343,
+      "build_time": 17343360,
       "increased_power": 7000,
       "level": 44,
       "requirements": [
@@ -1391,15 +1391,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 21216
+            "value": 21216000000
           },
           {
             "type": "tritanium",
-            "value": 292500
+            "value": 292500000
           }
         ]
       },
-      "build_time": 22390,
+      "build_time": 22390560,
       "increased_power": 7000,
       "level": 45,
       "requirements": [
@@ -1434,15 +1434,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 29172
+            "value": 29172000000
           },
           {
             "type": "tritanium",
-            "value": 402187
+            "value": 402187500
           }
         ]
       },
-      "build_time": 28620,
+      "build_time": 28620000,
       "increased_power": 8000,
       "level": 46,
       "requirements": [
@@ -1477,15 +1477,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 42432
+            "value": 42432000000
           },
           {
             "type": "tritanium",
-            "value": 585000
+            "value": 585000000
           }
         ]
       },
-      "build_time": 36256,
+      "build_time": 36256320,
       "increased_power": 9000,
       "level": 47,
       "requirements": [
@@ -1520,15 +1520,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 68544
+            "value": 68544000000
           },
           {
             "type": "tritanium",
-            "value": 945000
+            "value": 945000000
           }
         ]
       },
-      "build_time": 45550,
+      "build_time": 45550080,
       "increased_power": 8000,
       "level": 48,
       "requirements": [
@@ -1563,15 +1563,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 114240
+            "value": 114240000000
           },
           {
             "type": "tritanium",
-            "value": 1575
+            "value": 1575000000
           }
         ]
       },
-      "build_time": 56793,
+      "build_time": 56793600,
       "increased_power": 10000,
       "level": 49,
       "requirements": [
@@ -1593,15 +1593,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 199920
+            "value": 199920000000
           },
           {
             "type": "tritanium",
-            "value": 2756
+            "value": 2756250000
           }
         ]
       },
-      "build_time": 70313,
+      "build_time": 70313760,
       "increased_power": 9000,
       "level": 50,
       "requirements": [

--- a/buildings/engine_technology_lab.json
+++ b/buildings/engine_technology_lab.json
@@ -30,15 +30,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 198288
+            "value": 198288000
           },
           {
             "type": "dilithium",
-            "value": 3645
+            "value": 3645000
           }
         ]
       },
-      "build_time": 1095,
+      "build_time": 1095840,
       "increased_power": 2500,
       "level": 37,
       "requirements": [
@@ -77,15 +77,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 3484
+            "value": 3484320000
           },
           {
             "type": "dilithium",
-            "value": 32025
+            "value": 32025000
           }
         ]
       },
-      "build_time": 6033,
+      "build_time": 6033600,
       "increased_power": 3500,
       "level": 42,
       "requirements": [
@@ -124,15 +124,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 4977
+            "value": 4977600000
           },
           {
             "type": "dilithium",
-            "value": 45750
+            "value": 45750000
           }
         ]
       },
-      "build_time": 7971,
+      "build_time": 7971840,
       "increased_power": 3500,
       "level": 43,
       "requirements": [
@@ -171,15 +171,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 7466
+            "value": 7466400000
           },
           {
             "type": "dilithium",
-            "value": 68625
+            "value": 68625000
           }
         ]
       },
-      "build_time": 10405,
+      "build_time": 10405440,
       "increased_power": 3500,
       "level": 44,
       "requirements": [
@@ -218,15 +218,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 10608
+            "value": 10608000000
           },
           {
             "type": "dilithium",
-            "value": 97500
+            "value": 97500000
           }
         ]
       },
-      "build_time": 13433,
+      "build_time": 13433760,
       "increased_power": 3500,
       "level": 45,
       "requirements": [
@@ -269,15 +269,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 2339
+            "value": 2339200000
           },
           {
             "type": "dilithium",
-            "value": 21500
+            "value": 21500000
           }
         ]
       },
-      "build_time": 3925,
+      "build_time": 3925440,
       "increased_power": 3000,
       "level": 41,
       "requirements": [
@@ -316,15 +316,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 57120
+            "value": 57120000000
           },
           {
             "type": "dilithium",
-            "value": 525000
+            "value": 525000000
           }
         ]
       },
-      "build_time": 34076,
+      "build_time": 34076160,
       "increased_power": 4000,
       "level": 49,
       "requirements": [
@@ -363,15 +363,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 34272
+            "value": 34272000000
           },
           {
             "type": "dilithium",
-            "value": 315000
+            "value": 315000000
           }
         ]
       },
-      "build_time": 27329,
+      "build_time": 27329760,
       "increased_power": 5000,
       "level": 48,
       "requirements": [
@@ -410,15 +410,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 21216
+            "value": 21216000000
           },
           {
             "type": "dilithium",
-            "value": 195000
+            "value": 195000000
           }
         ]
       },
-      "build_time": 21754,
+      "build_time": 21754080,
       "increased_power": 4000,
       "level": 47,
       "requirements": [
@@ -457,15 +457,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 14586
+            "value": 14586000000
           },
           {
             "type": "dilithium",
-            "value": 134062
+            "value": 134062500
           }
         ]
       },
-      "build_time": 17172,
+      "build_time": 17172000,
       "increased_power": 4000,
       "level": 46,
       "requirements": [
@@ -498,15 +498,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 526320
+            "value": 526320000
           },
           {
             "type": "dilithium",
-            "value": 9675
+            "value": 9675000
           }
         ]
       },
-      "build_time": 2360,
+      "build_time": 2360160,
       "increased_power": 2500,
       "level": 39,
       "requirements": [
@@ -549,15 +549,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 308448
+            "value": 308448000
           },
           {
             "type": "dilithium",
-            "value": 5670
+            "value": 5670000
           }
         ]
       },
-      "build_time": 1778,
+      "build_time": 1778400,
       "increased_power": 2500,
       "level": 38,
       "requirements": [
@@ -596,7 +596,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 16768
+            "value": 16768800
           },
           {
             "type": "dilithium",
@@ -1420,7 +1420,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1272
+            "value": 1272960
           },
           {
             "type": "dilithium",
@@ -1461,7 +1461,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1989
+            "value": 1989000
           },
           {
             "type": "dilithium",
@@ -1508,7 +1508,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 3035
+            "value": 3035520
           },
           {
             "type": "dilithium",
@@ -1555,7 +1555,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 4553
+            "value": 4553280
           },
           {
             "type": "dilithium",
@@ -1596,7 +1596,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 7248
+            "value": 7248800
           },
           {
             "type": "dilithium",
@@ -1637,7 +1637,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 10608
+            "value": 10608000
           },
           {
             "type": "dilithium",
@@ -1684,7 +1684,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 24221
+            "value": 24221600
           },
           {
             "type": "dilithium",
@@ -1731,7 +1731,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 37468
+            "value": 37468000
           },
           {
             "type": "dilithium",
@@ -1772,11 +1772,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 59160
+            "value": 59160000
           },
           {
             "type": "dilithium",
-            "value": 1087
+            "value": 1087500
           }
         ]
       },
@@ -1813,11 +1813,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 91555
+            "value": 91555200
           },
           {
             "type": "dilithium",
-            "value": 1683
+            "value": 1683000
           }
         ]
       },
@@ -1860,15 +1860,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 129009
+            "value": 129009600
           },
           {
             "type": "dilithium",
-            "value": 2371
+            "value": 2371500
           }
         ]
       },
-      "build_time": 1061,
+      "build_time": 1061280,
       "increased_power": 2000,
       "level": 36,
       "requirements": [
@@ -1907,15 +1907,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 2292
+            "value": 2292416000
           },
           {
             "type": "dilithium",
-            "value": 15050
+            "value": 15050000
           }
         ]
       },
-      "build_time": 4188,
+      "build_time": 4188960,
       "increased_power": 3000,
       "level": 40,
       "requirements": [
@@ -1941,15 +1941,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 99960
+            "value": 99960000000
           },
           {
             "type": "dilithium",
-            "value": 918750
+            "value": 918750000
           }
         ]
       },
-      "build_time": 42189,
+      "build_time": 42189120,
       "increased_power": 5000,
       "level": 50,
       "requirements": [

--- a/buildings/foundry.json
+++ b/buildings/foundry.json
@@ -93,15 +93,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 247860
+            "value": 247860000
           },
           {
             "type": "tritanium",
-            "value": 10935
+            "value": 10935000
           }
         ]
       },
-      "build_time": 1095,
+      "build_time": 1095840,
       "increased_power": 2500,
       "level": 37,
       "requirements": [
@@ -140,11 +140,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 114444
+            "value": 114444000
           },
           {
             "type": "tritanium",
-            "value": 5049
+            "value": 5049000
           }
         ]
       },
@@ -187,15 +187,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 4355
+            "value": 4355400000
           },
           {
             "type": "tritanium",
-            "value": 96075
+            "value": 96075000
           }
         ]
       },
-      "build_time": 6033,
+      "build_time": 6033600,
       "increased_power": 3500,
       "level": 42,
       "requirements": [
@@ -234,15 +234,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 6222
+            "value": 6222000000
           },
           {
             "type": "tritanium",
-            "value": 137250
+            "value": 137250000
           }
         ]
       },
-      "build_time": 7971,
+      "build_time": 7971840,
       "increased_power": 3500,
       "level": 43,
       "requirements": [
@@ -281,15 +281,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 9333
+            "value": 9333000000
           },
           {
             "type": "tritanium",
-            "value": 205875
+            "value": 205875000
           }
         ]
       },
-      "build_time": 10405,
+      "build_time": 10405440,
       "increased_power": 3500,
       "level": 44,
       "requirements": [
@@ -328,15 +328,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 13260
+            "value": 13260000000
           },
           {
             "type": "tritanium",
-            "value": 292500
+            "value": 292500000
           }
         ]
       },
-      "build_time": 13433,
+      "build_time": 13433760,
       "increased_power": 3500,
       "level": 45,
       "requirements": [
@@ -375,15 +375,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 71400
+            "value": 71400000000
           },
           {
             "type": "tritanium",
-            "value": 1575
+            "value": 1575000000
           }
         ]
       },
-      "build_time": 34076,
+      "build_time": 34076160,
       "increased_power": 4000,
       "level": 49,
       "requirements": [
@@ -426,15 +426,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 42840
+            "value": 42840000000
           },
           {
             "type": "tritanium",
-            "value": 945000
+            "value": 945000000
           }
         ]
       },
-      "build_time": 27329,
+      "build_time": 27329760,
       "increased_power": 5000,
       "level": 48,
       "requirements": [
@@ -473,15 +473,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 26520
+            "value": 26520000000
           },
           {
             "type": "tritanium",
-            "value": 585000
+            "value": 585000000
           }
         ]
       },
-      "build_time": 21754,
+      "build_time": 21754080,
       "increased_power": 4000,
       "level": 47,
       "requirements": [
@@ -520,15 +520,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 18232
+            "value": 18232500000
           },
           {
             "type": "tritanium",
-            "value": 402187
+            "value": 402187500
           }
         ]
       },
-      "build_time": 17172,
+      "build_time": 17172000,
       "increased_power": 4000,
       "level": 46,
       "requirements": [
@@ -567,15 +567,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 657900
+            "value": 657900000
           },
           {
             "type": "tritanium",
-            "value": 29025
+            "value": 29025000
           }
         ]
       },
-      "build_time": 2360,
+      "build_time": 2360160,
       "increased_power": 2500,
       "level": 39,
       "requirements": [
@@ -618,15 +618,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 385560
+            "value": 385560000
           },
           {
             "type": "tritanium",
-            "value": 17010
+            "value": 17010000
           }
         ]
       },
-      "build_time": 1778,
+      "build_time": 1778400,
       "increased_power": 2500,
       "level": 38,
       "requirements": [
@@ -659,7 +659,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 20961
+            "value": 20961000
           },
           {
             "type": "tritanium",
@@ -710,15 +710,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 2924
+            "value": 2924000000
           },
           {
             "type": "tritanium",
-            "value": 64500
+            "value": 64500000
           }
         ]
       },
-      "build_time": 3925,
+      "build_time": 3925440,
       "increased_power": 3000,
       "level": 41,
       "requirements": [
@@ -1487,7 +1487,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1591
+            "value": 1591200
           },
           {
             "type": "tritanium",
@@ -1528,7 +1528,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 2486
+            "value": 2486250
           },
           {
             "type": "tritanium",
@@ -1575,7 +1575,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 3794
+            "value": 3794400
           },
           {
             "type": "tritanium",
@@ -1622,7 +1622,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 5691
+            "value": 5691600
           },
           {
             "type": "tritanium",
@@ -1663,7 +1663,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 9061
+            "value": 9061000
           },
           {
             "type": "tritanium",
@@ -1710,7 +1710,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 13260
+            "value": 13260000
           },
           {
             "type": "tritanium",
@@ -1757,11 +1757,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 30277
+            "value": 30277000
           },
           {
             "type": "tritanium",
-            "value": 1335
+            "value": 1335750
           }
         ]
       },
@@ -1808,11 +1808,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 46835
+            "value": 46835000
           },
           {
             "type": "tritanium",
-            "value": 2066
+            "value": 2066250
           }
         ]
       },
@@ -1849,11 +1849,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 73950
+            "value": 73950000
           },
           {
             "type": "tritanium",
-            "value": 3262
+            "value": 3262500
           }
         ]
       },
@@ -1890,15 +1890,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 161262
+            "value": 161262000
           },
           {
             "type": "tritanium",
-            "value": 7114
+            "value": 7114500
           }
         ]
       },
-      "build_time": 1061,
+      "build_time": 1061280,
       "increased_power": 2000,
       "level": 36,
       "requirements": [
@@ -1937,15 +1937,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 2865
+            "value": 2865520000
           },
           {
             "type": "tritanium",
-            "value": 45150
+            "value": 45150000
           }
         ]
       },
-      "build_time": 4188,
+      "build_time": 4188960,
       "increased_power": 3000,
       "level": 40,
       "requirements": [
@@ -1971,15 +1971,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 124950
+            "value": 124950000000
           },
           {
             "type": "tritanium",
-            "value": 2756
+            "value": 2756250000
           }
         ]
       },
-      "build_time": 42189,
+      "build_time": 42189120,
       "increased_power": 5000,
       "level": 50,
       "requirements": [

--- a/buildings/operations.json
+++ b/buildings/operations.json
@@ -31,19 +31,19 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 22399
+            "value": 22399200000
           },
           {
             "type": "tritanium",
-            "value": 205875
+            "value": 205875000
           },
           {
             "type": "dilithium",
-            "value": 68625
+            "value": 68625000
           }
         ]
       },
-      "build_time": 86715,
+      "build_time": 86715360,
       "increased_power": 7000,
       "level": 44,
       "requirements": [
@@ -90,19 +90,19 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 31824
+            "value": 31824000000
           },
           {
             "type": "tritanium",
-            "value": 292500
+            "value": 292500000
           },
           {
             "type": "dilithium",
-            "value": 97500
+            "value": 97500000
           }
         ]
       },
-      "build_time": 111949,
+      "build_time": 111949920,
       "increased_power": 7000,
       "level": 45,
       "requirements": [
@@ -149,19 +149,19 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 43758
+            "value": 43758000000
           },
           {
             "type": "tritanium",
-            "value": 402187
+            "value": 402187500
           },
           {
             "type": "dilithium",
-            "value": 134062
+            "value": 134062500
           }
         ]
       },
-      "build_time": 143101,
+      "build_time": 143101440,
       "increased_power": 8000,
       "level": 46,
       "requirements": [
@@ -208,19 +208,19 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 63648
+            "value": 63648000000
           },
           {
             "type": "tritanium",
-            "value": 585000
+            "value": 585000000
           },
           {
             "type": "dilithium",
-            "value": 195000
+            "value": 195000000
           }
         ]
       },
-      "build_time": 181280,
+      "build_time": 181280160,
       "increased_power": 9000,
       "level": 47,
       "requirements": [
@@ -263,19 +263,19 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 102816
+            "value": 102816000000
           },
           {
             "type": "tritanium",
-            "value": 945000
+            "value": 945000000
           },
           {
             "type": "dilithium",
-            "value": 315000
+            "value": 315000000
           }
         ]
       },
-      "build_time": 227753,
+      "build_time": 227753280,
       "increased_power": 8000,
       "level": 48,
       "requirements": [
@@ -322,19 +322,19 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 171360
+            "value": 171360000000
           },
           {
             "type": "tritanium",
-            "value": 1575
+            "value": 1575000000
           },
           {
             "type": "dilithium",
-            "value": 525000
+            "value": 525000000
           }
         ]
       },
-      "build_time": 283966,
+      "build_time": 283966560,
       "increased_power": 10000,
       "level": 49,
       "requirements": [
@@ -373,19 +373,19 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 299880
+            "value": 299880000000
           },
           {
             "type": "tritanium",
-            "value": 2756
+            "value": 2756250000
           },
           {
             "type": "dilithium",
-            "value": 918750
+            "value": 918750000
           }
         ]
       },
-      "build_time": 351570,
+      "build_time": 351570240,
       "increased_power": 9000,
       "level": 50,
       "requirements": [
@@ -432,7 +432,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 3818
+            "value": 3818880
           },
           {
             "type": "tritanium",
@@ -487,7 +487,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 5967
+            "value": 5967000
           },
           {
             "type": "tritanium",
@@ -499,7 +499,7 @@
           }
         ]
       },
-      "build_time": 1346,
+      "build_time": 1346400,
       "increased_power": 2000,
       "level": 26,
       "requirements": [
@@ -542,7 +542,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 9106
+            "value": 9106560
           },
           {
             "type": "tritanium",
@@ -554,7 +554,7 @@
           }
         ]
       },
-      "build_time": 1533,
+      "build_time": 1533600,
       "increased_power": 2500,
       "level": 27,
       "requirements": [
@@ -597,7 +597,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 13659
+            "value": 13659840
           },
           {
             "type": "tritanium",
@@ -609,7 +609,7 @@
           }
         ]
       },
-      "build_time": 1779,
+      "build_time": 1779840,
       "increased_power": 2500,
       "level": 28,
       "requirements": [
@@ -652,7 +652,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 21746
+            "value": 21746400
           },
           {
             "type": "tritanium",
@@ -664,7 +664,7 @@
           }
         ]
       },
-      "build_time": 1962,
+      "build_time": 1962720,
       "increased_power": 2500,
       "level": 29,
       "requirements": [
@@ -711,7 +711,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 31824
+            "value": 31824000
           },
           {
             "type": "tritanium",
@@ -723,7 +723,7 @@
           }
         ]
       },
-      "build_time": 2128,
+      "build_time": 2128320,
       "increased_power": 3000,
       "level": 30,
       "requirements": [
@@ -770,7 +770,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 50306
+            "value": 50306400
           },
           {
             "type": "tritanium",
@@ -782,7 +782,7 @@
           }
         ]
       },
-      "build_time": 2792,
+      "build_time": 2792160,
       "increased_power": 3000,
       "level": 31,
       "requirements": [
@@ -829,11 +829,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 72664
+            "value": 72664800
           },
           {
             "type": "tritanium",
-            "value": 1335
+            "value": 1335750
           },
           {
             "type": "dilithium",
@@ -841,7 +841,7 @@
           }
         ]
       },
-      "build_time": 2727,
+      "build_time": 2727360,
       "increased_power": 3500,
       "level": 32,
       "requirements": [
@@ -888,11 +888,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 112404
+            "value": 112404000
           },
           {
             "type": "tritanium",
-            "value": 2066
+            "value": 2066250
           },
           {
             "type": "dilithium",
@@ -900,7 +900,7 @@
           }
         ]
       },
-      "build_time": 3964,
+      "build_time": 3964320,
       "increased_power": 3500,
       "level": 33,
       "requirements": [
@@ -947,19 +947,19 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 177480
+            "value": 177480000
           },
           {
             "type": "tritanium",
-            "value": 3262
+            "value": 3262500
           },
           {
             "type": "dilithium",
-            "value": 1087
+            "value": 1087500
           }
         ]
       },
-      "build_time": 5248,
+      "build_time": 5248800,
       "increased_power": 4000,
       "level": 34,
       "requirements": [
@@ -1002,19 +1002,19 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 274665
+            "value": 274665600
           },
           {
             "type": "tritanium",
-            "value": 5049
+            "value": 5049000
           },
           {
             "type": "dilithium",
-            "value": 1683
+            "value": 1683000
           }
         ]
       },
-      "build_time": 6917,
+      "build_time": 6917760,
       "increased_power": 4000,
       "level": 35,
       "requirements": [
@@ -1061,19 +1061,19 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 387028
+            "value": 387028800
           },
           {
             "type": "tritanium",
-            "value": 7114
+            "value": 7114500
           },
           {
             "type": "dilithium",
-            "value": 2371
+            "value": 2371500
           }
         ]
       },
-      "build_time": 8841,
+      "build_time": 8841600,
       "increased_power": 4500,
       "level": 36,
       "requirements": [
@@ -1116,19 +1116,19 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 594864
+            "value": 594864000
           },
           {
             "type": "tritanium",
-            "value": 10935
+            "value": 10935000
           },
           {
             "type": "dilithium",
-            "value": 3645
+            "value": 3645000
           }
         ]
       },
-      "build_time": 9136,
+      "build_time": 9136800,
       "increased_power": 5000,
       "level": 37,
       "requirements": [
@@ -1167,19 +1167,19 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 925344
+            "value": 925344000
           },
           {
             "type": "tritanium",
-            "value": 17010
+            "value": 17010000
           },
           {
             "type": "dilithium",
-            "value": 5670
+            "value": 5670000
           }
         ]
       },
-      "build_time": 14817,
+      "build_time": 14817600,
       "increased_power": 5000,
       "level": 38,
       "requirements": [
@@ -1218,19 +1218,19 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1578
+            "value": 1578960000
           },
           {
             "type": "tritanium",
-            "value": 29025
+            "value": 29025000
           },
           {
             "type": "dilithium",
-            "value": 9675
+            "value": 9675000
           }
         ]
       },
-      "build_time": 19667,
+      "build_time": 19667520,
       "increased_power": 5000,
       "level": 39,
       "requirements": [
@@ -1265,19 +1265,19 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 6877
+            "value": 6877248000
           },
           {
             "type": "tritanium",
-            "value": 45150
+            "value": 45150000
           },
           {
             "type": "dilithium",
-            "value": 15050
+            "value": 15050000
           }
         ]
       },
-      "build_time": 34905,
+      "build_time": 34905600,
       "increased_power": 6000,
       "level": 40,
       "requirements": [
@@ -1314,19 +1314,19 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 7017
+            "value": 7017600000
           },
           {
             "type": "tritanium",
-            "value": 64500
+            "value": 64500000
           },
           {
             "type": "dilithium",
-            "value": 21500
+            "value": 21500000
           }
         ]
       },
-      "build_time": 32713,
+      "build_time": 32713920,
       "increased_power": 6000,
       "level": 41,
       "requirements": [
@@ -1369,19 +1369,19 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 10452
+            "value": 10452960000
           },
           {
             "type": "tritanium",
-            "value": 96075
+            "value": 96075000
           },
           {
             "type": "dilithium",
-            "value": 32025
+            "value": 32025000
           }
         ]
       },
-      "build_time": 50284,
+      "build_time": 50284800,
       "increased_power": 7000,
       "level": 42,
       "requirements": [
@@ -1428,19 +1428,19 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 14932
+            "value": 14932800000
           },
           {
             "type": "tritanium",
-            "value": 137250
+            "value": 137250000
           },
           {
             "type": "dilithium",
-            "value": 45750
+            "value": 45750000
           }
         ]
       },
-      "build_time": 66437,
+      "build_time": 66437280,
       "increased_power": 7000,
       "level": 43,
       "requirements": [
@@ -1916,7 +1916,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1494
+            "value": 1494504
           },
           {
             "type": "tritanium",
@@ -1975,7 +1975,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 2354
+            "value": 2354976
           },
           {
             "type": "tritanium",
@@ -1987,7 +1987,7 @@
           }
         ]
       },
-      "build_time": 1071,
+      "build_time": 1071360,
       "increased_power": 1750,
       "level": 24,
       "requirements": [

--- a/buildings/parsteel_generator_a.json
+++ b/buildings/parsteel_generator_a.json
@@ -30,15 +30,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 15050
+            "value": 15050000
           },
           {
             "type": "dilithium",
-            "value": 15050
+            "value": 15050000
           }
         ]
       },
-      "build_time": 1396,
+      "build_time": 1396800,
       "increased_power": 1000,
       "level": 40,
       "requirements": [
@@ -97,15 +97,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 32025
+            "value": 32025000
           },
           {
             "type": "dilithium",
-            "value": 32025
+            "value": 32025000
           }
         ]
       },
-      "build_time": 2011,
+      "build_time": 2011680,
       "increased_power": 1000,
       "level": 42,
       "requirements": [
@@ -134,15 +134,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 45750
+            "value": 45750000
           },
           {
             "type": "dilithium",
-            "value": 45750
+            "value": 45750000
           }
         ]
       },
-      "build_time": 2656,
+      "build_time": 2656800,
       "increased_power": 1250,
       "level": 43,
       "requirements": [
@@ -171,15 +171,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 68625
+            "value": 68625000
           },
           {
             "type": "dilithium",
-            "value": 68625
+            "value": 68625000
           }
         ]
       },
-      "build_time": 3468,
+      "build_time": 3468960,
       "increased_power": 1250,
       "level": 44,
       "requirements": [
@@ -201,11 +201,11 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 1087
+            "value": 1087500
           },
           {
             "type": "dilithium",
-            "value": 1087
+            "value": 1087500
           }
         ]
       },
@@ -244,15 +244,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 195000
+            "value": 195000000
           },
           {
             "type": "dilithium",
-            "value": 195000
+            "value": 195000000
           }
         ]
       },
-      "build_time": 7251,
+      "build_time": 7251840,
       "increased_power": 1500,
       "level": 47,
       "requirements": [
@@ -287,15 +287,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 134062
+            "value": 134062500
           },
           {
             "type": "dilithium",
-            "value": 134062
+            "value": 134062500
           }
         ]
       },
-      "build_time": 5724,
+      "build_time": 5724000,
       "increased_power": 1250,
       "level": 46,
       "requirements": [
@@ -324,15 +324,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 97500
+            "value": 97500000
           },
           {
             "type": "dilithium",
-            "value": 97500
+            "value": 97500000
           }
         ]
       },
-      "build_time": 4478,
+      "build_time": 4478400,
       "increased_power": 1250,
       "level": 45,
       "requirements": [
@@ -361,15 +361,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 21500
+            "value": 21500000
           },
           {
             "type": "dilithium",
-            "value": 21500
+            "value": 21500000
           }
         ]
       },
-      "build_time": 1308,
+      "build_time": 1308960,
       "increased_power": 1000,
       "level": 41,
       "requirements": [
@@ -404,15 +404,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 315000
+            "value": 315000000
           },
           {
             "type": "dilithium",
-            "value": 315000
+            "value": 315000000
           }
         ]
       },
-      "build_time": 9109,
+      "build_time": 9109440,
       "increased_power": 1500,
       "level": 48,
       "requirements": [
@@ -447,15 +447,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 525000
+            "value": 525000000
           },
           {
             "type": "dilithium",
-            "value": 525000
+            "value": 525000000
           }
         ]
       },
-      "build_time": 11358,
+      "build_time": 11358720,
       "increased_power": 1500,
       "level": 49,
       "requirements": [
@@ -477,15 +477,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 918750
+            "value": 918750000
           },
           {
             "type": "dilithium",
-            "value": 918750
+            "value": 918750000
           }
         ]
       },
-      "build_time": 14063,
+      "build_time": 14063040,
       "increased_power": 1500,
       "level": 50,
       "requirements": [
@@ -507,11 +507,11 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 9675
+            "value": 9675000
           },
           {
             "type": "dilithium",
-            "value": 9675
+            "value": 9675000
           }
         ]
       },
@@ -537,11 +537,11 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 5670
+            "value": 5670000
           },
           {
             "type": "dilithium",
-            "value": 5670
+            "value": 5670000
           }
         ]
       },
@@ -1227,11 +1227,11 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 1683
+            "value": 1683000
           },
           {
             "type": "dilithium",
-            "value": 1683
+            "value": 1683000
           }
         ]
       },
@@ -1257,11 +1257,11 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 2371
+            "value": 2371500
           },
           {
             "type": "dilithium",
-            "value": 2371
+            "value": 2371500
           }
         ]
       },
@@ -1287,11 +1287,11 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 3645
+            "value": 3645000
           },
           {
             "type": "dilithium",
-            "value": 3645
+            "value": 3645000
           }
         ]
       },

--- a/buildings/parsteel_generator_b.json
+++ b/buildings/parsteel_generator_b.json
@@ -30,15 +30,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 15050
+            "value": 15050000
           },
           {
             "type": "dilithium",
-            "value": 15050
+            "value": 15050000
           }
         ]
       },
-      "build_time": 1396,
+      "build_time": 1396800,
       "increased_power": 1000,
       "level": 40,
       "requirements": [
@@ -71,15 +71,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 32025
+            "value": 32025000
           },
           {
             "type": "dilithium",
-            "value": 32025
+            "value": 32025000
           }
         ]
       },
-      "build_time": 2011,
+      "build_time": 2011680,
       "increased_power": 1000,
       "level": 42,
       "requirements": [
@@ -112,15 +112,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 45750
+            "value": 45750000
           },
           {
             "type": "dilithium",
-            "value": 45750
+            "value": 45750000
           }
         ]
       },
-      "build_time": 2656,
+      "build_time": 2656800,
       "increased_power": 1250,
       "level": 43,
       "requirements": [
@@ -153,15 +153,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 68625
+            "value": 68625000
           },
           {
             "type": "dilithium",
-            "value": 68625
+            "value": 68625000
           }
         ]
       },
-      "build_time": 3468,
+      "build_time": 3468960,
       "increased_power": 1250,
       "level": 44,
       "requirements": [
@@ -228,15 +228,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 21500
+            "value": 21500000
           },
           {
             "type": "dilithium",
-            "value": 21500
+            "value": 21500000
           }
         ]
       },
-      "build_time": 1308,
+      "build_time": 1308960,
       "increased_power": 1000,
       "level": 41,
       "requirements": [
@@ -262,11 +262,11 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 5670
+            "value": 5670000
           },
           {
             "type": "dilithium",
-            "value": 5670
+            "value": 5670000
           }
         ]
       },
@@ -296,11 +296,11 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 9675
+            "value": 9675000
           },
           {
             "type": "dilithium",
-            "value": 9675
+            "value": 9675000
           }
         ]
       },
@@ -330,11 +330,11 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 3645
+            "value": 3645000
           },
           {
             "type": "dilithium",
-            "value": 3645
+            "value": 3645000
           }
         ]
       },
@@ -371,15 +371,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 97500
+            "value": 97500000
           },
           {
             "type": "dilithium",
-            "value": 97500
+            "value": 97500000
           }
         ]
       },
-      "build_time": 4478,
+      "build_time": 4478400,
       "increased_power": 1250,
       "level": 45,
       "requirements": [
@@ -418,15 +418,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 134062
+            "value": 134062500
           },
           {
             "type": "dilithium",
-            "value": 134062
+            "value": 134062500
           }
         ]
       },
-      "build_time": 5724,
+      "build_time": 5724000,
       "increased_power": 1250,
       "level": 46,
       "requirements": [
@@ -465,15 +465,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 195000
+            "value": 195000000
           },
           {
             "type": "dilithium",
-            "value": 195000
+            "value": 195000000
           }
         ]
       },
-      "build_time": 7251,
+      "build_time": 7251840,
       "increased_power": 1500,
       "level": 47,
       "requirements": [
@@ -512,15 +512,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 315000
+            "value": 315000000
           },
           {
             "type": "dilithium",
-            "value": 315000
+            "value": 315000000
           }
         ]
       },
-      "build_time": 9109,
+      "build_time": 9109440,
       "increased_power": 1500,
       "level": 48,
       "requirements": [
@@ -559,15 +559,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 525000
+            "value": 525000000
           },
           {
             "type": "dilithium",
-            "value": 525000
+            "value": 525000000
           }
         ]
       },
-      "build_time": 11358,
+      "build_time": 11358720,
       "increased_power": 1500,
       "level": 49,
       "requirements": [
@@ -1341,11 +1341,11 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 1087
+            "value": 1087500
           },
           {
             "type": "dilithium",
-            "value": 1087
+            "value": 1087500
           }
         ]
       },
@@ -1375,11 +1375,11 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 1683
+            "value": 1683000
           },
           {
             "type": "dilithium",
-            "value": 1683
+            "value": 1683000
           }
         ]
       },
@@ -1409,11 +1409,11 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 2371
+            "value": 2371500
           },
           {
             "type": "dilithium",
-            "value": 2371
+            "value": 2371500
           }
         ]
       },
@@ -1443,15 +1443,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 918750
+            "value": 918750000
           },
           {
             "type": "dilithium",
-            "value": 918750
+            "value": 918750000
           }
         ]
       },
-      "build_time": 14063,
+      "build_time": 14063040,
       "increased_power": 1500,
       "level": 50,
       "requirements": [

--- a/buildings/parsteel_generator_c.json
+++ b/buildings/parsteel_generator_c.json
@@ -23,15 +23,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 15050
+            "value": 15050000
           },
           {
             "type": "dilithium",
-            "value": 15050
+            "value": 15050000
           }
         ]
       },
-      "build_time": 1396,
+      "build_time": 1396800,
       "increased_power": 1000,
       "level": 40,
       "requirements": [
@@ -57,15 +57,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 32025
+            "value": 32025000
           },
           {
             "type": "dilithium",
-            "value": 32025
+            "value": 32025000
           }
         ]
       },
-      "build_time": 2011,
+      "build_time": 2011680,
       "increased_power": 1000,
       "level": 42,
       "requirements": [
@@ -91,15 +91,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 21500
+            "value": 21500000
           },
           {
             "type": "dilithium",
-            "value": 21500
+            "value": 21500000
           }
         ]
       },
-      "build_time": 1308,
+      "build_time": 1308960,
       "increased_power": 1000,
       "level": 41,
       "requirements": [
@@ -125,15 +125,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 45750
+            "value": 45750000
           },
           {
             "type": "dilithium",
-            "value": 45750
+            "value": 45750000
           }
         ]
       },
-      "build_time": 2656,
+      "build_time": 2656800,
       "increased_power": 1250,
       "level": 43,
       "requirements": [
@@ -159,15 +159,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 68625
+            "value": 68625000
           },
           {
             "type": "dilithium",
-            "value": 68625
+            "value": 68625000
           }
         ]
       },
-      "build_time": 3468,
+      "build_time": 3468960,
       "increased_power": 1250,
       "level": 44,
       "requirements": [
@@ -193,15 +193,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 97500
+            "value": 97500000
           },
           {
             "type": "dilithium",
-            "value": 97500
+            "value": 97500000
           }
         ]
       },
-      "build_time": 4478,
+      "build_time": 4478400,
       "increased_power": 1250,
       "level": 45,
       "requirements": [
@@ -227,15 +227,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 134062
+            "value": 134062500
           },
           {
             "type": "dilithium",
-            "value": 134062
+            "value": 134062500
           }
         ]
       },
-      "build_time": 5724,
+      "build_time": 5724000,
       "increased_power": 1250,
       "level": 46,
       "requirements": [
@@ -261,15 +261,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 195000
+            "value": 195000000
           },
           {
             "type": "dilithium",
-            "value": 195000
+            "value": 195000000
           }
         ]
       },
-      "build_time": 7251,
+      "build_time": 7251840,
       "increased_power": 1500,
       "level": 47,
       "requirements": [
@@ -295,15 +295,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 315000
+            "value": 315000000
           },
           {
             "type": "dilithium",
-            "value": 315000
+            "value": 315000000
           }
         ]
       },
-      "build_time": 9109,
+      "build_time": 9109440,
       "increased_power": 1500,
       "level": 48,
       "requirements": [
@@ -329,15 +329,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 525000
+            "value": 525000000
           },
           {
             "type": "dilithium",
-            "value": 525000
+            "value": 525000000
           }
         ]
       },
-      "build_time": 11358,
+      "build_time": 11358720,
       "increased_power": 1500,
       "level": 49,
       "requirements": [
@@ -1213,11 +1213,11 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 1087
+            "value": 1087500
           },
           {
             "type": "dilithium",
-            "value": 1087
+            "value": 1087500
           }
         ]
       },
@@ -1247,11 +1247,11 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 1683
+            "value": 1683000
           },
           {
             "type": "dilithium",
-            "value": 1683
+            "value": 1683000
           }
         ]
       },
@@ -1281,11 +1281,11 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 2371
+            "value": 2371500
           },
           {
             "type": "dilithium",
-            "value": 2371
+            "value": 2371500
           }
         ]
       },
@@ -1315,11 +1315,11 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 3645
+            "value": 3645000
           },
           {
             "type": "dilithium",
-            "value": 3645
+            "value": 3645000
           }
         ]
       },
@@ -1349,11 +1349,11 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 5670
+            "value": 5670000
           },
           {
             "type": "dilithium",
-            "value": 5670
+            "value": 5670000
           }
         ]
       },
@@ -1383,11 +1383,11 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 9675
+            "value": 9675000
           },
           {
             "type": "dilithium",
-            "value": 9675
+            "value": 9675000
           }
         ]
       },
@@ -1417,15 +1417,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 918750
+            "value": 918750000
           },
           {
             "type": "dilithium",
-            "value": 918750
+            "value": 918750000
           }
         ]
       },
-      "build_time": 14063,
+      "build_time": 14063040,
       "increased_power": 1500,
       "level": 50,
       "requirements": [

--- a/buildings/parsteel_generator_d.json
+++ b/buildings/parsteel_generator_d.json
@@ -23,15 +23,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 15050
+            "value": 15050000
           },
           {
             "type": "dilithium",
-            "value": 15050
+            "value": 15050000
           }
         ]
       },
-      "build_time": 1396,
+      "build_time": 1396800,
       "increased_power": 1000,
       "level": 40,
       "requirements": [
@@ -57,15 +57,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 32025
+            "value": 32025000
           },
           {
             "type": "dilithium",
-            "value": 32025
+            "value": 32025000
           }
         ]
       },
-      "build_time": 2011,
+      "build_time": 2011680,
       "increased_power": 1000,
       "level": 42,
       "requirements": [
@@ -91,15 +91,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 21500
+            "value": 21500000
           },
           {
             "type": "dilithium",
-            "value": 21500
+            "value": 21500000
           }
         ]
       },
-      "build_time": 1308,
+      "build_time": 1308960,
       "increased_power": 1000,
       "level": 41,
       "requirements": [
@@ -125,15 +125,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 45750
+            "value": 45750000
           },
           {
             "type": "dilithium",
-            "value": 45750
+            "value": 45750000
           }
         ]
       },
-      "build_time": 2656,
+      "build_time": 2656800,
       "increased_power": 1250,
       "level": 43,
       "requirements": [
@@ -159,15 +159,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 68625
+            "value": 68625000
           },
           {
             "type": "dilithium",
-            "value": 68625
+            "value": 68625000
           }
         ]
       },
-      "build_time": 3468,
+      "build_time": 3468960,
       "increased_power": 1250,
       "level": 44,
       "requirements": [
@@ -193,15 +193,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 97500
+            "value": 97500000
           },
           {
             "type": "dilithium",
-            "value": 97500
+            "value": 97500000
           }
         ]
       },
-      "build_time": 4478,
+      "build_time": 4478400,
       "increased_power": 1250,
       "level": 45,
       "requirements": [
@@ -227,15 +227,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 134062
+            "value": 134062500
           },
           {
             "type": "dilithium",
-            "value": 134062
+            "value": 134062500
           }
         ]
       },
-      "build_time": 5724,
+      "build_time": 5724000,
       "increased_power": 1250,
       "level": 46,
       "requirements": [
@@ -261,15 +261,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 195000
+            "value": 195000000
           },
           {
             "type": "dilithium",
-            "value": 195000
+            "value": 195000000
           }
         ]
       },
-      "build_time": 7251,
+      "build_time": 7251840,
       "increased_power": 1500,
       "level": 47,
       "requirements": [
@@ -295,15 +295,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 315000
+            "value": 315000000
           },
           {
             "type": "dilithium",
-            "value": 315000
+            "value": 315000000
           }
         ]
       },
-      "build_time": 9109,
+      "build_time": 9109440,
       "increased_power": 1500,
       "level": 48,
       "requirements": [
@@ -329,15 +329,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 525000
+            "value": 525000000
           },
           {
             "type": "dilithium",
-            "value": 525000
+            "value": 525000000
           }
         ]
       },
-      "build_time": 11358,
+      "build_time": 11358720,
       "increased_power": 1500,
       "level": 49,
       "requirements": [
@@ -941,11 +941,11 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 1087
+            "value": 1087500
           },
           {
             "type": "dilithium",
-            "value": 1087
+            "value": 1087500
           }
         ]
       },
@@ -975,11 +975,11 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 1683
+            "value": 1683000
           },
           {
             "type": "dilithium",
-            "value": 1683
+            "value": 1683000
           }
         ]
       },
@@ -1009,11 +1009,11 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 2371
+            "value": 2371500
           },
           {
             "type": "dilithium",
-            "value": 2371
+            "value": 2371500
           }
         ]
       },
@@ -1043,11 +1043,11 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 3645
+            "value": 3645000
           },
           {
             "type": "dilithium",
-            "value": 3645
+            "value": 3645000
           }
         ]
       },
@@ -1077,11 +1077,11 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 5670
+            "value": 5670000
           },
           {
             "type": "dilithium",
-            "value": 5670
+            "value": 5670000
           }
         ]
       },
@@ -1111,11 +1111,11 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 9675
+            "value": 9675000
           },
           {
             "type": "dilithium",
-            "value": 9675
+            "value": 9675000
           }
         ]
       },
@@ -1145,15 +1145,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 918750
+            "value": 918750000
           },
           {
             "type": "dilithium",
-            "value": 918750
+            "value": 918750000
           }
         ]
       },
-      "build_time": 14063,
+      "build_time": 14063040,
       "increased_power": 1500,
       "level": 50,
       "requirements": [

--- a/buildings/parsteel_generator_e.json
+++ b/buildings/parsteel_generator_e.json
@@ -23,15 +23,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 15050
+            "value": 15050000
           },
           {
             "type": "dilithium",
-            "value": 15050
+            "value": 15050000
           }
         ]
       },
-      "build_time": 1396,
+      "build_time": 1396800,
       "increased_power": 1000,
       "level": 40,
       "requirements": [
@@ -57,15 +57,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 32025
+            "value": 32025000
           },
           {
             "type": "dilithium",
-            "value": 32025
+            "value": 32025000
           }
         ]
       },
-      "build_time": 2011,
+      "build_time": 2011680,
       "increased_power": 1000,
       "level": 42,
       "requirements": [
@@ -91,15 +91,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 21500
+            "value": 21500000
           },
           {
             "type": "dilithium",
-            "value": 21500
+            "value": 21500000
           }
         ]
       },
-      "build_time": 1308,
+      "build_time": 1308960,
       "increased_power": 1000,
       "level": 41,
       "requirements": [
@@ -159,15 +159,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 45750
+            "value": 45750000
           },
           {
             "type": "dilithium",
-            "value": 45750
+            "value": 45750000
           }
         ]
       },
-      "build_time": 2656,
+      "build_time": 2656800,
       "increased_power": 1250,
       "level": 43,
       "requirements": [
@@ -193,15 +193,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 68625
+            "value": 68625000
           },
           {
             "type": "dilithium",
-            "value": 68625
+            "value": 68625000
           }
         ]
       },
-      "build_time": 3468,
+      "build_time": 3468960,
       "increased_power": 1250,
       "level": 44,
       "requirements": [
@@ -227,15 +227,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 97500
+            "value": 97500000
           },
           {
             "type": "dilithium",
-            "value": 97500
+            "value": 97500000
           }
         ]
       },
-      "build_time": 4478,
+      "build_time": 4478400,
       "increased_power": 1250,
       "level": 45,
       "requirements": [
@@ -261,15 +261,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 134062
+            "value": 134062500
           },
           {
             "type": "dilithium",
-            "value": 134062
+            "value": 134062500
           }
         ]
       },
-      "build_time": 5724,
+      "build_time": 5724000,
       "increased_power": 1250,
       "level": 46,
       "requirements": [
@@ -295,15 +295,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 195000
+            "value": 195000000
           },
           {
             "type": "dilithium",
-            "value": 195000
+            "value": 195000000
           }
         ]
       },
-      "build_time": 7251,
+      "build_time": 7251840,
       "increased_power": 1500,
       "level": 47,
       "requirements": [
@@ -329,15 +329,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 315000
+            "value": 315000000
           },
           {
             "type": "dilithium",
-            "value": 315000
+            "value": 315000000
           }
         ]
       },
-      "build_time": 9109,
+      "build_time": 9109440,
       "increased_power": 1500,
       "level": 48,
       "requirements": [
@@ -363,15 +363,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 525000
+            "value": 525000000
           },
           {
             "type": "dilithium",
-            "value": 525000
+            "value": 525000000
           }
         ]
       },
-      "build_time": 11358,
+      "build_time": 11358720,
       "increased_power": 1500,
       "level": 49,
       "requirements": [
@@ -465,11 +465,11 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 1087
+            "value": 1087500
           },
           {
             "type": "dilithium",
-            "value": 1087
+            "value": 1087500
           }
         ]
       },
@@ -499,11 +499,11 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 1683
+            "value": 1683000
           },
           {
             "type": "dilithium",
-            "value": 1683
+            "value": 1683000
           }
         ]
       },
@@ -533,11 +533,11 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 2371
+            "value": 2371500
           },
           {
             "type": "dilithium",
-            "value": 2371
+            "value": 2371500
           }
         ]
       },
@@ -567,11 +567,11 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 3645
+            "value": 3645000
           },
           {
             "type": "dilithium",
-            "value": 3645
+            "value": 3645000
           }
         ]
       },
@@ -601,11 +601,11 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 5670
+            "value": 5670000
           },
           {
             "type": "dilithium",
-            "value": 5670
+            "value": 5670000
           }
         ]
       },
@@ -635,11 +635,11 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 9675
+            "value": 9675000
           },
           {
             "type": "dilithium",
-            "value": 9675
+            "value": 9675000
           }
         ]
       },
@@ -669,15 +669,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 918750
+            "value": 918750000
           },
           {
             "type": "dilithium",
-            "value": 918750
+            "value": 918750000
           }
         ]
       },
-      "build_time": 14063,
+      "build_time": 14063040,
       "increased_power": 1500,
       "level": 50,
       "requirements": [

--- a/buildings/parsteel_generator_f.json
+++ b/buildings/parsteel_generator_f.json
@@ -23,15 +23,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 32025
+            "value": 32025000
           },
           {
             "type": "dilithium",
-            "value": 32025
+            "value": 32025000
           }
         ]
       },
-      "build_time": 2011,
+      "build_time": 2011680,
       "increased_power": 1000,
       "level": 42,
       "requirements": [
@@ -91,15 +91,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 45750
+            "value": 45750000
           },
           {
             "type": "dilithium",
-            "value": 45750
+            "value": 45750000
           }
         ]
       },
-      "build_time": 2656,
+      "build_time": 2656800,
       "increased_power": 1250,
       "level": 43,
       "requirements": [
@@ -125,15 +125,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 68625
+            "value": 68625000
           },
           {
             "type": "dilithium",
-            "value": 68625
+            "value": 68625000
           }
         ]
       },
-      "build_time": 3468,
+      "build_time": 3468960,
       "increased_power": 1250,
       "level": 44,
       "requirements": [
@@ -159,15 +159,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 97500
+            "value": 97500000
           },
           {
             "type": "dilithium",
-            "value": 97500
+            "value": 97500000
           }
         ]
       },
-      "build_time": 4478,
+      "build_time": 4478400,
       "increased_power": 1250,
       "level": 45,
       "requirements": [
@@ -193,15 +193,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 134062
+            "value": 134062500
           },
           {
             "type": "dilithium",
-            "value": 134062
+            "value": 134062500
           }
         ]
       },
-      "build_time": 5724,
+      "build_time": 5724000,
       "increased_power": 1250,
       "level": 46,
       "requirements": [
@@ -227,15 +227,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 195000
+            "value": 195000000
           },
           {
             "type": "dilithium",
-            "value": 195000
+            "value": 195000000
           }
         ]
       },
-      "build_time": 7251,
+      "build_time": 7251840,
       "increased_power": 1500,
       "level": 47,
       "requirements": [
@@ -261,15 +261,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 315000
+            "value": 315000000
           },
           {
             "type": "dilithium",
-            "value": 315000
+            "value": 315000000
           }
         ]
       },
-      "build_time": 9109,
+      "build_time": 9109440,
       "increased_power": 1500,
       "level": 48,
       "requirements": [
@@ -295,15 +295,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 525000
+            "value": 525000000
           },
           {
             "type": "dilithium",
-            "value": 525000
+            "value": 525000000
           }
         ]
       },
-      "build_time": 11358,
+      "build_time": 11358720,
       "increased_power": 1500,
       "level": 49,
       "requirements": [
@@ -329,15 +329,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 918750
+            "value": 918750000
           },
           {
             "type": "dilithium",
-            "value": 918750
+            "value": 918750000
           }
         ]
       },
-      "build_time": 14063,
+      "build_time": 14063040,
       "increased_power": 1500,
       "level": 50,
       "requirements": [

--- a/buildings/parsteel_generator_g.json
+++ b/buildings/parsteel_generator_g.json
@@ -23,15 +23,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 918750
+            "value": 918750000
           },
           {
             "type": "dilithium",
-            "value": 918750
+            "value": 918750000
           }
         ]
       },
-      "build_time": 14063,
+      "build_time": 14063040,
       "increased_power": 1500,
       "level": 50,
       "requirements": [

--- a/buildings/parsteel_generator_h.json
+++ b/buildings/parsteel_generator_h.json
@@ -23,15 +23,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 918750
+            "value": 918750000
           },
           {
             "type": "dilithium",
-            "value": 918750
+            "value": 918750000
           }
         ]
       },
-      "build_time": 14063,
+      "build_time": 14063040,
       "increased_power": 1500,
       "level": 50,
       "requirements": [

--- a/buildings/parsteel_vault.json
+++ b/buildings/parsteel_vault.json
@@ -10,7 +10,7 @@
   "levels": [
     {
       "bonuses": {
-        "bonus1": 47600
+        "bonus1": 47600000
       },
       "build_costs": {
         "materials": [
@@ -25,15 +25,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 7163
+            "value": 7163800000
           },
           {
             "type": "tritanium",
-            "value": 45150
+            "value": 45150000
           }
         ]
       },
-      "build_time": 5584,
+      "build_time": 5584320,
       "increased_power": 3500,
       "level": 40,
       "requirements": [
@@ -58,7 +58,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1135
+            "value": 1135260
           },
           {
             "type": "tritanium",
@@ -83,7 +83,7 @@
     },
     {
       "bonuses": {
-        "bonus1": 64600
+        "bonus1": 64600000
       },
       "build_costs": {
         "materials": [
@@ -98,15 +98,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 7310
+            "value": 7310000000
           },
           {
             "type": "tritanium",
-            "value": 64500
+            "value": 64500000
           }
         ]
       },
-      "build_time": 5234,
+      "build_time": 5234400,
       "increased_power": 4000,
       "level": 41,
       "requirements": [
@@ -123,7 +123,7 @@
     },
     {
       "bonuses": {
-        "bonus1": 85700
+        "bonus1": 85700000
       },
       "build_costs": {
         "materials": [
@@ -144,15 +144,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 10888
+            "value": 10888500000
           },
           {
             "type": "tritanium",
-            "value": 96075
+            "value": 96075000
           }
         ]
       },
-      "build_time": 8045,
+      "build_time": 8045280,
       "increased_power": 4500,
       "level": 42,
       "requirements": [
@@ -169,7 +169,7 @@
     },
     {
       "bonuses": {
-        "bonus1": 115600
+        "bonus1": 115600000
       },
       "build_costs": {
         "materials": [
@@ -190,15 +190,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 15555
+            "value": 15555000000
           },
           {
             "type": "tritanium",
-            "value": 137250
+            "value": 137250000
           }
         ]
       },
-      "build_time": 10630,
+      "build_time": 10630080,
       "increased_power": 4500,
       "level": 43,
       "requirements": [
@@ -215,7 +215,7 @@
     },
     {
       "bonuses": {
-        "bonus1": 163200
+        "bonus1": 163200000
       },
       "build_costs": {
         "materials": [
@@ -236,15 +236,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 23332
+            "value": 23332500000
           },
           {
             "type": "tritanium",
-            "value": 205875
+            "value": 205875000
           }
         ]
       },
-      "build_time": 13874,
+      "build_time": 13874400,
       "increased_power": 5000,
       "level": 44,
       "requirements": [
@@ -261,7 +261,7 @@
     },
     {
       "bonuses": {
-        "bonus1": 1600
+        "bonus1": 1600000
       },
       "build_costs": {
         "materials": [
@@ -282,7 +282,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 27183
+            "value": 27183000
           },
           {
             "type": "tritanium",
@@ -307,7 +307,7 @@
     },
     {
       "bonuses": {
-        "bonus1": 22850
+        "bonus1": 22850000
       },
       "build_costs": {
         "materials": [
@@ -328,15 +328,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1156
+            "value": 1156680000
           },
           {
             "type": "tritanium",
-            "value": 17010
+            "value": 17010000
           }
         ]
       },
-      "build_time": 2370,
+      "build_time": 2370240,
       "increased_power": 3000,
       "level": 38,
       "requirements": [
@@ -357,7 +357,7 @@
     },
     {
       "bonuses": {
-        "bonus1": 353600
+        "bonus1": 353600000
       },
       "build_costs": {
         "materials": [
@@ -378,15 +378,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 66300
+            "value": 66300000000
           },
           {
             "type": "tritanium",
-            "value": 585000
+            "value": 585000000
           }
         ]
       },
-      "build_time": 29004,
+      "build_time": 29004480,
       "increased_power": 6000,
       "level": 47,
       "requirements": [
@@ -407,7 +407,7 @@
     },
     {
       "bonuses": {
-        "bonus1": 261800
+        "bonus1": 261800000
       },
       "build_costs": {
         "materials": [
@@ -428,15 +428,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 45581
+            "value": 45581250000
           },
           {
             "type": "tritanium",
-            "value": 402187
+            "value": 402187500
           }
         ]
       },
-      "build_time": 22896,
+      "build_time": 22896000,
       "increased_power": 5000,
       "level": 46,
       "requirements": [
@@ -453,7 +453,7 @@
     },
     {
       "bonuses": {
-        "bonus1": 204000
+        "bonus1": 204000000
       },
       "build_costs": {
         "materials": [
@@ -468,15 +468,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 33150
+            "value": 33150000000
           },
           {
             "type": "tritanium",
-            "value": 292500
+            "value": 292500000
           }
         ]
       },
-      "build_time": 17912,
+      "build_time": 17912160,
       "increased_power": 5000,
       "level": 45,
       "requirements": [
@@ -530,7 +530,7 @@
     },
     {
       "bonuses": {
-        "bonus1": 3500
+        "bonus1": 3500000
       },
       "build_costs": {
         "materials": [
@@ -545,11 +545,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 90831
+            "value": 90831000
           },
           {
             "type": "tritanium",
-            "value": 1335
+            "value": 1335750
           }
         ]
       },
@@ -1238,7 +1238,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1868
+            "value": 1868130
           },
           {
             "type": "tritanium",
@@ -1271,7 +1271,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 2943
+            "value": 2943720
           },
           {
             "type": "tritanium",
@@ -1317,7 +1317,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 4773
+            "value": 4773600
           },
           {
             "type": "tritanium",
@@ -1357,7 +1357,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 7458
+            "value": 7458750
           },
           {
             "type": "tritanium",
@@ -1382,7 +1382,7 @@
     },
     {
       "bonuses": {
-        "bonus1": 1100
+        "bonus1": 1100000
       },
       "build_costs": {
         "materials": [
@@ -1397,7 +1397,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 11383
+            "value": 11383200
           },
           {
             "type": "tritanium",
@@ -1422,7 +1422,7 @@
     },
     {
       "bonuses": {
-        "bonus1": 1300
+        "bonus1": 1300000
       },
       "build_costs": {
         "materials": [
@@ -1443,7 +1443,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 17074
+            "value": 17074800
           },
           {
             "type": "tritanium",
@@ -1468,7 +1468,7 @@
     },
     {
       "bonuses": {
-        "bonus1": 2000
+        "bonus1": 2000000
       },
       "build_costs": {
         "materials": [
@@ -1483,7 +1483,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 39780
+            "value": 39780000
           },
           {
             "type": "tritanium",
@@ -1508,7 +1508,7 @@
     },
     {
       "bonuses": {
-        "bonus1": 2600
+        "bonus1": 2600000
       },
       "build_costs": {
         "materials": [
@@ -1523,7 +1523,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 62883
+            "value": 62883000
           },
           {
             "type": "tritanium",
@@ -1548,7 +1548,7 @@
     },
     {
       "bonuses": {
-        "bonus1": 4800
+        "bonus1": 4800000
       },
       "build_costs": {
         "materials": [
@@ -1569,11 +1569,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 140505
+            "value": 140505000
           },
           {
             "type": "tritanium",
-            "value": 2066
+            "value": 2066250
           }
         ]
       },
@@ -1594,7 +1594,7 @@
     },
     {
       "bonuses": {
-        "bonus1": 6500
+        "bonus1": 6500000
       },
       "build_costs": {
         "materials": [
@@ -1609,11 +1609,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 221850
+            "value": 221850000
           },
           {
             "type": "tritanium",
-            "value": 3262
+            "value": 3262500
           }
         ]
       },
@@ -1634,7 +1634,7 @@
     },
     {
       "bonuses": {
-        "bonus1": 9000
+        "bonus1": 9000000
       },
       "build_costs": {
         "materials": [
@@ -1649,15 +1649,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 343332
+            "value": 343332000
           },
           {
             "type": "tritanium",
-            "value": 5049
+            "value": 5049000
           }
         ]
       },
-      "build_time": 1107,
+      "build_time": 1107360,
       "increased_power": 2500,
       "level": 35,
       "requirements": [
@@ -1674,7 +1674,7 @@
     },
     {
       "bonuses": {
-        "bonus1": 11800
+        "bonus1": 11800000
       },
       "build_costs": {
         "materials": [
@@ -1695,15 +1695,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 483786
+            "value": 483786000
           },
           {
             "type": "tritanium",
-            "value": 7114
+            "value": 7114500
           }
         ]
       },
-      "build_time": 1414,
+      "build_time": 1414080,
       "increased_power": 3000,
       "level": 36,
       "requirements": [
@@ -1720,7 +1720,7 @@
     },
     {
       "bonuses": {
-        "bonus1": 15900
+        "bonus1": 15900000
       },
       "build_costs": {
         "materials": [
@@ -1735,15 +1735,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 743580
+            "value": 743580000
           },
           {
             "type": "tritanium",
-            "value": 10935
+            "value": 10935000
           }
         ]
       },
-      "build_time": 1461,
+      "build_time": 1461600,
       "increased_power": 3500,
       "level": 37,
       "requirements": [
@@ -1760,7 +1760,7 @@
     },
     {
       "bonuses": {
-        "bonus1": 33650
+        "bonus1": 33650000
       },
       "build_costs": {
         "materials": [],
@@ -1768,15 +1768,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1973
+            "value": 1973700000
           },
           {
             "type": "tritanium",
-            "value": 29025
+            "value": 29025000
           }
         ]
       },
-      "build_time": 3146,
+      "build_time": 3146400,
       "increased_power": 4000,
       "level": 39,
       "requirements": [
@@ -1797,7 +1797,7 @@
     },
     {
       "bonuses": {
-        "bonus1": 489600
+        "bonus1": 489600000
       },
       "build_costs": {
         "materials": [
@@ -1818,15 +1818,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 107100
+            "value": 107100000000
           },
           {
             "type": "tritanium",
-            "value": 945000
+            "value": 945000000
           }
         ]
       },
-      "build_time": 36440,
+      "build_time": 36440640,
       "increased_power": 6000,
       "level": 48,
       "requirements": [
@@ -1843,7 +1843,7 @@
     },
     {
       "bonuses": {
-        "bonus1": 748000
+        "bonus1": 748000000
       },
       "build_costs": {
         "materials": [
@@ -1864,15 +1864,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 178500
+            "value": 178500000000
           },
           {
             "type": "tritanium",
-            "value": 1575
+            "value": 1575000000
           }
         ]
       },
-      "build_time": 45434,
+      "build_time": 45434880,
       "increased_power": 6000,
       "level": 49,
       "requirements": [
@@ -1893,7 +1893,7 @@
     },
     {
       "bonuses": {
-        "bonus1": 1190
+        "bonus1": 1190000000
       },
       "build_costs": {
         "materials": [],
@@ -1901,15 +1901,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 312375
+            "value": 312375000000
           },
           {
             "type": "tritanium",
-            "value": 2756
+            "value": 2756250000
           }
         ]
       },
-      "build_time": 56250,
+      "build_time": 56250720,
       "increased_power": 6000,
       "level": 50,
       "requirements": [

--- a/buildings/parsteel_warehouse.json
+++ b/buildings/parsteel_warehouse.json
@@ -10,7 +10,7 @@
   "levels": [
     {
       "bonuses": {
-        "bonus1": 94500
+        "bonus1": 94500000
       },
       "build_costs": {
         "materials": [
@@ -25,15 +25,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 4298
+            "value": 4298280000
           },
           {
             "type": "tritanium",
-            "value": 15050
+            "value": 15050000
           }
         ]
       },
-      "build_time": 3490,
+      "build_time": 3490560,
       "increased_power": 2000,
       "level": 40,
       "requirements": [
@@ -50,7 +50,7 @@
     },
     {
       "bonuses": {
-        "bonus1": 120000
+        "bonus1": 120000000
       },
       "build_costs": {
         "materials": [
@@ -65,15 +65,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 4386
+            "value": 4386000000
           },
           {
             "type": "tritanium",
-            "value": 21500
+            "value": 21500000
           }
         ]
       },
-      "build_time": 3271,
+      "build_time": 3271680,
       "increased_power": 2000,
       "level": 41,
       "requirements": [
@@ -90,7 +90,7 @@
     },
     {
       "bonuses": {
-        "bonus1": 160000
+        "bonus1": 160000000
       },
       "build_costs": {
         "materials": [
@@ -111,15 +111,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 6533
+            "value": 6533100000
           },
           {
             "type": "tritanium",
-            "value": 32025
+            "value": 32025000
           }
         ]
       },
-      "build_time": 5028,
+      "build_time": 5028480,
       "increased_power": 2000,
       "level": 42,
       "requirements": [
@@ -136,7 +136,7 @@
     },
     {
       "bonuses": {
-        "bonus1": 220000
+        "bonus1": 220000000
       },
       "build_costs": {
         "materials": [
@@ -157,15 +157,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 9333
+            "value": 9333000000
           },
           {
             "type": "tritanium",
-            "value": 45750
+            "value": 45750000
           }
         ]
       },
-      "build_time": 6644,
+      "build_time": 6644160,
       "increased_power": 2500,
       "level": 43,
       "requirements": [
@@ -182,7 +182,7 @@
     },
     {
       "bonuses": {
-        "bonus1": 310000
+        "bonus1": 310000000
       },
       "build_costs": {
         "materials": [
@@ -203,15 +203,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 13999
+            "value": 13999500000
           },
           {
             "type": "tritanium",
-            "value": 68625
+            "value": 68625000
           }
         ]
       },
-      "build_time": 8671,
+      "build_time": 8671680,
       "increased_power": 2500,
       "level": 44,
       "requirements": [
@@ -268,7 +268,7 @@
     },
     {
       "bonuses": {
-        "bonus1": 685000
+        "bonus1": 685000000
       },
       "build_costs": {
         "materials": [
@@ -289,15 +289,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 39780
+            "value": 39780000000
           },
           {
             "type": "tritanium",
-            "value": 195000
+            "value": 195000000
           }
         ]
       },
-      "build_time": 18128,
+      "build_time": 18128160,
       "increased_power": 3000,
       "level": 47,
       "requirements": [
@@ -314,7 +314,7 @@
     },
     {
       "bonuses": {
-        "bonus1": 505000
+        "bonus1": 505000000
       },
       "build_costs": {
         "materials": [
@@ -335,15 +335,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 27348
+            "value": 27348750000
           },
           {
             "type": "tritanium",
-            "value": 134062
+            "value": 134062500
           }
         ]
       },
-      "build_time": 14310,
+      "build_time": 14310720,
       "increased_power": 2500,
       "level": 46,
       "requirements": [
@@ -360,7 +360,7 @@
     },
     {
       "bonuses": {
-        "bonus1": 390000
+        "bonus1": 390000000
       },
       "build_costs": {
         "materials": [
@@ -375,15 +375,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 19890
+            "value": 19890000000
           },
           {
             "type": "tritanium",
-            "value": 97500
+            "value": 97500000
           }
         ]
       },
-      "build_time": 11194,
+      "build_time": 11194560,
       "increased_power": 2500,
       "level": 45,
       "requirements": [
@@ -549,7 +549,7 @@
     },
     {
       "bonuses": {
-        "bonus1": 33500
+        "bonus1": 33500000
       },
       "build_costs": {
         "materials": [
@@ -570,11 +570,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 110925
+            "value": 110925000
           },
           {
             "type": "tritanium",
-            "value": 1087
+            "value": 1087500
           }
         ]
       },
@@ -595,7 +595,7 @@
     },
     {
       "bonuses": {
-        "bonus1": 18500
+        "bonus1": 18500000
       },
       "build_costs": {
         "materials": [
@@ -610,7 +610,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 45415
+            "value": 45415500
           },
           {
             "type": "tritanium",
@@ -1218,7 +1218,7 @@
     },
     {
       "bonuses": {
-        "bonus1": 1300
+        "bonus1": 1300000
       },
       "build_costs": {
         "materials": [
@@ -1233,7 +1233,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1471
+            "value": 1471860
           },
           {
             "type": "tritanium",
@@ -1258,7 +1258,7 @@
     },
     {
       "bonuses": {
-        "bonus1": 1900
+        "bonus1": 1900000
       },
       "build_costs": {
         "materials": [
@@ -1273,7 +1273,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 2386
+            "value": 2386800
           },
           {
             "type": "tritanium",
@@ -1298,7 +1298,7 @@
     },
     {
       "bonuses": {
-        "bonus1": 2800
+        "bonus1": 2800000
       },
       "build_costs": {
         "materials": [
@@ -1319,7 +1319,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 3729
+            "value": 3729375
           },
           {
             "type": "tritanium",
@@ -1344,7 +1344,7 @@
     },
     {
       "bonuses": {
-        "bonus1": 3800
+        "bonus1": 3800000
       },
       "build_costs": {
         "materials": [
@@ -1359,7 +1359,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 5691
+            "value": 5691600
           },
           {
             "type": "tritanium",
@@ -1384,7 +1384,7 @@
     },
     {
       "bonuses": {
-        "bonus1": 5300
+        "bonus1": 5300000
       },
       "build_costs": {
         "materials": [
@@ -1399,7 +1399,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 8537
+            "value": 8537400
           },
           {
             "type": "tritanium",
@@ -1424,7 +1424,7 @@
     },
     {
       "bonuses": {
-        "bonus1": 7550
+        "bonus1": 7550000
       },
       "build_costs": {
         "materials": [
@@ -1445,7 +1445,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 13591
+            "value": 13591500
           },
           {
             "type": "tritanium",
@@ -1470,7 +1470,7 @@
     },
     {
       "bonuses": {
-        "bonus1": 10000
+        "bonus1": 10000000
       },
       "build_costs": {
         "materials": [
@@ -1485,7 +1485,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 19890
+            "value": 19890000
           },
           {
             "type": "tritanium",
@@ -1510,7 +1510,7 @@
     },
     {
       "bonuses": {
-        "bonus1": 14000
+        "bonus1": 14000000
       },
       "build_costs": {
         "materials": [
@@ -1531,7 +1531,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 31441
+            "value": 31441500
           },
           {
             "type": "tritanium",
@@ -1556,7 +1556,7 @@
     },
     {
       "bonuses": {
-        "bonus1": 24000
+        "bonus1": 24000000
       },
       "build_costs": {
         "materials": [
@@ -1571,7 +1571,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 70252
+            "value": 70252500
           },
           {
             "type": "tritanium",
@@ -1596,7 +1596,7 @@
     },
     {
       "bonuses": {
-        "bonus1": 43000
+        "bonus1": 43000000
       },
       "build_costs": {
         "materials": [
@@ -1611,11 +1611,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 171666
+            "value": 171666000
           },
           {
             "type": "tritanium",
-            "value": 1683
+            "value": 1683000
           }
         ]
       },
@@ -1636,7 +1636,7 @@
     },
     {
       "bonuses": {
-        "bonus1": 51500
+        "bonus1": 51500000
       },
       "build_costs": {
         "materials": [
@@ -1657,11 +1657,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 241893
+            "value": 241893000
           },
           {
             "type": "tritanium",
-            "value": 2371
+            "value": 2371500
           }
         ]
       },
@@ -1682,7 +1682,7 @@
     },
     {
       "bonuses": {
-        "bonus1": 62000
+        "bonus1": 62000000
       },
       "build_costs": {
         "materials": [
@@ -1697,11 +1697,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 371790
+            "value": 371790000
           },
           {
             "type": "tritanium",
-            "value": 3645
+            "value": 3645000
           }
         ]
       },
@@ -1722,7 +1722,7 @@
     },
     {
       "bonuses": {
-        "bonus1": 76000
+        "bonus1": 76000000
       },
       "build_costs": {
         "materials": [
@@ -1743,15 +1743,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 578340
+            "value": 578340000
           },
           {
             "type": "tritanium",
-            "value": 5670
+            "value": 5670000
           }
         ]
       },
-      "build_time": 1481,
+      "build_time": 1481760,
       "increased_power": 1750,
       "level": 38,
       "requirements": [
@@ -1768,7 +1768,7 @@
     },
     {
       "bonuses": {
-        "bonus1": 90000
+        "bonus1": 90000000
       },
       "build_costs": {
         "materials": [],
@@ -1776,15 +1776,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 986850
+            "value": 986850000
           },
           {
             "type": "tritanium",
-            "value": 9675
+            "value": 9675000
           }
         ]
       },
-      "build_time": 1967,
+      "build_time": 1967040,
       "increased_power": 1500,
       "level": 39,
       "requirements": [
@@ -1801,7 +1801,7 @@
     },
     {
       "bonuses": {
-        "bonus1": 960000
+        "bonus1": 960000000
       },
       "build_costs": {
         "materials": [
@@ -1822,15 +1822,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 64260
+            "value": 64260000000
           },
           {
             "type": "tritanium",
-            "value": 315000
+            "value": 315000000
           }
         ]
       },
-      "build_time": 22775,
+      "build_time": 22775040,
       "increased_power": 3000,
       "level": 48,
       "requirements": [
@@ -1847,7 +1847,7 @@
     },
     {
       "bonuses": {
-        "bonus1": 1500
+        "bonus1": 1500000000
       },
       "build_costs": {
         "materials": [
@@ -1868,15 +1868,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 107100
+            "value": 107100000000
           },
           {
             "type": "tritanium",
-            "value": 525000
+            "value": 525000000
           }
         ]
       },
-      "build_time": 28396,
+      "build_time": 28396800,
       "increased_power": 3000,
       "level": 49,
       "requirements": [
@@ -1893,7 +1893,7 @@
     },
     {
       "bonuses": {
-        "bonus1": 2400
+        "bonus1": 2400000000
       },
       "build_costs": {
         "materials": [],
@@ -1901,15 +1901,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 187425
+            "value": 187425000000
           },
           {
             "type": "tritanium",
-            "value": 918750
+            "value": 918750000
           }
         ]
       },
-      "build_time": 35157,
+      "build_time": 35157600,
       "increased_power": 3000,
       "level": 50,
       "requirements": [

--- a/buildings/r_d_department.json
+++ b/buildings/r_d_department.json
@@ -31,7 +31,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 88740
+            "value": 88740000
           },
           {
             "type": "dilithium",
@@ -39,7 +39,7 @@
           }
         ]
       },
-      "build_time": 2099,
+      "build_time": 2099520,
       "increased_power": 2250,
       "level": 34,
       "requirements": [
@@ -71,15 +71,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 3438
+            "value": 3438624000
           },
           {
             "type": "dilithium",
-            "value": 9030
+            "value": 9030000
           }
         ]
       },
-      "build_time": 13962,
+      "build_time": 13962240,
       "increased_power": 3000,
       "level": 40,
       "requirements": [
@@ -117,15 +117,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 3508
+            "value": 3508800000
           },
           {
             "type": "dilithium",
-            "value": 12900
+            "value": 12900000
           }
         ]
       },
-      "build_time": 13085,
+      "build_time": 13085280,
       "increased_power": 3000,
       "level": 41,
       "requirements": [
@@ -167,15 +167,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 462672
+            "value": 462672000
           },
           {
             "type": "dilithium",
-            "value": 3402
+            "value": 3402000
           }
         ]
       },
-      "build_time": 5927,
+      "build_time": 5927040,
       "increased_power": 2500,
       "level": 38,
       "requirements": [
@@ -213,15 +213,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 5226
+            "value": 5226480000
           },
           {
             "type": "dilithium",
-            "value": 19215
+            "value": 19215000
           }
         ]
       },
-      "build_time": 20113,
+      "build_time": 20113920,
       "increased_power": 3500,
       "level": 42,
       "requirements": [
@@ -263,15 +263,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 7466
+            "value": 7466400000
           },
           {
             "type": "dilithium",
-            "value": 27450
+            "value": 27450000
           }
         ]
       },
-      "build_time": 26575,
+      "build_time": 26575200,
       "increased_power": 3500,
       "level": 43,
       "requirements": [
@@ -313,15 +313,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 11199
+            "value": 11199600000
           },
           {
             "type": "dilithium",
-            "value": 41175
+            "value": 41175000
           }
         ]
       },
-      "build_time": 34686,
+      "build_time": 34686720,
       "increased_power": 3500,
       "level": 44,
       "requirements": [
@@ -363,15 +363,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 21879
+            "value": 21879000000
           },
           {
             "type": "dilithium",
-            "value": 80437
+            "value": 80437500
           }
         ]
       },
-      "build_time": 57241,
+      "build_time": 57241440,
       "increased_power": 4000,
       "level": 46,
       "requirements": [
@@ -409,15 +409,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 193514
+            "value": 193514400
           },
           {
             "type": "dilithium",
-            "value": 1422
+            "value": 1422900
           }
         ]
       },
-      "build_time": 3536,
+      "build_time": 3536640,
       "increased_power": 2000,
       "level": 36,
       "requirements": [
@@ -459,15 +459,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 297432
+            "value": 297432000
           },
           {
             "type": "dilithium",
-            "value": 2187
+            "value": 2187000
           }
         ]
       },
-      "build_time": 3654,
+      "build_time": 3654720,
       "increased_power": 2500,
       "level": 37,
       "requirements": [
@@ -509,15 +509,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 137332
+            "value": 137332800
           },
           {
             "type": "dilithium",
-            "value": 1009
+            "value": 1009800
           }
         ]
       },
-      "build_time": 2767,
+      "build_time": 2767680,
       "increased_power": 2000,
       "level": 35,
       "requirements": [
@@ -1384,7 +1384,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1177
+            "value": 1177488
           },
           {
             "type": "dilithium",
@@ -1434,7 +1434,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1909
+            "value": 1909440
           },
           {
             "type": "dilithium",
@@ -1484,7 +1484,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 2983
+            "value": 2983500
           },
           {
             "type": "dilithium",
@@ -1530,7 +1530,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 4553
+            "value": 4553280
           },
           {
             "type": "dilithium",
@@ -1580,7 +1580,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 6829
+            "value": 6829920
           },
           {
             "type": "dilithium",
@@ -1630,7 +1630,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 10873
+            "value": 10873200
           },
           {
             "type": "dilithium",
@@ -1680,7 +1680,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 15912
+            "value": 15912000
           },
           {
             "type": "dilithium",
@@ -1730,7 +1730,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 25153
+            "value": 25153200
           },
           {
             "type": "dilithium",
@@ -1738,7 +1738,7 @@
           }
         ]
       },
-      "build_time": 1117,
+      "build_time": 1117440,
       "increased_power": 1500,
       "level": 31,
       "requirements": [
@@ -1780,7 +1780,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 36332
+            "value": 36332400
           },
           {
             "type": "dilithium",
@@ -1788,7 +1788,7 @@
           }
         ]
       },
-      "build_time": 1091,
+      "build_time": 1091520,
       "increased_power": 1750,
       "level": 32,
       "requirements": [
@@ -1826,7 +1826,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 56202
+            "value": 56202000
           },
           {
             "type": "dilithium",
@@ -1834,7 +1834,7 @@
           }
         ]
       },
-      "build_time": 1585,
+      "build_time": 1585440,
       "increased_power": 1750,
       "level": 33,
       "requirements": [
@@ -1872,15 +1872,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 789480
+            "value": 789480000
           },
           {
             "type": "dilithium",
-            "value": 5805
+            "value": 5805000
           }
         ]
       },
-      "build_time": 7866,
+      "build_time": 7866720,
       "increased_power": 2500,
       "level": 39,
       "requirements": [
@@ -1918,15 +1918,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 15912
+            "value": 15912000000
           },
           {
             "type": "dilithium",
-            "value": 58500
+            "value": 58500000
           }
         ]
       },
-      "build_time": 44779,
+      "build_time": 44779680,
       "increased_power": 3500,
       "level": 45,
       "requirements": [
@@ -1964,15 +1964,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 31824
+            "value": 31824000000
           },
           {
             "type": "dilithium",
-            "value": 117000
+            "value": 117000000
           }
         ]
       },
-      "build_time": 72511,
+      "build_time": 72511200,
       "increased_power": 4000,
       "level": 47,
       "requirements": [
@@ -2014,15 +2014,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 51408
+            "value": 51408000000
           },
           {
             "type": "dilithium",
-            "value": 189000
+            "value": 189000000
           }
         ]
       },
-      "build_time": 91101,
+      "build_time": 91101600,
       "increased_power": 5000,
       "level": 48,
       "requirements": [
@@ -2060,15 +2060,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 85680
+            "value": 85680000000
           },
           {
             "type": "dilithium",
-            "value": 315000
+            "value": 315000000
           }
         ]
       },
-      "build_time": 113587,
+      "build_time": 113587200,
       "increased_power": 4000,
       "level": 49,
       "requirements": [
@@ -2097,15 +2097,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 149940
+            "value": 149940000000
           },
           {
             "type": "dilithium",
-            "value": 551250
+            "value": 551250000
           }
         ]
       },
-      "build_time": 140627,
+      "build_time": 140627520,
       "increased_power": 5000,
       "level": 50,
       "requirements": [

--- a/buildings/refinery.json
+++ b/buildings/refinery.json
@@ -16,15 +16,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 2865
+            "value": 2865520000
           },
           {
             "type": "dilithium",
-            "value": 18060
+            "value": 18060000
           }
         ]
       },
-      "build_time": 8377,
+      "build_time": 8377920,
       "increased_power": 3000,
       "level": 40,
       "requirements": [
@@ -58,15 +58,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 2924
+            "value": 2924000000
           },
           {
             "type": "dilithium",
-            "value": 25800
+            "value": 25800000
           }
         ]
       },
-      "build_time": 7850,
+      "build_time": 7850880,
       "increased_power": 3000,
       "level": 41,
       "requirements": [
@@ -100,15 +100,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 114444
+            "value": 114444000
           },
           {
             "type": "dilithium",
-            "value": 2019
+            "value": 2019600
           }
         ]
       },
-      "build_time": 1660,
+      "build_time": 1660320,
       "increased_power": 2000,
       "level": 35,
       "requirements": [
@@ -142,15 +142,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 4355
+            "value": 4355400000
           },
           {
             "type": "dilithium",
-            "value": 38430
+            "value": 38430000
           }
         ]
       },
-      "build_time": 12068,
+      "build_time": 12068640,
       "increased_power": 3500,
       "level": 42,
       "requirements": [
@@ -184,15 +184,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 6222
+            "value": 6222000000
           },
           {
             "type": "dilithium",
-            "value": 54900
+            "value": 54900000
           }
         ]
       },
-      "build_time": 15945,
+      "build_time": 15945120,
       "increased_power": 3500,
       "level": 43,
       "requirements": [
@@ -226,15 +226,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 9333
+            "value": 9333000000
           },
           {
             "type": "dilithium",
-            "value": 82350
+            "value": 82350000
           }
         ]
       },
-      "build_time": 20812,
+      "build_time": 20812320,
       "increased_power": 3500,
       "level": 44,
       "requirements": [
@@ -274,15 +274,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 71400
+            "value": 71400000000
           },
           {
             "type": "dilithium",
-            "value": 630000
+            "value": 630000000
           }
         ]
       },
-      "build_time": 68152,
+      "build_time": 68152320,
       "increased_power": 4000,
       "level": 49,
       "requirements": [
@@ -326,15 +326,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 42840
+            "value": 42840000000
           },
           {
             "type": "dilithium",
-            "value": 378000
+            "value": 378000000
           }
         ]
       },
-      "build_time": 54660,
+      "build_time": 54660960,
       "increased_power": 5000,
       "level": 48,
       "requirements": [
@@ -374,15 +374,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 26520
+            "value": 26520000000
           },
           {
             "type": "dilithium",
-            "value": 234000
+            "value": 234000000
           }
         ]
       },
-      "build_time": 43506,
+      "build_time": 43506720,
       "increased_power": 4000,
       "level": 47,
       "requirements": [
@@ -422,15 +422,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 18232
+            "value": 18232500000
           },
           {
             "type": "dilithium",
-            "value": 160875
+            "value": 160875000
           }
         ]
       },
-      "build_time": 34344,
+      "build_time": 34344000,
       "increased_power": 4000,
       "level": 46,
       "requirements": [
@@ -470,15 +470,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 657900
+            "value": 657900000
           },
           {
             "type": "dilithium",
-            "value": 11610
+            "value": 11610000
           }
         ]
       },
-      "build_time": 4720,
+      "build_time": 4720320,
       "increased_power": 2500,
       "level": 39,
       "requirements": [
@@ -512,7 +512,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1591
+            "value": 1591200
           },
           {
             "type": "dilithium",
@@ -554,15 +554,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 13260
+            "value": 13260000000
           },
           {
             "type": "dilithium",
-            "value": 117000
+            "value": 117000000
           }
         ]
       },
-      "build_time": 26867,
+      "build_time": 26867520,
       "increased_power": 3500,
       "level": 45,
       "requirements": [
@@ -606,15 +606,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 385560
+            "value": 385560000
           },
           {
             "type": "dilithium",
-            "value": 6804
+            "value": 6804000
           }
         ]
       },
-      "build_time": 3556,
+      "build_time": 3556800,
       "increased_power": 2500,
       "level": 38,
       "requirements": [
@@ -648,7 +648,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 20961
+            "value": 20961000
           },
           {
             "type": "dilithium",
@@ -1496,7 +1496,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 2486
+            "value": 2486250
           },
           {
             "type": "dilithium",
@@ -1538,7 +1538,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 3794
+            "value": 3794400
           },
           {
             "type": "dilithium",
@@ -1586,7 +1586,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 5691
+            "value": 5691600
           },
           {
             "type": "dilithium",
@@ -1634,7 +1634,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 9061
+            "value": 9061000
           },
           {
             "type": "dilithium",
@@ -1682,7 +1682,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 13260
+            "value": 13260000
           },
           {
             "type": "dilithium",
@@ -1730,7 +1730,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 30277
+            "value": 30277000
           },
           {
             "type": "dilithium",
@@ -1778,7 +1778,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 46835
+            "value": 46835000
           },
           {
             "type": "dilithium",
@@ -1826,15 +1826,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 73950
+            "value": 73950000
           },
           {
             "type": "dilithium",
-            "value": 1305
+            "value": 1305000
           }
         ]
       },
-      "build_time": 1260,
+      "build_time": 1260000,
       "increased_power": 2250,
       "level": 34,
       "requirements": [
@@ -1874,15 +1874,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 161262
+            "value": 161262000
           },
           {
             "type": "dilithium",
-            "value": 2845
+            "value": 2845800
           }
         ]
       },
-      "build_time": 2121,
+      "build_time": 2121120,
       "increased_power": 2000,
       "level": 36,
       "requirements": [
@@ -1922,15 +1922,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 247860
+            "value": 247860000
           },
           {
             "type": "dilithium",
-            "value": 4374
+            "value": 4374000
           }
         ]
       },
-      "build_time": 2193,
+      "build_time": 2193120,
       "increased_power": 2500,
       "level": 37,
       "requirements": [
@@ -1957,15 +1957,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 124950
+            "value": 124950000000
           },
           {
             "type": "dilithium",
-            "value": 1102
+            "value": 1102500000
           }
         ]
       },
-      "build_time": 84376,
+      "build_time": 84376800,
       "increased_power": 5000,
       "level": 50,
       "requirements": [

--- a/buildings/science_lab.json
+++ b/buildings/science_lab.json
@@ -30,15 +30,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 247860
+            "value": 247860000
           },
           {
             "type": "dilithium",
-            "value": 2187
+            "value": 2187000
           }
         ]
       },
-      "build_time": 1095,
+      "build_time": 1095840,
       "increased_power": 2500,
       "level": 37,
       "requirements": [
@@ -77,15 +77,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 4355
+            "value": 4355400000
           },
           {
             "type": "dilithium",
-            "value": 19215
+            "value": 19215000
           }
         ]
       },
-      "build_time": 6033,
+      "build_time": 6033600,
       "increased_power": 3500,
       "level": 42,
       "requirements": [
@@ -124,15 +124,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 6222
+            "value": 6222000000
           },
           {
             "type": "dilithium",
-            "value": 27450
+            "value": 27450000
           }
         ]
       },
-      "build_time": 7971,
+      "build_time": 7971840,
       "increased_power": 3500,
       "level": 43,
       "requirements": [
@@ -171,15 +171,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 9333
+            "value": 9333000000
           },
           {
             "type": "dilithium",
-            "value": 41175
+            "value": 41175000
           }
         ]
       },
-      "build_time": 10405,
+      "build_time": 10405440,
       "increased_power": 3500,
       "level": 44,
       "requirements": [
@@ -212,11 +212,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 114444
+            "value": 114444000
           },
           {
             "type": "dilithium",
-            "value": 1009
+            "value": 1009800
           }
         ]
       },
@@ -259,15 +259,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 13260
+            "value": 13260000000
           },
           {
             "type": "dilithium",
-            "value": 58500
+            "value": 58500000
           }
         ]
       },
-      "build_time": 13433,
+      "build_time": 13433760,
       "increased_power": 3500,
       "level": 45,
       "requirements": [
@@ -306,15 +306,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 2924
+            "value": 2924000000
           },
           {
             "type": "dilithium",
-            "value": 12900
+            "value": 12900000
           }
         ]
       },
-      "build_time": 3925,
+      "build_time": 3925440,
       "increased_power": 3000,
       "level": 41,
       "requirements": [
@@ -353,15 +353,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 71400
+            "value": 71400000000
           },
           {
             "type": "dilithium",
-            "value": 315000
+            "value": 315000000
           }
         ]
       },
-      "build_time": 34076,
+      "build_time": 34076160,
       "increased_power": 4000,
       "level": 49,
       "requirements": [
@@ -404,15 +404,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 42840
+            "value": 42840000000
           },
           {
             "type": "dilithium",
-            "value": 189000
+            "value": 189000000
           }
         ]
       },
-      "build_time": 27329,
+      "build_time": 27329760,
       "increased_power": 5000,
       "level": 48,
       "requirements": [
@@ -451,15 +451,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 26520
+            "value": 26520000000
           },
           {
             "type": "dilithium",
-            "value": 117000
+            "value": 117000000
           }
         ]
       },
-      "build_time": 21754,
+      "build_time": 21754080,
       "increased_power": 4000,
       "level": 47,
       "requirements": [
@@ -498,15 +498,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 18232
+            "value": 18232500000
           },
           {
             "type": "dilithium",
-            "value": 80437
+            "value": 80437500
           }
         ]
       },
-      "build_time": 17172,
+      "build_time": 17172000,
       "increased_power": 4000,
       "level": 46,
       "requirements": [
@@ -545,15 +545,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 657900
+            "value": 657900000
           },
           {
             "type": "dilithium",
-            "value": 5805
+            "value": 5805000
           }
         ]
       },
-      "build_time": 2360,
+      "build_time": 2360160,
       "increased_power": 2500,
       "level": 39,
       "requirements": [
@@ -596,7 +596,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 20961
+            "value": 20961000
           },
           {
             "type": "dilithium",
@@ -1424,7 +1424,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1591
+            "value": 1591200
           },
           {
             "type": "dilithium",
@@ -1465,7 +1465,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 2486
+            "value": 2486250
           },
           {
             "type": "dilithium",
@@ -1512,7 +1512,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 3794
+            "value": 3794400
           },
           {
             "type": "dilithium",
@@ -1559,7 +1559,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 5691
+            "value": 5691600
           },
           {
             "type": "dilithium",
@@ -1600,7 +1600,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 9061
+            "value": 9061000
           },
           {
             "type": "dilithium",
@@ -1647,7 +1647,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 13260
+            "value": 13260000
           },
           {
             "type": "dilithium",
@@ -1688,7 +1688,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 30277
+            "value": 30277000
           },
           {
             "type": "dilithium",
@@ -1735,7 +1735,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 46835
+            "value": 46835000
           },
           {
             "type": "dilithium",
@@ -1782,7 +1782,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 73950
+            "value": 73950000
           },
           {
             "type": "dilithium",
@@ -1829,15 +1829,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 161262
+            "value": 161262000
           },
           {
             "type": "dilithium",
-            "value": 1422
+            "value": 1422900
           }
         ]
       },
-      "build_time": 1061,
+      "build_time": 1061280,
       "increased_power": 2000,
       "level": 36,
       "requirements": [
@@ -1876,15 +1876,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 385560
+            "value": 385560000
           },
           {
             "type": "dilithium",
-            "value": 3402
+            "value": 3402000
           }
         ]
       },
-      "build_time": 1778,
+      "build_time": 1778400,
       "increased_power": 2500,
       "level": 38,
       "requirements": [
@@ -1923,15 +1923,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 2865
+            "value": 2865520000
           },
           {
             "type": "dilithium",
-            "value": 9030
+            "value": 9030000
           }
         ]
       },
-      "build_time": 4188,
+      "build_time": 4188960,
       "increased_power": 3000,
       "level": 40,
       "requirements": [
@@ -1957,15 +1957,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 124950
+            "value": 124950000000
           },
           {
             "type": "dilithium",
-            "value": 551250
+            "value": 551250000
           }
         ]
       },
-      "build_time": 42189,
+      "build_time": 42189120,
       "increased_power": 5000,
       "level": 50,
       "requirements": [

--- a/buildings/scrapyard.json
+++ b/buildings/scrapyard.json
@@ -18,15 +18,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 221850
+            "value": 221850000
           },
           {
             "type": "tritanium",
-            "value": 4350
+            "value": 4350000
           }
         ]
       },
-      "build_time": 2099,
+      "build_time": 2099520,
       "increased_power": 1250,
       "level": 34,
       "requirements": [
@@ -51,15 +51,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 343332
+            "value": 343332000
           },
           {
             "type": "tritanium",
-            "value": 6732
+            "value": 6732000
           }
         ]
       },
-      "build_time": 2767,
+      "build_time": 2767680,
       "increased_power": 1250,
       "level": 35,
       "requirements": [
@@ -91,15 +91,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 214200
+            "value": 214200000000
           },
           {
             "type": "tritanium",
-            "value": 2100
+            "value": 2100000000
           }
         ]
       },
-      "build_time": 113587,
+      "build_time": 113587200,
       "increased_power": 3000,
       "level": 49,
       "requirements": [
@@ -131,15 +131,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 128520
+            "value": 128520000000
           },
           {
             "type": "tritanium",
-            "value": 1260
+            "value": 1260000000
           }
         ]
       },
-      "build_time": 91101,
+      "build_time": 91101600,
       "increased_power": 3000,
       "level": 48,
       "requirements": [
@@ -171,15 +171,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 79560
+            "value": 79560000000
           },
           {
             "type": "tritanium",
-            "value": 780000
+            "value": 780000000
           }
         ]
       },
-      "build_time": 72511,
+      "build_time": 72511200,
       "increased_power": 3000,
       "level": 47,
       "requirements": [
@@ -211,15 +211,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 54697
+            "value": 54697500000
           },
           {
             "type": "tritanium",
-            "value": 536250
+            "value": 536250000
           }
         ]
       },
-      "build_time": 57241,
+      "build_time": 57241440,
       "increased_power": 2500,
       "level": 46,
       "requirements": [
@@ -251,15 +251,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 39780
+            "value": 39780000000
           },
           {
             "type": "tritanium",
-            "value": 390000
+            "value": 390000000
           }
         ]
       },
-      "build_time": 44779,
+      "build_time": 44779680,
       "increased_power": 2500,
       "level": 45,
       "requirements": [
@@ -291,15 +291,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 27999
+            "value": 27999000000
           },
           {
             "type": "tritanium",
-            "value": 274500
+            "value": 274500000
           }
         ]
       },
-      "build_time": 34686,
+      "build_time": 34686720,
       "increased_power": 2500,
       "level": 44,
       "requirements": [
@@ -331,15 +331,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 18666
+            "value": 18666000000
           },
           {
             "type": "tritanium",
-            "value": 183000
+            "value": 183000000
           }
         ]
       },
-      "build_time": 26575,
+      "build_time": 26575200,
       "increased_power": 2500,
       "level": 43,
       "requirements": [
@@ -371,15 +371,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 13066
+            "value": 13066200000
           },
           {
             "type": "tritanium",
-            "value": 128100
+            "value": 128100000
           }
         ]
       },
-      "build_time": 20113,
+      "build_time": 20113920,
       "increased_power": 2000,
       "level": 42,
       "requirements": [
@@ -411,15 +411,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 8772
+            "value": 8772000000
           },
           {
             "type": "tritanium",
-            "value": 86000
+            "value": 86000000
           }
         ]
       },
-      "build_time": 13085,
+      "build_time": 13085280,
       "increased_power": 2000,
       "level": 41,
       "requirements": [
@@ -451,15 +451,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 8596
+            "value": 8596560000
           },
           {
             "type": "tritanium",
-            "value": 60200
+            "value": 60200000
           }
         ]
       },
-      "build_time": 13962,
+      "build_time": 13962240,
       "increased_power": 2000,
       "level": 40,
       "requirements": [
@@ -484,15 +484,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1973
+            "value": 1973700000
           },
           {
             "type": "tritanium",
-            "value": 38700
+            "value": 38700000
           }
         ]
       },
-      "build_time": 7866,
+      "build_time": 7866720,
       "increased_power": 1500,
       "level": 39,
       "requirements": [
@@ -517,15 +517,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1156
+            "value": 1156680000
           },
           {
             "type": "tritanium",
-            "value": 22680
+            "value": 22680000
           }
         ]
       },
-      "build_time": 5927,
+      "build_time": 5927040,
       "increased_power": 1750,
       "level": 38,
       "requirements": [
@@ -550,15 +550,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 743580
+            "value": 743580000
           },
           {
             "type": "tritanium",
-            "value": 14580
+            "value": 14580000
           }
         ]
       },
-      "build_time": 3654,
+      "build_time": 3654720,
       "increased_power": 1750,
       "level": 37,
       "requirements": [
@@ -583,7 +583,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 4773
+            "value": 4773600
           },
           {
             "type": "tritanium",
@@ -1281,7 +1281,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1135
+            "value": 1135260
           },
           {
             "type": "tritanium",
@@ -1314,7 +1314,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1868
+            "value": 1868130
           },
           {
             "type": "tritanium",
@@ -1347,7 +1347,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 2943
+            "value": 2943720
           },
           {
             "type": "tritanium",
@@ -1380,7 +1380,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 7458
+            "value": 7458750
           },
           {
             "type": "tritanium",
@@ -1413,7 +1413,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 11383
+            "value": 11383200
           },
           {
             "type": "tritanium",
@@ -1446,7 +1446,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 17074
+            "value": 17074800
           },
           {
             "type": "tritanium",
@@ -1479,7 +1479,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 27183
+            "value": 27183000
           },
           {
             "type": "tritanium",
@@ -1512,7 +1512,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 39780
+            "value": 39780000
           },
           {
             "type": "tritanium",
@@ -1545,15 +1545,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 62883
+            "value": 62883000
           },
           {
             "type": "tritanium",
-            "value": 1233
+            "value": 1233000
           }
         ]
       },
-      "build_time": 1117,
+      "build_time": 1117440,
       "increased_power": 1000,
       "level": 31,
       "requirements": [
@@ -1578,15 +1578,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 90831
+            "value": 90831000
           },
           {
             "type": "tritanium",
-            "value": 1781
+            "value": 1781000
           }
         ]
       },
-      "build_time": 1091,
+      "build_time": 1091520,
       "increased_power": 1250,
       "level": 32,
       "requirements": [
@@ -1611,15 +1611,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 140505
+            "value": 140505000
           },
           {
             "type": "tritanium",
-            "value": 2755
+            "value": 2755000
           }
         ]
       },
-      "build_time": 1585,
+      "build_time": 1585440,
       "increased_power": 1250,
       "level": 33,
       "requirements": [
@@ -1644,15 +1644,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 483786
+            "value": 483786000
           },
           {
             "type": "tritanium",
-            "value": 9486
+            "value": 9486000
           }
         ]
       },
-      "build_time": 3536,
+      "build_time": 3536640,
       "increased_power": 1500,
       "level": 36,
       "requirements": [
@@ -1677,15 +1677,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 374850
+            "value": 374850000000
           },
           {
             "type": "tritanium",
-            "value": 3675
+            "value": 3675000000
           }
         ]
       },
-      "build_time": 140627,
+      "build_time": 140627520,
       "increased_power": 3000,
       "level": 50,
       "requirements": [

--- a/buildings/ship_hangar.json
+++ b/buildings/ship_hangar.json
@@ -36,15 +36,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1156
+            "value": 1156680000
           },
           {
             "type": "tritanium",
-            "value": 22680
+            "value": 22680000
           }
         ]
       },
-      "build_time": 8890,
+      "build_time": 8890560,
       "increased_power": 1000,
       "level": 38,
       "requirements": [
@@ -87,15 +87,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 343332
+            "value": 343332000
           },
           {
             "type": "tritanium",
-            "value": 6732
+            "value": 6732000
           }
         ]
       },
-      "build_time": 4151,
+      "build_time": 4151520,
       "increased_power": 750,
       "level": 35,
       "requirements": [
@@ -128,15 +128,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 483786
+            "value": 483786000
           },
           {
             "type": "tritanium",
-            "value": 9486
+            "value": 9486000
           }
         ]
       },
-      "build_time": 5304,
+      "build_time": 5304960,
       "increased_power": 750,
       "level": 36,
       "requirements": [
@@ -175,15 +175,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 743580
+            "value": 743580000
           },
           {
             "type": "tritanium",
-            "value": 14580
+            "value": 14580000
           }
         ]
       },
-      "build_time": 5482,
+      "build_time": 5482080,
       "increased_power": 750,
       "level": 37,
       "requirements": [
@@ -216,15 +216,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 221850
+            "value": 221850000
           },
           {
             "type": "tritanium",
-            "value": 4350
+            "value": 4350000
           }
         ]
       },
-      "build_time": 3149,
+      "build_time": 3149280,
       "increased_power": 500,
       "level": 34,
       "requirements": [
@@ -263,15 +263,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1973
+            "value": 1973700000
           },
           {
             "type": "tritanium",
-            "value": 38700
+            "value": 38700000
           }
         ]
       },
-      "build_time": 11800,
+      "build_time": 11800800,
       "increased_power": 750,
       "level": 39,
       "requirements": [
@@ -314,15 +314,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 13066
+            "value": 13066200000
           },
           {
             "type": "tritanium",
-            "value": 128100
+            "value": 128100000
           }
         ]
       },
-      "build_time": 30170,
+      "build_time": 30170880,
       "increased_power": 1000,
       "level": 42,
       "requirements": [
@@ -365,15 +365,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 8596
+            "value": 8596560000
           },
           {
             "type": "tritanium",
-            "value": 60200
+            "value": 60200000
           }
         ]
       },
-      "build_time": 20943,
+      "build_time": 20943360,
       "increased_power": 1000,
       "level": 40,
       "requirements": [
@@ -412,15 +412,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 8772
+            "value": 8772000000
           },
           {
             "type": "tritanium",
-            "value": 86000
+            "value": 86000000
           }
         ]
       },
-      "build_time": 19628,
+      "build_time": 19628640,
       "increased_power": 1000,
       "level": 41,
       "requirements": [
@@ -459,15 +459,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 18666
+            "value": 18666000000
           },
           {
             "type": "tritanium",
-            "value": 183000
+            "value": 183000000
           }
         ]
       },
-      "build_time": 39862,
+      "build_time": 39862080,
       "increased_power": 1250,
       "level": 43,
       "requirements": [
@@ -506,15 +506,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 27999
+            "value": 27999000000
           },
           {
             "type": "tritanium",
-            "value": 274500
+            "value": 274500000
           }
         ]
       },
-      "build_time": 52030,
+      "build_time": 52030080,
       "increased_power": 1250,
       "level": 44,
       "requirements": [
@@ -553,15 +553,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 79560
+            "value": 79560000000
           },
           {
             "type": "tritanium",
-            "value": 780000
+            "value": 780000000
           }
         ]
       },
-      "build_time": 108767,
+      "build_time": 108767520,
       "increased_power": 1500,
       "level": 47,
       "requirements": [
@@ -600,15 +600,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 214200
+            "value": 214200000000
           },
           {
             "type": "tritanium",
-            "value": 2100
+            "value": 2100000000
           }
         ]
       },
-      "build_time": 170380,
+      "build_time": 170380800,
       "increased_power": 1500,
       "level": 49,
       "requirements": [
@@ -647,15 +647,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 128520
+            "value": 128520000000
           },
           {
             "type": "tritanium",
-            "value": 1260
+            "value": 1260000000
           }
         ]
       },
-      "build_time": 136651,
+      "build_time": 136651680,
       "increased_power": 1500,
       "level": 48,
       "requirements": [
@@ -694,7 +694,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 4773
+            "value": 4773600
           },
           {
             "type": "tritanium",
@@ -735,7 +735,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 2943
+            "value": 2943720
           },
           {
             "type": "tritanium",
@@ -782,15 +782,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 39780
+            "value": 39780000000
           },
           {
             "type": "tritanium",
-            "value": 390000
+            "value": 390000000
           }
         ]
       },
-      "build_time": 67170,
+      "build_time": 67170240,
       "increased_power": 1250,
       "level": 45,
       "requirements": [
@@ -829,15 +829,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 54697
+            "value": 54697500000
           },
           {
             "type": "tritanium",
-            "value": 536250
+            "value": 536250000
           }
         ]
       },
-      "build_time": 85861,
+      "build_time": 85861440,
       "increased_power": 1250,
       "level": 46,
       "requirements": [
@@ -863,15 +863,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 374850
+            "value": 374850000000
           },
           {
             "type": "tritanium",
-            "value": 3675
+            "value": 3675000000
           }
         ]
       },
-      "build_time": 210942,
+      "build_time": 210942720,
       "increased_power": 1500,
       "level": 50,
       "requirements": [
@@ -910,15 +910,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 90831
+            "value": 90831000
           },
           {
             "type": "tritanium",
-            "value": 1781
+            "value": 1781000
           }
         ]
       },
-      "build_time": 1637,
+      "build_time": 1637280,
       "increased_power": 500,
       "level": 32,
       "requirements": [
@@ -957,7 +957,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 27183
+            "value": 27183000
           },
           {
             "type": "tritanium",
@@ -965,7 +965,7 @@
           }
         ]
       },
-      "build_time": 1177,
+      "build_time": 1177920,
       "increased_power": 500,
       "level": 29,
       "requirements": [
@@ -1004,7 +1004,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 39780
+            "value": 39780000
           },
           {
             "type": "tritanium",
@@ -1012,7 +1012,7 @@
           }
         ]
       },
-      "build_time": 1277,
+      "build_time": 1277280,
       "increased_power": 400,
       "level": 30,
       "requirements": [
@@ -1045,15 +1045,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 62883
+            "value": 62883000
           },
           {
             "type": "tritanium",
-            "value": 1233
+            "value": 1233000
           }
         ]
       },
-      "build_time": 1676,
+      "build_time": 1676160,
       "increased_power": 550,
       "level": 31,
       "requirements": [
@@ -1764,7 +1764,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1135
+            "value": 1135260
           },
           {
             "type": "tritanium",
@@ -1798,7 +1798,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1868
+            "value": 1868130
           },
           {
             "type": "tritanium",
@@ -1845,7 +1845,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 7458
+            "value": 7458750
           },
           {
             "type": "tritanium",
@@ -1892,7 +1892,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 11383
+            "value": 11383200
           },
           {
             "type": "tritanium",
@@ -1939,7 +1939,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 17074
+            "value": 17074800
           },
           {
             "type": "tritanium",
@@ -1947,7 +1947,7 @@
           }
         ]
       },
-      "build_time": 1068,
+      "build_time": 1068480,
       "increased_power": 400,
       "level": 28,
       "requirements": [
@@ -1986,15 +1986,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 140505
+            "value": 140505000
           },
           {
             "type": "tritanium",
-            "value": 2755
+            "value": 2755000
           }
         ]
       },
-      "build_time": 2378,
+      "build_time": 2378880,
       "increased_power": 750,
       "level": 33,
       "requirements": [

--- a/buildings/shipyard.json
+++ b/buildings/shipyard.json
@@ -36,15 +36,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 32818
+            "value": 32818500000
           },
           {
             "type": "tritanium",
-            "value": 268125
+            "value": 268125000
           }
         ]
       },
-      "build_time": 68689,
+      "build_time": 68689440,
       "increased_power": 2500,
       "level": 46,
       "requirements": [
@@ -81,15 +81,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 5157
+            "value": 5157936000
           },
           {
             "type": "tritanium",
-            "value": 30100
+            "value": 30100000
           }
         ]
       },
-      "build_time": 16754,
+      "build_time": 16754400,
       "increased_power": 2000,
       "level": 40,
       "requirements": [
@@ -132,15 +132,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 5263
+            "value": 5263200000
           },
           {
             "type": "tritanium",
-            "value": 43000
+            "value": 43000000
           }
         ]
       },
-      "build_time": 15703,
+      "build_time": 15703200,
       "increased_power": 2000,
       "level": 41,
       "requirements": [
@@ -183,15 +183,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 446148
+            "value": 446148000
           },
           {
             "type": "tritanium",
-            "value": 7290
+            "value": 7290000
           }
         ]
       },
-      "build_time": 4386,
+      "build_time": 4386240,
       "increased_power": 1750,
       "level": 37,
       "requirements": [
@@ -230,15 +230,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 694008
+            "value": 694008000
           },
           {
             "type": "tritanium",
-            "value": 11340
+            "value": 11340000
           }
         ]
       },
-      "build_time": 7112,
+      "build_time": 7112160,
       "increased_power": 1750,
       "level": 38,
       "requirements": [
@@ -277,15 +277,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 205999
+            "value": 205999200
           },
           {
             "type": "tritanium",
-            "value": 3366
+            "value": 3366000
           }
         ]
       },
-      "build_time": 3320,
+      "build_time": 3320640,
       "increased_power": 1250,
       "level": 35,
       "requirements": [
@@ -328,7 +328,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 16309
+            "value": 16309800
           },
           {
             "type": "tritanium",
@@ -379,15 +379,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 7839
+            "value": 7839720000
           },
           {
             "type": "tritanium",
-            "value": 64050
+            "value": 64050000
           }
         ]
       },
-      "build_time": 24137,
+      "build_time": 24137280,
       "increased_power": 2000,
       "level": 42,
       "requirements": [
@@ -430,15 +430,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 11199
+            "value": 11199600000
           },
           {
             "type": "tritanium",
-            "value": 91500
+            "value": 91500000
           }
         ]
       },
-      "build_time": 31890,
+      "build_time": 31890240,
       "increased_power": 2500,
       "level": 43,
       "requirements": [
@@ -477,15 +477,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 16799
+            "value": 16799400000
           },
           {
             "type": "tritanium",
-            "value": 137250
+            "value": 137250000
           }
         ]
       },
-      "build_time": 41623,
+      "build_time": 41623200,
       "increased_power": 2500,
       "level": 44,
       "requirements": [
@@ -528,15 +528,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 290271
+            "value": 290271600
           },
           {
             "type": "tritanium",
-            "value": 4743
+            "value": 4743000
           }
         ]
       },
-      "build_time": 4243,
+      "build_time": 4243680,
       "increased_power": 1500,
       "level": 36,
       "requirements": [
@@ -579,15 +579,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1184
+            "value": 1184220000
           },
           {
             "type": "tritanium",
-            "value": 19350
+            "value": 19350000
           }
         ]
       },
-      "build_time": 9440,
+      "build_time": 9440640,
       "increased_power": 1500,
       "level": 39,
       "requirements": [
@@ -1453,7 +1453,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1120
+            "value": 1120878
           },
           {
             "type": "tritanium",
@@ -1498,7 +1498,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1766
+            "value": 1766232
           },
           {
             "type": "tritanium",
@@ -1549,7 +1549,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 2864
+            "value": 2864160
           },
           {
             "type": "tritanium",
@@ -1600,7 +1600,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 4475
+            "value": 4475250
           },
           {
             "type": "tritanium",
@@ -1651,7 +1651,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 6829
+            "value": 6829920
           },
           {
             "type": "tritanium",
@@ -1698,7 +1698,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 10244
+            "value": 10244880
           },
           {
             "type": "tritanium",
@@ -1749,7 +1749,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 23868
+            "value": 23868000
           },
           {
             "type": "tritanium",
@@ -1757,7 +1757,7 @@
           }
         ]
       },
-      "build_time": 1020,
+      "build_time": 1020960,
       "increased_power": 1000,
       "level": 30,
       "requirements": [
@@ -1800,7 +1800,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 37729
+            "value": 37729800
           },
           {
             "type": "tritanium",
@@ -1808,7 +1808,7 @@
           }
         ]
       },
-      "build_time": 1340,
+      "build_time": 1340640,
       "increased_power": 1000,
       "level": 31,
       "requirements": [
@@ -1851,7 +1851,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 54498
+            "value": 54498600
           },
           {
             "type": "tritanium",
@@ -1859,7 +1859,7 @@
           }
         ]
       },
-      "build_time": 1308,
+      "build_time": 1308960,
       "increased_power": 1250,
       "level": 32,
       "requirements": [
@@ -1902,15 +1902,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 84303
+            "value": 84303000
           },
           {
             "type": "tritanium",
-            "value": 1377
+            "value": 1377500
           }
         ]
       },
-      "build_time": 1902,
+      "build_time": 1902240,
       "increased_power": 1250,
       "level": 33,
       "requirements": [
@@ -1953,15 +1953,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 133110
+            "value": 133110000
           },
           {
             "type": "tritanium",
-            "value": 2175
+            "value": 2175000
           }
         ]
       },
-      "build_time": 2520,
+      "build_time": 2520000,
       "increased_power": 1250,
       "level": 34,
       "requirements": [
@@ -2004,15 +2004,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 23868
+            "value": 23868000000
           },
           {
             "type": "tritanium",
-            "value": 195000
+            "value": 195000000
           }
         ]
       },
-      "build_time": 53736,
+      "build_time": 53736480,
       "increased_power": 2500,
       "level": 45,
       "requirements": [
@@ -2051,15 +2051,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 47736
+            "value": 47736000000
           },
           {
             "type": "tritanium",
-            "value": 390000
+            "value": 390000000
           }
         ]
       },
-      "build_time": 87014,
+      "build_time": 87014880,
       "increased_power": 3000,
       "level": 47,
       "requirements": [
@@ -2098,15 +2098,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 77112
+            "value": 77112000000
           },
           {
             "type": "tritanium",
-            "value": 630000
+            "value": 630000000
           }
         ]
       },
-      "build_time": 109321,
+      "build_time": 109321920,
       "increased_power": 3000,
       "level": 48,
       "requirements": [
@@ -2145,15 +2145,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 128520
+            "value": 128520000000
           },
           {
             "type": "tritanium",
-            "value": 1050
+            "value": 1050000000
           }
         ]
       },
-      "build_time": 136304,
+      "build_time": 136304640,
       "increased_power": 3000,
       "level": 49,
       "requirements": [
@@ -2183,15 +2183,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 224910
+            "value": 224910000000
           },
           {
             "type": "tritanium",
-            "value": 1837
+            "value": 1837500000
           }
         ]
       },
-      "build_time": 168753,
+      "build_time": 168753600,
       "increased_power": 3000,
       "level": 50,
       "requirements": [

--- a/buildings/shuttle_bay.json
+++ b/buildings/shuttle_bay.json
@@ -36,15 +36,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 175918
+            "value": 175918200
           },
           {
             "type": "tritanium",
-            "value": 2874
+            "value": 2874500
           }
         ]
       },
-      "build_time": 2099,
+      "build_time": 2099520,
       "increased_power": 1250,
       "level": 34,
       "requirements": [
@@ -79,15 +79,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 272248
+            "value": 272248550
           },
           {
             "type": "tritanium",
-            "value": 4448
+            "value": 4448550
           }
         ]
       },
-      "build_time": 2767,
+      "build_time": 2767680,
       "increased_power": 1250,
       "level": 35,
       "requirements": [
@@ -122,15 +122,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 383622
+            "value": 383622950
           },
           {
             "type": "tritanium",
-            "value": 6268
+            "value": 6268350
           }
         ]
       },
-      "build_time": 3536,
+      "build_time": 3536640,
       "increased_power": 1500,
       "level": 36,
       "requirements": [
@@ -165,7 +165,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 49863
+            "value": 49863700
           },
           {
             "type": "tritanium",
@@ -173,7 +173,7 @@
           }
         ]
       },
-      "build_time": 1117,
+      "build_time": 1117440,
       "increased_power": 1000,
       "level": 31,
       "requirements": [
@@ -208,15 +208,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 72025
+            "value": 72025350
           },
           {
             "type": "tritanium",
-            "value": 1176
+            "value": 1176900
           }
         ]
       },
-      "build_time": 1091,
+      "build_time": 1091520,
       "increased_power": 1250,
       "level": 32,
       "requirements": [
@@ -251,15 +251,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 111414
+            "value": 111414850
           },
           {
             "type": "tritanium",
-            "value": 1820
+            "value": 1820500
           }
         ]
       },
-      "build_time": 1585,
+      "build_time": 1585440,
       "increased_power": 1250,
       "level": 33,
       "requirements": [
@@ -294,15 +294,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 589629
+            "value": 589629200
           },
           {
             "type": "tritanium",
-            "value": 9634
+            "value": 9634450
           }
         ]
       },
-      "build_time": 3654,
+      "build_time": 3654720,
       "increased_power": 1750,
       "level": 37,
       "requirements": [
@@ -337,15 +337,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 917201
+            "value": 917201000
           },
           {
             "type": "tritanium",
-            "value": 14986
+            "value": 14986950
           }
         ]
       },
-      "build_time": 5927,
+      "build_time": 5927040,
       "increased_power": 1750,
       "level": 38,
       "requirements": [
@@ -380,15 +380,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1565
+            "value": 1565065150
           },
           {
             "type": "tritanium",
-            "value": 25572
+            "value": 25572950
           }
         ]
       },
-      "build_time": 7866,
+      "build_time": 7866720,
       "increased_power": 1500,
       "level": 39,
       "requirements": [
@@ -423,7 +423,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 5914
+            "value": 5914500
           },
           {
             "type": "tritanium",
@@ -466,7 +466,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 9026
+            "value": 9026400
           },
           {
             "type": "tritanium",
@@ -509,7 +509,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 13539
+            "value": 13539600
           },
           {
             "type": "tritanium",
@@ -552,7 +552,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 21555
+            "value": 21555000
           },
           {
             "type": "tritanium",
@@ -595,7 +595,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 31543
+            "value": 31543950
           },
           {
             "type": "tritanium",
@@ -705,15 +705,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 5932
+            "value": 5932067500
           },
           {
             "type": "tritanium",
-            "value": 48464
+            "value": 48464600
           }
         ]
       },
-      "build_time": 20113,
+      "build_time": 20113920,
       "increased_power": 2000,
       "level": 42,
       "requirements": [
@@ -742,15 +742,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 3902
+            "value": 3902846600
           },
           {
             "type": "tritanium",
-            "value": 22775
+            "value": 22775700
           }
         ]
       },
-      "build_time": 13962,
+      "build_time": 13962240,
       "increased_power": 2000,
       "level": 40,
       "requirements": [
@@ -785,15 +785,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 3982
+            "value": 3982496500
           },
           {
             "type": "tritanium",
-            "value": 32536
+            "value": 32536750
           }
         ]
       },
-      "build_time": 13085,
+      "build_time": 13085280,
       "increased_power": 2000,
       "level": 41,
       "requirements": [
@@ -828,15 +828,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 8474
+            "value": 8474382150
           },
           {
             "type": "tritanium",
-            "value": 69235
+            "value": 69235150
           }
         ]
       },
-      "build_time": 26575,
+      "build_time": 26575200,
       "increased_power": 2500,
       "level": 43,
       "requirements": [
@@ -871,15 +871,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 12711
+            "value": 12711573250
           },
           {
             "type": "tritanium",
-            "value": 103852
+            "value": 103852700
           }
         ]
       },
-      "build_time": 34686,
+      "build_time": 34686720,
       "increased_power": 2500,
       "level": 44,
       "requirements": [
@@ -914,15 +914,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 18060
+            "value": 18060158700
           },
           {
             "type": "tritanium",
-            "value": 147550
+            "value": 147550300
           }
         ]
       },
-      "build_time": 44779,
+      "build_time": 44779680,
       "increased_power": 2500,
       "level": 45,
       "requirements": [
@@ -957,15 +957,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 24832
+            "value": 24832718200
           },
           {
             "type": "tritanium",
-            "value": 202881
+            "value": 202881700
           }
         ]
       },
-      "build_time": 57241,
+      "build_time": 57241440,
       "increased_power": 2500,
       "level": 46,
       "requirements": [
@@ -1000,15 +1000,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 36120
+            "value": 36120317350
           },
           {
             "type": "tritanium",
-            "value": 295100
+            "value": 295100650
           }
         ]
       },
-      "build_time": 72511,
+      "build_time": 72511200,
       "increased_power": 3000,
       "level": 47,
       "requirements": [
@@ -1043,15 +1043,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 58348
+            "value": 58348204950
           },
           {
             "type": "tritanium",
-            "value": 476701
+            "value": 476701000
           }
         ]
       },
-      "build_time": 91101,
+      "build_time": 91101600,
       "increased_power": 3000,
       "level": 48,
       "requirements": [
@@ -1086,15 +1086,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 97247
+            "value": 97247008250
           },
           {
             "type": "tritanium",
-            "value": 794501
+            "value": 794501700
           }
         ]
       },
-      "build_time": 113587,
+      "build_time": 113587200,
       "increased_power": 3000,
       "level": 49,
       "requirements": [
@@ -1129,15 +1129,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 170182
+            "value": 170182264450
           },
           {
             "type": "tritanium",
-            "value": 1390
+            "value": 1390378000
           }
         ]
       },
-      "build_time": 140627,
+      "build_time": 140627520,
       "increased_power": 3000,
       "level": 50,
       "requirements": [
@@ -1172,7 +1172,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 3785
+            "value": 3785250
           },
           {
             "type": "tritanium",
@@ -1862,7 +1862,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1481
+            "value": 1481350
           },
           {
             "type": "tritanium",
@@ -1899,7 +1899,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 2334
+            "value": 2334250
           },
           {
             "type": "tritanium",

--- a/buildings/tritanium_generator_a.json
+++ b/buildings/tritanium_generator_a.json
@@ -23,7 +23,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 13260
+            "value": 13260000
           },
           {
             "type": "dilithium",
@@ -60,15 +60,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 2865
+            "value": 2865520000
           },
           {
             "type": "dilithium",
-            "value": 6020
+            "value": 6020000
           }
         ]
       },
-      "build_time": 2792,
+      "build_time": 2792160,
       "increased_power": 1000,
       "level": 40,
       "requirements": [
@@ -97,15 +97,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 2924
+            "value": 2924000000
           },
           {
             "type": "dilithium",
-            "value": 8600
+            "value": 8600000
           }
         ]
       },
-      "build_time": 2616,
+      "build_time": 2616480,
       "increased_power": 1000,
       "level": 41,
       "requirements": [
@@ -134,15 +134,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 4355
+            "value": 4355400000
           },
           {
             "type": "dilithium",
-            "value": 12810
+            "value": 12810000
           }
         ]
       },
-      "build_time": 4023,
+      "build_time": 4023360,
       "increased_power": 1000,
       "level": 42,
       "requirements": [
@@ -171,15 +171,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 6222
+            "value": 6222000000
           },
           {
             "type": "dilithium",
-            "value": 18300
+            "value": 18300000
           }
         ]
       },
-      "build_time": 5315,
+      "build_time": 5315040,
       "increased_power": 1250,
       "level": 43,
       "requirements": [
@@ -208,15 +208,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 9333
+            "value": 9333000000
           },
           {
             "type": "dilithium",
-            "value": 27450
+            "value": 27450000
           }
         ]
       },
-      "build_time": 6937,
+      "build_time": 6937920,
       "increased_power": 1250,
       "level": 44,
       "requirements": [
@@ -251,15 +251,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 18232
+            "value": 18232500000
           },
           {
             "type": "dilithium",
-            "value": 53625
+            "value": 53625000
           }
         ]
       },
-      "build_time": 11448,
+      "build_time": 11448000,
       "increased_power": 1250,
       "level": 46,
       "requirements": [
@@ -288,15 +288,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 13260
+            "value": 13260000000
           },
           {
             "type": "dilithium",
-            "value": 39000
+            "value": 39000000
           }
         ]
       },
-      "build_time": 8955,
+      "build_time": 8955360,
       "increased_power": 1250,
       "level": 45,
       "requirements": [
@@ -318,7 +318,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 73950
+            "value": 73950000
           },
           {
             "type": "dilithium",
@@ -361,15 +361,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 26520
+            "value": 26520000000
           },
           {
             "type": "dilithium",
-            "value": 78000
+            "value": 78000000
           }
         ]
       },
-      "build_time": 14502,
+      "build_time": 14502240,
       "increased_power": 1500,
       "level": 47,
       "requirements": [
@@ -404,15 +404,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 42840
+            "value": 42840000000
           },
           {
             "type": "dilithium",
-            "value": 126000
+            "value": 126000000
           }
         ]
       },
-      "build_time": 18220,
+      "build_time": 18220320,
       "increased_power": 1500,
       "level": 48,
       "requirements": [
@@ -447,15 +447,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 71400
+            "value": 71400000000
           },
           {
             "type": "dilithium",
-            "value": 210000
+            "value": 210000000
           }
         ]
       },
-      "build_time": 22717,
+      "build_time": 22717440,
       "increased_power": 1500,
       "level": 49,
       "requirements": [
@@ -477,15 +477,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 124950
+            "value": 124950000000
           },
           {
             "type": "dilithium",
-            "value": 367500
+            "value": 367500000
           }
         ]
       },
-      "build_time": 28126,
+      "build_time": 28126080,
       "increased_power": 1500,
       "level": 50,
       "requirements": [
@@ -589,7 +589,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 114444
+            "value": 114444000
           },
           {
             "type": "dilithium",
@@ -649,7 +649,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 161262
+            "value": 161262000
           },
           {
             "type": "dilithium",
@@ -679,11 +679,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 247860
+            "value": 247860000
           },
           {
             "type": "dilithium",
-            "value": 1458
+            "value": 1458000
           }
         ]
       },
@@ -709,15 +709,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 385560
+            "value": 385560000
           },
           {
             "type": "dilithium",
-            "value": 2268
+            "value": 2268000
           }
         ]
       },
-      "build_time": 1185,
+      "build_time": 1185120,
       "increased_power": 1000,
       "level": 38,
       "requirements": [
@@ -739,15 +739,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 657900
+            "value": 657900000
           },
           {
             "type": "dilithium",
-            "value": 3870
+            "value": 3870000
           }
         ]
       },
-      "build_time": 1573,
+      "build_time": 1573920,
       "increased_power": 750,
       "level": 39,
       "requirements": [
@@ -769,7 +769,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 30277
+            "value": 30277000
           },
           {
             "type": "dilithium",
@@ -799,7 +799,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 2486
+            "value": 2486250
           },
           {
             "type": "dilithium",
@@ -829,7 +829,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 9061
+            "value": 9061000
           },
           {
             "type": "dilithium",
@@ -859,7 +859,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 20961
+            "value": 20961000
           },
           {
             "type": "dilithium",
@@ -1465,7 +1465,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1591
+            "value": 1591200
           },
           {
             "type": "dilithium",
@@ -1495,7 +1495,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 3794
+            "value": 3794400
           },
           {
             "type": "dilithium",
@@ -1525,7 +1525,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 5691
+            "value": 5691600
           },
           {
             "type": "dilithium",
@@ -1555,7 +1555,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 46835
+            "value": 46835000
           },
           {
             "type": "dilithium",

--- a/buildings/tritanium_generator_b.json
+++ b/buildings/tritanium_generator_b.json
@@ -30,15 +30,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 2865
+            "value": 2865520000
           },
           {
             "type": "dilithium",
-            "value": 6020
+            "value": 6020000
           }
         ]
       },
-      "build_time": 2792,
+      "build_time": 2792160,
       "increased_power": 1000,
       "level": 40,
       "requirements": [
@@ -71,15 +71,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 2924
+            "value": 2924000000
           },
           {
             "type": "dilithium",
-            "value": 8600
+            "value": 8600000
           }
         ]
       },
-      "build_time": 2616,
+      "build_time": 2616480,
       "increased_power": 1000,
       "level": 41,
       "requirements": [
@@ -112,15 +112,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 4355
+            "value": 4355400000
           },
           {
             "type": "dilithium",
-            "value": 12810
+            "value": 12810000
           }
         ]
       },
-      "build_time": 4023,
+      "build_time": 4023360,
       "increased_power": 1000,
       "level": 42,
       "requirements": [
@@ -153,15 +153,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 6222
+            "value": 6222000000
           },
           {
             "type": "dilithium",
-            "value": 18300
+            "value": 18300000
           }
         ]
       },
-      "build_time": 5315,
+      "build_time": 5315040,
       "increased_power": 1250,
       "level": 43,
       "requirements": [
@@ -194,15 +194,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 9333
+            "value": 9333000000
           },
           {
             "type": "dilithium",
-            "value": 27450
+            "value": 27450000
           }
         ]
       },
-      "build_time": 6937,
+      "build_time": 6937920,
       "increased_power": 1250,
       "level": 44,
       "requirements": [
@@ -241,15 +241,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 26520
+            "value": 26520000000
           },
           {
             "type": "dilithium",
-            "value": 78000
+            "value": 78000000
           }
         ]
       },
-      "build_time": 14502,
+      "build_time": 14502240,
       "increased_power": 1500,
       "level": 47,
       "requirements": [
@@ -312,15 +312,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 13260
+            "value": 13260000000
           },
           {
             "type": "dilithium",
-            "value": 39000
+            "value": 39000000
           }
         ]
       },
-      "build_time": 8955,
+      "build_time": 8955360,
       "increased_power": 1250,
       "level": 45,
       "requirements": [
@@ -359,15 +359,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 18232
+            "value": 18232500000
           },
           {
             "type": "dilithium",
-            "value": 53625
+            "value": 53625000
           }
         ]
       },
-      "build_time": 11448,
+      "build_time": 11448000,
       "increased_power": 1250,
       "level": 46,
       "requirements": [
@@ -406,15 +406,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 42840
+            "value": 42840000000
           },
           {
             "type": "dilithium",
-            "value": 126000
+            "value": 126000000
           }
         ]
       },
-      "build_time": 18220,
+      "build_time": 18220320,
       "increased_power": 1500,
       "level": 48,
       "requirements": [
@@ -453,15 +453,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 71400
+            "value": 71400000000
           },
           {
             "type": "dilithium",
-            "value": 210000
+            "value": 210000000
           }
         ]
       },
-      "build_time": 22717,
+      "build_time": 22717440,
       "increased_power": 1500,
       "level": 49,
       "requirements": [
@@ -487,7 +487,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 30277
+            "value": 30277000
           },
           {
             "type": "dilithium",
@@ -521,7 +521,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 2486
+            "value": 2486250
           },
           {
             "type": "dilithium",
@@ -555,7 +555,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 13260
+            "value": 13260000
           },
           {
             "type": "dilithium",
@@ -589,7 +589,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 9061
+            "value": 9061000
           },
           {
             "type": "dilithium",
@@ -623,7 +623,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 20961
+            "value": 20961000
           },
           {
             "type": "dilithium",
@@ -657,7 +657,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 73950
+            "value": 73950000
           },
           {
             "type": "dilithium",
@@ -793,7 +793,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 46835
+            "value": 46835000
           },
           {
             "type": "dilithium",
@@ -827,7 +827,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1591
+            "value": 1591200
           },
           {
             "type": "dilithium",
@@ -955,15 +955,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 385560
+            "value": 385560000
           },
           {
             "type": "dilithium",
-            "value": 2268
+            "value": 2268000
           }
         ]
       },
-      "build_time": 1185,
+      "build_time": 1185120,
       "increased_power": 1000,
       "level": 38,
       "requirements": [
@@ -989,11 +989,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 247860
+            "value": 247860000
           },
           {
             "type": "dilithium",
-            "value": 1458
+            "value": 1458000
           }
         ]
       },
@@ -1091,7 +1091,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 5691
+            "value": 5691600
           },
           {
             "type": "dilithium",
@@ -1125,7 +1125,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 3794
+            "value": 3794400
           },
           {
             "type": "dilithium",
@@ -1461,7 +1461,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 114444
+            "value": 114444000
           },
           {
             "type": "dilithium",
@@ -1495,7 +1495,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 161262
+            "value": 161262000
           },
           {
             "type": "dilithium",
@@ -1529,15 +1529,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 657900
+            "value": 657900000
           },
           {
             "type": "dilithium",
-            "value": 3870
+            "value": 3870000
           }
         ]
       },
-      "build_time": 1573,
+      "build_time": 1573920,
       "increased_power": 750,
       "level": 39,
       "requirements": [
@@ -1563,15 +1563,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 124950
+            "value": 124950000000
           },
           {
             "type": "dilithium",
-            "value": 367500
+            "value": 367500000
           }
         ]
       },
-      "build_time": 28126,
+      "build_time": 28126080,
       "increased_power": 1500,
       "level": 50,
       "requirements": [

--- a/buildings/tritanium_generator_c.json
+++ b/buildings/tritanium_generator_c.json
@@ -23,15 +23,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 4355
+            "value": 4355400000
           },
           {
             "type": "dilithium",
-            "value": 12810
+            "value": 12810000
           }
         ]
       },
-      "build_time": 4023,
+      "build_time": 4023360,
       "increased_power": 1000,
       "level": 42,
       "requirements": [
@@ -57,15 +57,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 2924
+            "value": 2924000000
           },
           {
             "type": "dilithium",
-            "value": 8600
+            "value": 8600000
           }
         ]
       },
-      "build_time": 2616,
+      "build_time": 2616480,
       "increased_power": 1000,
       "level": 41,
       "requirements": [
@@ -91,15 +91,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 2865
+            "value": 2865520000
           },
           {
             "type": "dilithium",
-            "value": 6020
+            "value": 6020000
           }
         ]
       },
-      "build_time": 2792,
+      "build_time": 2792160,
       "increased_power": 1000,
       "level": 40,
       "requirements": [
@@ -125,15 +125,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 6222
+            "value": 6222000000
           },
           {
             "type": "dilithium",
-            "value": 18300
+            "value": 18300000
           }
         ]
       },
-      "build_time": 5315,
+      "build_time": 5315040,
       "increased_power": 1250,
       "level": 43,
       "requirements": [
@@ -159,15 +159,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 9333
+            "value": 9333000000
           },
           {
             "type": "dilithium",
-            "value": 27450
+            "value": 27450000
           }
         ]
       },
-      "build_time": 6937,
+      "build_time": 6937920,
       "increased_power": 1250,
       "level": 44,
       "requirements": [
@@ -193,15 +193,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 13260
+            "value": 13260000000
           },
           {
             "type": "dilithium",
-            "value": 39000
+            "value": 39000000
           }
         ]
       },
-      "build_time": 8955,
+      "build_time": 8955360,
       "increased_power": 1250,
       "level": 45,
       "requirements": [
@@ -227,15 +227,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 18232
+            "value": 18232500000
           },
           {
             "type": "dilithium",
-            "value": 53625
+            "value": 53625000
           }
         ]
       },
-      "build_time": 11448,
+      "build_time": 11448000,
       "increased_power": 1250,
       "level": 46,
       "requirements": [
@@ -261,15 +261,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 26520
+            "value": 26520000000
           },
           {
             "type": "dilithium",
-            "value": 78000
+            "value": 78000000
           }
         ]
       },
-      "build_time": 14502,
+      "build_time": 14502240,
       "increased_power": 1500,
       "level": 47,
       "requirements": [
@@ -295,15 +295,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 42840
+            "value": 42840000000
           },
           {
             "type": "dilithium",
-            "value": 126000
+            "value": 126000000
           }
         ]
       },
-      "build_time": 18220,
+      "build_time": 18220320,
       "increased_power": 1500,
       "level": 48,
       "requirements": [
@@ -329,15 +329,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 71400
+            "value": 71400000000
           },
           {
             "type": "dilithium",
-            "value": 210000
+            "value": 210000000
           }
         ]
       },
-      "build_time": 22717,
+      "build_time": 22717440,
       "increased_power": 1500,
       "level": 49,
       "requirements": [
@@ -363,7 +363,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 30277
+            "value": 30277000
           },
           {
             "type": "dilithium",
@@ -397,7 +397,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 2486
+            "value": 2486250
           },
           {
             "type": "dilithium",
@@ -431,7 +431,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 13260
+            "value": 13260000
           },
           {
             "type": "dilithium",
@@ -465,7 +465,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 9061
+            "value": 9061000
           },
           {
             "type": "dilithium",
@@ -499,7 +499,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 20961
+            "value": 20961000
           },
           {
             "type": "dilithium",
@@ -533,7 +533,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 73950
+            "value": 73950000
           },
           {
             "type": "dilithium",
@@ -635,7 +635,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1591
+            "value": 1591200
           },
           {
             "type": "dilithium",
@@ -669,7 +669,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 46835
+            "value": 46835000
           },
           {
             "type": "dilithium",
@@ -703,7 +703,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 114444
+            "value": 114444000
           },
           {
             "type": "dilithium",
@@ -805,11 +805,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 247860
+            "value": 247860000
           },
           {
             "type": "dilithium",
-            "value": 1458
+            "value": 1458000
           }
         ]
       },
@@ -907,15 +907,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 385560
+            "value": 385560000
           },
           {
             "type": "dilithium",
-            "value": 2268
+            "value": 2268000
           }
         ]
       },
-      "build_time": 1185,
+      "build_time": 1185120,
       "increased_power": 1000,
       "level": 38,
       "requirements": [
@@ -941,7 +941,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 5691
+            "value": 5691600
           },
           {
             "type": "dilithium",
@@ -975,7 +975,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 3794
+            "value": 3794400
           },
           {
             "type": "dilithium",
@@ -1111,7 +1111,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 161262
+            "value": 161262000
           },
           {
             "type": "dilithium",
@@ -1281,15 +1281,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 657900
+            "value": 657900000
           },
           {
             "type": "dilithium",
-            "value": 3870
+            "value": 3870000
           }
         ]
       },
-      "build_time": 1573,
+      "build_time": 1573920,
       "increased_power": 750,
       "level": 39,
       "requirements": [
@@ -1383,15 +1383,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 124950
+            "value": 124950000000
           },
           {
             "type": "dilithium",
-            "value": 367500
+            "value": 367500000
           }
         ]
       },
-      "build_time": 28126,
+      "build_time": 28126080,
       "increased_power": 1500,
       "level": 50,
       "requirements": [

--- a/buildings/tritanium_generator_d.json
+++ b/buildings/tritanium_generator_d.json
@@ -23,15 +23,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 4355
+            "value": 4355400000
           },
           {
             "type": "dilithium",
-            "value": 12810
+            "value": 12810000
           }
         ]
       },
-      "build_time": 4023,
+      "build_time": 4023360,
       "increased_power": 1000,
       "level": 42,
       "requirements": [
@@ -57,15 +57,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 2924
+            "value": 2924000000
           },
           {
             "type": "dilithium",
-            "value": 8600
+            "value": 8600000
           }
         ]
       },
-      "build_time": 2616,
+      "build_time": 2616480,
       "increased_power": 1000,
       "level": 41,
       "requirements": [
@@ -91,15 +91,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 2865
+            "value": 2865520000
           },
           {
             "type": "dilithium",
-            "value": 6020
+            "value": 6020000
           }
         ]
       },
-      "build_time": 2792,
+      "build_time": 2792160,
       "increased_power": 1000,
       "level": 40,
       "requirements": [
@@ -125,15 +125,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 6222
+            "value": 6222000000
           },
           {
             "type": "dilithium",
-            "value": 18300
+            "value": 18300000
           }
         ]
       },
-      "build_time": 5315,
+      "build_time": 5315040,
       "increased_power": 1250,
       "level": 43,
       "requirements": [
@@ -159,15 +159,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 9333
+            "value": 9333000000
           },
           {
             "type": "dilithium",
-            "value": 27450
+            "value": 27450000
           }
         ]
       },
-      "build_time": 6937,
+      "build_time": 6937920,
       "increased_power": 1250,
       "level": 44,
       "requirements": [
@@ -193,15 +193,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 13260
+            "value": 13260000000
           },
           {
             "type": "dilithium",
-            "value": 39000
+            "value": 39000000
           }
         ]
       },
-      "build_time": 8955,
+      "build_time": 8955360,
       "increased_power": 1250,
       "level": 45,
       "requirements": [
@@ -227,15 +227,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 18232
+            "value": 18232500000
           },
           {
             "type": "dilithium",
-            "value": 53625
+            "value": 53625000
           }
         ]
       },
-      "build_time": 11448,
+      "build_time": 11448000,
       "increased_power": 1250,
       "level": 46,
       "requirements": [
@@ -261,15 +261,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 26520
+            "value": 26520000000
           },
           {
             "type": "dilithium",
-            "value": 78000
+            "value": 78000000
           }
         ]
       },
-      "build_time": 14502,
+      "build_time": 14502240,
       "increased_power": 1500,
       "level": 47,
       "requirements": [
@@ -295,15 +295,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 42840
+            "value": 42840000000
           },
           {
             "type": "dilithium",
-            "value": 126000
+            "value": 126000000
           }
         ]
       },
-      "build_time": 18220,
+      "build_time": 18220320,
       "increased_power": 1500,
       "level": 48,
       "requirements": [
@@ -329,15 +329,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 71400
+            "value": 71400000000
           },
           {
             "type": "dilithium",
-            "value": 210000
+            "value": 210000000
           }
         ]
       },
-      "build_time": 22717,
+      "build_time": 22717440,
       "increased_power": 1500,
       "level": 49,
       "requirements": [
@@ -397,7 +397,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 30277
+            "value": 30277000
           },
           {
             "type": "dilithium",
@@ -461,7 +461,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 13260
+            "value": 13260000
           },
           {
             "type": "dilithium",
@@ -495,7 +495,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 9061
+            "value": 9061000
           },
           {
             "type": "dilithium",
@@ -529,7 +529,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 20961
+            "value": 20961000
           },
           {
             "type": "dilithium",
@@ -563,7 +563,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 73950
+            "value": 73950000
           },
           {
             "type": "dilithium",
@@ -597,7 +597,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1591
+            "value": 1591200
           },
           {
             "type": "dilithium",
@@ -631,7 +631,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 2486
+            "value": 2486250
           },
           {
             "type": "dilithium",
@@ -699,7 +699,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 46835
+            "value": 46835000
           },
           {
             "type": "dilithium",
@@ -733,11 +733,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 247860
+            "value": 247860000
           },
           {
             "type": "dilithium",
-            "value": 1458
+            "value": 1458000
           }
         ]
       },
@@ -767,15 +767,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 385560
+            "value": 385560000
           },
           {
             "type": "dilithium",
-            "value": 2268
+            "value": 2268000
           }
         ]
       },
-      "build_time": 1185,
+      "build_time": 1185120,
       "increased_power": 1000,
       "level": 38,
       "requirements": [
@@ -801,7 +801,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 5691
+            "value": 5691600
           },
           {
             "type": "dilithium",
@@ -835,15 +835,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 657900
+            "value": 657900000
           },
           {
             "type": "dilithium",
-            "value": 3870
+            "value": 3870000
           }
         ]
       },
-      "build_time": 1573,
+      "build_time": 1573920,
       "increased_power": 750,
       "level": 39,
       "requirements": [
@@ -1551,7 +1551,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 161262
+            "value": 161262000
           },
           {
             "type": "dilithium",
@@ -1585,7 +1585,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 114444
+            "value": 114444000
           },
           {
             "type": "dilithium",
@@ -1619,7 +1619,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 3794
+            "value": 3794400
           },
           {
             "type": "dilithium",
@@ -1653,15 +1653,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 124950
+            "value": 124950000000
           },
           {
             "type": "dilithium",
-            "value": 367500
+            "value": 367500000
           }
         ]
       },
-      "build_time": 28126,
+      "build_time": 28126080,
       "increased_power": 1500,
       "level": 50,
       "requirements": [

--- a/buildings/tritanium_generator_e.json
+++ b/buildings/tritanium_generator_e.json
@@ -23,15 +23,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 4355
+            "value": 4355400000
           },
           {
             "type": "dilithium",
-            "value": 12810
+            "value": 12810000
           }
         ]
       },
-      "build_time": 4023,
+      "build_time": 4023360,
       "increased_power": 1000,
       "level": 42,
       "requirements": [
@@ -57,15 +57,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 2924
+            "value": 2924000000
           },
           {
             "type": "dilithium",
-            "value": 8600
+            "value": 8600000
           }
         ]
       },
-      "build_time": 2616,
+      "build_time": 2616480,
       "increased_power": 1000,
       "level": 41,
       "requirements": [
@@ -121,15 +121,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 2865
+            "value": 2865520000
           },
           {
             "type": "dilithium",
-            "value": 6020
+            "value": 6020000
           }
         ]
       },
-      "build_time": 2792,
+      "build_time": 2792160,
       "increased_power": 1000,
       "level": 40,
       "requirements": [
@@ -155,15 +155,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 6222
+            "value": 6222000000
           },
           {
             "type": "dilithium",
-            "value": 18300
+            "value": 18300000
           }
         ]
       },
-      "build_time": 5315,
+      "build_time": 5315040,
       "increased_power": 1250,
       "level": 43,
       "requirements": [
@@ -189,15 +189,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 9333
+            "value": 9333000000
           },
           {
             "type": "dilithium",
-            "value": 27450
+            "value": 27450000
           }
         ]
       },
-      "build_time": 6937,
+      "build_time": 6937920,
       "increased_power": 1250,
       "level": 44,
       "requirements": [
@@ -223,15 +223,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 13260
+            "value": 13260000000
           },
           {
             "type": "dilithium",
-            "value": 39000
+            "value": 39000000
           }
         ]
       },
-      "build_time": 8955,
+      "build_time": 8955360,
       "increased_power": 1250,
       "level": 45,
       "requirements": [
@@ -257,15 +257,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 18232
+            "value": 18232500000
           },
           {
             "type": "dilithium",
-            "value": 53625
+            "value": 53625000
           }
         ]
       },
-      "build_time": 11448,
+      "build_time": 11448000,
       "increased_power": 1250,
       "level": 46,
       "requirements": [
@@ -291,15 +291,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 26520
+            "value": 26520000000
           },
           {
             "type": "dilithium",
-            "value": 78000
+            "value": 78000000
           }
         ]
       },
-      "build_time": 14502,
+      "build_time": 14502240,
       "increased_power": 1500,
       "level": 47,
       "requirements": [
@@ -325,15 +325,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 42840
+            "value": 42840000000
           },
           {
             "type": "dilithium",
-            "value": 126000
+            "value": 126000000
           }
         ]
       },
-      "build_time": 18220,
+      "build_time": 18220320,
       "increased_power": 1500,
       "level": 48,
       "requirements": [
@@ -359,15 +359,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 71400
+            "value": 71400000000
           },
           {
             "type": "dilithium",
-            "value": 210000
+            "value": 210000000
           }
         ]
       },
-      "build_time": 22717,
+      "build_time": 22717440,
       "increased_power": 1500,
       "level": 49,
       "requirements": [
@@ -427,15 +427,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 385560
+            "value": 385560000
           },
           {
             "type": "dilithium",
-            "value": 2268
+            "value": 2268000
           }
         ]
       },
-      "build_time": 1185,
+      "build_time": 1185120,
       "increased_power": 1000,
       "level": 38,
       "requirements": [
@@ -461,15 +461,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 657900
+            "value": 657900000
           },
           {
             "type": "dilithium",
-            "value": 3870
+            "value": 3870000
           }
         ]
       },
-      "build_time": 1573,
+      "build_time": 1573920,
       "increased_power": 750,
       "level": 39,
       "requirements": [
@@ -563,7 +563,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 161262
+            "value": 161262000
           },
           {
             "type": "dilithium",
@@ -597,15 +597,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 124950
+            "value": 124950000000
           },
           {
             "type": "dilithium",
-            "value": 367500
+            "value": 367500000
           }
         ]
       },
-      "build_time": 28126,
+      "build_time": 28126080,
       "increased_power": 1500,
       "level": 50,
       "requirements": [

--- a/buildings/tritanium_generator_f.json
+++ b/buildings/tritanium_generator_f.json
@@ -53,15 +53,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 42840
+            "value": 42840000000
           },
           {
             "type": "dilithium",
-            "value": 126000
+            "value": 126000000
           }
         ]
       },
-      "build_time": 18220,
+      "build_time": 18220320,
       "increased_power": 1500,
       "level": 48,
       "requirements": [
@@ -87,15 +87,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 71400
+            "value": 71400000000
           },
           {
             "type": "dilithium",
-            "value": 210000
+            "value": 210000000
           }
         ]
       },
-      "build_time": 22717,
+      "build_time": 22717440,
       "increased_power": 1500,
       "level": 49,
       "requirements": [
@@ -121,15 +121,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 124950
+            "value": 124950000000
           },
           {
             "type": "dilithium",
-            "value": 367500
+            "value": 367500000
           }
         ]
       },
-      "build_time": 28126,
+      "build_time": 28126080,
       "increased_power": 1500,
       "level": 50,
       "requirements": [

--- a/buildings/tritanium_generator_g.json
+++ b/buildings/tritanium_generator_g.json
@@ -23,15 +23,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 124950
+            "value": 124950000000
           },
           {
             "type": "dilithium",
-            "value": 367500
+            "value": 367500000
           }
         ]
       },
-      "build_time": 28126,
+      "build_time": 28126080,
       "increased_power": 1500,
       "level": 50,
       "requirements": [

--- a/buildings/tritanium_generator_h.json
+++ b/buildings/tritanium_generator_h.json
@@ -23,15 +23,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 124950
+            "value": 124950000000
           },
           {
             "type": "dilithium",
-            "value": 367500
+            "value": 367500000
           }
         ]
       },
-      "build_time": 28126,
+      "build_time": 28126080,
       "increased_power": 1500,
       "level": 50,
       "requirements": [

--- a/buildings/tritanium_vault.json
+++ b/buildings/tritanium_vault.json
@@ -43,7 +43,7 @@
     },
     {
       "bonuses": {
-        "bonus1": 7130
+        "bonus1": 7130000
       },
       "build_costs": {
         "materials": [
@@ -58,15 +58,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 9356
+            "value": 9356800000
           },
           {
             "type": "tritanium",
-            "value": 215000
+            "value": 215000000
           }
         ]
       },
-      "build_time": 7850,
+      "build_time": 7850880,
       "increased_power": 4000,
       "level": 41,
       "requirements": [
@@ -83,7 +83,7 @@
     },
     {
       "bonuses": {
-        "bonus1": 9450
+        "bonus1": 9450000
       },
       "build_costs": {
         "materials": [
@@ -104,15 +104,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 13937
+            "value": 13937280000
           },
           {
             "type": "tritanium",
-            "value": 320250
+            "value": 320250000
           }
         ]
       },
-      "build_time": 12068,
+      "build_time": 12068640,
       "increased_power": 4500,
       "level": 42,
       "requirements": [
@@ -129,7 +129,7 @@
     },
     {
       "bonuses": {
-        "bonus1": 12750
+        "bonus1": 12750000
       },
       "build_costs": {
         "materials": [
@@ -150,15 +150,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 19910
+            "value": 19910400000
           },
           {
             "type": "tritanium",
-            "value": 457500
+            "value": 457500000
           }
         ]
       },
-      "build_time": 15945,
+      "build_time": 15945120,
       "increased_power": 4500,
       "level": 43,
       "requirements": [
@@ -175,7 +175,7 @@
     },
     {
       "bonuses": {
-        "bonus1": 18000
+        "bonus1": 18000000
       },
       "build_costs": {
         "materials": [
@@ -196,15 +196,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 29865
+            "value": 29865600000
           },
           {
             "type": "tritanium",
-            "value": 686250
+            "value": 686250000
           }
         ]
       },
-      "build_time": 20812,
+      "build_time": 20812320,
       "increased_power": 5000,
       "level": 44,
       "requirements": [
@@ -236,11 +236,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 28995
+            "value": 28995200
           },
           {
             "type": "tritanium",
-            "value": 1332
+            "value": 1332500
           }
         ]
       },
@@ -298,7 +298,7 @@
     },
     {
       "bonuses": {
-        "bonus1": 39000
+        "bonus1": 39000000
       },
       "build_costs": {
         "materials": [
@@ -319,15 +319,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 84864
+            "value": 84864000000
           },
           {
             "type": "tritanium",
-            "value": 1950
+            "value": 1950000000
           }
         ]
       },
-      "build_time": 43506,
+      "build_time": 43506720,
       "increased_power": 6000,
       "level": 47,
       "requirements": [
@@ -348,7 +348,7 @@
     },
     {
       "bonuses": {
-        "bonus1": 28900
+        "bonus1": 28900000
       },
       "build_costs": {
         "materials": [
@@ -369,15 +369,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 58344
+            "value": 58344000000
           },
           {
             "type": "tritanium",
-            "value": 1340
+            "value": 1340625000
           }
         ]
       },
-      "build_time": 34344,
+      "build_time": 34344000,
       "increased_power": 5000,
       "level": 46,
       "requirements": [
@@ -394,7 +394,7 @@
     },
     {
       "bonuses": {
-        "bonus1": 22500
+        "bonus1": 22500000
       },
       "build_costs": {
         "materials": [
@@ -409,15 +409,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 42432
+            "value": 42432000000
           },
           {
             "type": "tritanium",
-            "value": 975000
+            "value": 975000000
           }
         ]
       },
-      "build_time": 26867,
+      "build_time": 26867520,
       "increased_power": 5000,
       "level": 45,
       "requirements": [
@@ -1073,7 +1073,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1210
+            "value": 1210944
           },
           {
             "type": "tritanium",
@@ -1106,7 +1106,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1992
+            "value": 1992672
           },
           {
             "type": "tritanium",
@@ -1139,7 +1139,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 3139
+            "value": 3139968
           },
           {
             "type": "tritanium",
@@ -1189,7 +1189,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 5091
+            "value": 5091840
           },
           {
             "type": "tritanium",
@@ -1235,7 +1235,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 7956
+            "value": 7956000
           },
           {
             "type": "tritanium",
@@ -1281,7 +1281,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 12142
+            "value": 12142080
           },
           {
             "type": "tritanium",
@@ -1321,7 +1321,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 18213
+            "value": 18213120
           },
           {
             "type": "tritanium",
@@ -1367,11 +1367,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 42432
+            "value": 42432000
           },
           {
             "type": "tritanium",
-            "value": 1950
+            "value": 1950000
           }
         ]
       },
@@ -1413,11 +1413,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 67075
+            "value": 67075200
           },
           {
             "type": "tritanium",
-            "value": 3082
+            "value": 3082500
           }
         ]
       },
@@ -1459,11 +1459,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 96886
+            "value": 96886400
           },
           {
             "type": "tritanium",
-            "value": 4452
+            "value": 4452500
           }
         ]
       },
@@ -1499,11 +1499,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 149872
+            "value": 149872000
           },
           {
             "type": "tritanium",
-            "value": 6887
+            "value": 6887500
           }
         ]
       },
@@ -1539,15 +1539,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 236640
+            "value": 236640000
           },
           {
             "type": "tritanium",
-            "value": 10875
+            "value": 10875000
           }
         ]
       },
-      "build_time": 1260,
+      "build_time": 1260000,
       "increased_power": 2500,
       "level": 34,
       "requirements": [
@@ -1564,7 +1564,7 @@
     },
     {
       "bonuses": {
-        "bonus1": 1100
+        "bonus1": 1100000
       },
       "build_costs": {
         "materials": [
@@ -1585,15 +1585,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 366220
+            "value": 366220800
           },
           {
             "type": "tritanium",
-            "value": 16830
+            "value": 16830000
           }
         ]
       },
-      "build_time": 1660,
+      "build_time": 1660320,
       "increased_power": 2500,
       "level": 35,
       "requirements": [
@@ -1610,7 +1610,7 @@
     },
     {
       "bonuses": {
-        "bonus1": 1430
+        "bonus1": 1430000
       },
       "build_costs": {
         "materials": [
@@ -1625,15 +1625,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 516038
+            "value": 516038400
           },
           {
             "type": "tritanium",
-            "value": 23715
+            "value": 23715000
           }
         ]
       },
-      "build_time": 2121,
+      "build_time": 2121120,
       "increased_power": 3000,
       "level": 36,
       "requirements": [
@@ -1650,7 +1650,7 @@
     },
     {
       "bonuses": {
-        "bonus1": 1890
+        "bonus1": 1890000
       },
       "build_costs": {
         "materials": [
@@ -1665,15 +1665,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 793152
+            "value": 793152000
           },
           {
             "type": "tritanium",
-            "value": 36450
+            "value": 36450000
           }
         ]
       },
-      "build_time": 2193,
+      "build_time": 2193120,
       "increased_power": 3500,
       "level": 37,
       "requirements": [
@@ -1690,7 +1690,7 @@
     },
     {
       "bonuses": {
-        "bonus1": 2660
+        "bonus1": 2660000
       },
       "build_costs": {
         "materials": [
@@ -1711,15 +1711,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1233
+            "value": 1233792000
           },
           {
             "type": "tritanium",
-            "value": 56700
+            "value": 56700000
           }
         ]
       },
-      "build_time": 3556,
+      "build_time": 3556800,
       "increased_power": 3000,
       "level": 38,
       "requirements": [
@@ -1740,7 +1740,7 @@
     },
     {
       "bonuses": {
-        "bonus1": 3830
+        "bonus1": 3830000
       },
       "build_costs": {
         "materials": [],
@@ -1748,15 +1748,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 2105
+            "value": 2105280000
           },
           {
             "type": "tritanium",
-            "value": 96750
+            "value": 96750000
           }
         ]
       },
-      "build_time": 4720,
+      "build_time": 4720320,
       "increased_power": 4000,
       "level": 39,
       "requirements": [
@@ -1773,7 +1773,7 @@
     },
     {
       "bonuses": {
-        "bonus1": 5250
+        "bonus1": 5250000
       },
       "build_costs": {
         "materials": [
@@ -1788,15 +1788,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 9169
+            "value": 9169664000
           },
           {
             "type": "tritanium",
-            "value": 150500
+            "value": 150500000
           }
         ]
       },
-      "build_time": 8377,
+      "build_time": 8377920,
       "increased_power": 3500,
       "level": 40,
       "requirements": [
@@ -1813,7 +1813,7 @@
     },
     {
       "bonuses": {
-        "bonus1": 54000
+        "bonus1": 54000000
       },
       "build_costs": {
         "materials": [
@@ -1834,15 +1834,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 137088
+            "value": 137088000000
           },
           {
             "type": "tritanium",
-            "value": 3150
+            "value": 3150000000
           }
         ]
       },
-      "build_time": 54660,
+      "build_time": 54660960,
       "increased_power": 6000,
       "level": 48,
       "requirements": [
@@ -1859,7 +1859,7 @@
     },
     {
       "bonuses": {
-        "bonus1": 82500
+        "bonus1": 82500000
       },
       "build_costs": {
         "materials": [
@@ -1880,15 +1880,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 228480
+            "value": 228480000000
           },
           {
             "type": "tritanium",
-            "value": 5250
+            "value": 5250000000
           }
         ]
       },
-      "build_time": 68152,
+      "build_time": 68152320,
       "increased_power": 6000,
       "level": 49,
       "requirements": [
@@ -1909,7 +1909,7 @@
     },
     {
       "bonuses": {
-        "bonus1": 131300
+        "bonus1": 131300000
       },
       "build_costs": {
         "materials": [],
@@ -1917,15 +1917,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 399840
+            "value": 399840000000
           },
           {
             "type": "tritanium",
-            "value": 9187
+            "value": 9187500000
           }
         ]
       },
-      "build_time": 84376,
+      "build_time": 84376800,
       "increased_power": 6000,
       "level": 50,
       "requirements": [

--- a/buildings/tritanium_warehouse.json
+++ b/buildings/tritanium_warehouse.json
@@ -10,7 +10,7 @@
   "levels": [
     {
       "bonuses": {
-        "bonus1": 21500
+        "bonus1": 21500000
       },
       "build_costs": {
         "materials": [
@@ -25,15 +25,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 2339
+            "value": 2339200000
           },
           {
             "type": "tritanium",
-            "value": 387000
+            "value": 387000000
           }
         ]
       },
-      "build_time": 5888,
+      "build_time": 5888160,
       "increased_power": 2000,
       "level": 41,
       "requirements": [
@@ -50,7 +50,7 @@
     },
     {
       "bonuses": {
-        "bonus1": 24000
+        "bonus1": 24000000
       },
       "build_costs": {
         "materials": [
@@ -71,15 +71,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 3484
+            "value": 3484320000
           },
           {
             "type": "tritanium",
-            "value": 576450
+            "value": 576450000
           }
         ]
       },
-      "build_time": 9051,
+      "build_time": 9051840,
       "increased_power": 2000,
       "level": 42,
       "requirements": [
@@ -96,7 +96,7 @@
     },
     {
       "bonuses": {
-        "bonus1": 32500
+        "bonus1": 32500000
       },
       "build_costs": {
         "materials": [
@@ -117,15 +117,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 4977
+            "value": 4977600000
           },
           {
             "type": "tritanium",
-            "value": 823500
+            "value": 823500000
           }
         ]
       },
-      "build_time": 11959,
+      "build_time": 11959200,
       "increased_power": 2500,
       "level": 43,
       "requirements": [
@@ -142,7 +142,7 @@
     },
     {
       "bonuses": {
-        "bonus1": 46000
+        "bonus1": 46000000
       },
       "build_costs": {
         "materials": [
@@ -163,15 +163,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 7466
+            "value": 7466400000
           },
           {
             "type": "tritanium",
-            "value": 1235
+            "value": 1235250000
           }
         ]
       },
-      "build_time": 15608,
+      "build_time": 15608160,
       "increased_power": 2500,
       "level": 44,
       "requirements": [
@@ -188,7 +188,7 @@
     },
     {
       "bonuses": {
-        "bonus1": 5300
+        "bonus1": 5300000
       },
       "build_costs": {
         "materials": [
@@ -203,11 +203,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 24221
+            "value": 24221600
           },
           {
             "type": "tritanium",
-            "value": 8014
+            "value": 8014500
           }
         ]
       },
@@ -228,7 +228,7 @@
     },
     {
       "bonuses": {
-        "bonus1": 100000
+        "bonus1": 100000000
       },
       "build_costs": {
         "materials": [
@@ -249,15 +249,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 21216
+            "value": 21216000000
           },
           {
             "type": "tritanium",
-            "value": 3510
+            "value": 3510000000
           }
         ]
       },
-      "build_time": 32630,
+      "build_time": 32630400,
       "increased_power": 3000,
       "level": 47,
       "requirements": [
@@ -278,7 +278,7 @@
     },
     {
       "bonuses": {
-        "bonus1": 74500
+        "bonus1": 74500000
       },
       "build_costs": {
         "materials": [
@@ -299,15 +299,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 14586
+            "value": 14586000000
           },
           {
             "type": "tritanium",
-            "value": 2413
+            "value": 2413125000
           }
         ]
       },
-      "build_time": 25758,
+      "build_time": 25758720,
       "increased_power": 2500,
       "level": 46,
       "requirements": [
@@ -324,7 +324,7 @@
     },
     {
       "bonuses": {
-        "bonus1": 57500
+        "bonus1": 57500000
       },
       "build_costs": {
         "materials": [
@@ -339,15 +339,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 10608
+            "value": 10608000000
           },
           {
             "type": "tritanium",
-            "value": 1755
+            "value": 1755000000
           }
         ]
       },
-      "build_time": 20151,
+      "build_time": 20151360,
       "increased_power": 2500,
       "level": 45,
       "requirements": [
@@ -368,7 +368,7 @@
     },
     {
       "bonuses": {
-        "bonus1": 20500
+        "bonus1": 20500000
       },
       "build_costs": {
         "materials": [
@@ -383,15 +383,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 2292
+            "value": 2292416000
           },
           {
             "type": "tritanium",
-            "value": 270900
+            "value": 270900000
           }
         ]
       },
-      "build_time": 6282,
+      "build_time": 6282720,
       "increased_power": 2000,
       "level": 40,
       "requirements": [
@@ -408,7 +408,7 @@
     },
     {
       "bonuses": {
-        "bonus1": 19500
+        "bonus1": 19500000
       },
       "build_costs": {
         "materials": [],
@@ -416,15 +416,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 526320
+            "value": 526320000
           },
           {
             "type": "tritanium",
-            "value": 174150
+            "value": 174150000
           }
         ]
       },
-      "build_time": 3540,
+      "build_time": 3540960,
       "increased_power": 1500,
       "level": 39,
       "requirements": [
@@ -441,7 +441,7 @@
     },
     {
       "bonuses": {
-        "bonus1": 9450
+        "bonus1": 9450000
       },
       "build_costs": {
         "materials": [
@@ -462,11 +462,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 59160
+            "value": 59160000
           },
           {
             "type": "tritanium",
-            "value": 19575
+            "value": 19575000
           }
         ]
       },
@@ -1298,7 +1298,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1272
+            "value": 1272960
           },
           {
             "type": "tritanium",
@@ -1342,7 +1342,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1989
+            "value": 1989000
           },
           {
             "type": "tritanium",
@@ -1367,7 +1367,7 @@
     },
     {
       "bonuses": {
-        "bonus1": 1150
+        "bonus1": 1150000
       },
       "build_costs": {
         "materials": [
@@ -1388,11 +1388,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 3035
+            "value": 3035520
           },
           {
             "type": "tritanium",
-            "value": 1004
+            "value": 1004400
           }
         ]
       },
@@ -1413,7 +1413,7 @@
     },
     {
       "bonuses": {
-        "bonus1": 1600
+        "bonus1": 1600000
       },
       "build_costs": {
         "materials": [
@@ -1428,11 +1428,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 4553
+            "value": 4553280
           },
           {
             "type": "tritanium",
-            "value": 1506
+            "value": 1506600
           }
         ]
       },
@@ -1453,7 +1453,7 @@
     },
     {
       "bonuses": {
-        "bonus1": 2250
+        "bonus1": 2250000
       },
       "build_costs": {
         "materials": [
@@ -1468,11 +1468,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 7248
+            "value": 7248800
           },
           {
             "type": "tritanium",
-            "value": 2398
+            "value": 2398500
           }
         ]
       },
@@ -1493,7 +1493,7 @@
     },
     {
       "bonuses": {
-        "bonus1": 3000
+        "bonus1": 3000000
       },
       "build_costs": {
         "materials": [
@@ -1508,11 +1508,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 10608
+            "value": 10608000
           },
           {
             "type": "tritanium",
-            "value": 3510
+            "value": 3510000
           }
         ]
       },
@@ -1533,7 +1533,7 @@
     },
     {
       "bonuses": {
-        "bonus1": 4100
+        "bonus1": 4100000
       },
       "build_costs": {
         "materials": [
@@ -1554,11 +1554,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 16768
+            "value": 16768800
           },
           {
             "type": "tritanium",
-            "value": 5548
+            "value": 5548500
           }
         ]
       },
@@ -1579,7 +1579,7 @@
     },
     {
       "bonuses": {
-        "bonus1": 6850
+        "bonus1": 6850000
       },
       "build_costs": {
         "materials": [
@@ -1594,11 +1594,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 37468
+            "value": 37468000
           },
           {
             "type": "tritanium",
-            "value": 12397
+            "value": 12397500
           }
         ]
       },
@@ -1619,7 +1619,7 @@
     },
     {
       "bonuses": {
-        "bonus1": 12000
+        "bonus1": 12000000
       },
       "build_costs": {
         "materials": [
@@ -1640,15 +1640,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 91555
+            "value": 91555200
           },
           {
             "type": "tritanium",
-            "value": 30294
+            "value": 30294000
           }
         ]
       },
-      "build_time": 1245,
+      "build_time": 1245600,
       "increased_power": 1250,
       "level": 35,
       "requirements": [
@@ -1665,7 +1665,7 @@
     },
     {
       "bonuses": {
-        "bonus1": 14000
+        "bonus1": 14000000
       },
       "build_costs": {
         "materials": [
@@ -1680,15 +1680,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 129009
+            "value": 129009600
           },
           {
             "type": "tritanium",
-            "value": 42687
+            "value": 42687000
           }
         ]
       },
-      "build_time": 1591,
+      "build_time": 1591200,
       "increased_power": 1500,
       "level": 36,
       "requirements": [
@@ -1705,7 +1705,7 @@
     },
     {
       "bonuses": {
-        "bonus1": 16000
+        "bonus1": 16000000
       },
       "build_costs": {
         "materials": [
@@ -1726,15 +1726,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 198288
+            "value": 198288000
           },
           {
             "type": "tritanium",
-            "value": 65610
+            "value": 65610000
           }
         ]
       },
-      "build_time": 1644,
+      "build_time": 1644480,
       "increased_power": 1750,
       "level": 37,
       "requirements": [
@@ -1751,7 +1751,7 @@
     },
     {
       "bonuses": {
-        "bonus1": 18000
+        "bonus1": 18000000
       },
       "build_costs": {
         "materials": [
@@ -1772,15 +1772,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 308448
+            "value": 308448000
           },
           {
             "type": "tritanium",
-            "value": 102060
+            "value": 102060000
           }
         ]
       },
-      "build_time": 2666,
+      "build_time": 2666880,
       "increased_power": 1750,
       "level": 38,
       "requirements": [
@@ -1801,7 +1801,7 @@
     },
     {
       "bonuses": {
-        "bonus1": 140000
+        "bonus1": 140000000
       },
       "build_costs": {
         "materials": [
@@ -1822,15 +1822,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 34272
+            "value": 34272000000
           },
           {
             "type": "tritanium",
-            "value": 5670
+            "value": 5670000000
           }
         ]
       },
-      "build_time": 40995,
+      "build_time": 40995360,
       "increased_power": 3000,
       "level": 48,
       "requirements": [
@@ -1847,7 +1847,7 @@
     },
     {
       "bonuses": {
-        "bonus1": 220000
+        "bonus1": 220000000
       },
       "build_costs": {
         "materials": [
@@ -1868,15 +1868,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 57120
+            "value": 57120000000
           },
           {
             "type": "tritanium",
-            "value": 9450
+            "value": 9450000000
           }
         ]
       },
-      "build_time": 51114,
+      "build_time": 51114240,
       "increased_power": 3000,
       "level": 49,
       "requirements": [
@@ -1897,7 +1897,7 @@
     },
     {
       "bonuses": {
-        "bonus1": 350000
+        "bonus1": 350000000
       },
       "build_costs": {
         "materials": [],
@@ -1905,15 +1905,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 99960
+            "value": 99960000000
           },
           {
             "type": "tritanium",
-            "value": 16537
+            "value": 16537500000
           }
         ]
       },
-      "build_time": 63282,
+      "build_time": 63282240,
       "increased_power": 3000,
       "level": 50,
       "requirements": [

--- a/research/1_isogen_extraction.json
+++ b/research/1_isogen_extraction.json
@@ -44,7 +44,7 @@
           }
         ]
       },
-      "research_time": 1937
+      "research_time": 1937880
     },
     {
       "bonus": {
@@ -84,11 +84,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1660
+            "value": 1660000
           }
         ]
       },
-      "research_time": 3499
+      "research_time": 3499500
     },
     {
       "bonus": {
@@ -128,11 +128,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 3860
+            "value": 3860000
           }
         ]
       },
-      "research_time": 5965
+      "research_time": 5965920
     },
     {
       "bonus": {
@@ -172,11 +172,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 10400
+            "value": 10400000
           }
         ]
       },
-      "research_time": 14125
+      "research_time": 14125380
     },
     {
       "bonus": {
@@ -220,11 +220,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 22450
+            "value": 22450000
           }
         ]
       },
-      "research_time": 21017
+      "research_time": 21017460
     },
     {
       "bonus": {
@@ -264,11 +264,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 49650
+            "value": 49650000
           }
         ]
       },
-      "research_time": 38934
+      "research_time": 38934120
     },
     {
       "bonus": {
@@ -308,11 +308,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 98750
+            "value": 98750000
           }
         ]
       },
-      "research_time": 68900
+      "research_time": 68900340
     },
     {
       "bonus": {
@@ -352,11 +352,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 235800
+            "value": 235800000
           }
         ]
       },
-      "research_time": 113694
+      "research_time": 113694240
     },
     {
       "bonus": {
@@ -396,11 +396,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 708800
+            "value": 708800000
           }
         ]
       },
-      "research_time": 189523
+      "research_time": 189523500
     },
     {
       "bonus": {

--- a/research/2_isogen_extraction.json
+++ b/research/2_isogen_extraction.json
@@ -31,7 +31,7 @@
           }
         ]
       },
-      "research_time": 1937
+      "research_time": 1937880
     },
     {
       "bonus": {
@@ -58,11 +58,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1660
+            "value": 1660000
           }
         ]
       },
-      "research_time": 3499
+      "research_time": 3499500
     },
     {
       "bonus": {
@@ -102,11 +102,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 3860
+            "value": 3860000
           }
         ]
       },
-      "research_time": 5965
+      "research_time": 5965920
     },
     {
       "bonus": {
@@ -133,11 +133,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 10400
+            "value": 10400000
           }
         ]
       },
-      "research_time": 14125
+      "research_time": 14125380
     },
     {
       "bonus": {
@@ -173,11 +173,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 22450
+            "value": 22450000
           }
         ]
       },
-      "research_time": 21017
+      "research_time": 21017460
     },
     {
       "bonus": {
@@ -204,11 +204,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 49650
+            "value": 49650000
           }
         ]
       },
-      "research_time": 38934
+      "research_time": 38934120
     },
     {
       "bonus": {
@@ -235,11 +235,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 98750
+            "value": 98750000
           }
         ]
       },
-      "research_time": 68900
+      "research_time": 68900340
     },
     {
       "bonus": {
@@ -279,11 +279,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 235800
+            "value": 235800000
           }
         ]
       },
-      "research_time": 113694
+      "research_time": 113694240
     },
     {
       "bonus": {
@@ -331,11 +331,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 708800
+            "value": 708800000
           }
         ]
       },
-      "research_time": 189523
+      "research_time": 189523500
     },
     {
       "bonus": {

--- a/research/3_crystal_extractor.json
+++ b/research/3_crystal_extractor.json
@@ -26,7 +26,7 @@
         ],
         "resources": []
       },
-      "research_time": 1045
+      "research_time": 1045620
     },
     {
       "bonus": {
@@ -61,7 +61,7 @@
         ],
         "resources": []
       },
-      "research_time": 1076
+      "research_time": 1076400
     },
     {
       "bonus": {
@@ -92,7 +92,7 @@
         ],
         "resources": []
       },
-      "research_time": 1594
+      "research_time": 1594380
     },
     {
       "bonus": {
@@ -127,7 +127,7 @@
         ],
         "resources": []
       },
-      "research_time": 2131
+      "research_time": 2131680
     },
     {
       "bonus": {
@@ -153,7 +153,7 @@
         ],
         "resources": []
       },
-      "research_time": 2860
+      "research_time": 2860080
     },
     {
       "bonus": {
@@ -188,7 +188,7 @@
         ],
         "resources": []
       },
-      "research_time": 3849
+      "research_time": 3849480
     },
     {
       "bonus": {
@@ -214,7 +214,7 @@
         ],
         "resources": []
       },
-      "research_time": 3832
+      "research_time": 3832380
     },
     {
       "bonus": {
@@ -244,7 +244,7 @@
         ],
         "resources": []
       },
-      "research_time": 6562
+      "research_time": 6562560
     },
     {
       "bonus": {
@@ -279,7 +279,7 @@
         ],
         "resources": []
       },
-      "research_time": 8864
+      "research_time": 8864580
     },
     {
       "bonus": {

--- a/research/3_gas_extractor.json
+++ b/research/3_gas_extractor.json
@@ -26,7 +26,7 @@
         ],
         "resources": []
       },
-      "research_time": 2860
+      "research_time": 2860080
     },
     {
       "bonus": {
@@ -52,7 +52,7 @@
         ],
         "resources": []
       },
-      "research_time": 1045
+      "research_time": 1045620
     },
     {
       "bonus": {
@@ -87,7 +87,7 @@
         ],
         "resources": []
       },
-      "research_time": 1076
+      "research_time": 1076400
     },
     {
       "bonus": {
@@ -122,7 +122,7 @@
         ],
         "resources": []
       },
-      "research_time": 1594
+      "research_time": 1594380
     },
     {
       "bonus": {
@@ -153,7 +153,7 @@
         ],
         "resources": []
       },
-      "research_time": 2131
+      "research_time": 2131680
     },
     {
       "bonus": {
@@ -188,7 +188,7 @@
         ],
         "resources": []
       },
-      "research_time": 3849
+      "research_time": 3849480
     },
     {
       "bonus": {
@@ -214,7 +214,7 @@
         ],
         "resources": []
       },
-      "research_time": 3832
+      "research_time": 3832380
     },
     {
       "bonus": {
@@ -244,7 +244,7 @@
         ],
         "resources": []
       },
-      "research_time": 6562
+      "research_time": 6562560
     },
     {
       "bonus": {
@@ -275,7 +275,7 @@
         ],
         "resources": []
       },
-      "research_time": 8864
+      "research_time": 8864580
     },
     {
       "bonus": {

--- a/research/3_isogen_extraction.json
+++ b/research/3_isogen_extraction.json
@@ -44,11 +44,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1110
+            "value": 1110000
           }
         ]
       },
-      "research_time": 2600
+      "research_time": 2600040
     },
     {
       "bonus": {
@@ -75,11 +75,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1660
+            "value": 1660000
           }
         ]
       },
-      "research_time": 3499
+      "research_time": 3499500
     },
     {
       "bonus": {
@@ -106,11 +106,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 2440
+            "value": 2440000
           }
         ]
       },
-      "research_time": 3483
+      "research_time": 3483960
     },
     {
       "bonus": {
@@ -137,11 +137,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 3860
+            "value": 3860000
           }
         ]
       },
-      "research_time": 5965
+      "research_time": 5965920
     },
     {
       "bonus": {
@@ -168,11 +168,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 10400
+            "value": 10400000
           }
         ]
       },
-      "research_time": 14125
+      "research_time": 14125380
     },
     {
       "bonus": {
@@ -216,11 +216,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 22450
+            "value": 22450000
           }
         ]
       },
-      "research_time": 21017
+      "research_time": 21017460
     },
     {
       "bonus": {
@@ -247,11 +247,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 49650
+            "value": 49650000
           }
         ]
       },
-      "research_time": 38934
+      "research_time": 38934120
     },
     {
       "bonus": {
@@ -278,11 +278,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 98750
+            "value": 98750000
           }
         ]
       },
-      "research_time": 68900
+      "research_time": 68900340
     },
     {
       "bonus": {
@@ -322,11 +322,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 235800
+            "value": 235800000
           }
         ]
       },
-      "research_time": 113694
+      "research_time": 113694240
     },
     {
       "bonus": {
@@ -370,11 +370,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 708800
+            "value": 708800000
           }
         ]
       },
-      "research_time": 189523
+      "research_time": 189523500
     }
   ],
   "location": {

--- a/research/3_ore_extractor.json
+++ b/research/3_ore_extractor.json
@@ -39,7 +39,7 @@
         ],
         "resources": []
       },
-      "research_time": 3849
+      "research_time": 3849480
     },
     {
       "bonus": {
@@ -65,7 +65,7 @@
         ],
         "resources": []
       },
-      "research_time": 1045
+      "research_time": 1045620
     },
     {
       "bonus": {
@@ -96,7 +96,7 @@
         ],
         "resources": []
       },
-      "research_time": 1076
+      "research_time": 1076400
     },
     {
       "bonus": {
@@ -126,7 +126,7 @@
         ],
         "resources": []
       },
-      "research_time": 1594
+      "research_time": 1594380
     },
     {
       "bonus": {
@@ -161,7 +161,7 @@
         ],
         "resources": []
       },
-      "research_time": 2131
+      "research_time": 2131680
     },
     {
       "bonus": {
@@ -187,7 +187,7 @@
         ],
         "resources": []
       },
-      "research_time": 2860
+      "research_time": 2860080
     },
     {
       "bonus": {
@@ -213,7 +213,7 @@
         ],
         "resources": []
       },
-      "research_time": 3832
+      "research_time": 3832380
     },
     {
       "bonus": {
@@ -248,7 +248,7 @@
         ],
         "resources": []
       },
-      "research_time": 6562
+      "research_time": 6562560
     },
     {
       "bonus": {
@@ -278,7 +278,7 @@
         ],
         "resources": []
       },
-      "research_time": 8864
+      "research_time": 8864580
     },
     {
       "bonus": {

--- a/research/4_assembly_line.json
+++ b/research/4_assembly_line.json
@@ -41,11 +41,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 337100
+            "value": 337100000
           }
         ]
       },
-      "research_time": 18915
+      "research_time": 18915720
     },
     {
       "bonus": {
@@ -74,11 +74,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 489000
+            "value": 489000000
           }
         ]
       },
-      "research_time": 26404
+      "research_time": 26404920
     },
     {
       "bonus": {
@@ -113,11 +113,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 744800
+            "value": 744800000
           }
         ]
       },
-      "research_time": 35040
+      "research_time": 35040720
     },
     {
       "bonus": {
@@ -152,11 +152,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1062
+            "value": 1062000000
           }
         ]
       },
-      "research_time": 45981
+      "research_time": 45981360
     },
     {
       "bonus": {
@@ -191,11 +191,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1481
+            "value": 1481000000
           }
         ]
       },
-      "research_time": 62010
+      "research_time": 62010300
     },
     {
       "bonus": {
@@ -242,11 +242,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 2190
+            "value": 2190000000
           }
         ]
       },
-      "research_time": 79999
+      "research_time": 79999620
     },
     {
       "bonus": {
@@ -281,11 +281,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 3537
+            "value": 3537000000
           }
         ]
       },
-      "research_time": 102324
+      "research_time": 102324840
     },
     {
       "bonus": {
@@ -314,11 +314,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 5985
+            "value": 5985000000
           }
         ]
       },
-      "research_time": 135507
+      "research_time": 135507360
     },
     {
       "bonus": {
@@ -365,11 +365,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 10631
+            "value": 10631000000
           }
         ]
       },
-      "research_time": 170571
+      "research_time": 170571120
     },
     {
       "bonus": {
@@ -411,11 +411,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 16183
+            "value": 16183000000
           }
         ]
       },
-      "research_time": 194400
+      "research_time": 194400000
     }
   ],
   "location": {

--- a/research/4_battleship_defense_formation.json
+++ b/research/4_battleship_defense_formation.json
@@ -37,11 +37,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 987300
+            "value": 987300000
           }
         ]
       },
-      "research_time": 68900
+      "research_time": 68900340
     }
   ],
   "location": {

--- a/research/4_battleship_penetration.json
+++ b/research/4_battleship_penetration.json
@@ -56,15 +56,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 2394
+            "value": 2394000000
           },
           {
             "type": "dilithium",
-            "value": 3192
+            "value": 3192000000
           }
         ]
       },
-      "research_time": 31147
+      "research_time": 31147320
     },
     {
       "bonus": {
@@ -108,15 +108,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 4253
+            "value": 4253000000
           },
           {
             "type": "dilithium",
-            "value": 5670
+            "value": 5670000000
           }
         ]
       },
-      "research_time": 40872
+      "research_time": 40872300
     },
     {
       "bonus": {
@@ -147,15 +147,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 6473
+            "value": 6473000000
           },
           {
             "type": "dilithium",
-            "value": 8631
+            "value": 8631000000
           }
         ]
       },
-      "research_time": 55120
+      "research_time": 55120260
     },
     {
       "bonus": {
@@ -186,15 +186,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 9923
+            "value": 9923000000
           },
           {
             "type": "dilithium",
-            "value": 13230
+            "value": 13230000000
           }
         ]
       },
-      "research_time": 71110
+      "research_time": 71110740
     },
     {
       "bonus": {
@@ -225,15 +225,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 8859
+            "value": 8859000000
           },
           {
             "type": "dilithium",
-            "value": 11813
+            "value": 11813000000
           }
         ]
       },
-      "research_time": 90955
+      "research_time": 90955380
     },
     {
       "bonus": {
@@ -264,15 +264,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 13289
+            "value": 13289000000
           },
           {
             "type": "dilithium",
-            "value": 17719
+            "value": 17719000000
           }
         ]
       },
-      "research_time": 120450
+      "research_time": 120450960
     },
     {
       "bonus": {
@@ -303,15 +303,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 19934
+            "value": 19934000000
           },
           {
             "type": "dilithium",
-            "value": 26578
+            "value": 26578000000
           }
         ]
       },
-      "research_time": 151618
+      "research_time": 151618800
     },
     {
       "bonus": {
@@ -333,15 +333,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 29900
+            "value": 29900000000
           },
           {
             "type": "dilithium",
-            "value": 39867
+            "value": 39867000000
           }
         ]
       },
-      "research_time": 184933
+      "research_time": 184933380
     },
     {
       "bonus": {
@@ -363,15 +363,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 44851
+            "value": 44851000000
           },
           {
             "type": "dilithium",
-            "value": 59801
+            "value": 59801000000
           }
         ]
       },
-      "research_time": 238070
+      "research_time": 238070580
     },
     {
       "bonus": {
@@ -393,15 +393,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 67276
+            "value": 67276000000
           },
           {
             "type": "dilithium",
-            "value": 89701
+            "value": 89701000000
           }
         ]
       },
-      "research_time": 163658
+      "research_time": 163658580
     }
   ],
   "location": {

--- a/research/4_battleship_pillager.json
+++ b/research/4_battleship_pillager.json
@@ -35,15 +35,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 4316
+            "value": 4316000000
           },
           {
             "type": "dilithium",
-            "value": 8631
+            "value": 8631000000
           }
         ]
       },
-      "research_time": 216000
+      "research_time": 216000000
     },
     {
       "bonus": {
@@ -84,15 +84,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 1596
+            "value": 1596000000
           },
           {
             "type": "dilithium",
-            "value": 3192
+            "value": 3192000000
           }
         ]
       },
-      "research_time": 150563
+      "research_time": 150563760
     }
   ],
   "location": {

--- a/research/4_battleship_pure_dilithium.json
+++ b/research/4_battleship_pure_dilithium.json
@@ -33,15 +33,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 62350
+            "value": 62350000
           },
           {
             "type": "dilithium",
-            "value": 124700
+            "value": 124700000
           }
         ]
       },
-      "research_time": 22600
+      "research_time": 22600620
     },
     {
       "bonus": {
@@ -76,15 +76,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 90450
+            "value": 90450000
           },
           {
             "type": "dilithium",
-            "value": 180900
+            "value": 180900000
           }
         ]
       },
-      "research_time": 21529
+      "research_time": 21529800
     },
     {
       "bonus": {
@@ -123,15 +123,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 134800
+            "value": 134800000
           },
           {
             "type": "dilithium",
-            "value": 269600
+            "value": 269600000
           }
         ]
       },
-      "research_time": 33627
+      "research_time": 33627960
     },
     {
       "bonus": {
@@ -172,15 +172,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 195600
+            "value": 195600000
           },
           {
             "type": "dilithium",
-            "value": 391200
+            "value": 391200000
           }
         ]
       },
-      "research_time": 46942
+      "research_time": 46942080
     },
     {
       "bonus": {
@@ -225,15 +225,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 297900
+            "value": 297900000
           },
           {
             "type": "dilithium",
-            "value": 595800
+            "value": 595800000
           }
         ]
       },
-      "research_time": 62294
+      "research_time": 62294640
     },
     {
       "bonus": {
@@ -274,15 +274,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 424800
+            "value": 424800000
           },
           {
             "type": "dilithium",
-            "value": 849600
+            "value": 849600000
           }
         ]
       },
-      "research_time": 81744
+      "research_time": 81744660
     },
     {
       "bonus": {
@@ -327,15 +327,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 592400
+            "value": 592400000
           },
           {
             "type": "dilithium",
-            "value": 1185
+            "value": 1185000000
           }
         ]
       },
-      "research_time": 110240
+      "research_time": 110240520
     },
     {
       "bonus": {
@@ -380,15 +380,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 876000
+            "value": 876000000
           },
           {
             "type": "dilithium",
-            "value": 1752
+            "value": 1752000000
           }
         ]
       },
-      "research_time": 142221
+      "research_time": 142221540
     },
     {
       "bonus": {
@@ -433,15 +433,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 1415
+            "value": 1415000000
           },
           {
             "type": "dilithium",
-            "value": 2830
+            "value": 2830000000
           }
         ]
       },
-      "research_time": 181910
+      "research_time": 181910760
     },
     {
       "bonus": {
@@ -480,15 +480,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 2394
+            "value": 2394000000
           },
           {
             "type": "dilithium",
-            "value": 4788
+            "value": 4788000000
           }
         ]
       },
-      "research_time": 240901
+      "research_time": 240901980
     }
   ],
   "location": {

--- a/research/4_battleship_pure_ore.json
+++ b/research/4_battleship_pure_ore.json
@@ -33,15 +33,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 104000
+            "value": 104000000
           },
           {
             "type": "dilithium",
-            "value": 104000
+            "value": 104000000
           }
         ]
       },
-      "research_time": 22600
+      "research_time": 22600620
     },
     {
       "bonus": {
@@ -76,15 +76,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 150800
+            "value": 150800000
           },
           {
             "type": "dilithium",
-            "value": 150800
+            "value": 150800000
           }
         ]
       },
-      "research_time": 21529
+      "research_time": 21529800
     },
     {
       "bonus": {
@@ -123,15 +123,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 224700
+            "value": 224700000
           },
           {
             "type": "dilithium",
-            "value": 224700
+            "value": 224700000
           }
         ]
       },
-      "research_time": 33627
+      "research_time": 33627960
     },
     {
       "bonus": {
@@ -172,15 +172,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 326000
+            "value": 326000000
           },
           {
             "type": "dilithium",
-            "value": 326000
+            "value": 326000000
           }
         ]
       },
-      "research_time": 46942
+      "research_time": 46942080
     },
     {
       "bonus": {
@@ -225,15 +225,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 496500
+            "value": 496500000
           },
           {
             "type": "dilithium",
-            "value": 496500
+            "value": 496500000
           }
         ]
       },
-      "research_time": 62294
+      "research_time": 62294640
     },
     {
       "bonus": {
@@ -274,15 +274,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 708000
+            "value": 708000000
           },
           {
             "type": "dilithium",
-            "value": 708000
+            "value": 708000000
           }
         ]
       },
-      "research_time": 81744
+      "research_time": 81744660
     },
     {
       "bonus": {
@@ -327,15 +327,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 987300
+            "value": 987300000
           },
           {
             "type": "dilithium",
-            "value": 987300
+            "value": 987300000
           }
         ]
       },
-      "research_time": 110240
+      "research_time": 110240520
     },
     {
       "bonus": {
@@ -380,15 +380,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 1460
+            "value": 1460000000
           },
           {
             "type": "dilithium",
-            "value": 1460
+            "value": 1460000000
           }
         ]
       },
-      "research_time": 142221
+      "research_time": 142221540
     },
     {
       "bonus": {
@@ -433,15 +433,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 2358
+            "value": 2358000000
           },
           {
             "type": "dilithium",
-            "value": 2358
+            "value": 2358000000
           }
         ]
       },
-      "research_time": 181910
+      "research_time": 181910760
     },
     {
       "bonus": {
@@ -480,15 +480,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 3990
+            "value": 3990000000
           },
           {
             "type": "dilithium",
-            "value": 3990
+            "value": 3990000000
           }
         ]
       },
-      "research_time": 240901
+      "research_time": 240901980
     }
   ],
   "location": {

--- a/research/4_battleship_pure_tritanium.json
+++ b/research/4_battleship_pure_tritanium.json
@@ -33,15 +33,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 145500
+            "value": 145500000
           },
           {
             "type": "dilithium",
-            "value": 83150
+            "value": 83150000
           }
         ]
       },
-      "research_time": 22600
+      "research_time": 22600620
     },
     {
       "bonus": {
@@ -76,15 +76,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 211100
+            "value": 211100000
           },
           {
             "type": "dilithium",
-            "value": 120600
+            "value": 120600000
           }
         ]
       },
-      "research_time": 21529
+      "research_time": 21529800
     },
     {
       "bonus": {
@@ -119,15 +119,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 314600
+            "value": 314600000
           },
           {
             "type": "dilithium",
-            "value": 179800
+            "value": 179800000
           }
         ]
       },
-      "research_time": 33627
+      "research_time": 33627960
     },
     {
       "bonus": {
@@ -168,15 +168,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 456400
+            "value": 456400000
           },
           {
             "type": "dilithium",
-            "value": 260800
+            "value": 260800000
           }
         ]
       },
-      "research_time": 46942
+      "research_time": 46942080
     },
     {
       "bonus": {
@@ -217,15 +217,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 695100
+            "value": 695100000
           },
           {
             "type": "dilithium",
-            "value": 397200
+            "value": 397200000
           }
         ]
       },
-      "research_time": 62294
+      "research_time": 62294640
     },
     {
       "bonus": {
@@ -266,15 +266,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 991200
+            "value": 991200000
           },
           {
             "type": "dilithium",
-            "value": 566400
+            "value": 566400000
           }
         ]
       },
-      "research_time": 81744
+      "research_time": 81744660
     },
     {
       "bonus": {
@@ -319,15 +319,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 1382
+            "value": 1382000000
           },
           {
             "type": "dilithium",
-            "value": 789800
+            "value": 789800000
           }
         ]
       },
-      "research_time": 110240
+      "research_time": 110240520
     },
     {
       "bonus": {
@@ -372,15 +372,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 2044
+            "value": 2044000000
           },
           {
             "type": "dilithium",
-            "value": 1168
+            "value": 1168000000
           }
         ]
       },
-      "research_time": 142221
+      "research_time": 142221540
     },
     {
       "bonus": {
@@ -425,15 +425,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 3301
+            "value": 3301000000
           },
           {
             "type": "dilithium",
-            "value": 1886
+            "value": 1886000000
           }
         ]
       },
-      "research_time": 181910
+      "research_time": 181910760
     },
     {
       "bonus": {
@@ -478,15 +478,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 5586
+            "value": 5586000000
           },
           {
             "type": "dilithium",
-            "value": 3192
+            "value": 3192000000
           }
         ]
       },
-      "research_time": 240901
+      "research_time": 240901980
     }
   ],
   "location": {

--- a/research/4_battleship_regeneration.json
+++ b/research/4_battleship_regeneration.json
@@ -42,11 +42,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 637200
+            "value": 637200000
           }
         ]
       },
-      "research_time": 45981
+      "research_time": 45981360
     },
     {
       "bonus": {
@@ -84,11 +84,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 888500
+            "value": 888500000
           }
         ]
       },
-      "research_time": 62010
+      "research_time": 62010300
     },
     {
       "bonus": {
@@ -132,11 +132,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1314
+            "value": 1314000000
           }
         ]
       },
-      "research_time": 79999
+      "research_time": 79999620
     },
     {
       "bonus": {
@@ -174,11 +174,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 2122
+            "value": 2122000000
           }
         ]
       },
-      "research_time": 102324
+      "research_time": 102324840
     },
     {
       "bonus": {
@@ -222,11 +222,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 3591
+            "value": 3591000000
           }
         ]
       },
-      "research_time": 135507
+      "research_time": 135507360
     }
   ],
   "location": {

--- a/research/4_battleship_repair_cost.json
+++ b/research/4_battleship_repair_cost.json
@@ -33,15 +33,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 916800
+            "value": 916800000
           },
           {
             "type": "dilithium",
-            "value": 269600
+            "value": 269600000
           }
         ]
       },
-      "research_time": 31526
+      "research_time": 31526220
     },
     {
       "bonus": {
@@ -80,15 +80,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1330
+            "value": 1330000000
           },
           {
             "type": "dilithium",
-            "value": 391200
+            "value": 391200000
           }
         ]
       },
-      "research_time": 44008
+      "research_time": 44008200
     },
     {
       "bonus": {
@@ -131,15 +131,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 2026
+            "value": 2026000000
           },
           {
             "type": "dilithium",
-            "value": 595800
+            "value": 595800000
           }
         ]
       },
-      "research_time": 58401
+      "research_time": 58401240
     },
     {
       "bonus": {
@@ -178,15 +178,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 2889
+            "value": 2889000000
           },
           {
             "type": "dilithium",
-            "value": 849600
+            "value": 849600000
           }
         ]
       },
-      "research_time": 76635
+      "research_time": 76635600
     },
     {
       "bonus": {
@@ -225,15 +225,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 4028
+            "value": 4028000000
           },
           {
             "type": "dilithium",
-            "value": 1185
+            "value": 1185000000
           }
         ]
       },
-      "research_time": 103350
+      "research_time": 103350540
     },
     {
       "bonus": {
@@ -276,15 +276,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 5957
+            "value": 5957000000
           },
           {
             "type": "dilithium",
-            "value": 1752
+            "value": 1752000000
           }
         ]
       },
-      "research_time": 133332
+      "research_time": 133332660
     },
     {
       "bonus": {
@@ -323,15 +323,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 9621
+            "value": 9621000000
           },
           {
             "type": "dilithium",
-            "value": 2830
+            "value": 2830000000
           }
         ]
       },
-      "research_time": 170541
+      "research_time": 170541360
     },
     {
       "bonus": {
@@ -364,15 +364,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 16279
+            "value": 16279000000
           },
           {
             "type": "dilithium",
-            "value": 4788
+            "value": 4788000000
           }
         ]
       },
-      "research_time": 225845
+      "research_time": 225845580
     },
     {
       "bonus": {
@@ -415,15 +415,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 28917
+            "value": 28917000000
           },
           {
             "type": "dilithium",
-            "value": 8505
+            "value": 8505000000
           }
         ]
       },
-      "research_time": 284285
+      "research_time": 284285220
     },
     {
       "bonus": {
@@ -458,15 +458,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 44018
+            "value": 44018000000
           },
           {
             "type": "dilithium",
-            "value": 12947
+            "value": 12947000000
           }
         ]
       },
-      "research_time": 324000
+      "research_time": 324000000
     }
   ],
   "location": {

--- a/research/4_battleship_station_piercing.json
+++ b/research/4_battleship_station_piercing.json
@@ -37,15 +37,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 1886
+            "value": 1886000000
           },
           {
             "type": "dilithium",
-            "value": 2358
+            "value": 2358000000
           }
         ]
       },
-      "research_time": 113694
+      "research_time": 113694240
     }
   ],
   "location": {

--- a/research/4_battleship_swift_repair.json
+++ b/research/4_battleship_swift_repair.json
@@ -33,15 +33,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 4028
+            "value": 4028000000
           },
           {
             "type": "dilithium",
-            "value": 987300
+            "value": 987300000
           }
         ]
       },
-      "research_time": 68900
+      "research_time": 68900340
     },
     {
       "bonus": {
@@ -74,15 +74,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 5957
+            "value": 5957000000
           },
           {
             "type": "dilithium",
-            "value": 1460
+            "value": 1460000000
           }
         ]
       },
-      "research_time": 88888
+      "research_time": 88888440
     },
     {
       "bonus": {
@@ -115,15 +115,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 9621
+            "value": 9621000000
           },
           {
             "type": "dilithium",
-            "value": 2358
+            "value": 2358000000
           }
         ]
       },
-      "research_time": 113694
+      "research_time": 113694240
     },
     {
       "bonus": {
@@ -162,15 +162,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 16279
+            "value": 16279000000
           },
           {
             "type": "dilithium",
-            "value": 3990
+            "value": 3990000000
           }
         ]
       },
-      "research_time": 150563
+      "research_time": 150563760
     },
     {
       "bonus": {
@@ -205,15 +205,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 28917
+            "value": 28917000000
           },
           {
             "type": "dilithium",
-            "value": 7088
+            "value": 7088000000
           }
         ]
       },
-      "research_time": 189523
+      "research_time": 189523500
     },
     {
       "bonus": {
@@ -252,15 +252,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 44018
+            "value": 44018000000
           },
           {
             "type": "dilithium",
-            "value": 10789
+            "value": 10789000000
           }
         ]
       },
-      "research_time": 216000
+      "research_time": 216000000
     },
     {
       "bonus": {
@@ -299,15 +299,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 67473
+            "value": 67473000000
           },
           {
             "type": "dilithium",
-            "value": 16538
+            "value": 16538000000
           }
         ]
       },
-      "research_time": 246000
+      "research_time": 246000000
     },
     {
       "bonus": {
@@ -346,15 +346,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 60244
+            "value": 60244000000
           },
           {
             "type": "dilithium",
-            "value": 14766
+            "value": 14766000000
           }
         ]
       },
-      "research_time": 279000
+      "research_time": 279000000
     },
     {
       "bonus": {
@@ -393,15 +393,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 90366
+            "value": 90366000000
           },
           {
             "type": "dilithium",
-            "value": 22148
+            "value": 22148000000
           }
         ]
       },
-      "research_time": 315000
+      "research_time": 315000000
     },
     {
       "bonus": {
@@ -444,15 +444,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 135548
+            "value": 135548000000
           },
           {
             "type": "dilithium",
-            "value": 33223
+            "value": 33223000000
           }
         ]
       },
-      "research_time": 354000
+      "research_time": 354000000
     }
   ],
   "location": {

--- a/research/4_battleship_weaponry.json
+++ b/research/4_battleship_weaponry.json
@@ -38,11 +38,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1283
+            "value": 1283000000
           }
         ]
       },
-      "research_time": 89570
+      "research_time": 89570460
     },
     {
       "bonus": {
@@ -64,11 +64,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 28793
+            "value": 28793000000
           }
         ]
       },
-      "research_time": 319134
+      "research_time": 319134180
     },
     {
       "bonus": {
@@ -112,11 +112,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1898
+            "value": 1898000000
           }
         ]
       },
-      "research_time": 115554
+      "research_time": 115554960
     },
     {
       "bonus": {
@@ -150,11 +150,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 3065
+            "value": 3065000000
           }
         ]
       },
-      "research_time": 147802
+      "research_time": 147802500
     },
     {
       "bonus": {
@@ -198,11 +198,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 5187
+            "value": 5187000000
           }
         ]
       },
-      "research_time": 195732
+      "research_time": 195732840
     },
     {
       "bonus": {
@@ -254,11 +254,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 9214
+            "value": 9214000000
           }
         ]
       },
-      "research_time": 246380
+      "research_time": 246380520
     },
     {
       "bonus": {
@@ -280,11 +280,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 14025
+            "value": 14025000000
           }
         ]
       },
-      "research_time": 300516
+      "research_time": 300516720
     },
     {
       "bonus": {
@@ -306,11 +306,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 21499
+            "value": 21499000000
           }
         ]
       },
-      "research_time": 386864
+      "research_time": 386864640
     },
     {
       "bonus": {
@@ -332,11 +332,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 19195
+            "value": 19195000000
           }
         ]
       },
-      "research_time": 265945
+      "research_time": 265945140
     },
     {
       "bonus": {
@@ -358,11 +358,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 43189
+            "value": 43189000000
           }
         ]
       },
-      "research_time": 419913
+      "research_time": 419913420
     }
   ],
   "location": {

--- a/research/4_crystal_prospector.json
+++ b/research/4_crystal_prospector.json
@@ -43,7 +43,7 @@
         ],
         "resources": []
       },
-      "research_time": 32272
+      "research_time": 32272680
     },
     {
       "bonus": {
@@ -73,7 +73,7 @@
         ],
         "resources": []
       },
-      "research_time": 42827
+      "research_time": 42827580
     },
     {
       "bonus": {
@@ -107,7 +107,7 @@
         ],
         "resources": []
       },
-      "research_time": 56199
+      "research_time": 56199420
     },
     {
       "bonus": {
@@ -146,7 +146,7 @@
         ],
         "resources": []
       },
-      "research_time": 75790
+      "research_time": 75790380
     },
     {
       "bonus": {
@@ -175,12 +175,12 @@
           },
           {
             "type": "Service\u00a0Award",
-            "value": 1259
+            "value": 1259626
           }
         ],
         "resources": []
       },
-      "research_time": 97777
+      "research_time": 97777320
     },
     {
       "bonus": {
@@ -210,12 +210,12 @@
           },
           {
             "type": "Service\u00a0Award",
-            "value": 1259
+            "value": 1259626
           }
         ],
         "resources": []
       },
-      "research_time": 125063
+      "research_time": 125063640
     },
     {
       "bonus": {
@@ -240,7 +240,7 @@
         "others": [
           {
             "type": "Service\u00a0Award",
-            "value": 1796
+            "value": 1796553
           },
           {
             "type": "Merit\u00a0of\u00a0Honor",
@@ -249,7 +249,7 @@
         ],
         "resources": []
       },
-      "research_time": 165620
+      "research_time": 165620100
     },
     {
       "bonus": {
@@ -279,12 +279,12 @@
           },
           {
             "type": "Service\u00a0Award",
-            "value": 1796
+            "value": 1796553
           }
         ],
         "resources": []
       },
-      "research_time": 208475
+      "research_time": 208475820
     },
     {
       "bonus": {
@@ -313,12 +313,12 @@
           },
           {
             "type": "Service\u00a0Award",
-            "value": 2669
+            "value": 2669728
           }
         ],
         "resources": []
       },
-      "research_time": 254283
+      "research_time": 254283360
     },
     {
       "bonus": {
@@ -356,12 +356,12 @@
           },
           {
             "type": "Service\u00a0Award",
-            "value": 4412
+            "value": 4412607
           }
         ],
         "resources": []
       },
-      "research_time": 327347
+      "research_time": 327347040
     }
   ],
   "location": {

--- a/research/4_energy_blast.json
+++ b/research/4_energy_blast.json
@@ -48,11 +48,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1898
+            "value": 1898000000
           }
         ]
       },
-      "research_time": 115554
+      "research_time": 115554960
     },
     {
       "bonus": {
@@ -92,11 +92,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 3065
+            "value": 3065000000
           }
         ]
       },
-      "research_time": 147802
+      "research_time": 147802500
     },
     {
       "bonus": {
@@ -144,11 +144,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 5187
+            "value": 5187000000
           }
         ]
       },
-      "research_time": 195732
+      "research_time": 195732840
     },
     {
       "bonus": {
@@ -200,11 +200,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 9214
+            "value": 9214000000
           }
         ]
       },
-      "research_time": 246380
+      "research_time": 246380520
     },
     {
       "bonus": {
@@ -226,11 +226,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 14025
+            "value": 14025000000
           }
         ]
       },
-      "research_time": 300516
+      "research_time": 300516720
     },
     {
       "bonus": {
@@ -252,11 +252,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 21499
+            "value": 21499000000
           }
         ]
       },
-      "research_time": 386864
+      "research_time": 386864640
     },
     {
       "bonus": {
@@ -278,11 +278,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 19195
+            "value": 19195000000
           }
         ]
       },
-      "research_time": 265945
+      "research_time": 265945140
     },
     {
       "bonus": {
@@ -304,11 +304,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 28793
+            "value": 28793000000
           }
         ]
       },
-      "research_time": 319134
+      "research_time": 319134180
     },
     {
       "bonus": {
@@ -330,11 +330,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 43189
+            "value": 43189000000
           }
         ]
       },
-      "research_time": 419913
+      "research_time": 419913420
     },
     {
       "bonus": {
@@ -356,11 +356,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 64784
+            "value": 64784000000
           }
         ]
       },
-      "research_time": 503896
+      "research_time": 503896080
     }
   ],
   "location": {

--- a/research/4_evasive_interceptors.json
+++ b/research/4_evasive_interceptors.json
@@ -38,15 +38,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 195600
+            "value": 195600000
           },
           {
             "type": "dilithium",
-            "value": 260800
+            "value": 260800000
           }
         ]
       },
-      "research_time": 23471
+      "research_time": 23471040
     },
     {
       "bonus": {
@@ -90,15 +90,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 297900
+            "value": 297900000
           },
           {
             "type": "dilithium",
-            "value": 397200
+            "value": 397200000
           }
         ]
       },
-      "research_time": 31147
+      "research_time": 31147320
     },
     {
       "bonus": {
@@ -131,15 +131,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 424800
+            "value": 424800000
           },
           {
             "type": "dilithium",
-            "value": 566400
+            "value": 566400000
           }
         ]
       },
-      "research_time": 40872
+      "research_time": 40872300
     },
     {
       "bonus": {
@@ -183,15 +183,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 592400
+            "value": 592400000
           },
           {
             "type": "dilithium",
-            "value": 789800
+            "value": 789800000
           }
         ]
       },
-      "research_time": 55120
+      "research_time": 55120260
     },
     {
       "bonus": {
@@ -224,15 +224,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 876000
+            "value": 876000000
           },
           {
             "type": "dilithium",
-            "value": 1168
+            "value": 1168000000
           }
         ]
       },
-      "research_time": 71110
+      "research_time": 71110740
     },
     {
       "bonus": {
@@ -271,15 +271,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 1415
+            "value": 1415000000
           },
           {
             "type": "dilithium",
-            "value": 1886
+            "value": 1886000000
           }
         ]
       },
-      "research_time": 90955
+      "research_time": 90955380
     },
     {
       "bonus": {
@@ -312,15 +312,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 2394
+            "value": 2394000000
           },
           {
             "type": "dilithium",
-            "value": 3192
+            "value": 3192000000
           }
         ]
       },
-      "research_time": 120450
+      "research_time": 120450960
     },
     {
       "bonus": {
@@ -349,15 +349,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 4253
+            "value": 4253000000
           },
           {
             "type": "dilithium",
-            "value": 5670
+            "value": 5670000000
           }
         ]
       },
-      "research_time": 151618
+      "research_time": 151618800
     },
     {
       "bonus": {
@@ -396,15 +396,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 6473
+            "value": 6473000000
           },
           {
             "type": "dilithium",
-            "value": 8631
+            "value": 8631000000
           }
         ]
       },
-      "research_time": 184933
+      "research_time": 184933380
     },
     {
       "bonus": {
@@ -439,15 +439,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 9923
+            "value": 9923000000
           },
           {
             "type": "dilithium",
-            "value": 13230
+            "value": 13230000000
           }
         ]
       },
-      "research_time": 238070
+      "research_time": 238070580
     }
   ],
   "location": {

--- a/research/4_evasive_maneuvers.json
+++ b/research/4_evasive_maneuvers.json
@@ -42,15 +42,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 297900
+            "value": 297900000
           },
           {
             "type": "dilithium",
-            "value": 397200
+            "value": 397200000
           }
         ]
       },
-      "research_time": 120450
+      "research_time": 120450960
     },
     {
       "bonus": {
@@ -94,15 +94,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 424800
+            "value": 424800000
           },
           {
             "type": "dilithium",
-            "value": 566400
+            "value": 566400000
           }
         ]
       },
-      "research_time": 151618
+      "research_time": 151618800
     },
     {
       "bonus": {
@@ -131,15 +131,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 592400
+            "value": 592400000
           },
           {
             "type": "dilithium",
-            "value": 789800
+            "value": 789800000
           }
         ]
       },
-      "research_time": 184933
+      "research_time": 184933380
     },
     {
       "bonus": {
@@ -174,15 +174,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 876000
+            "value": 876000000
           },
           {
             "type": "dilithium",
-            "value": 1168
+            "value": 1168000000
           }
         ]
       },
-      "research_time": 238070
+      "research_time": 238070580
     },
     {
       "bonus": {
@@ -211,15 +211,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 1415
+            "value": 1415000000
           },
           {
             "type": "dilithium",
-            "value": 1886
+            "value": 1886000000
           }
         ]
       },
-      "research_time": 163658
+      "research_time": 163658580
     },
     {
       "bonus": {
@@ -254,15 +254,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 2394
+            "value": 2394000000
           },
           {
             "type": "dilithium",
-            "value": 3192
+            "value": 3192000000
           }
         ]
       },
-      "research_time": 196390
+      "research_time": 196390260
     },
     {
       "bonus": {
@@ -291,15 +291,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 4253
+            "value": 4253000000
           },
           {
             "type": "dilithium",
-            "value": 5670
+            "value": 5670000000
           }
         ]
       },
-      "research_time": 258408
+      "research_time": 258408240
     },
     {
       "bonus": {
@@ -321,15 +321,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 6473
+            "value": 6473000000
           },
           {
             "type": "dilithium",
-            "value": 8631
+            "value": 8631000000
           }
         ]
       },
-      "research_time": 310089
+      "research_time": 310089900
     },
     {
       "bonus": {
@@ -351,15 +351,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 9923
+            "value": 9923000000
           },
           {
             "type": "dilithium",
-            "value": 13230
+            "value": 13230000000
           }
         ]
       },
-      "research_time": 372107
+      "research_time": 372107880
     },
     {
       "bonus": {
@@ -381,15 +381,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 8859
+            "value": 8859000000
           },
           {
             "type": "dilithium",
-            "value": 11813
+            "value": 11813000000
           }
         ]
       },
-      "research_time": 446529
+      "research_time": 446529480
     }
   ],
   "location": {

--- a/research/4_explorer_barriers.json
+++ b/research/4_explorer_barriers.json
@@ -38,15 +38,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 62350
+            "value": 62350000
           },
           {
             "type": "dilithium",
-            "value": 83150
+            "value": 83150000
           }
         ]
       },
-      "research_time": 11300
+      "research_time": 11300340
     },
     {
       "bonus": {
@@ -84,15 +84,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 90450
+            "value": 90450000
           },
           {
             "type": "dilithium",
-            "value": 120600
+            "value": 120600000
           }
         ]
       },
-      "research_time": 10764
+      "research_time": 10764900
     },
     {
       "bonus": {
@@ -134,15 +134,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 134800
+            "value": 134800000
           },
           {
             "type": "dilithium",
-            "value": 179800
+            "value": 179800000
           }
         ]
       },
-      "research_time": 16813
+      "research_time": 16813980
     },
     {
       "bonus": {
@@ -180,15 +180,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 195600
+            "value": 195600000
           },
           {
             "type": "dilithium",
-            "value": 260800
+            "value": 260800000
           }
         ]
       },
-      "research_time": 23471
+      "research_time": 23471040
     },
     {
       "bonus": {
@@ -232,15 +232,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 297900
+            "value": 297900000
           },
           {
             "type": "dilithium",
-            "value": 397200
+            "value": 397200000
           }
         ]
       },
-      "research_time": 31147
+      "research_time": 31147320
     },
     {
       "bonus": {
@@ -278,15 +278,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 424800
+            "value": 424800000
           },
           {
             "type": "dilithium",
-            "value": 566400
+            "value": 566400000
           }
         ]
       },
-      "research_time": 40872
+      "research_time": 40872300
     },
     {
       "bonus": {
@@ -330,15 +330,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 592400
+            "value": 592400000
           },
           {
             "type": "dilithium",
-            "value": 789800
+            "value": 789800000
           }
         ]
       },
-      "research_time": 55120
+      "research_time": 55120260
     },
     {
       "bonus": {
@@ -371,15 +371,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 876000
+            "value": 876000000
           },
           {
             "type": "dilithium",
-            "value": 1168
+            "value": 1168000000
           }
         ]
       },
-      "research_time": 71110
+      "research_time": 71110740
     },
     {
       "bonus": {
@@ -418,15 +418,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 1415
+            "value": 1415000000
           },
           {
             "type": "dilithium",
-            "value": 1886
+            "value": 1886000000
           }
         ]
       },
-      "research_time": 90955
+      "research_time": 90955380
     },
     {
       "bonus": {
@@ -459,15 +459,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 2394
+            "value": 2394000000
           },
           {
             "type": "dilithium",
-            "value": 3192
+            "value": 3192000000
           }
         ]
       },
-      "research_time": 120450
+      "research_time": 120450960
     }
   ],
   "location": {

--- a/research/4_explorer_defense_formation.json
+++ b/research/4_explorer_defense_formation.json
@@ -37,11 +37,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 987300
+            "value": 987300000
           }
         ]
       },
-      "research_time": 68900
+      "research_time": 68900340
     }
   ],
   "location": {

--- a/research/4_explorer_pillager.json
+++ b/research/4_explorer_pillager.json
@@ -41,15 +41,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 1596
+            "value": 1596000000
           },
           {
             "type": "dilithium",
-            "value": 3192
+            "value": 3192000000
           }
         ]
       },
-      "research_time": 150563
+      "research_time": 150563760
     }
   ],
   "location": {

--- a/research/4_explorer_pure_dilithium.json
+++ b/research/4_explorer_pure_dilithium.json
@@ -37,15 +37,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 62350
+            "value": 62350000
           },
           {
             "type": "dilithium",
-            "value": 124700
+            "value": 124700000
           }
         ]
       },
-      "research_time": 22600
+      "research_time": 22600620
     },
     {
       "bonus": {
@@ -80,15 +80,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 90450
+            "value": 90450000
           },
           {
             "type": "dilithium",
-            "value": 180900
+            "value": 180900000
           }
         ]
       },
-      "research_time": 21529
+      "research_time": 21529800
     },
     {
       "bonus": {
@@ -131,15 +131,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 134800
+            "value": 134800000
           },
           {
             "type": "dilithium",
-            "value": 269600
+            "value": 269600000
           }
         ]
       },
-      "research_time": 33627
+      "research_time": 33627960
     },
     {
       "bonus": {
@@ -180,15 +180,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 195600
+            "value": 195600000
           },
           {
             "type": "dilithium",
-            "value": 391200
+            "value": 391200000
           }
         ]
       },
-      "research_time": 46942
+      "research_time": 46942080
     },
     {
       "bonus": {
@@ -241,15 +241,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 297900
+            "value": 297900000
           },
           {
             "type": "dilithium",
-            "value": 595800
+            "value": 595800000
           }
         ]
       },
-      "research_time": 62294
+      "research_time": 62294640
     },
     {
       "bonus": {
@@ -290,15 +290,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 424800
+            "value": 424800000
           },
           {
             "type": "dilithium",
-            "value": 849600
+            "value": 849600000
           }
         ]
       },
-      "research_time": 81744
+      "research_time": 81744660
     },
     {
       "bonus": {
@@ -347,15 +347,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 592400
+            "value": 592400000
           },
           {
             "type": "dilithium",
-            "value": 1185
+            "value": 1185000000
           }
         ]
       },
-      "research_time": 110240
+      "research_time": 110240520
     },
     {
       "bonus": {
@@ -396,15 +396,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 876000
+            "value": 876000000
           },
           {
             "type": "dilithium",
-            "value": 1752
+            "value": 1752000000
           }
         ]
       },
-      "research_time": 142221
+      "research_time": 142221540
     },
     {
       "bonus": {
@@ -453,15 +453,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 1415
+            "value": 1415000000
           },
           {
             "type": "dilithium",
-            "value": 2830
+            "value": 2830000000
           }
         ]
       },
-      "research_time": 181910
+      "research_time": 181910760
     },
     {
       "bonus": {
@@ -504,15 +504,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 2394
+            "value": 2394000000
           },
           {
             "type": "dilithium",
-            "value": 4788
+            "value": 4788000000
           }
         ]
       },
-      "research_time": 240901
+      "research_time": 240901980
     }
   ],
   "location": {

--- a/research/4_explorer_pure_gas.json
+++ b/research/4_explorer_pure_gas.json
@@ -37,15 +37,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 104000
+            "value": 104000000
           },
           {
             "type": "dilithium",
-            "value": 104000
+            "value": 104000000
           }
         ]
       },
-      "research_time": 22600
+      "research_time": 22600620
     },
     {
       "bonus": {
@@ -85,15 +85,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 150800
+            "value": 150800000
           },
           {
             "type": "dilithium",
-            "value": 150800
+            "value": 150800000
           }
         ]
       },
-      "research_time": 21529
+      "research_time": 21529800
     },
     {
       "bonus": {
@@ -142,15 +142,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 224700
+            "value": 224700000
           },
           {
             "type": "dilithium",
-            "value": 224700
+            "value": 224700000
           }
         ]
       },
-      "research_time": 33627
+      "research_time": 33627960
     },
     {
       "bonus": {
@@ -191,15 +191,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 326000
+            "value": 326000000
           },
           {
             "type": "dilithium",
-            "value": 326000
+            "value": 326000000
           }
         ]
       },
-      "research_time": 46942
+      "research_time": 46942080
     },
     {
       "bonus": {
@@ -252,15 +252,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 496500
+            "value": 496500000
           },
           {
             "type": "dilithium",
-            "value": 496500
+            "value": 496500000
           }
         ]
       },
-      "research_time": 62294
+      "research_time": 62294640
     },
     {
       "bonus": {
@@ -301,15 +301,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 708000
+            "value": 708000000
           },
           {
             "type": "dilithium",
-            "value": 708000
+            "value": 708000000
           }
         ]
       },
-      "research_time": 81744
+      "research_time": 81744660
     },
     {
       "bonus": {
@@ -358,15 +358,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 987300
+            "value": 987300000
           },
           {
             "type": "dilithium",
-            "value": 987300
+            "value": 987300000
           }
         ]
       },
-      "research_time": 110240
+      "research_time": 110240520
     },
     {
       "bonus": {
@@ -407,15 +407,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 1460
+            "value": 1460000000
           },
           {
             "type": "dilithium",
-            "value": 1460
+            "value": 1460000000
           }
         ]
       },
-      "research_time": 142221
+      "research_time": 142221540
     },
     {
       "bonus": {
@@ -464,15 +464,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 2358
+            "value": 2358000000
           },
           {
             "type": "dilithium",
-            "value": 2358
+            "value": 2358000000
           }
         ]
       },
-      "research_time": 181910
+      "research_time": 181910760
     },
     {
       "bonus": {
@@ -515,15 +515,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 3990
+            "value": 3990000000
           },
           {
             "type": "dilithium",
-            "value": 3990
+            "value": 3990000000
           }
         ]
       },
-      "research_time": 240901
+      "research_time": 240901980
     }
   ],
   "location": {

--- a/research/4_explorer_pure_tritanium.json
+++ b/research/4_explorer_pure_tritanium.json
@@ -37,15 +37,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 145500
+            "value": 145500000
           },
           {
             "type": "dilithium",
-            "value": 83150
+            "value": 83150000
           }
         ]
       },
-      "research_time": 22600
+      "research_time": 22600620
     },
     {
       "bonus": {
@@ -85,15 +85,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 211100
+            "value": 211100000
           },
           {
             "type": "dilithium",
-            "value": 120600
+            "value": 120600000
           }
         ]
       },
-      "research_time": 21529
+      "research_time": 21529800
     },
     {
       "bonus": {
@@ -141,15 +141,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 314600
+            "value": 314600000
           },
           {
             "type": "dilithium",
-            "value": 179800
+            "value": 179800000
           }
         ]
       },
-      "research_time": 33627
+      "research_time": 33627960
     },
     {
       "bonus": {
@@ -190,15 +190,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 456400
+            "value": 456400000
           },
           {
             "type": "dilithium",
-            "value": 260800
+            "value": 260800000
           }
         ]
       },
-      "research_time": 46942
+      "research_time": 46942080
     },
     {
       "bonus": {
@@ -251,15 +251,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 695100
+            "value": 695100000
           },
           {
             "type": "dilithium",
-            "value": 397200
+            "value": 397200000
           }
         ]
       },
-      "research_time": 62294
+      "research_time": 62294640
     },
     {
       "bonus": {
@@ -300,15 +300,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 991200
+            "value": 991200000
           },
           {
             "type": "dilithium",
-            "value": 566400
+            "value": 566400000
           }
         ]
       },
-      "research_time": 81744
+      "research_time": 81744660
     },
     {
       "bonus": {
@@ -357,15 +357,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 1382
+            "value": 1382000000
           },
           {
             "type": "dilithium",
-            "value": 789800
+            "value": 789800000
           }
         ]
       },
-      "research_time": 110240
+      "research_time": 110240520
     },
     {
       "bonus": {
@@ -406,15 +406,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 2044
+            "value": 2044000000
           },
           {
             "type": "dilithium",
-            "value": 1168
+            "value": 1168000000
           }
         ]
       },
-      "research_time": 142221
+      "research_time": 142221540
     },
     {
       "bonus": {
@@ -463,15 +463,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 3301
+            "value": 3301000000
           },
           {
             "type": "dilithium",
-            "value": 1886
+            "value": 1886000000
           }
         ]
       },
-      "research_time": 181910
+      "research_time": 181910760
     },
     {
       "bonus": {
@@ -520,15 +520,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 5586
+            "value": 5586000000
           },
           {
             "type": "dilithium",
-            "value": 3192
+            "value": 3192000000
           }
         ]
       },
-      "research_time": 240901
+      "research_time": 240901980
     }
   ],
   "location": {

--- a/research/4_explorer_regeneration.json
+++ b/research/4_explorer_regeneration.json
@@ -46,11 +46,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 637200
+            "value": 637200000
           }
         ]
       },
-      "research_time": 45981
+      "research_time": 45981360
     },
     {
       "bonus": {
@@ -88,11 +88,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 888500
+            "value": 888500000
           }
         ]
       },
-      "research_time": 62010
+      "research_time": 62010300
     },
     {
       "bonus": {
@@ -136,11 +136,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1314
+            "value": 1314000000
           }
         ]
       },
-      "research_time": 79999
+      "research_time": 79999620
     },
     {
       "bonus": {
@@ -178,11 +178,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 2122
+            "value": 2122000000
           }
         ]
       },
-      "research_time": 102324
+      "research_time": 102324840
     },
     {
       "bonus": {
@@ -226,11 +226,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 3591
+            "value": 3591000000
           }
         ]
       },
-      "research_time": 135507
+      "research_time": 135507360
     }
   ],
   "location": {

--- a/research/4_explorer_repair_cost.json
+++ b/research/4_explorer_repair_cost.json
@@ -33,15 +33,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 916800
+            "value": 916800000
           },
           {
             "type": "dilithium",
-            "value": 269600
+            "value": 269600000
           }
         ]
       },
-      "research_time": 31526
+      "research_time": 31526220
     },
     {
       "bonus": {
@@ -80,15 +80,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1330
+            "value": 1330000000
           },
           {
             "type": "dilithium",
-            "value": 391200
+            "value": 391200000
           }
         ]
       },
-      "research_time": 44008
+      "research_time": 44008200
     },
     {
       "bonus": {
@@ -131,15 +131,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 2026
+            "value": 2026000000
           },
           {
             "type": "dilithium",
-            "value": 595800
+            "value": 595800000
           }
         ]
       },
-      "research_time": 58401
+      "research_time": 58401240
     },
     {
       "bonus": {
@@ -178,15 +178,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 2889
+            "value": 2889000000
           },
           {
             "type": "dilithium",
-            "value": 849600
+            "value": 849600000
           }
         ]
       },
-      "research_time": 76635
+      "research_time": 76635600
     },
     {
       "bonus": {
@@ -225,15 +225,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 4028
+            "value": 4028000000
           },
           {
             "type": "dilithium",
-            "value": 1185
+            "value": 1185000000
           }
         ]
       },
-      "research_time": 103350
+      "research_time": 103350540
     },
     {
       "bonus": {
@@ -276,15 +276,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 5957
+            "value": 5957000000
           },
           {
             "type": "dilithium",
-            "value": 1752
+            "value": 1752000000
           }
         ]
       },
-      "research_time": 133332
+      "research_time": 133332660
     },
     {
       "bonus": {
@@ -323,15 +323,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 9621
+            "value": 9621000000
           },
           {
             "type": "dilithium",
-            "value": 2830
+            "value": 2830000000
           }
         ]
       },
-      "research_time": 170541
+      "research_time": 170541360
     },
     {
       "bonus": {
@@ -364,15 +364,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 16279
+            "value": 16279000000
           },
           {
             "type": "dilithium",
-            "value": 4788
+            "value": 4788000000
           }
         ]
       },
-      "research_time": 225845
+      "research_time": 225845580
     },
     {
       "bonus": {
@@ -415,15 +415,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 28917
+            "value": 28917000000
           },
           {
             "type": "dilithium",
-            "value": 8505
+            "value": 8505000000
           }
         ]
       },
-      "research_time": 284285
+      "research_time": 284285220
     },
     {
       "bonus": {
@@ -463,15 +463,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 44018
+            "value": 44018000000
           },
           {
             "type": "dilithium",
-            "value": 12947
+            "value": 12947000000
           }
         ]
       },
-      "research_time": 324000
+      "research_time": 324000000
     }
   ],
   "location": {

--- a/research/4_explorer_station_piercing.json
+++ b/research/4_explorer_station_piercing.json
@@ -37,15 +37,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 566400
+            "value": 566400000
           },
           {
             "type": "dilithium",
-            "value": 708000
+            "value": 708000000
           }
         ]
       },
-      "research_time": 51090
+      "research_time": 51090420
     }
   ],
   "location": {

--- a/research/4_explorer_targeting_array.json
+++ b/research/4_explorer_targeting_array.json
@@ -56,15 +56,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 2394
+            "value": 2394000000
           },
           {
             "type": "dilithium",
-            "value": 3192
+            "value": 3192000000
           }
         ]
       },
-      "research_time": 31147
+      "research_time": 31147320
     },
     {
       "bonus": {
@@ -112,15 +112,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 4253
+            "value": 4253000000
           },
           {
             "type": "dilithium",
-            "value": 5670
+            "value": 5670000000
           }
         ]
       },
-      "research_time": 40872
+      "research_time": 40872300
     },
     {
       "bonus": {
@@ -151,15 +151,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 6473
+            "value": 6473000000
           },
           {
             "type": "dilithium",
-            "value": 8631
+            "value": 8631000000
           }
         ]
       },
-      "research_time": 55120
+      "research_time": 55120260
     },
     {
       "bonus": {
@@ -190,15 +190,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 9923
+            "value": 9923000000
           },
           {
             "type": "dilithium",
-            "value": 13230
+            "value": 13230000000
           }
         ]
       },
-      "research_time": 71110
+      "research_time": 71110740
     },
     {
       "bonus": {
@@ -229,15 +229,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 8859
+            "value": 8859000000
           },
           {
             "type": "dilithium",
-            "value": 11813
+            "value": 11813000000
           }
         ]
       },
-      "research_time": 90955
+      "research_time": 90955380
     },
     {
       "bonus": {
@@ -272,15 +272,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 13289
+            "value": 13289000000
           },
           {
             "type": "dilithium",
-            "value": 17719
+            "value": 17719000000
           }
         ]
       },
-      "research_time": 120450
+      "research_time": 120450960
     },
     {
       "bonus": {
@@ -310,15 +310,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 19934
+            "value": 19934000000
           },
           {
             "type": "dilithium",
-            "value": 26578
+            "value": 26578000000
           }
         ]
       },
-      "research_time": 151618
+      "research_time": 151618800
     },
     {
       "bonus": {
@@ -340,15 +340,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 29900
+            "value": 29900000000
           },
           {
             "type": "dilithium",
-            "value": 39867
+            "value": 39867000000
           }
         ]
       },
-      "research_time": 184933
+      "research_time": 184933380
     },
     {
       "bonus": {
@@ -370,15 +370,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 44851
+            "value": 44851000000
           },
           {
             "type": "dilithium",
-            "value": 59801
+            "value": 59801000000
           }
         ]
       },
-      "research_time": 238070
+      "research_time": 238070580
     },
     {
       "bonus": {
@@ -400,15 +400,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 67276
+            "value": 67276000000
           },
           {
             "type": "dilithium",
-            "value": 89701
+            "value": 89701000000
           }
         ]
       },
-      "research_time": 163658
+      "research_time": 163658580
     }
   ],
   "location": {

--- a/research/4_explorer_weaponry.json
+++ b/research/4_explorer_weaponry.json
@@ -38,11 +38,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1283
+            "value": 1283000000
           }
         ]
       },
-      "research_time": 89570
+      "research_time": 89570460
     },
     {
       "bonus": {
@@ -86,11 +86,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1898
+            "value": 1898000000
           }
         ]
       },
-      "research_time": 115554
+      "research_time": 115554960
     },
     {
       "bonus": {
@@ -124,11 +124,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 3065
+            "value": 3065000000
           }
         ]
       },
-      "research_time": 147802
+      "research_time": 147802500
     },
     {
       "bonus": {
@@ -172,11 +172,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 5187
+            "value": 5187000000
           }
         ]
       },
-      "research_time": 195732
+      "research_time": 195732840
     },
     {
       "bonus": {
@@ -224,11 +224,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 9214
+            "value": 9214000000
           }
         ]
       },
-      "research_time": 246380
+      "research_time": 246380520
     },
     {
       "bonus": {
@@ -250,11 +250,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 14025
+            "value": 14025000000
           }
         ]
       },
-      "research_time": 300516
+      "research_time": 300516720
     },
     {
       "bonus": {
@@ -276,11 +276,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 21499
+            "value": 21499000000
           }
         ]
       },
-      "research_time": 386864
+      "research_time": 386864640
     },
     {
       "bonus": {
@@ -302,11 +302,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 19195
+            "value": 19195000000
           }
         ]
       },
-      "research_time": 265945
+      "research_time": 265945140
     },
     {
       "bonus": {
@@ -328,11 +328,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 28793
+            "value": 28793000000
           }
         ]
       },
-      "research_time": 319134
+      "research_time": 319134180
     },
     {
       "bonus": {
@@ -354,11 +354,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 43189
+            "value": 43189000000
           }
         ]
       },
-      "research_time": 419913
+      "research_time": 419913420
     }
   ],
   "location": {

--- a/research/4_fortified_battleships.json
+++ b/research/4_fortified_battleships.json
@@ -38,15 +38,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 195600
+            "value": 195600000
           },
           {
             "type": "dilithium",
-            "value": 260800
+            "value": 260800000
           }
         ]
       },
-      "research_time": 23471
+      "research_time": 23471040
     },
     {
       "bonus": {
@@ -90,15 +90,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 297900
+            "value": 297900000
           },
           {
             "type": "dilithium",
-            "value": 397200
+            "value": 397200000
           }
         ]
       },
-      "research_time": 31147
+      "research_time": 31147320
     },
     {
       "bonus": {
@@ -131,15 +131,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 424800
+            "value": 424800000
           },
           {
             "type": "dilithium",
-            "value": 566400
+            "value": 566400000
           }
         ]
       },
-      "research_time": 40872
+      "research_time": 40872300
     },
     {
       "bonus": {
@@ -183,15 +183,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 592400
+            "value": 592400000
           },
           {
             "type": "dilithium",
-            "value": 789800
+            "value": 789800000
           }
         ]
       },
-      "research_time": 55120
+      "research_time": 55120260
     },
     {
       "bonus": {
@@ -224,15 +224,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 876000
+            "value": 876000000
           },
           {
             "type": "dilithium",
-            "value": 1168
+            "value": 1168000000
           }
         ]
       },
-      "research_time": 71110
+      "research_time": 71110740
     },
     {
       "bonus": {
@@ -271,15 +271,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 1415
+            "value": 1415000000
           },
           {
             "type": "dilithium",
-            "value": 1886
+            "value": 1886000000
           }
         ]
       },
-      "research_time": 90955
+      "research_time": 90955380
     },
     {
       "bonus": {
@@ -312,15 +312,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 2394
+            "value": 2394000000
           },
           {
             "type": "dilithium",
-            "value": 3192
+            "value": 3192000000
           }
         ]
       },
-      "research_time": 120450
+      "research_time": 120450960
     },
     {
       "bonus": {
@@ -349,15 +349,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 4253
+            "value": 4253000000
           },
           {
             "type": "dilithium",
-            "value": 5670
+            "value": 5670000000
           }
         ]
       },
-      "research_time": 151618
+      "research_time": 151618800
     },
     {
       "bonus": {
@@ -396,15 +396,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 6473
+            "value": 6473000000
           },
           {
             "type": "dilithium",
-            "value": 8631
+            "value": 8631000000
           }
         ]
       },
-      "research_time": 184933
+      "research_time": 184933380
     },
     {
       "bonus": {
@@ -439,15 +439,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 9923
+            "value": 9923000000
           },
           {
             "type": "dilithium",
-            "value": 13230
+            "value": 13230000000
           }
         ]
       },
-      "research_time": 238070
+      "research_time": 238070580
     }
   ],
   "location": {

--- a/research/4_gas_prospector.json
+++ b/research/4_gas_prospector.json
@@ -43,7 +43,7 @@
         ],
         "resources": []
       },
-      "research_time": 32272
+      "research_time": 32272680
     },
     {
       "bonus": {
@@ -73,7 +73,7 @@
         ],
         "resources": []
       },
-      "research_time": 42827
+      "research_time": 42827580
     },
     {
       "bonus": {
@@ -107,7 +107,7 @@
         ],
         "resources": []
       },
-      "research_time": 56199
+      "research_time": 56199420
     },
     {
       "bonus": {
@@ -142,7 +142,7 @@
         ],
         "resources": []
       },
-      "research_time": 75790
+      "research_time": 75790380
     },
     {
       "bonus": {
@@ -176,12 +176,12 @@
           },
           {
             "type": "Service\u00a0Award",
-            "value": 1259
+            "value": 1259626
           }
         ],
         "resources": []
       },
-      "research_time": 97777
+      "research_time": 97777320
     },
     {
       "bonus": {
@@ -211,12 +211,12 @@
           },
           {
             "type": "Service\u00a0Award",
-            "value": 1259
+            "value": 1259626
           }
         ],
         "resources": []
       },
-      "research_time": 125063
+      "research_time": 125063640
     },
     {
       "bonus": {
@@ -245,12 +245,12 @@
           },
           {
             "type": "Service\u00a0Award",
-            "value": 1796
+            "value": 1796553
           }
         ],
         "resources": []
       },
-      "research_time": 165620
+      "research_time": 165620100
     },
     {
       "bonus": {
@@ -280,12 +280,12 @@
           },
           {
             "type": "Service\u00a0Award",
-            "value": 1796
+            "value": 1796553
           }
         ],
         "resources": []
       },
-      "research_time": 208475
+      "research_time": 208475820
     },
     {
       "bonus": {
@@ -314,12 +314,12 @@
           },
           {
             "type": "Service\u00a0Award",
-            "value": 2669
+            "value": 2669728
           }
         ],
         "resources": []
       },
-      "research_time": 254283
+      "research_time": 254283360
     },
     {
       "bonus": {
@@ -353,7 +353,7 @@
         "others": [
           {
             "type": "Service\u00a0Award",
-            "value": 4412
+            "value": 4412607
           },
           {
             "type": "Merit\u00a0of\u00a0Honor",
@@ -362,7 +362,7 @@
         ],
         "resources": []
       },
-      "research_time": 327347
+      "research_time": 327347040
     }
   ],
   "location": {

--- a/research/4_hull_density.json
+++ b/research/4_hull_density.json
@@ -52,15 +52,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 104000
+            "value": 104000000
           },
           {
             "type": "dilithium",
-            "value": 62350
+            "value": 62350000
           }
         ]
       },
-      "research_time": 14125
+      "research_time": 14125380
     },
     {
       "bonus": {
@@ -99,15 +99,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 150800
+            "value": 150800000
           },
           {
             "type": "dilithium",
-            "value": 90450
+            "value": 90450000
           }
         ]
       },
-      "research_time": 13456
+      "research_time": 13456140
     },
     {
       "bonus": {
@@ -146,15 +146,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 224700
+            "value": 224700000
           },
           {
             "type": "dilithium",
-            "value": 134800
+            "value": 134800000
           }
         ]
       },
-      "research_time": 21017
+      "research_time": 21017460
     },
     {
       "bonus": {
@@ -193,15 +193,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 326000
+            "value": 326000000
           },
           {
             "type": "dilithium",
-            "value": 195600
+            "value": 195600000
           }
         ]
       },
-      "research_time": 29338
+      "research_time": 29338800
     },
     {
       "bonus": {
@@ -248,15 +248,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 496500
+            "value": 496500000
           },
           {
             "type": "dilithium",
-            "value": 297900
+            "value": 297900000
           }
         ]
       },
-      "research_time": 38934
+      "research_time": 38934120
     },
     {
       "bonus": {
@@ -295,15 +295,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 708000
+            "value": 708000000
           },
           {
             "type": "dilithium",
-            "value": 424800
+            "value": 424800000
           }
         ]
       },
-      "research_time": 51090
+      "research_time": 51090420
     },
     {
       "bonus": {
@@ -350,15 +350,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 987300
+            "value": 987300000
           },
           {
             "type": "dilithium",
-            "value": 592400
+            "value": 592400000
           }
         ]
       },
-      "research_time": 68900
+      "research_time": 68900340
     },
     {
       "bonus": {
@@ -397,15 +397,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 1460
+            "value": 1460000000
           },
           {
             "type": "dilithium",
-            "value": 876000
+            "value": 876000000
           }
         ]
       },
-      "research_time": 88888
+      "research_time": 88888440
     },
     {
       "bonus": {
@@ -444,15 +444,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 2358
+            "value": 2358000000
           },
           {
             "type": "dilithium",
-            "value": 1415
+            "value": 1415000000
           }
         ]
       },
-      "research_time": 113694
+      "research_time": 113694240
     },
     {
       "bonus": {
@@ -491,15 +491,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 3990
+            "value": 3990000000
           },
           {
             "type": "dilithium",
-            "value": 2394
+            "value": 2394000000
           }
         ]
       },
-      "research_time": 150563
+      "research_time": 150563760
     }
   ],
   "location": {

--- a/research/4_interceptor_armor_piercing.json
+++ b/research/4_interceptor_armor_piercing.json
@@ -52,15 +52,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 2394
+            "value": 2394000000
           },
           {
             "type": "dilithium",
-            "value": 3192
+            "value": 3192000000
           }
         ]
       },
-      "research_time": 31147
+      "research_time": 31147320
     },
     {
       "bonus": {
@@ -104,15 +104,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 4253
+            "value": 4253000000
           },
           {
             "type": "dilithium",
-            "value": 5670
+            "value": 5670000000
           }
         ]
       },
-      "research_time": 40872
+      "research_time": 40872300
     },
     {
       "bonus": {
@@ -143,15 +143,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 6473
+            "value": 6473000000
           },
           {
             "type": "dilithium",
-            "value": 8631
+            "value": 8631000000
           }
         ]
       },
-      "research_time": 55120
+      "research_time": 55120260
     },
     {
       "bonus": {
@@ -182,15 +182,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 9923
+            "value": 9923000000
           },
           {
             "type": "dilithium",
-            "value": 13230
+            "value": 13230000000
           }
         ]
       },
-      "research_time": 71110
+      "research_time": 71110740
     },
     {
       "bonus": {
@@ -221,15 +221,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 8859
+            "value": 8859000000
           },
           {
             "type": "dilithium",
-            "value": 11813
+            "value": 11813000000
           }
         ]
       },
-      "research_time": 90955
+      "research_time": 90955380
     },
     {
       "bonus": {
@@ -260,15 +260,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 13289
+            "value": 13289000000
           },
           {
             "type": "dilithium",
-            "value": 17719
+            "value": 17719000000
           }
         ]
       },
-      "research_time": 120450
+      "research_time": 120450960
     },
     {
       "bonus": {
@@ -299,15 +299,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 19934
+            "value": 19934000000
           },
           {
             "type": "dilithium",
-            "value": 26578
+            "value": 26578000000
           }
         ]
       },
-      "research_time": 151618
+      "research_time": 151618800
     },
     {
       "bonus": {
@@ -329,15 +329,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 29900
+            "value": 29900000000
           },
           {
             "type": "dilithium",
-            "value": 39867
+            "value": 39867000000
           }
         ]
       },
-      "research_time": 184933
+      "research_time": 184933380
     },
     {
       "bonus": {
@@ -359,15 +359,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 44851
+            "value": 44851000000
           },
           {
             "type": "dilithium",
-            "value": 59801
+            "value": 59801000000
           }
         ]
       },
-      "research_time": 238070
+      "research_time": 238070580
     },
     {
       "bonus": {
@@ -389,15 +389,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 67276
+            "value": 67276000000
           },
           {
             "type": "dilithium",
-            "value": 89701
+            "value": 89701000000
           }
         ]
       },
-      "research_time": 163658
+      "research_time": 163658580
     }
   ],
   "location": {

--- a/research/4_interceptor_defense_formation.json
+++ b/research/4_interceptor_defense_formation.json
@@ -37,11 +37,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 987300
+            "value": 987300000
           }
         ]
       },
-      "research_time": 68900
+      "research_time": 68900340
     }
   ],
   "location": {

--- a/research/4_interceptor_pillager.json
+++ b/research/4_interceptor_pillager.json
@@ -41,15 +41,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 1596
+            "value": 1596000000
           },
           {
             "type": "dilithium",
-            "value": 3192
+            "value": 3192000000
           }
         ]
       },
-      "research_time": 150563
+      "research_time": 150563760
     }
   ],
   "location": {

--- a/research/4_interceptor_pure_crystal.json
+++ b/research/4_interceptor_pure_crystal.json
@@ -33,15 +33,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 104000
+            "value": 104000000
           },
           {
             "type": "dilithium",
-            "value": 104000
+            "value": 104000000
           }
         ]
       },
-      "research_time": 22600
+      "research_time": 22600620
     },
     {
       "bonus": {
@@ -76,15 +76,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 150800
+            "value": 150800000
           },
           {
             "type": "dilithium",
-            "value": 150800
+            "value": 150800000
           }
         ]
       },
-      "research_time": 21529
+      "research_time": 21529800
     },
     {
       "bonus": {
@@ -123,15 +123,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 224700
+            "value": 224700000
           },
           {
             "type": "dilithium",
-            "value": 224700
+            "value": 224700000
           }
         ]
       },
-      "research_time": 33627
+      "research_time": 33627960
     },
     {
       "bonus": {
@@ -172,15 +172,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 326000
+            "value": 326000000
           },
           {
             "type": "dilithium",
-            "value": 326000
+            "value": 326000000
           }
         ]
       },
-      "research_time": 46942
+      "research_time": 46942080
     },
     {
       "bonus": {
@@ -225,15 +225,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 496500
+            "value": 496500000
           },
           {
             "type": "dilithium",
-            "value": 496500
+            "value": 496500000
           }
         ]
       },
-      "research_time": 62294
+      "research_time": 62294640
     },
     {
       "bonus": {
@@ -274,15 +274,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 708000
+            "value": 708000000
           },
           {
             "type": "dilithium",
-            "value": 708000
+            "value": 708000000
           }
         ]
       },
-      "research_time": 81744
+      "research_time": 81744660
     },
     {
       "bonus": {
@@ -327,15 +327,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 987300
+            "value": 987300000
           },
           {
             "type": "dilithium",
-            "value": 987300
+            "value": 987300000
           }
         ]
       },
-      "research_time": 110240
+      "research_time": 110240520
     },
     {
       "bonus": {
@@ -380,15 +380,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 1460
+            "value": 1460000000
           },
           {
             "type": "dilithium",
-            "value": 1460
+            "value": 1460000000
           }
         ]
       },
-      "research_time": 142221
+      "research_time": 142221540
     },
     {
       "bonus": {
@@ -433,15 +433,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 2358
+            "value": 2358000000
           },
           {
             "type": "dilithium",
-            "value": 2358
+            "value": 2358000000
           }
         ]
       },
-      "research_time": 181910
+      "research_time": 181910760
     },
     {
       "bonus": {
@@ -480,15 +480,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 3990
+            "value": 3990000000
           },
           {
             "type": "dilithium",
-            "value": 3990
+            "value": 3990000000
           }
         ]
       },
-      "research_time": 240901
+      "research_time": 240901980
     }
   ],
   "location": {

--- a/research/4_interceptor_pure_dilithium.json
+++ b/research/4_interceptor_pure_dilithium.json
@@ -33,15 +33,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 62350
+            "value": 62350000
           },
           {
             "type": "dilithium",
-            "value": 124700
+            "value": 124700000
           }
         ]
       },
-      "research_time": 22600
+      "research_time": 22600620
     },
     {
       "bonus": {
@@ -76,15 +76,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 90450
+            "value": 90450000
           },
           {
             "type": "dilithium",
-            "value": 180900
+            "value": 180900000
           }
         ]
       },
-      "research_time": 21529
+      "research_time": 21529800
     },
     {
       "bonus": {
@@ -123,15 +123,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 134800
+            "value": 134800000
           },
           {
             "type": "dilithium",
-            "value": 269600
+            "value": 269600000
           }
         ]
       },
-      "research_time": 33627
+      "research_time": 33627960
     },
     {
       "bonus": {
@@ -172,15 +172,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 195600
+            "value": 195600000
           },
           {
             "type": "dilithium",
-            "value": 391200
+            "value": 391200000
           }
         ]
       },
-      "research_time": 46942
+      "research_time": 46942080
     },
     {
       "bonus": {
@@ -225,15 +225,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 297900
+            "value": 297900000
           },
           {
             "type": "dilithium",
-            "value": 595800
+            "value": 595800000
           }
         ]
       },
-      "research_time": 62294
+      "research_time": 62294640
     },
     {
       "bonus": {
@@ -274,15 +274,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 424800
+            "value": 424800000
           },
           {
             "type": "dilithium",
-            "value": 849600
+            "value": 849600000
           }
         ]
       },
-      "research_time": 81744
+      "research_time": 81744660
     },
     {
       "bonus": {
@@ -327,15 +327,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 592400
+            "value": 592400000
           },
           {
             "type": "dilithium",
-            "value": 1185
+            "value": 1185000000
           }
         ]
       },
-      "research_time": 110240
+      "research_time": 110240520
     },
     {
       "bonus": {
@@ -380,15 +380,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 876000
+            "value": 876000000
           },
           {
             "type": "dilithium",
-            "value": 1752
+            "value": 1752000000
           }
         ]
       },
-      "research_time": 142221
+      "research_time": 142221540
     },
     {
       "bonus": {
@@ -433,15 +433,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 1415
+            "value": 1415000000
           },
           {
             "type": "dilithium",
-            "value": 2830
+            "value": 2830000000
           }
         ]
       },
-      "research_time": 181910
+      "research_time": 181910760
     },
     {
       "bonus": {
@@ -480,15 +480,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 2394
+            "value": 2394000000
           },
           {
             "type": "dilithium",
-            "value": 4788
+            "value": 4788000000
           }
         ]
       },
-      "research_time": 240901
+      "research_time": 240901980
     }
   ],
   "location": {

--- a/research/4_interceptor_pure_tritanium.json
+++ b/research/4_interceptor_pure_tritanium.json
@@ -33,15 +33,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 145500
+            "value": 145500000
           },
           {
             "type": "dilithium",
-            "value": 83150
+            "value": 83150000
           }
         ]
       },
-      "research_time": 22600
+      "research_time": 22600620
     },
     {
       "bonus": {
@@ -76,15 +76,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 211100
+            "value": 211100000
           },
           {
             "type": "dilithium",
-            "value": 120600
+            "value": 120600000
           }
         ]
       },
-      "research_time": 21529
+      "research_time": 21529800
     },
     {
       "bonus": {
@@ -119,15 +119,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 314600
+            "value": 314600000
           },
           {
             "type": "dilithium",
-            "value": 179800
+            "value": 179800000
           }
         ]
       },
-      "research_time": 33627
+      "research_time": 33627960
     },
     {
       "bonus": {
@@ -162,15 +162,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 456400
+            "value": 456400000
           },
           {
             "type": "dilithium",
-            "value": 260800
+            "value": 260800000
           }
         ]
       },
-      "research_time": 46942
+      "research_time": 46942080
     },
     {
       "bonus": {
@@ -205,15 +205,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 695100
+            "value": 695100000
           },
           {
             "type": "dilithium",
-            "value": 397200
+            "value": 397200000
           }
         ]
       },
-      "research_time": 62294
+      "research_time": 62294640
     },
     {
       "bonus": {
@@ -248,15 +248,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 991200
+            "value": 991200000
           },
           {
             "type": "dilithium",
-            "value": 566400
+            "value": 566400000
           }
         ]
       },
-      "research_time": 81744
+      "research_time": 81744660
     },
     {
       "bonus": {
@@ -295,15 +295,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 1382
+            "value": 1382000000
           },
           {
             "type": "dilithium",
-            "value": 789800
+            "value": 789800000
           }
         ]
       },
-      "research_time": 110240
+      "research_time": 110240520
     },
     {
       "bonus": {
@@ -342,15 +342,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 2044
+            "value": 2044000000
           },
           {
             "type": "dilithium",
-            "value": 1168
+            "value": 1168000000
           }
         ]
       },
-      "research_time": 142221
+      "research_time": 142221540
     },
     {
       "bonus": {
@@ -389,15 +389,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 3301
+            "value": 3301000000
           },
           {
             "type": "dilithium",
-            "value": 1886
+            "value": 1886000000
           }
         ]
       },
-      "research_time": 181910
+      "research_time": 181910760
     },
     {
       "bonus": {
@@ -436,15 +436,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 5586
+            "value": 5586000000
           },
           {
             "type": "dilithium",
-            "value": 3192
+            "value": 3192000000
           }
         ]
       },
-      "research_time": 240901
+      "research_time": 240901980
     }
   ],
   "location": {

--- a/research/4_interceptor_regeneration.json
+++ b/research/4_interceptor_regeneration.json
@@ -42,11 +42,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 637200
+            "value": 637200000
           }
         ]
       },
-      "research_time": 45981
+      "research_time": 45981360
     },
     {
       "bonus": {
@@ -84,11 +84,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 888500
+            "value": 888500000
           }
         ]
       },
-      "research_time": 62010
+      "research_time": 62010300
     },
     {
       "bonus": {
@@ -132,11 +132,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1314
+            "value": 1314000000
           }
         ]
       },
-      "research_time": 79999
+      "research_time": 79999620
     },
     {
       "bonus": {
@@ -174,11 +174,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 2122
+            "value": 2122000000
           }
         ]
       },
-      "research_time": 102324
+      "research_time": 102324840
     },
     {
       "bonus": {
@@ -222,11 +222,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 3591
+            "value": 3591000000
           }
         ]
       },
-      "research_time": 135507
+      "research_time": 135507360
     }
   ],
   "location": {

--- a/research/4_interceptor_repair_cost.json
+++ b/research/4_interceptor_repair_cost.json
@@ -33,15 +33,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 916800
+            "value": 916800000
           },
           {
             "type": "dilithium",
-            "value": 269600
+            "value": 269600000
           }
         ]
       },
-      "research_time": 31526
+      "research_time": 31526220
     },
     {
       "bonus": {
@@ -80,15 +80,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1330
+            "value": 1330000000
           },
           {
             "type": "dilithium",
-            "value": 391200
+            "value": 391200000
           }
         ]
       },
-      "research_time": 44008
+      "research_time": 44008200
     },
     {
       "bonus": {
@@ -131,15 +131,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 2026
+            "value": 2026000000
           },
           {
             "type": "dilithium",
-            "value": 595800
+            "value": 595800000
           }
         ]
       },
-      "research_time": 58401
+      "research_time": 58401240
     },
     {
       "bonus": {
@@ -183,15 +183,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 2889
+            "value": 2889000000
           },
           {
             "type": "dilithium",
-            "value": 849600
+            "value": 849600000
           }
         ]
       },
-      "research_time": 76635
+      "research_time": 76635600
     },
     {
       "bonus": {
@@ -230,15 +230,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 4028
+            "value": 4028000000
           },
           {
             "type": "dilithium",
-            "value": 1185
+            "value": 1185000000
           }
         ]
       },
-      "research_time": 103350
+      "research_time": 103350540
     },
     {
       "bonus": {
@@ -281,15 +281,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 5957
+            "value": 5957000000
           },
           {
             "type": "dilithium",
-            "value": 1752
+            "value": 1752000000
           }
         ]
       },
-      "research_time": 133332
+      "research_time": 133332660
     },
     {
       "bonus": {
@@ -328,15 +328,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 9621
+            "value": 9621000000
           },
           {
             "type": "dilithium",
-            "value": 2830
+            "value": 2830000000
           }
         ]
       },
-      "research_time": 170541
+      "research_time": 170541360
     },
     {
       "bonus": {
@@ -369,15 +369,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 16279
+            "value": 16279000000
           },
           {
             "type": "dilithium",
-            "value": 4788
+            "value": 4788000000
           }
         ]
       },
-      "research_time": 225845
+      "research_time": 225845580
     },
     {
       "bonus": {
@@ -420,15 +420,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 28917
+            "value": 28917000000
           },
           {
             "type": "dilithium",
-            "value": 8505
+            "value": 8505000000
           }
         ]
       },
-      "research_time": 284285
+      "research_time": 284285220
     },
     {
       "bonus": {
@@ -463,15 +463,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 44018
+            "value": 44018000000
           },
           {
             "type": "dilithium",
-            "value": 12947
+            "value": 12947000000
           }
         ]
       },
-      "research_time": 324000
+      "research_time": 324000000
     }
   ],
   "location": {

--- a/research/4_interceptor_station_piercing.json
+++ b/research/4_interceptor_station_piercing.json
@@ -33,15 +33,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 566400
+            "value": 566400000
           },
           {
             "type": "dilithium",
-            "value": 708000
+            "value": 708000000
           }
         ]
       },
-      "research_time": 51090
+      "research_time": 51090420
     }
   ],
   "location": {

--- a/research/4_interceptor_weaponry.json
+++ b/research/4_interceptor_weaponry.json
@@ -38,11 +38,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1283
+            "value": 1283000000
           }
         ]
       },
-      "research_time": 89570
+      "research_time": 89570460
     },
     {
       "bonus": {
@@ -86,11 +86,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1898
+            "value": 1898000000
           }
         ]
       },
-      "research_time": 115554
+      "research_time": 115554960
     },
     {
       "bonus": {
@@ -124,11 +124,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 3065
+            "value": 3065000000
           }
         ]
       },
-      "research_time": 147802
+      "research_time": 147802500
     },
     {
       "bonus": {
@@ -172,11 +172,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 5187
+            "value": 5187000000
           }
         ]
       },
-      "research_time": 195732
+      "research_time": 195732840
     },
     {
       "bonus": {
@@ -224,11 +224,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 9214
+            "value": 9214000000
           }
         ]
       },
-      "research_time": 246380
+      "research_time": 246380520
     },
     {
       "bonus": {
@@ -250,11 +250,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 14025
+            "value": 14025000000
           }
         ]
       },
-      "research_time": 300516
+      "research_time": 300516720
     },
     {
       "bonus": {
@@ -276,11 +276,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 21499
+            "value": 21499000000
           }
         ]
       },
-      "research_time": 386864
+      "research_time": 386864640
     },
     {
       "bonus": {
@@ -302,11 +302,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 19195
+            "value": 19195000000
           }
         ]
       },
-      "research_time": 265945
+      "research_time": 265945140
     },
     {
       "bonus": {
@@ -328,11 +328,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 28793
+            "value": 28793000000
           }
         ]
       },
-      "research_time": 319134
+      "research_time": 319134180
     },
     {
       "bonus": {
@@ -354,11 +354,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 43189
+            "value": 43189000000
           }
         ]
       },
-      "research_time": 419913
+      "research_time": 419913420
     }
   ],
   "location": {

--- a/research/4_kinetic_shockwave.json
+++ b/research/4_kinetic_shockwave.json
@@ -48,11 +48,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1898
+            "value": 1898000000
           }
         ]
       },
-      "research_time": 115554
+      "research_time": 115554960
     },
     {
       "bonus": {
@@ -96,11 +96,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 3065
+            "value": 3065000000
           }
         ]
       },
-      "research_time": 147802
+      "research_time": 147802500
     },
     {
       "bonus": {
@@ -148,11 +148,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 5187
+            "value": 5187000000
           }
         ]
       },
-      "research_time": 195732
+      "research_time": 195732840
     },
     {
       "bonus": {
@@ -200,11 +200,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 9214
+            "value": 9214000000
           }
         ]
       },
-      "research_time": 246380
+      "research_time": 246380520
     },
     {
       "bonus": {
@@ -226,11 +226,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 14025
+            "value": 14025000000
           }
         ]
       },
-      "research_time": 300516
+      "research_time": 300516720
     },
     {
       "bonus": {
@@ -252,11 +252,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 21499
+            "value": 21499000000
           }
         ]
       },
-      "research_time": 386864
+      "research_time": 386864640
     },
     {
       "bonus": {
@@ -278,11 +278,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 19195
+            "value": 19195000000
           }
         ]
       },
-      "research_time": 265945
+      "research_time": 265945140
     },
     {
       "bonus": {
@@ -304,11 +304,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 28793
+            "value": 28793000000
           }
         ]
       },
-      "research_time": 319134
+      "research_time": 319134180
     },
     {
       "bonus": {
@@ -330,11 +330,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 43189
+            "value": 43189000000
           }
         ]
       },
-      "research_time": 419913
+      "research_time": 419913420
     },
     {
       "bonus": {
@@ -356,11 +356,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 64784
+            "value": 64784000000
           }
         ]
       },
-      "research_time": 503896
+      "research_time": 503896080
     }
   ],
   "location": {

--- a/research/4_offensive_strategies.json
+++ b/research/4_offensive_strategies.json
@@ -68,11 +68,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1283
+            "value": 1283000000
           }
         ]
       },
-      "research_time": 89570
+      "research_time": 89570460
     },
     {
       "bonus": {
@@ -116,11 +116,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1898
+            "value": 1898000000
           }
         ]
       },
-      "research_time": 115554
+      "research_time": 115554960
     },
     {
       "bonus": {
@@ -164,11 +164,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 3065
+            "value": 3065000000
           }
         ]
       },
-      "research_time": 147802
+      "research_time": 147802500
     },
     {
       "bonus": {
@@ -212,11 +212,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 5187
+            "value": 5187000000
           }
         ]
       },
-      "research_time": 195732
+      "research_time": 195732840
     },
     {
       "bonus": {
@@ -260,11 +260,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 9214
+            "value": 9214000000
           }
         ]
       },
-      "research_time": 246380
+      "research_time": 246380520
     },
     {
       "bonus": {
@@ -286,11 +286,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 14025
+            "value": 14025000000
           }
         ]
       },
-      "research_time": 300516
+      "research_time": 300516720
     },
     {
       "bonus": {
@@ -312,11 +312,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 21499
+            "value": 21499000000
           }
         ]
       },
-      "research_time": 386864
+      "research_time": 386864640
     },
     {
       "bonus": {
@@ -338,11 +338,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 19195
+            "value": 19195000000
           }
         ]
       },
-      "research_time": 265945
+      "research_time": 265945140
     },
     {
       "bonus": {
@@ -364,11 +364,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 28793
+            "value": 28793000000
           }
         ]
       },
-      "research_time": 319134
+      "research_time": 319134180
     },
     {
       "bonus": {
@@ -390,11 +390,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 43189
+            "value": 43189000000
           }
         ]
       },
-      "research_time": 419913
+      "research_time": 419913420
     }
   ],
   "location": {

--- a/research/4_ore_prospector.json
+++ b/research/4_ore_prospector.json
@@ -43,7 +43,7 @@
         ],
         "resources": []
       },
-      "research_time": 32272
+      "research_time": 32272680
     },
     {
       "bonus": {
@@ -73,7 +73,7 @@
         ],
         "resources": []
       },
-      "research_time": 42827
+      "research_time": 42827580
     },
     {
       "bonus": {
@@ -107,7 +107,7 @@
         ],
         "resources": []
       },
-      "research_time": 56199
+      "research_time": 56199420
     },
     {
       "bonus": {
@@ -142,7 +142,7 @@
         ],
         "resources": []
       },
-      "research_time": 75790
+      "research_time": 75790380
     },
     {
       "bonus": {
@@ -172,7 +172,7 @@
         "others": [
           {
             "type": "Service\u00a0Award",
-            "value": 1259
+            "value": 1259626
           },
           {
             "type": "Merit\u00a0of\u00a0Honor",
@@ -181,7 +181,7 @@
         ],
         "resources": []
       },
-      "research_time": 97777
+      "research_time": 97777320
     },
     {
       "bonus": {
@@ -211,12 +211,12 @@
           },
           {
             "type": "Service\u00a0Award",
-            "value": 1259
+            "value": 1259626
           }
         ],
         "resources": []
       },
-      "research_time": 125063
+      "research_time": 125063640
     },
     {
       "bonus": {
@@ -245,12 +245,12 @@
           },
           {
             "type": "Service\u00a0Award",
-            "value": 1796
+            "value": 1796553
           }
         ],
         "resources": []
       },
-      "research_time": 165620
+      "research_time": 165620100
     },
     {
       "bonus": {
@@ -276,7 +276,7 @@
         "others": [
           {
             "type": "Service\u00a0Award",
-            "value": 1796
+            "value": 1796553
           },
           {
             "type": "Merit\u00a0of\u00a0Honor",
@@ -285,7 +285,7 @@
         ],
         "resources": []
       },
-      "research_time": 208475
+      "research_time": 208475820
     },
     {
       "bonus": {
@@ -319,12 +319,12 @@
           },
           {
             "type": "Service\u00a0Award",
-            "value": 2669
+            "value": 2669728
           }
         ],
         "resources": []
       },
-      "research_time": 254283
+      "research_time": 254283360
     },
     {
       "bonus": {
@@ -358,12 +358,12 @@
           },
           {
             "type": "Service\u00a0Award",
-            "value": 4412
+            "value": 4412607
           }
         ],
         "resources": []
       },
-      "research_time": 327347
+      "research_time": 327347040
     }
   ],
   "location": {

--- a/research/4_piercing_shots.json
+++ b/research/4_piercing_shots.json
@@ -52,15 +52,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 394900
+            "value": 394900000
           },
           {
             "type": "dilithium",
-            "value": 888500
+            "value": 888500000
           }
         ]
       },
-      "research_time": 55120
+      "research_time": 55120260
     },
     {
       "bonus": {
@@ -98,15 +98,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 584000
+            "value": 584000000
           },
           {
             "type": "dilithium",
-            "value": 1314
+            "value": 1314000000
           }
         ]
       },
-      "research_time": 71110
+      "research_time": 71110740
     },
     {
       "bonus": {
@@ -150,15 +150,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 943200
+            "value": 943200000
           },
           {
             "type": "dilithium",
-            "value": 2122
+            "value": 2122000000
           }
         ]
       },
-      "research_time": 90955
+      "research_time": 90955380
     },
     {
       "bonus": {
@@ -196,15 +196,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 1596
+            "value": 1596000000
           },
           {
             "type": "dilithium",
-            "value": 3591
+            "value": 3591000000
           }
         ]
       },
-      "research_time": 120450
+      "research_time": 120450960
     },
     {
       "bonus": {
@@ -248,15 +248,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 2835
+            "value": 2835000000
           },
           {
             "type": "dilithium",
-            "value": 6379
+            "value": 6379000000
           }
         ]
       },
-      "research_time": 151618
+      "research_time": 151618800
     },
     {
       "bonus": {
@@ -278,15 +278,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 4316
+            "value": 4316000000
           },
           {
             "type": "dilithium",
-            "value": 9710
+            "value": 9710000000
           }
         ]
       },
-      "research_time": 184933
+      "research_time": 184933380
     },
     {
       "bonus": {
@@ -308,15 +308,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 6615
+            "value": 6615000000
           },
           {
             "type": "dilithium",
-            "value": 14884
+            "value": 14884000000
           }
         ]
       },
-      "research_time": 238070
+      "research_time": 238070580
     },
     {
       "bonus": {
@@ -338,15 +338,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 5906
+            "value": 5906000000
           },
           {
             "type": "dilithium",
-            "value": 13289
+            "value": 13289000000
           }
         ]
       },
-      "research_time": 163658
+      "research_time": 163658580
     },
     {
       "bonus": {
@@ -368,15 +368,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 8859
+            "value": 8859000000
           },
           {
             "type": "dilithium",
-            "value": 19934
+            "value": 19934000000
           }
         ]
       },
-      "research_time": 196390
+      "research_time": 196390260
     },
     {
       "bonus": {
@@ -398,15 +398,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 13289
+            "value": 13289000000
           },
           {
             "type": "dilithium",
-            "value": 29900
+            "value": 29900000000
           }
         ]
       },
-      "research_time": 258408
+      "research_time": 258408240
     }
   ],
   "location": {

--- a/research/4_pillager_critical.json
+++ b/research/4_pillager_critical.json
@@ -46,15 +46,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 13230
+            "value": 13230000000
           },
           {
             "type": "dilithium",
-            "value": 16538
+            "value": 16538000000
           }
         ]
       },
-      "research_time": 246000
+      "research_time": 246000000
     },
     {
       "bonus": {
@@ -106,15 +106,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 5670
+            "value": 5670000000
           },
           {
             "type": "dilithium",
-            "value": 7088
+            "value": 7088000000
           }
         ]
       },
-      "research_time": 189523
+      "research_time": 189523500
     }
   ],
   "location": {

--- a/research/4_reinforced_bulkheads.json
+++ b/research/4_reinforced_bulkheads.json
@@ -42,15 +42,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 297900
+            "value": 297900000
           },
           {
             "type": "dilithium",
-            "value": 397200
+            "value": 397200000
           }
         ]
       },
-      "research_time": 120450
+      "research_time": 120450960
     },
     {
       "bonus": {
@@ -94,15 +94,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 424800
+            "value": 424800000
           },
           {
             "type": "dilithium",
-            "value": 566400
+            "value": 566400000
           }
         ]
       },
-      "research_time": 151618
+      "research_time": 151618800
     },
     {
       "bonus": {
@@ -131,15 +131,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 592400
+            "value": 592400000
           },
           {
             "type": "dilithium",
-            "value": 789800
+            "value": 789800000
           }
         ]
       },
-      "research_time": 184933
+      "research_time": 184933380
     },
     {
       "bonus": {
@@ -174,15 +174,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 876000
+            "value": 876000000
           },
           {
             "type": "dilithium",
-            "value": 1168
+            "value": 1168000000
           }
         ]
       },
-      "research_time": 238070
+      "research_time": 238070580
     },
     {
       "bonus": {
@@ -211,15 +211,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 1415
+            "value": 1415000000
           },
           {
             "type": "dilithium",
-            "value": 1886
+            "value": 1886000000
           }
         ]
       },
-      "research_time": 163658
+      "research_time": 163658580
     },
     {
       "bonus": {
@@ -254,15 +254,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 2394
+            "value": 2394000000
           },
           {
             "type": "dilithium",
-            "value": 3192
+            "value": 3192000000
           }
         ]
       },
-      "research_time": 196390
+      "research_time": 196390260
     },
     {
       "bonus": {
@@ -291,15 +291,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 4253
+            "value": 4253000000
           },
           {
             "type": "dilithium",
-            "value": 5670
+            "value": 5670000000
           }
         ]
       },
-      "research_time": 258408
+      "research_time": 258408240
     },
     {
       "bonus": {
@@ -321,15 +321,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 6473
+            "value": 6473000000
           },
           {
             "type": "dilithium",
-            "value": 8631
+            "value": 8631000000
           }
         ]
       },
-      "research_time": 310089
+      "research_time": 310089900
     },
     {
       "bonus": {
@@ -351,15 +351,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 9923
+            "value": 9923000000
           },
           {
             "type": "dilithium",
-            "value": 13230
+            "value": 13230000000
           }
         ]
       },
-      "research_time": 372107
+      "research_time": 372107880
     },
     {
       "bonus": {
@@ -381,15 +381,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 8859
+            "value": 8859000000
           },
           {
             "type": "dilithium",
-            "value": 11813
+            "value": 11813000000
           }
         ]
       },
-      "research_time": 446529
+      "research_time": 446529480
     }
   ],
   "location": {

--- a/research/4_shield_efficiency.json
+++ b/research/4_shield_efficiency.json
@@ -42,15 +42,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 297900
+            "value": 297900000
           },
           {
             "type": "dilithium",
-            "value": 397200
+            "value": 397200000
           }
         ]
       },
-      "research_time": 120450
+      "research_time": 120450960
     },
     {
       "bonus": {
@@ -89,15 +89,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 424800
+            "value": 424800000
           },
           {
             "type": "dilithium",
-            "value": 566400
+            "value": 566400000
           }
         ]
       },
-      "research_time": 151618
+      "research_time": 151618800
     },
     {
       "bonus": {
@@ -126,15 +126,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 592400
+            "value": 592400000
           },
           {
             "type": "dilithium",
-            "value": 789800
+            "value": 789800000
           }
         ]
       },
-      "research_time": 184933
+      "research_time": 184933380
     },
     {
       "bonus": {
@@ -169,15 +169,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 876000
+            "value": 876000000
           },
           {
             "type": "dilithium",
-            "value": 1168
+            "value": 1168000000
           }
         ]
       },
-      "research_time": 238070
+      "research_time": 238070580
     },
     {
       "bonus": {
@@ -206,15 +206,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 1415
+            "value": 1415000000
           },
           {
             "type": "dilithium",
-            "value": 1886
+            "value": 1886000000
           }
         ]
       },
-      "research_time": 163658
+      "research_time": 163658580
     },
     {
       "bonus": {
@@ -249,15 +249,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 2394
+            "value": 2394000000
           },
           {
             "type": "dilithium",
-            "value": 3192
+            "value": 3192000000
           }
         ]
       },
-      "research_time": 196390
+      "research_time": 196390260
     },
     {
       "bonus": {
@@ -286,15 +286,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 4253
+            "value": 4253000000
           },
           {
             "type": "dilithium",
-            "value": 5670
+            "value": 5670000000
           }
         ]
       },
-      "research_time": 258408
+      "research_time": 258408240
     },
     {
       "bonus": {
@@ -316,15 +316,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 6473
+            "value": 6473000000
           },
           {
             "type": "dilithium",
-            "value": 8631
+            "value": 8631000000
           }
         ]
       },
-      "research_time": 310089
+      "research_time": 310089900
     },
     {
       "bonus": {
@@ -346,15 +346,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 9923
+            "value": 9923000000
           },
           {
             "type": "dilithium",
-            "value": 13230
+            "value": 13230000000
           }
         ]
       },
-      "research_time": 372107
+      "research_time": 372107880
     },
     {
       "bonus": {
@@ -376,15 +376,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 8859
+            "value": 8859000000
           },
           {
             "type": "dilithium",
-            "value": 11813
+            "value": 11813000000
           }
         ]
       },
-      "research_time": 446529
+      "research_time": 446529480
     }
   ],
   "location": {

--- a/research/4_shield_modulation.json
+++ b/research/4_shield_modulation.json
@@ -60,15 +60,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 150800
+            "value": 150800000
           },
           {
             "type": "dilithium",
-            "value": 90450
+            "value": 90450000
           }
         ]
       },
-      "research_time": 13456
+      "research_time": 13456140
     },
     {
       "bonus": {
@@ -110,15 +110,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 224700
+            "value": 224700000
           },
           {
             "type": "dilithium",
-            "value": 134800
+            "value": 134800000
           }
         ]
       },
-      "research_time": 21017
+      "research_time": 21017460
     },
     {
       "bonus": {
@@ -166,15 +166,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 326000
+            "value": 326000000
           },
           {
             "type": "dilithium",
-            "value": 195600
+            "value": 195600000
           }
         ]
       },
-      "research_time": 29338
+      "research_time": 29338800
     },
     {
       "bonus": {
@@ -207,15 +207,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 496500
+            "value": 496500000
           },
           {
             "type": "dilithium",
-            "value": 297900
+            "value": 297900000
           }
         ]
       },
-      "research_time": 38934
+      "research_time": 38934120
     },
     {
       "bonus": {
@@ -263,15 +263,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 708000
+            "value": 708000000
           },
           {
             "type": "dilithium",
-            "value": 424800
+            "value": 424800000
           }
         ]
       },
-      "research_time": 51090
+      "research_time": 51090420
     },
     {
       "bonus": {
@@ -304,15 +304,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 987300
+            "value": 987300000
           },
           {
             "type": "dilithium",
-            "value": 592400
+            "value": 592400000
           }
         ]
       },
-      "research_time": 68900
+      "research_time": 68900340
     },
     {
       "bonus": {
@@ -356,15 +356,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 1460
+            "value": 1460000000
           },
           {
             "type": "dilithium",
-            "value": 876000
+            "value": 876000000
           }
         ]
       },
-      "research_time": 88888
+      "research_time": 88888440
     },
     {
       "bonus": {
@@ -402,15 +402,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 2358
+            "value": 2358000000
           },
           {
             "type": "dilithium",
-            "value": 1415
+            "value": 1415000000
           }
         ]
       },
-      "research_time": 113694
+      "research_time": 113694240
     },
     {
       "bonus": {
@@ -454,15 +454,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 3990
+            "value": 3990000000
           },
           {
             "type": "dilithium",
-            "value": 2394
+            "value": 2394000000
           }
         ]
       },
-      "research_time": 150563
+      "research_time": 150563760
     },
     {
       "bonus": {
@@ -499,15 +499,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 7088
+            "value": 7088000000
           },
           {
             "type": "dilithium",
-            "value": 4253
+            "value": 4253000000
           }
         ]
       },
-      "research_time": 189523
+      "research_time": 189523500
     }
   ],
   "location": {

--- a/research/4_shield_penetration.json
+++ b/research/4_shield_penetration.json
@@ -52,15 +52,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 394900
+            "value": 394900000
           },
           {
             "type": "dilithium",
-            "value": 888500
+            "value": 888500000
           }
         ]
       },
-      "research_time": 55120
+      "research_time": 55120260
     },
     {
       "bonus": {
@@ -104,15 +104,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 943200
+            "value": 943200000
           },
           {
             "type": "dilithium",
-            "value": 2122
+            "value": 2122000000
           }
         ]
       },
-      "research_time": 90955
+      "research_time": 90955380
     },
     {
       "bonus": {
@@ -150,15 +150,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 1596
+            "value": 1596000000
           },
           {
             "type": "dilithium",
-            "value": 3591
+            "value": 3591000000
           }
         ]
       },
-      "research_time": 120450
+      "research_time": 120450960
     },
     {
       "bonus": {
@@ -202,15 +202,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 2835
+            "value": 2835000000
           },
           {
             "type": "dilithium",
-            "value": 6379
+            "value": 6379000000
           }
         ]
       },
-      "research_time": 151618
+      "research_time": 151618800
     }
   ],
   "location": {

--- a/research/4_ship_bombardment.json
+++ b/research/4_ship_bombardment.json
@@ -39,11 +39,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 9923
+            "value": 9923000000
           }
         ]
       },
-      "research_time": 265332
+      "research_time": 265332840
     }
   ],
   "location": {

--- a/research/4_siege_warfare.json
+++ b/research/4_siege_warfare.json
@@ -70,11 +70,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 9923
+            "value": 9923000000
           }
         ]
       },
-      "research_time": 265332
+      "research_time": 265332840
     },
     {
       "bonus": {
@@ -115,11 +115,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 15104
+            "value": 15104000000
           }
         ]
       },
-      "research_time": 323633
+      "research_time": 323633400
     },
     {
       "bonus": {
@@ -141,11 +141,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 235466
+            "value": 235466000000
           }
         ]
       },
-      "research_time": 937711
+      "research_time": 937711860
     },
     {
       "bonus": {
@@ -186,11 +186,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 23153
+            "value": 23153000000
           }
         ]
       },
-      "research_time": 416623
+      "research_time": 416623500
     },
     {
       "bonus": {
@@ -220,11 +220,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 20672
+            "value": 20672000000
           }
         ]
       },
-      "research_time": 286402
+      "research_time": 286402500
     },
     {
       "bonus": {
@@ -254,11 +254,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 31008
+            "value": 31008000000
           }
         ]
       },
-      "research_time": 343683
+      "research_time": 343683000
     },
     {
       "bonus": {
@@ -280,11 +280,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 46512
+            "value": 46512000000
           }
         ]
       },
-      "research_time": 452214
+      "research_time": 452214420
     }
   ],
   "location": {

--- a/research/4_survey_pure_dilithium.json
+++ b/research/4_survey_pure_dilithium.json
@@ -37,15 +37,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 90450
+            "value": 90450000
           },
           {
             "type": "dilithium",
-            "value": 180900
+            "value": 180900000
           }
         ]
       },
-      "research_time": 21529
+      "research_time": 21529800
     },
     {
       "bonus": {
@@ -88,15 +88,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 134800
+            "value": 134800000
           },
           {
             "type": "dilithium",
-            "value": 269600
+            "value": 269600000
           }
         ]
       },
-      "research_time": 33627
+      "research_time": 33627960
     },
     {
       "bonus": {
@@ -143,15 +143,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 195600
+            "value": 195600000
           },
           {
             "type": "dilithium",
-            "value": 391200
+            "value": 391200000
           }
         ]
       },
-      "research_time": 46942
+      "research_time": 46942080
     },
     {
       "bonus": {
@@ -194,15 +194,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 297900
+            "value": 297900000
           },
           {
             "type": "dilithium",
-            "value": 595800
+            "value": 595800000
           }
         ]
       },
-      "research_time": 62294
+      "research_time": 62294640
     },
     {
       "bonus": {
@@ -245,15 +245,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 424800
+            "value": 424800000
           },
           {
             "type": "dilithium",
-            "value": 849600
+            "value": 849600000
           }
         ]
       },
-      "research_time": 81744
+      "research_time": 81744660
     },
     {
       "bonus": {
@@ -304,15 +304,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 592400
+            "value": 592400000
           },
           {
             "type": "dilithium",
-            "value": 1185
+            "value": 1185000000
           }
         ]
       },
-      "research_time": 110240
+      "research_time": 110240520
     },
     {
       "bonus": {
@@ -355,15 +355,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 876000
+            "value": 876000000
           },
           {
             "type": "dilithium",
-            "value": 1752
+            "value": 1752000000
           }
         ]
       },
-      "research_time": 142221
+      "research_time": 142221540
     },
     {
       "bonus": {
@@ -406,15 +406,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 1415
+            "value": 1415000000
           },
           {
             "type": "dilithium",
-            "value": 2830
+            "value": 2830000000
           }
         ]
       },
-      "research_time": 181910
+      "research_time": 181910760
     },
     {
       "bonus": {
@@ -461,15 +461,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 2394
+            "value": 2394000000
           },
           {
             "type": "dilithium",
-            "value": 4788
+            "value": 4788000000
           }
         ]
       },
-      "research_time": 240901
+      "research_time": 240901980
     },
     {
       "bonus": {
@@ -512,15 +512,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 4253
+            "value": 4253000000
           },
           {
             "type": "dilithium",
-            "value": 8505
+            "value": 8505000000
           }
         ]
       },
-      "research_time": 303237
+      "research_time": 303237540
     }
   ],
   "location": {

--- a/research/4_survey_pure_materials.json
+++ b/research/4_survey_pure_materials.json
@@ -37,15 +37,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 150800
+            "value": 150800000
           },
           {
             "type": "dilithium",
-            "value": 150800
+            "value": 150800000
           }
         ]
       },
-      "research_time": 21529
+      "research_time": 21529800
     },
     {
       "bonus": {
@@ -88,15 +88,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 224700
+            "value": 224700000
           },
           {
             "type": "dilithium",
-            "value": 224700
+            "value": 224700000
           }
         ]
       },
-      "research_time": 33627
+      "research_time": 33627960
     },
     {
       "bonus": {
@@ -143,15 +143,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 326000
+            "value": 326000000
           },
           {
             "type": "dilithium",
-            "value": 326000
+            "value": 326000000
           }
         ]
       },
-      "research_time": 46942
+      "research_time": 46942080
     },
     {
       "bonus": {
@@ -194,15 +194,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 496500
+            "value": 496500000
           },
           {
             "type": "dilithium",
-            "value": 496500
+            "value": 496500000
           }
         ]
       },
-      "research_time": 62294
+      "research_time": 62294640
     },
     {
       "bonus": {
@@ -245,15 +245,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 708000
+            "value": 708000000
           },
           {
             "type": "dilithium",
-            "value": 708000
+            "value": 708000000
           }
         ]
       },
-      "research_time": 81744
+      "research_time": 81744660
     },
     {
       "bonus": {
@@ -304,15 +304,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 987300
+            "value": 987300000
           },
           {
             "type": "dilithium",
-            "value": 987300
+            "value": 987300000
           }
         ]
       },
-      "research_time": 110240
+      "research_time": 110240520
     },
     {
       "bonus": {
@@ -355,15 +355,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 1460
+            "value": 1460000000
           },
           {
             "type": "dilithium",
-            "value": 1460
+            "value": 1460000000
           }
         ]
       },
-      "research_time": 142221
+      "research_time": 142221540
     },
     {
       "bonus": {
@@ -406,15 +406,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 2358
+            "value": 2358000000
           },
           {
             "type": "dilithium",
-            "value": 2358
+            "value": 2358000000
           }
         ]
       },
-      "research_time": 181910
+      "research_time": 181910760
     },
     {
       "bonus": {
@@ -461,15 +461,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 3990
+            "value": 3990000000
           },
           {
             "type": "dilithium",
-            "value": 3990
+            "value": 3990000000
           }
         ]
       },
-      "research_time": 240901
+      "research_time": 240901980
     },
     {
       "bonus": {
@@ -512,15 +512,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 7088
+            "value": 7088000000
           },
           {
             "type": "dilithium",
-            "value": 7088
+            "value": 7088000000
           }
         ]
       },
-      "research_time": 303237
+      "research_time": 303237540
     }
   ],
   "location": {

--- a/research/4_survey_pure_tritanium.json
+++ b/research/4_survey_pure_tritanium.json
@@ -37,15 +37,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 211100
+            "value": 211100000
           },
           {
             "type": "dilithium",
-            "value": 120600
+            "value": 120600000
           }
         ]
       },
-      "research_time": 21529
+      "research_time": 21529800
     },
     {
       "bonus": {
@@ -93,15 +93,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 314600
+            "value": 314600000
           },
           {
             "type": "dilithium",
-            "value": 179800
+            "value": 179800000
           }
         ]
       },
-      "research_time": 33627
+      "research_time": 33627960
     },
     {
       "bonus": {
@@ -148,15 +148,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 456400
+            "value": 456400000
           },
           {
             "type": "dilithium",
-            "value": 260800
+            "value": 260800000
           }
         ]
       },
-      "research_time": 46942
+      "research_time": 46942080
     },
     {
       "bonus": {
@@ -199,15 +199,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 695100
+            "value": 695100000
           },
           {
             "type": "dilithium",
-            "value": 397200
+            "value": 397200000
           }
         ]
       },
-      "research_time": 62294
+      "research_time": 62294640
     },
     {
       "bonus": {
@@ -250,15 +250,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 991200
+            "value": 991200000
           },
           {
             "type": "dilithium",
-            "value": 566400
+            "value": 566400000
           }
         ]
       },
-      "research_time": 81744
+      "research_time": 81744660
     },
     {
       "bonus": {
@@ -309,15 +309,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 1382
+            "value": 1382000000
           },
           {
             "type": "dilithium",
-            "value": 789800
+            "value": 789800000
           }
         ]
       },
-      "research_time": 110240
+      "research_time": 110240520
     },
     {
       "bonus": {
@@ -360,15 +360,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 2044
+            "value": 2044000000
           },
           {
             "type": "dilithium",
-            "value": 1168
+            "value": 1168000000
           }
         ]
       },
-      "research_time": 142221
+      "research_time": 142221540
     },
     {
       "bonus": {
@@ -411,15 +411,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 3301
+            "value": 3301000000
           },
           {
             "type": "dilithium",
-            "value": 1886
+            "value": 1886000000
           }
         ]
       },
-      "research_time": 181910
+      "research_time": 181910760
     },
     {
       "bonus": {
@@ -466,15 +466,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 5586
+            "value": 5586000000
           },
           {
             "type": "dilithium",
-            "value": 3192
+            "value": 3192000000
           }
         ]
       },
-      "research_time": 240901
+      "research_time": 240901980
     },
     {
       "bonus": {
@@ -517,15 +517,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 9923
+            "value": 9923000000
           },
           {
             "type": "dilithium",
-            "value": 5670
+            "value": 5670000000
           }
         ]
       },
-      "research_time": 303237
+      "research_time": 303237540
     }
   ],
   "location": {

--- a/research/4_survey_repair_cost.json
+++ b/research/4_survey_repair_cost.json
@@ -33,15 +33,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 615100
+            "value": 615100000
           },
           {
             "type": "dilithium",
-            "value": 180900
+            "value": 180900000
           }
         ]
       },
-      "research_time": 16147
+      "research_time": 16147380
     },
     {
       "bonus": {
@@ -83,15 +83,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 916800
+            "value": 916800000
           },
           {
             "type": "dilithium",
-            "value": 269600
+            "value": 269600000
           }
         ]
       },
-      "research_time": 25221
+      "research_time": 25221000
     },
     {
       "bonus": {
@@ -137,15 +137,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1330
+            "value": 1330000000
           },
           {
             "type": "dilithium",
-            "value": 391200
+            "value": 391200000
           }
         ]
       },
-      "research_time": 35206
+      "research_time": 35206560
     },
     {
       "bonus": {
@@ -217,15 +217,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 2026
+            "value": 2026000000
           },
           {
             "type": "dilithium",
-            "value": 595800
+            "value": 595800000
           }
         ]
       },
-      "research_time": 46720
+      "research_time": 46720980
     },
     {
       "bonus": {
@@ -264,15 +264,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 2889
+            "value": 2889000000
           },
           {
             "type": "dilithium",
-            "value": 849600
+            "value": 849600000
           }
         ]
       },
-      "research_time": 61308
+      "research_time": 61308480
     },
     {
       "bonus": {
@@ -319,15 +319,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 4028
+            "value": 4028000000
           },
           {
             "type": "dilithium",
-            "value": 1185
+            "value": 1185000000
           }
         ]
       },
-      "research_time": 82680
+      "research_time": 82680420
     },
     {
       "bonus": {
@@ -366,15 +366,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 5957
+            "value": 5957000000
           },
           {
             "type": "dilithium",
-            "value": 1752
+            "value": 1752000000
           }
         ]
       },
-      "research_time": 106666
+      "research_time": 106666140
     },
     {
       "bonus": {
@@ -421,15 +421,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 9621
+            "value": 9621000000
           },
           {
             "type": "dilithium",
-            "value": 2830
+            "value": 2830000000
           }
         ]
       },
-      "research_time": 136433
+      "research_time": 136433100
     },
     {
       "bonus": {
@@ -468,15 +468,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 16279
+            "value": 16279000000
           },
           {
             "type": "dilithium",
-            "value": 4788
+            "value": 4788000000
           }
         ]
       },
-      "research_time": 180676
+      "research_time": 180676500
     },
     {
       "bonus": {
@@ -515,15 +515,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 28917
+            "value": 28917000000
           },
           {
             "type": "dilithium",
-            "value": 8505
+            "value": 8505000000
           }
         ]
       },
-      "research_time": 227428
+      "research_time": 227428200
     }
   ],
   "location": {

--- a/research/4_survey_repair_speed.json
+++ b/research/4_survey_repair_speed.json
@@ -33,15 +33,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 615100
+            "value": 615100000
           },
           {
             "type": "dilithium",
-            "value": 150800
+            "value": 150800000
           }
         ]
       },
-      "research_time": 13456
+      "research_time": 13456140
     },
     {
       "bonus": {
@@ -74,15 +74,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 916800
+            "value": 916800000
           },
           {
             "type": "dilithium",
-            "value": 224700
+            "value": 224700000
           }
         ]
       },
-      "research_time": 21017
+      "research_time": 21017460
     },
     {
       "bonus": {
@@ -115,15 +115,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1330
+            "value": 1330000000
           },
           {
             "type": "dilithium",
-            "value": 326000
+            "value": 326000000
           }
         ]
       },
-      "research_time": 29338
+      "research_time": 29338800
     },
     {
       "bonus": {
@@ -162,15 +162,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 2026
+            "value": 2026000000
           },
           {
             "type": "dilithium",
-            "value": 496500
+            "value": 496500000
           }
         ]
       },
-      "research_time": 38934
+      "research_time": 38934120
     },
     {
       "bonus": {
@@ -203,15 +203,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 2889
+            "value": 2889000000
           },
           {
             "type": "dilithium",
-            "value": 708000
+            "value": 708000000
           }
         ]
       },
-      "research_time": 51090
+      "research_time": 51090420
     },
     {
       "bonus": {
@@ -258,15 +258,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 4028
+            "value": 4028000000
           },
           {
             "type": "dilithium",
-            "value": 987300
+            "value": 987300000
           }
         ]
       },
-      "research_time": 68900
+      "research_time": 68900340
     },
     {
       "bonus": {
@@ -305,15 +305,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 5957
+            "value": 5957000000
           },
           {
             "type": "dilithium",
-            "value": 1460
+            "value": 1460000000
           }
         ]
       },
-      "research_time": 88888
+      "research_time": 88888440
     },
     {
       "bonus": {
@@ -360,15 +360,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 9621
+            "value": 9621000000
           },
           {
             "type": "dilithium",
-            "value": 2358
+            "value": 2358000000
           }
         ]
       },
-      "research_time": 113694
+      "research_time": 113694240
     },
     {
       "bonus": {
@@ -407,15 +407,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 16279
+            "value": 16279000000
           },
           {
             "type": "dilithium",
-            "value": 3990
+            "value": 3990000000
           }
         ]
       },
-      "research_time": 150563
+      "research_time": 150563760
     },
     {
       "bonus": {
@@ -454,15 +454,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 28917
+            "value": 28917000000
           },
           {
             "type": "dilithium",
-            "value": 7088
+            "value": 7088000000
           }
         ]
       },
-      "research_time": 189523
+      "research_time": 189523500
     }
   ],
   "location": {

--- a/research/4_tactical_battleships.json
+++ b/research/4_tactical_battleships.json
@@ -38,11 +38,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 135100
+            "value": 135100000
           }
         ]
       },
-      "research_time": 18363
+      "research_time": 18363000
     },
     {
       "bonus": {
@@ -77,11 +77,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 196000
+            "value": 196000000
           }
         ]
       },
-      "research_time": 17492
+      "research_time": 17492940
     },
     {
       "bonus": {
@@ -110,11 +110,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 292100
+            "value": 292100000
           }
         ]
       },
-      "research_time": 27322
+      "research_time": 27322740
     },
     {
       "bonus": {
@@ -149,11 +149,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 423800
+            "value": 423800000
           }
         ]
       },
-      "research_time": 38140
+      "research_time": 38140440
     },
     {
       "bonus": {
@@ -191,11 +191,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 645500
+            "value": 645500000
           }
         ]
       },
-      "research_time": 50614
+      "research_time": 50614380
     },
     {
       "bonus": {
@@ -239,11 +239,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 920400
+            "value": 920400000
           }
         ]
       },
-      "research_time": 66417
+      "research_time": 66417540
     },
     {
       "bonus": {
@@ -281,11 +281,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1283
+            "value": 1283000000
           }
         ]
       },
-      "research_time": 89570
+      "research_time": 89570460
     },
     {
       "bonus": {
@@ -329,11 +329,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1898
+            "value": 1898000000
           }
         ]
       },
-      "research_time": 115554
+      "research_time": 115554960
     },
     {
       "bonus": {
@@ -371,11 +371,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 3065
+            "value": 3065000000
           }
         ]
       },
-      "research_time": 147802
+      "research_time": 147802500
     },
     {
       "bonus": {
@@ -419,11 +419,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 5187
+            "value": 5187000000
           }
         ]
       },
-      "research_time": 195732
+      "research_time": 195732840
     }
   ],
   "location": {

--- a/research/4_tactical_explorers.json
+++ b/research/4_tactical_explorers.json
@@ -38,11 +38,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 135100
+            "value": 135100000
           }
         ]
       },
-      "research_time": 18363
+      "research_time": 18363000
     },
     {
       "bonus": {
@@ -86,11 +86,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 196000
+            "value": 196000000
           }
         ]
       },
-      "research_time": 17492
+      "research_time": 17492940
     },
     {
       "bonus": {
@@ -124,11 +124,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 292100
+            "value": 292100000
           }
         ]
       },
-      "research_time": 27322
+      "research_time": 27322740
     },
     {
       "bonus": {
@@ -168,11 +168,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 423800
+            "value": 423800000
           }
         ]
       },
-      "research_time": 38140
+      "research_time": 38140440
     },
     {
       "bonus": {
@@ -210,11 +210,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 645500
+            "value": 645500000
           }
         ]
       },
-      "research_time": 50614
+      "research_time": 50614380
     },
     {
       "bonus": {
@@ -252,11 +252,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1283
+            "value": 1283000000
           }
         ]
       },
-      "research_time": 89570
+      "research_time": 89570460
     },
     {
       "bonus": {
@@ -300,11 +300,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 920400
+            "value": 920400000
           }
         ]
       },
-      "research_time": 66417
+      "research_time": 66417540
     },
     {
       "bonus": {
@@ -348,11 +348,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1898
+            "value": 1898000000
           }
         ]
       },
-      "research_time": 115554
+      "research_time": 115554960
     },
     {
       "bonus": {
@@ -390,11 +390,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 3065
+            "value": 3065000000
           }
         ]
       },
-      "research_time": 147802
+      "research_time": 147802500
     },
     {
       "bonus": {
@@ -433,11 +433,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 5187
+            "value": 5187000000
           }
         ]
       },
-      "research_time": 195732
+      "research_time": 195732840
     }
   ],
   "location": {

--- a/research/4_tactical_interceptors.json
+++ b/research/4_tactical_interceptors.json
@@ -38,11 +38,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 135100
+            "value": 135100000
           }
         ]
       },
-      "research_time": 18363
+      "research_time": 18363000
     },
     {
       "bonus": {
@@ -77,11 +77,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 196000
+            "value": 196000000
           }
         ]
       },
-      "research_time": 17492
+      "research_time": 17492940
     },
     {
       "bonus": {
@@ -110,11 +110,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 292100
+            "value": 292100000
           }
         ]
       },
-      "research_time": 27322
+      "research_time": 27322740
     },
     {
       "bonus": {
@@ -149,11 +149,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 423800
+            "value": 423800000
           }
         ]
       },
-      "research_time": 38140
+      "research_time": 38140440
     },
     {
       "bonus": {
@@ -191,11 +191,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 645500
+            "value": 645500000
           }
         ]
       },
-      "research_time": 50614
+      "research_time": 50614380
     },
     {
       "bonus": {
@@ -239,11 +239,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 920400
+            "value": 920400000
           }
         ]
       },
-      "research_time": 66417
+      "research_time": 66417540
     },
     {
       "bonus": {
@@ -281,11 +281,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1283
+            "value": 1283000000
           }
         ]
       },
-      "research_time": 89570
+      "research_time": 89570460
     },
     {
       "bonus": {
@@ -329,11 +329,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1898
+            "value": 1898000000
           }
         ]
       },
-      "research_time": 115554
+      "research_time": 115554960
     },
     {
       "bonus": {
@@ -371,11 +371,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 3065
+            "value": 3065000000
           }
         ]
       },
-      "research_time": 147802
+      "research_time": 147802500
     },
     {
       "bonus": {
@@ -419,11 +419,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 5187
+            "value": 5187000000
           }
         ]
       },
-      "research_time": 195732
+      "research_time": 195732840
     }
   ],
   "location": {

--- a/research/4_targeting_array.json
+++ b/research/4_targeting_array.json
@@ -56,15 +56,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 394900
+            "value": 394900000
           },
           {
             "type": "dilithium",
-            "value": 888500
+            "value": 888500000
           }
         ]
       },
-      "research_time": 55120
+      "research_time": 55120260
     },
     {
       "bonus": {
@@ -102,15 +102,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 584000
+            "value": 584000000
           },
           {
             "type": "dilithium",
-            "value": 1314
+            "value": 1314000000
           }
         ]
       },
-      "research_time": 71110
+      "research_time": 71110740
     }
   ],
   "location": {

--- a/research/4_tier_up_boost.json
+++ b/research/4_tier_up_boost.json
@@ -41,11 +41,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 337100
+            "value": 337100000
           }
         ]
       },
-      "research_time": 23119
+      "research_time": 23119200
     },
     {
       "bonus": {
@@ -74,11 +74,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 489000
+            "value": 489000000
           }
         ]
       },
-      "research_time": 32272
+      "research_time": 32272680
     },
     {
       "bonus": {
@@ -107,11 +107,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 744800
+            "value": 744800000
           }
         ]
       },
-      "research_time": 42827
+      "research_time": 42827580
     },
     {
       "bonus": {
@@ -146,11 +146,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1062
+            "value": 1062000000
           }
         ]
       },
-      "research_time": 56199
+      "research_time": 56199420
     },
     {
       "bonus": {
@@ -197,11 +197,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1481
+            "value": 1481000000
           }
         ]
       },
-      "research_time": 75790
+      "research_time": 75790380
     },
     {
       "bonus": {
@@ -236,11 +236,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 2190
+            "value": 2190000000
           }
         ]
       },
-      "research_time": 97777
+      "research_time": 97777320
     },
     {
       "bonus": {
@@ -275,11 +275,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 3537
+            "value": 3537000000
           }
         ]
       },
-      "research_time": 125063
+      "research_time": 125063640
     },
     {
       "bonus": {
@@ -314,11 +314,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 5985
+            "value": 5985000000
           }
         ]
       },
-      "research_time": 165620
+      "research_time": 165620100
     },
     {
       "bonus": {
@@ -353,11 +353,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 10631
+            "value": 10631000000
           }
         ]
       },
-      "research_time": 208475
+      "research_time": 208475820
     },
     {
       "bonus": {
@@ -400,11 +400,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 16183
+            "value": 16183000000
           }
         ]
       },
-      "research_time": 237600
+      "research_time": 237600000
     }
   ],
   "location": {

--- a/research/adaptive_weaponry.json
+++ b/research/adaptive_weaponry.json
@@ -62,11 +62,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 3065
+            "value": 3065000000
           }
         ]
       },
-      "research_time": 147802
+      "research_time": 147802500
     },
     {
       "bonus": {
@@ -107,11 +107,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 9214
+            "value": 9214000000
           }
         ]
       },
-      "research_time": 246380
+      "research_time": 246380520
     },
     {
       "bonus": {
@@ -138,11 +138,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 97176
+            "value": 97176000000
           }
         ]
       },
-      "research_time": 604675
+      "research_time": 604675320
     },
     {
       "bonus": {
@@ -177,11 +177,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 5187
+            "value": 5187000000
           }
         ]
       },
-      "research_time": 195732
+      "research_time": 195732840
     },
     {
       "bonus": {
@@ -221,11 +221,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 14025
+            "value": 14025000000
           }
         ]
       },
-      "research_time": 300516
+      "research_time": 300516720
     },
     {
       "bonus": {
@@ -265,11 +265,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 21499
+            "value": 21499000000
           }
         ]
       },
-      "research_time": 386864
+      "research_time": 386864640
     },
     {
       "bonus": {
@@ -309,11 +309,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 19195
+            "value": 19195000000
           }
         ]
       },
-      "research_time": 265945
+      "research_time": 265945140
     },
     {
       "bonus": {
@@ -353,11 +353,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 28793
+            "value": 28793000000
           }
         ]
       },
-      "research_time": 319134
+      "research_time": 319134180
     },
     {
       "bonus": {
@@ -397,11 +397,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 43189
+            "value": 43189000000
           }
         ]
       },
-      "research_time": 419913
+      "research_time": 419913420
     },
     {
       "bonus": {
@@ -423,11 +423,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 64784
+            "value": 64784000000
           }
         ]
       },
-      "research_time": 503896
+      "research_time": 503896080
     }
   ],
   "location": {

--- a/research/advanced_research.json
+++ b/research/advanced_research.json
@@ -40,11 +40,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1110
+            "value": 1110000
           }
         ]
       },
-      "research_time": 2600
+      "research_time": 2600040
     },
     {
       "bonus": {
@@ -75,11 +75,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 3860
+            "value": 3860000
           }
         ]
       },
-      "research_time": 5965
+      "research_time": 5965920
     },
     {
       "bonus": {
@@ -110,11 +110,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 6580
+            "value": 6580000
           }
         ]
       },
-      "research_time": 8058
+      "research_time": 8058720
     },
     {
       "bonus": {
@@ -145,11 +145,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 10400
+            "value": 10400000
           }
         ]
       },
-      "research_time": 14125
+      "research_time": 14125380
     },
     {
       "bonus": {
@@ -180,11 +180,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 15100
+            "value": 15100000
           }
         ]
       },
-      "research_time": 13456
+      "research_time": 13456140
     },
     {
       "bonus": {
@@ -224,11 +224,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 22450
+            "value": 22450000
           }
         ]
       },
-      "research_time": 21017
+      "research_time": 21017460
     },
     {
       "bonus": {
@@ -259,11 +259,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 32600
+            "value": 32600000
           }
         ]
       },
-      "research_time": 29338
+      "research_time": 29338800
     },
     {
       "bonus": {
@@ -294,11 +294,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 70800
+            "value": 70800000
           }
         ]
       },
-      "research_time": 51090
+      "research_time": 51090420
     },
     {
       "bonus": {
@@ -329,11 +329,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 146000
+            "value": 146000000
           }
         ]
       },
-      "research_time": 88888
+      "research_time": 88888440
     },
     {
       "bonus": {
@@ -373,11 +373,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 399000
+            "value": 399000000
           }
         ]
       },
-      "research_time": 150563
+      "research_time": 150563760
     }
   ],
   "location": {

--- a/research/advanced_training.json
+++ b/research/advanced_training.json
@@ -41,11 +41,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 4470
+            "value": 4470000
           }
         ]
       },
-      "research_time": 1162
+      "research_time": 1162740
     },
     {
       "bonus": {
@@ -96,11 +96,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 6670
+            "value": 6670000
           }
         ]
       },
-      "research_time": 1560
+      "research_time": 1560000
     },
     {
       "bonus": {
@@ -141,11 +141,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 9950
+            "value": 9950000
           }
         ]
       },
-      "research_time": 2099
+      "research_time": 2099700
     },
     {
       "bonus": {
@@ -178,11 +178,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 14650
+            "value": 14650000
           }
         ]
       },
-      "research_time": 2090
+      "research_time": 2090400
     },
     {
       "bonus": {
@@ -220,11 +220,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 23200
+            "value": 23200000
           }
         ]
       },
-      "research_time": 3579
+      "research_time": 3579540
     },
     {
       "bonus": {
@@ -257,11 +257,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 39500
+            "value": 39500000
           }
         ]
       },
-      "research_time": 4835
+      "research_time": 4835220
     },
     {
       "bonus": {
@@ -311,11 +311,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 62350
+            "value": 62350000
           }
         ]
       },
-      "research_time": 8475
+      "research_time": 8475240
     },
     {
       "bonus": {
@@ -360,11 +360,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 90450
+            "value": 90450000
           }
         ]
       },
-      "research_time": 8073
+      "research_time": 8073660
     },
     {
       "bonus": {
@@ -414,11 +414,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 134800
+            "value": 134800000
           }
         ]
       },
-      "research_time": 12610
+      "research_time": 12610500
     },
     {
       "bonus": {
@@ -484,7 +484,7 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1230
+            "value": 1230000
           }
         ]
       },

--- a/research/advantage_battleship.json
+++ b/research/advantage_battleship.json
@@ -31,7 +31,7 @@
         ],
         "resources": []
       },
-      "research_time": 8352
+      "research_time": 8352300
     },
     {
       "bonus": {
@@ -70,7 +70,7 @@
         ],
         "resources": []
       },
-      "research_time": 19775
+      "research_time": 19775580
     },
     {
       "bonus": {
@@ -104,7 +104,7 @@
         ],
         "resources": []
       },
-      "research_time": 29424
+      "research_time": 29424480
     },
     {
       "bonus": {
@@ -138,7 +138,7 @@
         ],
         "resources": []
       },
-      "research_time": 54507
+      "research_time": 54507780
     },
     {
       "bonus": {
@@ -168,7 +168,7 @@
         "others": [
           {
             "type": "Service\u00a0Award",
-            "value": 1796
+            "value": 1796553
           },
           {
             "type": "Merit\u00a0of\u00a0Honor",
@@ -177,7 +177,7 @@
         ],
         "resources": []
       },
-      "research_time": 96460
+      "research_time": 96460500
     },
     {
       "bonus": {
@@ -207,12 +207,12 @@
           },
           {
             "type": "Service\u00a0Award",
-            "value": 4412
+            "value": 4412607
           }
         ],
         "resources": []
       },
-      "research_time": 159171
+      "research_time": 159171960
     },
     {
       "bonus": {
@@ -242,7 +242,7 @@
         "others": [
           {
             "type": "Service\u00a0Award",
-            "value": 2669
+            "value": 2669728
           },
           {
             "type": "Merit\u00a0of\u00a0Honor",
@@ -251,7 +251,7 @@
         ],
         "resources": []
       },
-      "research_time": 124443
+      "research_time": 124443840
     },
     {
       "bonus": {
@@ -280,12 +280,12 @@
           },
           {
             "type": "Service\u00a0Award",
-            "value": 7673
+            "value": 7673146
           }
         ],
         "resources": []
       },
-      "research_time": 210789
+      "research_time": 210789240
     },
     {
       "bonus": {
@@ -311,7 +311,7 @@
         "others": [
           {
             "type": "Service\u00a0Award",
-            "value": 12766
+            "value": 12766604
           },
           {
             "type": "Merit\u00a0of\u00a0Honor",
@@ -320,7 +320,7 @@
         ],
         "resources": []
       },
-      "research_time": 265332
+      "research_time": 265332840
     },
     {
       "bonus": {
@@ -359,7 +359,7 @@
         ],
         "resources": []
       },
-      "research_time": 3640
+      "research_time": 3640080
     }
   ],
   "location": {

--- a/research/advantage_explorer.json
+++ b/research/advantage_explorer.json
@@ -39,7 +39,7 @@
         ],
         "resources": []
       },
-      "research_time": 3640
+      "research_time": 3640080
     },
     {
       "bonus": {
@@ -70,7 +70,7 @@
         ],
         "resources": []
       },
-      "research_time": 8352
+      "research_time": 8352300
     },
     {
       "bonus": {
@@ -109,7 +109,7 @@
         ],
         "resources": []
       },
-      "research_time": 19775
+      "research_time": 19775580
     },
     {
       "bonus": {
@@ -143,7 +143,7 @@
         ],
         "resources": []
       },
-      "research_time": 29424
+      "research_time": 29424480
     },
     {
       "bonus": {
@@ -177,7 +177,7 @@
         ],
         "resources": []
       },
-      "research_time": 54507
+      "research_time": 54507780
     },
     {
       "bonus": {
@@ -207,7 +207,7 @@
         "others": [
           {
             "type": "Service\u00a0Award",
-            "value": 1796
+            "value": 1796553
           },
           {
             "type": "Merit\u00a0of\u00a0Honor",
@@ -216,7 +216,7 @@
         ],
         "resources": []
       },
-      "research_time": 96460
+      "research_time": 96460500
     },
     {
       "bonus": {
@@ -246,7 +246,7 @@
         "others": [
           {
             "type": "Service\u00a0Award",
-            "value": 2669
+            "value": 2669728
           },
           {
             "type": "Merit\u00a0of\u00a0Honor",
@@ -255,7 +255,7 @@
         ],
         "resources": []
       },
-      "research_time": 124443
+      "research_time": 124443840
     },
     {
       "bonus": {
@@ -281,7 +281,7 @@
         "others": [
           {
             "type": "Service\u00a0Award",
-            "value": 4412
+            "value": 4412607
           },
           {
             "type": "Merit\u00a0of\u00a0Honor",
@@ -290,7 +290,7 @@
         ],
         "resources": []
       },
-      "research_time": 159171
+      "research_time": 159171960
     },
     {
       "bonus": {
@@ -315,7 +315,7 @@
         "others": [
           {
             "type": "Service\u00a0Award",
-            "value": 7673
+            "value": 7673146
           },
           {
             "type": "Merit\u00a0of\u00a0Honor",
@@ -324,7 +324,7 @@
         ],
         "resources": []
       },
-      "research_time": 210789
+      "research_time": 210789240
     },
     {
       "bonus": {
@@ -350,7 +350,7 @@
         "others": [
           {
             "type": "Service\u00a0Award",
-            "value": 12766
+            "value": 12766604
           },
           {
             "type": "Merit\u00a0of\u00a0Honor",
@@ -359,7 +359,7 @@
         ],
         "resources": []
       },
-      "research_time": 265332
+      "research_time": 265332840
     }
   ],
   "location": {

--- a/research/advantage_interceptor.json
+++ b/research/advantage_interceptor.json
@@ -43,7 +43,7 @@
         ],
         "resources": []
       },
-      "research_time": 3640
+      "research_time": 3640080
     },
     {
       "bonus": {
@@ -74,7 +74,7 @@
         ],
         "resources": []
       },
-      "research_time": 8352
+      "research_time": 8352300
     },
     {
       "bonus": {
@@ -113,7 +113,7 @@
         ],
         "resources": []
       },
-      "research_time": 19775
+      "research_time": 19775580
     },
     {
       "bonus": {
@@ -147,7 +147,7 @@
         ],
         "resources": []
       },
-      "research_time": 29424
+      "research_time": 29424480
     },
     {
       "bonus": {
@@ -181,7 +181,7 @@
         ],
         "resources": []
       },
-      "research_time": 54507
+      "research_time": 54507780
     },
     {
       "bonus": {
@@ -211,7 +211,7 @@
         "others": [
           {
             "type": "Service\u00a0Award",
-            "value": 1796
+            "value": 1796553
           },
           {
             "type": "Merit\u00a0of\u00a0Honor",
@@ -220,7 +220,7 @@
         ],
         "resources": []
       },
-      "research_time": 96460
+      "research_time": 96460500
     },
     {
       "bonus": {
@@ -250,7 +250,7 @@
         "others": [
           {
             "type": "Service\u00a0Award",
-            "value": 2669
+            "value": 2669728
           },
           {
             "type": "Merit\u00a0of\u00a0Honor",
@@ -259,7 +259,7 @@
         ],
         "resources": []
       },
-      "research_time": 124443
+      "research_time": 124443840
     },
     {
       "bonus": {
@@ -285,7 +285,7 @@
         "others": [
           {
             "type": "Service\u00a0Award",
-            "value": 4412
+            "value": 4412607
           },
           {
             "type": "Merit\u00a0of\u00a0Honor",
@@ -294,7 +294,7 @@
         ],
         "resources": []
       },
-      "research_time": 159171
+      "research_time": 159171960
     },
     {
       "bonus": {
@@ -319,7 +319,7 @@
         "others": [
           {
             "type": "Service\u00a0Award",
-            "value": 7673
+            "value": 7673146
           },
           {
             "type": "Merit\u00a0of\u00a0Honor",
@@ -328,7 +328,7 @@
         ],
         "resources": []
       },
-      "research_time": 210789
+      "research_time": 210789240
     },
     {
       "bonus": {
@@ -354,7 +354,7 @@
         "others": [
           {
             "type": "Service\u00a0Award",
-            "value": 12766
+            "value": 12766604
           },
           {
             "type": "Merit\u00a0of\u00a0Honor",
@@ -363,7 +363,7 @@
         ],
         "resources": []
       },
-      "research_time": 265332
+      "research_time": 265332840
     }
   ],
   "location": {

--- a/research/anarchist_weaponry.json
+++ b/research/anarchist_weaponry.json
@@ -88,7 +88,7 @@
           },
           {
             "type": "dilithium",
-            "value": 1340
+            "value": 1340000
           }
         ]
       },
@@ -234,7 +234,7 @@
           },
           {
             "type": "dilithium",
-            "value": 2040
+            "value": 2040000
           }
         ]
       },
@@ -278,11 +278,11 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 1200
+            "value": 1200000
           },
           {
             "type": "dilithium",
-            "value": 3000
+            "value": 3000000
           }
         ]
       },
@@ -322,15 +322,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 1860
+            "value": 1860000
           },
           {
             "type": "dilithium",
-            "value": 4650
+            "value": 4650000
           }
         ]
       },
-      "research_time": 1449
+      "research_time": 1449420
     },
     {
       "bonus": {
@@ -366,15 +366,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 2980
+            "value": 2980000
           },
           {
             "type": "dilithium",
-            "value": 7460
+            "value": 7460000
           }
         ]
       },
-      "research_time": 1937
+      "research_time": 1937880
     },
     {
       "bonus": {
@@ -410,15 +410,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 4440
+            "value": 4440000
           },
           {
             "type": "dilithium",
-            "value": 11100
+            "value": 11100000
           }
         ]
       },
-      "research_time": 2600
+      "research_time": 2600040
     },
     {
       "bonus": {
@@ -462,15 +462,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 6630
+            "value": 6630000
           },
           {
             "type": "dilithium",
-            "value": 16600
+            "value": 16600000
           }
         ]
       },
-      "research_time": 3499
+      "research_time": 3499500
     }
   ],
   "location": {

--- a/research/apex_chop_shop.json
+++ b/research/apex_chop_shop.json
@@ -78,7 +78,7 @@
         ],
         "resources": []
       },
-      "research_time": 1449
+      "research_time": 1449420
     },
     {
       "bonus": {
@@ -104,7 +104,7 @@
         ],
         "resources": []
       },
-      "research_time": 1937
+      "research_time": 1937880
     },
     {
       "bonus": {
@@ -130,7 +130,7 @@
         ],
         "resources": []
       },
-      "research_time": 2600
+      "research_time": 2600040
     },
     {
       "bonus": {
@@ -156,7 +156,7 @@
         ],
         "resources": []
       },
-      "research_time": 3499
+      "research_time": 3499500
     },
     {
       "bonus": {
@@ -182,7 +182,7 @@
         ],
         "resources": []
       },
-      "research_time": 3483
+      "research_time": 3483960
     },
     {
       "bonus": {
@@ -208,7 +208,7 @@
         ],
         "resources": []
       },
-      "research_time": 5965
+      "research_time": 5965920
     },
     {
       "bonus": {
@@ -234,7 +234,7 @@
         ],
         "resources": []
       },
-      "research_time": 8058
+      "research_time": 8058720
     },
     {
       "bonus": {
@@ -260,7 +260,7 @@
         ],
         "resources": []
       },
-      "research_time": 14125
+      "research_time": 14125380
     },
     {
       "bonus": {
@@ -286,7 +286,7 @@
         ],
         "resources": []
       },
-      "research_time": 13456
+      "research_time": 13456140
     },
     {
       "bonus": {
@@ -312,7 +312,7 @@
         ],
         "resources": []
       },
-      "research_time": 21017
+      "research_time": 21017460
     },
     {
       "bonus": {
@@ -338,7 +338,7 @@
         ],
         "resources": []
       },
-      "research_time": 29338
+      "research_time": 29338800
     },
     {
       "bonus": {
@@ -364,7 +364,7 @@
         ],
         "resources": []
       },
-      "research_time": 38934
+      "research_time": 38934120
     },
     {
       "bonus": {
@@ -390,7 +390,7 @@
         ],
         "resources": []
       },
-      "research_time": 51090
+      "research_time": 51090420
     }
   ],
   "location": {

--- a/research/apex_construction_speed.json
+++ b/research/apex_construction_speed.json
@@ -26,7 +26,7 @@
         ],
         "resources": []
       },
-      "research_time": 2600
+      "research_time": 2600040
     },
     {
       "bonus": {
@@ -52,7 +52,7 @@
         ],
         "resources": []
       },
-      "research_time": 3499
+      "research_time": 3499500
     },
     {
       "bonus": {
@@ -78,7 +78,7 @@
         ],
         "resources": []
       },
-      "research_time": 3483
+      "research_time": 3483960
     },
     {
       "bonus": {
@@ -104,7 +104,7 @@
         ],
         "resources": []
       },
-      "research_time": 5965
+      "research_time": 5965920
     },
     {
       "bonus": {
@@ -130,7 +130,7 @@
         ],
         "resources": []
       },
-      "research_time": 8058
+      "research_time": 8058720
     },
     {
       "bonus": {
@@ -156,7 +156,7 @@
         ],
         "resources": []
       },
-      "research_time": 14125
+      "research_time": 14125380
     },
     {
       "bonus": {
@@ -182,7 +182,7 @@
         ],
         "resources": []
       },
-      "research_time": 13456
+      "research_time": 13456140
     },
     {
       "bonus": {
@@ -208,7 +208,7 @@
         ],
         "resources": []
       },
-      "research_time": 21017
+      "research_time": 21017460
     },
     {
       "bonus": {
@@ -234,7 +234,7 @@
         ],
         "resources": []
       },
-      "research_time": 29338
+      "research_time": 29338800
     },
     {
       "bonus": {
@@ -260,7 +260,7 @@
         ],
         "resources": []
       },
-      "research_time": 38934
+      "research_time": 38934120
     },
     {
       "bonus": {
@@ -286,7 +286,7 @@
         ],
         "resources": []
       },
-      "research_time": 51090
+      "research_time": 51090420
     },
     {
       "bonus": {
@@ -312,7 +312,7 @@
         ],
         "resources": []
       },
-      "research_time": 68900
+      "research_time": 68900340
     },
     {
       "bonus": {
@@ -338,7 +338,7 @@
         ],
         "resources": []
       },
-      "research_time": 88888
+      "research_time": 88888440
     },
     {
       "bonus": {
@@ -364,7 +364,7 @@
         ],
         "resources": []
       },
-      "research_time": 113694
+      "research_time": 113694240
     },
     {
       "bonus": {
@@ -390,7 +390,7 @@
         ],
         "resources": []
       },
-      "research_time": 150563
+      "research_time": 150563760
     }
   ],
   "location": {

--- a/research/apex_getaway_pilots.json
+++ b/research/apex_getaway_pilots.json
@@ -234,7 +234,7 @@
         ],
         "resources": []
       },
-      "research_time": 1449
+      "research_time": 1449420
     },
     {
       "bonus": {
@@ -260,7 +260,7 @@
         ],
         "resources": []
       },
-      "research_time": 1937
+      "research_time": 1937880
     },
     {
       "bonus": {
@@ -286,7 +286,7 @@
         ],
         "resources": []
       },
-      "research_time": 2600
+      "research_time": 2600040
     },
     {
       "bonus": {
@@ -312,7 +312,7 @@
         ],
         "resources": []
       },
-      "research_time": 3499
+      "research_time": 3499500
     },
     {
       "bonus": {

--- a/research/apex_research_speed.json
+++ b/research/apex_research_speed.json
@@ -26,7 +26,7 @@
         ],
         "resources": []
       },
-      "research_time": 2600
+      "research_time": 2600040
     },
     {
       "bonus": {
@@ -52,7 +52,7 @@
         ],
         "resources": []
       },
-      "research_time": 3499
+      "research_time": 3499500
     },
     {
       "bonus": {
@@ -78,7 +78,7 @@
         ],
         "resources": []
       },
-      "research_time": 3483
+      "research_time": 3483960
     },
     {
       "bonus": {
@@ -104,7 +104,7 @@
         ],
         "resources": []
       },
-      "research_time": 5965
+      "research_time": 5965920
     },
     {
       "bonus": {
@@ -130,7 +130,7 @@
         ],
         "resources": []
       },
-      "research_time": 8058
+      "research_time": 8058720
     },
     {
       "bonus": {
@@ -156,7 +156,7 @@
         ],
         "resources": []
       },
-      "research_time": 14125
+      "research_time": 14125380
     },
     {
       "bonus": {
@@ -182,7 +182,7 @@
         ],
         "resources": []
       },
-      "research_time": 13456
+      "research_time": 13456140
     },
     {
       "bonus": {
@@ -208,7 +208,7 @@
         ],
         "resources": []
       },
-      "research_time": 21017
+      "research_time": 21017460
     },
     {
       "bonus": {
@@ -234,7 +234,7 @@
         ],
         "resources": []
       },
-      "research_time": 29338
+      "research_time": 29338800
     },
     {
       "bonus": {
@@ -260,7 +260,7 @@
         ],
         "resources": []
       },
-      "research_time": 38934
+      "research_time": 38934120
     },
     {
       "bonus": {
@@ -286,7 +286,7 @@
         ],
         "resources": []
       },
-      "research_time": 51090
+      "research_time": 51090420
     },
     {
       "bonus": {
@@ -312,7 +312,7 @@
         ],
         "resources": []
       },
-      "research_time": 68900
+      "research_time": 68900340
     },
     {
       "bonus": {
@@ -338,7 +338,7 @@
         ],
         "resources": []
       },
-      "research_time": 88888
+      "research_time": 88888440
     },
     {
       "bonus": {
@@ -364,7 +364,7 @@
         ],
         "resources": []
       },
-      "research_time": 113694
+      "research_time": 113694240
     },
     {
       "bonus": {
@@ -390,7 +390,7 @@
         ],
         "resources": []
       },
-      "research_time": 150563
+      "research_time": 150563760
     }
   ],
   "location": {

--- a/research/apex_rogue_notoriety.json
+++ b/research/apex_rogue_notoriety.json
@@ -26,7 +26,7 @@
         ],
         "resources": []
       },
-      "research_time": 2600,
+      "research_time": 2600040,
       "reward": {
         "type": "Mission\u00a0Token\u00a0",
         "value": 1

--- a/research/armada_accuracy.json
+++ b/research/armada_accuracy.json
@@ -51,11 +51,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 16650
+            "value": 16650000
           }
         ]
       },
-      "research_time": 3900
+      "research_time": 3900060
     },
     {
       "bonus": {
@@ -103,11 +103,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 57950
+            "value": 57950000
           }
         ]
       },
-      "research_time": 8948
+      "research_time": 8948940
     },
     {
       "bonus": {
@@ -168,11 +168,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 98700
+            "value": 98700000
           }
         ]
       },
-      "research_time": 12088
+      "research_time": 12088080
     },
     {
       "bonus": {
@@ -233,11 +233,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 155900
+            "value": 155900000
           }
         ]
       },
-      "research_time": 21188
+      "research_time": 21188100
     },
     {
       "bonus": {
@@ -298,11 +298,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 226100
+            "value": 226100000
           }
         ]
       },
-      "research_time": 20184
+      "research_time": 20184180
     },
     {
       "bonus": {
@@ -363,11 +363,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 337100
+            "value": 337100000
           }
         ]
       },
-      "research_time": 31526
+      "research_time": 31526220
     },
     {
       "bonus": {
@@ -428,11 +428,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 489000
+            "value": 489000000
           }
         ]
       },
-      "research_time": 44008
+      "research_time": 44008200
     },
     {
       "bonus": {
@@ -493,11 +493,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 744800
+            "value": 744800000
           }
         ]
       },
-      "research_time": 58401
+      "research_time": 58401240
     },
     {
       "bonus": {
@@ -558,11 +558,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1062
+            "value": 1062000000
           }
         ]
       },
-      "research_time": 76635
+      "research_time": 76635600
     },
     {
       "bonus": {
@@ -615,11 +615,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1481
+            "value": 1481000000
           }
         ]
       },
-      "research_time": 103350
+      "research_time": 103350540
     }
   ],
   "location": {

--- a/research/armada_armor_piercing.json
+++ b/research/armada_armor_piercing.json
@@ -47,11 +47,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 16650
+            "value": 16650000
           }
         ]
       },
-      "research_time": 3900
+      "research_time": 3900060
     },
     {
       "bonus": {
@@ -99,11 +99,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 36650
+            "value": 36650000
           }
         ]
       },
-      "research_time": 5226
+      "research_time": 5226000
     },
     {
       "bonus": {
@@ -160,11 +160,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 57950
+            "value": 57950000
           }
         ]
       },
-      "research_time": 8948
+      "research_time": 8948940
     },
     {
       "bonus": {
@@ -221,11 +221,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 98700
+            "value": 98700000
           }
         ]
       },
-      "research_time": 12088
+      "research_time": 12088080
     },
     {
       "bonus": {
@@ -286,11 +286,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 155900
+            "value": 155900000
           }
         ]
       },
-      "research_time": 21188
+      "research_time": 21188100
     },
     {
       "bonus": {
@@ -339,11 +339,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 226100
+            "value": 226100000
           }
         ]
       },
-      "research_time": 20184
+      "research_time": 20184180
     },
     {
       "bonus": {
@@ -400,11 +400,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 337100
+            "value": 337100000
           }
         ]
       },
-      "research_time": 31526
+      "research_time": 31526220
     },
     {
       "bonus": {
@@ -453,11 +453,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 489000
+            "value": 489000000
           }
         ]
       },
-      "research_time": 44008
+      "research_time": 44008200
     },
     {
       "bonus": {
@@ -514,11 +514,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 744800
+            "value": 744800000
           }
         ]
       },
-      "research_time": 58401
+      "research_time": 58401240
     },
     {
       "bonus": {
@@ -575,11 +575,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1062
+            "value": 1062000000
           }
         ]
       },
-      "research_time": 76635
+      "research_time": 76635600
     }
   ],
   "location": {

--- a/research/armada_defense.json
+++ b/research/armada_defense.json
@@ -51,11 +51,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 16650
+            "value": 16650000
           }
         ]
       },
-      "research_time": 3900
+      "research_time": 3900060
     },
     {
       "bonus": {
@@ -103,11 +103,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 36650
+            "value": 36650000
           }
         ]
       },
-      "research_time": 5226
+      "research_time": 5226000
     },
     {
       "bonus": {
@@ -168,11 +168,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 57950
+            "value": 57950000
           }
         ]
       },
-      "research_time": 8948
+      "research_time": 8948940
     },
     {
       "bonus": {
@@ -233,11 +233,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 98700
+            "value": 98700000
           }
         ]
       },
-      "research_time": 12088
+      "research_time": 12088080
     },
     {
       "bonus": {
@@ -302,11 +302,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 155900
+            "value": 155900000
           }
         ]
       },
-      "research_time": 21188
+      "research_time": 21188100
     },
     {
       "bonus": {
@@ -359,11 +359,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 226100
+            "value": 226100000
           }
         ]
       },
-      "research_time": 20184
+      "research_time": 20184180
     },
     {
       "bonus": {
@@ -424,11 +424,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 337100
+            "value": 337100000
           }
         ]
       },
-      "research_time": 31526
+      "research_time": 31526220
     },
     {
       "bonus": {
@@ -481,11 +481,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 489000
+            "value": 489000000
           }
         ]
       },
-      "research_time": 44008
+      "research_time": 44008200
     },
     {
       "bonus": {
@@ -546,11 +546,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 744800
+            "value": 744800000
           }
         ]
       },
-      "research_time": 58401
+      "research_time": 58401240
     },
     {
       "bonus": {
@@ -611,11 +611,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1062
+            "value": 1062000000
           }
         ]
       },
-      "research_time": 76635
+      "research_time": 76635600
     }
   ],
   "location": {

--- a/research/armada_defenses.json
+++ b/research/armada_defenses.json
@@ -46,15 +46,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 397200
+            "value": 397200000
           },
           {
             "type": "dilithium",
-            "value": 347600
+            "value": 347600000
           }
         ]
       },
-      "research_time": 27253
+      "research_time": 27253920
     },
     {
       "bonus": {
@@ -88,15 +88,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 566400
+            "value": 566400000
           },
           {
             "type": "dilithium",
-            "value": 495600
+            "value": 495600000
           }
         ]
       },
-      "research_time": 35763
+      "research_time": 35763300
     },
     {
       "bonus": {
@@ -136,15 +136,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 789800
+            "value": 789800000
           },
           {
             "type": "dilithium",
-            "value": 691100
+            "value": 691100000
           }
         ]
       },
-      "research_time": 48230
+      "research_time": 48230220
     },
     {
       "bonus": {
@@ -177,15 +177,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 1168
+            "value": 1168000000
           },
           {
             "type": "dilithium",
-            "value": 1022
+            "value": 1022000000
           }
         ]
       },
-      "research_time": 62221
+      "research_time": 62221920
     },
     {
       "bonus": {
@@ -225,15 +225,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 1886
+            "value": 1886000000
           },
           {
             "type": "dilithium",
-            "value": 1651
+            "value": 1651000000
           }
         ]
       },
-      "research_time": 79585
+      "research_time": 79585980
     },
     {
       "bonus": {
@@ -279,15 +279,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 3192
+            "value": 3192000000
           },
           {
             "type": "dilithium",
-            "value": 2793
+            "value": 2793000000
           }
         ]
       },
-      "research_time": 105394
+      "research_time": 105394620
     },
     {
       "bonus": {
@@ -327,15 +327,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 5670
+            "value": 5670000000
           },
           {
             "type": "dilithium",
-            "value": 4961
+            "value": 4961000000
           }
         ]
       },
-      "research_time": 132666
+      "research_time": 132666420
     },
     {
       "bonus": {
@@ -357,15 +357,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 8631
+            "value": 8631000000
           },
           {
             "type": "dilithium",
-            "value": 7552
+            "value": 7552000000
           }
         ]
       },
-      "research_time": 161816
+      "research_time": 161816700
     },
     {
       "bonus": {
@@ -387,15 +387,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 13230
+            "value": 13230000000
           },
           {
             "type": "dilithium",
-            "value": 11576
+            "value": 11576000000
           }
         ]
       },
-      "research_time": 208311
+      "research_time": 208311720
     },
     {
       "bonus": {
@@ -417,15 +417,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 11813
+            "value": 11813000000
           },
           {
             "type": "dilithium",
-            "value": 10336
+            "value": 10336000000
           }
         ]
       },
-      "research_time": 143201
+      "research_time": 143201220
     }
   ],
   "location": {

--- a/research/armada_evasion.json
+++ b/research/armada_evasion.json
@@ -51,11 +51,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 16650
+            "value": 16650000
           }
         ]
       },
-      "research_time": 3900
+      "research_time": 3900060
     },
     {
       "bonus": {
@@ -103,11 +103,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 57950
+            "value": 57950000
           }
         ]
       },
-      "research_time": 8948
+      "research_time": 8948940
     },
     {
       "bonus": {
@@ -168,11 +168,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 98700
+            "value": 98700000
           }
         ]
       },
-      "research_time": 12088
+      "research_time": 12088080
     },
     {
       "bonus": {
@@ -233,11 +233,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 155900
+            "value": 155900000
           }
         ]
       },
-      "research_time": 21188
+      "research_time": 21188100
     },
     {
       "bonus": {
@@ -298,11 +298,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 226100
+            "value": 226100000
           }
         ]
       },
-      "research_time": 20184
+      "research_time": 20184180
     },
     {
       "bonus": {
@@ -363,11 +363,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 337100
+            "value": 337100000
           }
         ]
       },
-      "research_time": 31526
+      "research_time": 31526220
     },
     {
       "bonus": {
@@ -428,11 +428,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 489000
+            "value": 489000000
           }
         ]
       },
-      "research_time": 44008
+      "research_time": 44008200
     },
     {
       "bonus": {
@@ -493,11 +493,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 744800
+            "value": 744800000
           }
         ]
       },
-      "research_time": 58401
+      "research_time": 58401240
     },
     {
       "bonus": {
@@ -558,11 +558,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1062
+            "value": 1062000000
           }
         ]
       },
-      "research_time": 76635
+      "research_time": 76635600
     },
     {
       "bonus": {
@@ -615,11 +615,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1481
+            "value": 1481000000
           }
         ]
       },
-      "research_time": 103350
+      "research_time": 103350540
     }
   ],
   "location": {

--- a/research/armada_piercing.json
+++ b/research/armada_piercing.json
@@ -52,15 +52,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 397200
+            "value": 397200000
           },
           {
             "type": "dilithium",
-            "value": 347600
+            "value": 347600000
           }
         ]
       },
-      "research_time": 27253
+      "research_time": 27253920
     },
     {
       "bonus": {
@@ -99,15 +99,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 566400
+            "value": 566400000
           },
           {
             "type": "dilithium",
-            "value": 495600
+            "value": 495600000
           }
         ]
       },
-      "research_time": 35763
+      "research_time": 35763300
     },
     {
       "bonus": {
@@ -151,15 +151,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 789800
+            "value": 789800000
           },
           {
             "type": "dilithium",
-            "value": 691100
+            "value": 691100000
           }
         ]
       },
-      "research_time": 48230
+      "research_time": 48230220
     },
     {
       "bonus": {
@@ -199,15 +199,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 1168
+            "value": 1168000000
           },
           {
             "type": "dilithium",
-            "value": 1022
+            "value": 1022000000
           }
         ]
       },
-      "research_time": 62221
+      "research_time": 62221920
     },
     {
       "bonus": {
@@ -251,15 +251,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 1886
+            "value": 1886000000
           },
           {
             "type": "dilithium",
-            "value": 1651
+            "value": 1651000000
           }
         ]
       },
-      "research_time": 79585
+      "research_time": 79585980
     },
     {
       "bonus": {
@@ -298,15 +298,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 3192
+            "value": 3192000000
           },
           {
             "type": "dilithium",
-            "value": 2793
+            "value": 2793000000
           }
         ]
       },
-      "research_time": 105394
+      "research_time": 105394620
     },
     {
       "bonus": {
@@ -346,15 +346,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 5670
+            "value": 5670000000
           },
           {
             "type": "dilithium",
-            "value": 4961
+            "value": 4961000000
           }
         ]
       },
-      "research_time": 132666
+      "research_time": 132666420
     },
     {
       "bonus": {
@@ -376,15 +376,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 8631
+            "value": 8631000000
           },
           {
             "type": "dilithium",
-            "value": 7552
+            "value": 7552000000
           }
         ]
       },
-      "research_time": 161816
+      "research_time": 161816700
     },
     {
       "bonus": {
@@ -406,15 +406,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 13230
+            "value": 13230000000
           },
           {
             "type": "dilithium",
-            "value": 11576
+            "value": 11576000000
           }
         ]
       },
-      "research_time": 208311
+      "research_time": 208311720
     },
     {
       "bonus": {
@@ -436,15 +436,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 11813
+            "value": 11813000000
           },
           {
             "type": "dilithium",
-            "value": 10336
+            "value": 10336000000
           }
         ]
       },
-      "research_time": 143201
+      "research_time": 143201220
     }
   ],
   "location": {

--- a/research/armada_pillager.json
+++ b/research/armada_pillager.json
@@ -41,11 +41,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1250
+            "value": 1250000000
           }
         ]
       },
-      "research_time": 82680
+      "research_time": 82680420
     }
   ],
   "location": {

--- a/research/armada_shield_piercing.json
+++ b/research/armada_shield_piercing.json
@@ -47,11 +47,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 16650
+            "value": 16650000
           }
         ]
       },
-      "research_time": 3900
+      "research_time": 3900060
     },
     {
       "bonus": {
@@ -103,11 +103,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 98700
+            "value": 98700000
           }
         ]
       },
-      "research_time": 12088
+      "research_time": 12088080
     },
     {
       "bonus": {
@@ -159,11 +159,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 155900
+            "value": 155900000
           }
         ]
       },
-      "research_time": 21188
+      "research_time": 21188100
     },
     {
       "bonus": {
@@ -215,11 +215,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 226100
+            "value": 226100000
           }
         ]
       },
-      "research_time": 20184
+      "research_time": 20184180
     },
     {
       "bonus": {
@@ -271,11 +271,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 337100
+            "value": 337100000
           }
         ]
       },
-      "research_time": 31526
+      "research_time": 31526220
     },
     {
       "bonus": {
@@ -327,11 +327,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 489000
+            "value": 489000000
           }
         ]
       },
-      "research_time": 44008
+      "research_time": 44008200
     },
     {
       "bonus": {
@@ -383,11 +383,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 744800
+            "value": 744800000
           }
         ]
       },
-      "research_time": 58401
+      "research_time": 58401240
     },
     {
       "bonus": {
@@ -439,11 +439,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1062
+            "value": 1062000000
           }
         ]
       },
-      "research_time": 76635
+      "research_time": 76635600
     },
     {
       "bonus": {
@@ -495,11 +495,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1481
+            "value": 1481000000
           }
         ]
       },
-      "research_time": 103350
+      "research_time": 103350540
     },
     {
       "bonus": {
@@ -543,11 +543,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 2190
+            "value": 2190000000
           }
         ]
       },
-      "research_time": 133332
+      "research_time": 133332660
     }
   ],
   "location": {

--- a/research/armada_tactics.json
+++ b/research/armada_tactics.json
@@ -31,11 +31,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1110
+            "value": 1110000
           }
         ]
       },
-      "research_time": 2600
+      "research_time": 2600040
     },
     {
       "bonus": {
@@ -66,11 +66,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 2440
+            "value": 2440000
           }
         ]
       },
-      "research_time": 3483
+      "research_time": 3483960
     },
     {
       "bonus": {
@@ -101,11 +101,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 6580
+            "value": 6580000
           }
         ]
       },
-      "research_time": 8058
+      "research_time": 8058720
     },
     {
       "bonus": {
@@ -136,11 +136,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 15100
+            "value": 15100000
           }
         ]
       },
-      "research_time": 13456
+      "research_time": 13456140
     },
     {
       "bonus": {
@@ -171,11 +171,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 32600
+            "value": 32600000
           }
         ]
       },
-      "research_time": 29338
+      "research_time": 29338800
     },
     {
       "bonus": {
@@ -206,11 +206,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 70800
+            "value": 70800000
           }
         ]
       },
-      "research_time": 51090
+      "research_time": 51090420
     },
     {
       "bonus": {
@@ -241,11 +241,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 146000
+            "value": 146000000
           }
         ]
       },
-      "research_time": 88888
+      "research_time": 88888440
     },
     {
       "bonus": {
@@ -276,11 +276,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 399000
+            "value": 399000000
           }
         ]
       },
-      "research_time": 150563
+      "research_time": 150563760
     },
     {
       "bonus": {
@@ -552,7 +552,7 @@
           }
         ]
       },
-      "research_time": 1449
+      "research_time": 1449420
     }
   ],
   "location": {

--- a/research/armada_targeting.json
+++ b/research/armada_targeting.json
@@ -52,11 +52,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 337100
+            "value": 337100000
           }
         ]
       },
-      "research_time": 31526
+      "research_time": 31526220
     },
     {
       "bonus": {
@@ -99,11 +99,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 744800
+            "value": 744800000
           }
         ]
       },
-      "research_time": 58401
+      "research_time": 58401240
     },
     {
       "bonus": {
@@ -142,11 +142,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1481
+            "value": 1481000000
           }
         ]
       },
-      "research_time": 103350
+      "research_time": 103350540
     },
     {
       "bonus": {
@@ -185,11 +185,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 3537
+            "value": 3537000000
           }
         ]
       },
-      "research_time": 170541
+      "research_time": 170541360
     },
     {
       "bonus": {
@@ -229,11 +229,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 10631
+            "value": 10631000000
           }
         ]
       },
-      "research_time": 284285
+      "research_time": 284285220
     }
   ],
   "location": {

--- a/research/assembly_line.json
+++ b/research/assembly_line.json
@@ -54,7 +54,7 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 2010
+            "value": 2010000
           }
         ]
       },
@@ -116,11 +116,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 6970
+            "value": 6970000
           }
         ]
       },
-      "research_time": 1811
+      "research_time": 1811820
     },
     {
       "bonus": {
@@ -174,11 +174,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 24900
+            "value": 24900000
           }
         ]
       },
-      "research_time": 4374
+      "research_time": 4374420
     },
     {
       "bonus": {
@@ -227,11 +227,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 98700
+            "value": 98700000
           }
         ]
       },
-      "research_time": 10073
+      "research_time": 10073400
     },
     {
       "bonus": {

--- a/research/assimilated_credit_yield.json
+++ b/research/assimilated_credit_yield.json
@@ -57,11 +57,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 9290
+            "value": 9290000
           }
         ]
       },
-      "research_time": 2898,
+      "research_time": 2898900,
       "reward": {
         "type": "Mission\u00a0Token\u00a0",
         "value": 1
@@ -122,11 +122,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 14900
+            "value": 14900000
           }
         ]
       },
-      "research_time": 3875,
+      "research_time": 3875820,
       "reward": {
         "type": "Mission\u00a0Token\u00a0",
         "value": 1
@@ -183,11 +183,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 5990
+            "value": 5990000
           }
         ]
       },
-      "research_time": 1957,
+      "research_time": 1957020,
       "reward": {
         "type": "Mission\u00a0Token\u00a0",
         "value": 1
@@ -294,11 +294,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 4090
+            "value": 4090000
           }
         ]
       },
-      "research_time": 1901,
+      "research_time": 1901100,
       "reward": {
         "type": "Mission\u00a0Token\u00a0",
         "value": 1

--- a/research/attack_training.json
+++ b/research/attack_training.json
@@ -48,7 +48,7 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1020
+            "value": 1020000
           }
         ]
       },
@@ -91,11 +91,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 19300
+            "value": 19300000
           }
         ]
       },
-      "research_time": 2982
+      "research_time": 2982960
     },
     {
       "bonus": {
@@ -130,11 +130,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 32900
+            "value": 32900000
           }
         ]
       },
-      "research_time": 4029
+      "research_time": 4029360
     },
     {
       "bonus": {
@@ -168,11 +168,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 52000
+            "value": 52000000
           }
         ]
       },
-      "research_time": 7062
+      "research_time": 7062720
     },
     {
       "bonus": {
@@ -201,11 +201,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 75400
+            "value": 75400000
           }
         ]
       },
-      "research_time": 6728
+      "research_time": 6728040
     },
     {
       "bonus": {
@@ -244,11 +244,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 112400
+            "value": 112400000
           }
         ]
       },
-      "research_time": 10508
+      "research_time": 10508760
     },
     {
       "bonus": {
@@ -283,11 +283,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 163000
+            "value": 163000000
           }
         ]
       },
-      "research_time": 14669
+      "research_time": 14669400
     },
     {
       "bonus": {
@@ -326,11 +326,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 248300
+            "value": 248300000
           }
         ]
       },
-      "research_time": 19467
+      "research_time": 19467060
     },
     {
       "bonus": {
@@ -365,11 +365,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 354000
+            "value": 354000000
           }
         ]
       },
-      "research_time": 25545
+      "research_time": 25545180
     },
     {
       "bonus": {
@@ -404,11 +404,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 493600
+            "value": 493600000
           }
         ]
       },
-      "research_time": 34450
+      "research_time": 34450200
     }
   ],
   "location": {

--- a/research/augmented_credit_yield.json
+++ b/research/augmented_credit_yield.json
@@ -48,11 +48,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 4090
+            "value": 4090000
           }
         ]
       },
-      "research_time": 1901,
+      "research_time": 1901100,
       "reward": {
         "type": "Mission\u00a0Token\u00a0",
         "value": 1
@@ -113,11 +113,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 5990
+            "value": 5990000
           }
         ]
       },
-      "research_time": 1957,
+      "research_time": 1957020,
       "reward": {
         "type": "Mission\u00a0Token\u00a0",
         "value": 1
@@ -178,11 +178,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 9290
+            "value": 9290000
           }
         ]
       },
-      "research_time": 2898,
+      "research_time": 2898900,
       "reward": {
         "type": "Mission\u00a0Token\u00a0",
         "value": 1
@@ -243,11 +243,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 14900
+            "value": 14900000
           }
         ]
       },
-      "research_time": 3875,
+      "research_time": 3875820,
       "reward": {
         "type": "Mission\u00a0Token\u00a0",
         "value": 1

--- a/research/augmented_impulse.json
+++ b/research/augmented_impulse.json
@@ -170,7 +170,7 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1230
+            "value": 1230000
           }
         ]
       },

--- a/research/battleship_advanced_piercing.json
+++ b/research/battleship_advanced_piercing.json
@@ -30,7 +30,7 @@
         ],
         "resources": []
       },
-      "research_time": 8058
+      "research_time": 8058720
     },
     {
       "bonus": {
@@ -69,7 +69,7 @@
         ],
         "resources": []
       },
-      "research_time": 14125
+      "research_time": 14125380
     },
     {
       "bonus": {
@@ -104,7 +104,7 @@
         ],
         "resources": []
       },
-      "research_time": 13456
+      "research_time": 13456140
     },
     {
       "bonus": {
@@ -143,7 +143,7 @@
         ],
         "resources": []
       },
-      "research_time": 21017
+      "research_time": 21017460
     },
     {
       "bonus": {
@@ -178,7 +178,7 @@
         ],
         "resources": []
       },
-      "research_time": 29338
+      "research_time": 29338800
     },
     {
       "bonus": {
@@ -217,7 +217,7 @@
         ],
         "resources": []
       },
-      "research_time": 38934
+      "research_time": 38934120
     },
     {
       "bonus": {
@@ -247,12 +247,12 @@
           },
           {
             "type": "Service\u00a0Award",
-            "value": 1259
+            "value": 1259626
           }
         ],
         "resources": []
       },
-      "research_time": 51090
+      "research_time": 51090420
     },
     {
       "bonus": {
@@ -286,12 +286,12 @@
           },
           {
             "type": "Service\u00a0Award",
-            "value": 1796
+            "value": 1796553
           }
         ],
         "resources": []
       },
-      "research_time": 68900
+      "research_time": 68900340
     },
     {
       "bonus": {
@@ -321,12 +321,12 @@
           },
           {
             "type": "Service\u00a0Award",
-            "value": 2669
+            "value": 2669728
           }
         ],
         "resources": []
       },
-      "research_time": 88888
+      "research_time": 88888440
     },
     {
       "bonus": {
@@ -361,7 +361,7 @@
         ],
         "resources": []
       },
-      "research_time": 2600
+      "research_time": 2600040
     }
   ],
   "location": {

--- a/research/battleship_barrage.json
+++ b/research/battleship_barrage.json
@@ -27,11 +27,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 674100
+            "value": 674100000
           }
         ]
       },
-      "research_time": 42034
+      "research_time": 42034980
     }
   ],
   "location": {

--- a/research/battleship_bartering.json
+++ b/research/battleship_bartering.json
@@ -35,15 +35,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 611200
+            "value": 611200000
           },
           {
             "type": "dilithium",
-            "value": 67400
+            "value": 67400000
           }
         ]
       },
-      "research_time": 6305
+      "research_time": 6305220
     },
     {
       "bonus": {
@@ -78,11 +78,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 20300
+            "value": 20300000
           },
           {
             "type": "dilithium",
-            "value": 2240
+            "value": 2240000
           }
         ]
       },
@@ -121,15 +121,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 45100
+            "value": 45100000
           },
           {
             "type": "dilithium",
-            "value": 4980
+            "value": 4980000
           }
         ]
       },
-      "research_time": 1049
+      "research_time": 1049880
     },
     {
       "bonus": {
@@ -164,15 +164,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 105100
+            "value": 105100000
           },
           {
             "type": "dilithium",
-            "value": 11600
+            "value": 11600000
           }
         ]
       },
-      "research_time": 1789
+      "research_time": 1789800
     },
     {
       "bonus": {
@@ -207,15 +207,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 282700
+            "value": 282700000
           },
           {
             "type": "dilithium",
-            "value": 31200
+            "value": 31200000
           }
         ]
       },
-      "research_time": 4237
+      "research_time": 4237620
     },
     {
       "bonus": {
@@ -321,7 +321,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1520
+            "value": 1520000
           },
           {
             "type": "dilithium",
@@ -414,7 +414,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 8150
+            "value": 8150000
           },
           {
             "type": "dilithium",
@@ -474,7 +474,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 3650
+            "value": 3650000
           },
           {
             "type": "dilithium",

--- a/research/battleship_firepower.json
+++ b/research/battleship_firepower.json
@@ -49,15 +49,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 15450
+            "value": 15450000
           },
           {
             "type": "dilithium",
-            "value": 38650
+            "value": 38650000
           }
         ]
       },
-      "research_time": 7159
+      "research_time": 7159140
     },
     {
       "bonus": {
@@ -91,15 +91,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 26350
+            "value": 26350000
           },
           {
             "type": "dilithium",
-            "value": 65800
+            "value": 65800000
           }
         ]
       },
-      "research_time": 9670
+      "research_time": 9670500
     },
     {
       "bonus": {
@@ -129,15 +129,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 1860
+            "value": 1860000
           },
           {
             "type": "dilithium",
-            "value": 4650
+            "value": 4650000
           }
         ]
       },
-      "research_time": 1739
+      "research_time": 1739340
     },
     {
       "bonus": {
@@ -239,15 +239,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 1200
+            "value": 1200000
           },
           {
             "type": "dilithium",
-            "value": 3000
+            "value": 3000000
           }
         ]
       },
-      "research_time": 1174
+      "research_time": 1174200
     },
     {
       "bonus": {
@@ -277,15 +277,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 4440
+            "value": 4440000
           },
           {
             "type": "dilithium",
-            "value": 11100
+            "value": 11100000
           }
         ]
       },
-      "research_time": 3120
+      "research_time": 3120060
     },
     {
       "bonus": {
@@ -324,15 +324,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 6630
+            "value": 6630000
           },
           {
             "type": "dilithium",
-            "value": 16600
+            "value": 16600000
           }
         ]
       },
-      "research_time": 4199
+      "research_time": 4199400
     },
     {
       "bonus": {

--- a/research/battleship_focus_shot.json
+++ b/research/battleship_focus_shot.json
@@ -38,7 +38,7 @@
         ],
         "resources": []
       },
-      "research_time": 50614
+      "research_time": 50614380
     },
     {
       "bonus": {
@@ -72,12 +72,12 @@
           },
           {
             "type": "Service\u00a0Award",
-            "value": 1259
+            "value": 1259626
           }
         ],
         "resources": []
       },
-      "research_time": 66417
+      "research_time": 66417540
     },
     {
       "bonus": {
@@ -106,12 +106,12 @@
           },
           {
             "type": "Service\u00a0Award",
-            "value": 1796
+            "value": 1796553
           }
         ],
         "resources": []
       },
-      "research_time": 89570
+      "research_time": 89570460
     },
     {
       "bonus": {
@@ -141,7 +141,7 @@
         "others": [
           {
             "type": "Service\u00a0Award",
-            "value": 2669
+            "value": 2669728
           },
           {
             "type": "Merit\u00a0of\u00a0Honor",
@@ -150,7 +150,7 @@
         ],
         "resources": []
       },
-      "research_time": 115554
+      "research_time": 115554960
     },
     {
       "bonus": {
@@ -175,12 +175,12 @@
           },
           {
             "type": "Service\u00a0Award",
-            "value": 4412
+            "value": 4412607
           }
         ],
         "resources": []
       },
-      "research_time": 147802
+      "research_time": 147802500
     },
     {
       "bonus": {
@@ -210,7 +210,7 @@
         "others": [
           {
             "type": "Service\u00a0Award",
-            "value": 7673
+            "value": 7673146
           },
           {
             "type": "Merit\u00a0of\u00a0Honor",
@@ -219,7 +219,7 @@
         ],
         "resources": []
       },
-      "research_time": 195732
+      "research_time": 195732840
     },
     {
       "bonus": {
@@ -240,7 +240,7 @@
         "others": [
           {
             "type": "Service\u00a0Award",
-            "value": 12766
+            "value": 12766604
           },
           {
             "type": "Merit\u00a0of\u00a0Honor",
@@ -249,7 +249,7 @@
         ],
         "resources": []
       },
-      "research_time": 246380
+      "research_time": 246380520
     },
     {
       "bonus": {
@@ -283,12 +283,12 @@
           },
           {
             "type": "Service\u00a0Award",
-            "value": 14185
+            "value": 14185115
           }
         ],
         "resources": []
       },
-      "research_time": 300516
+      "research_time": 300516720
     },
     {
       "bonus": {
@@ -313,12 +313,12 @@
           },
           {
             "type": "Service\u00a0Award",
-            "value": 14185
+            "value": 14185115
           }
         ],
         "resources": []
       },
-      "research_time": 300516
+      "research_time": 300516720
     },
     {
       "bonus": {
@@ -348,7 +348,7 @@
         "others": [
           {
             "type": "Service\u00a0Award",
-            "value": 17022
+            "value": 17022138
           },
           {
             "type": "Merit\u00a0of\u00a0Honor",
@@ -357,7 +357,7 @@
         ],
         "resources": []
       },
-      "research_time": 265945
+      "research_time": 265945140
     }
   ],
   "location": {

--- a/research/battleship_hull_boost.json
+++ b/research/battleship_hull_boost.json
@@ -49,15 +49,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 38650
+            "value": 38650000
           },
           {
             "type": "dilithium",
-            "value": 23200
+            "value": 23200000
           }
         ]
       },
-      "research_time": 5965
+      "research_time": 5965920
     },
     {
       "bonus": {
@@ -91,15 +91,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 65800
+            "value": 65800000
           },
           {
             "type": "dilithium",
-            "value": 39500
+            "value": 39500000
           }
         ]
       },
-      "research_time": 8058
+      "research_time": 8058720
     },
     {
       "bonus": {
@@ -129,15 +129,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 4650
+            "value": 4650000
           },
           {
             "type": "dilithium",
-            "value": 2790
+            "value": 2790000
           }
         ]
       },
-      "research_time": 1449
+      "research_time": 1449420
     },
     {
       "bonus": {
@@ -296,11 +296,11 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 3000
+            "value": 3000000
           },
           {
             "type": "dilithium",
-            "value": 1800
+            "value": 1800000
           }
         ]
       },
@@ -334,15 +334,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 11100
+            "value": 11100000
           },
           {
             "type": "dilithium",
-            "value": 6670
+            "value": 6670000
           }
         ]
       },
-      "research_time": 2600
+      "research_time": 2600040
     },
     {
       "bonus": {
@@ -381,15 +381,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 16600
+            "value": 16600000
           },
           {
             "type": "dilithium",
-            "value": 9950
+            "value": 9950000
           }
         ]
       },
-      "research_time": 3499
+      "research_time": 3499500
     },
     {
       "bonus": {

--- a/research/battleship_hull_integrity.json
+++ b/research/battleship_hull_integrity.json
@@ -31,11 +31,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1110
+            "value": 1110000
           }
         ]
       },
-      "research_time": 2600
+      "research_time": 2600040
     },
     {
       "bonus": {
@@ -66,11 +66,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1660
+            "value": 1660000
           }
         ]
       },
-      "research_time": 3499
+      "research_time": 3499500
     },
     {
       "bonus": {
@@ -101,11 +101,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 2440
+            "value": 2440000
           }
         ]
       },
-      "research_time": 3483
+      "research_time": 3483960
     },
     {
       "bonus": {
@@ -136,11 +136,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 3860
+            "value": 3860000
           }
         ]
       },
-      "research_time": 5965
+      "research_time": 5965920
     },
     {
       "bonus": {
@@ -171,11 +171,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 6580
+            "value": 6580000
           }
         ]
       },
-      "research_time": 8058
+      "research_time": 8058720
     },
     {
       "bonus": {
@@ -219,11 +219,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 10400
+            "value": 10400000
           }
         ]
       },
-      "research_time": 14125
+      "research_time": 14125380
     },
     {
       "bonus": {
@@ -254,11 +254,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 15100
+            "value": 15100000
           }
         ]
       },
-      "research_time": 13456
+      "research_time": 13456140
     },
     {
       "bonus": {
@@ -289,11 +289,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 32600
+            "value": 32600000
           }
         ]
       },
-      "research_time": 29338
+      "research_time": 29338800
     },
     {
       "bonus": {
@@ -324,11 +324,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 70800
+            "value": 70800000
           }
         ]
       },
-      "research_time": 51090
+      "research_time": 51090420
     },
     {
       "bonus": {
@@ -359,11 +359,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 146000
+            "value": 146000000
           }
         ]
       },
-      "research_time": 88888
+      "research_time": 88888440
     },
     {
       "bonus": {
@@ -403,11 +403,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 399000
+            "value": 399000000
           }
         ]
       },
-      "research_time": 150563
+      "research_time": 150563760
     },
     {
       "bonus": {

--- a/research/battleship_nacelles.json
+++ b/research/battleship_nacelles.json
@@ -131,7 +131,7 @@
         ],
         "resources": []
       },
-      "research_time": 1162
+      "research_time": 1162740
     },
     {
       "bonus": {

--- a/research/battleship_overcharge.json
+++ b/research/battleship_overcharge.json
@@ -30,7 +30,7 @@
         ],
         "resources": []
       },
-      "research_time": 1272
+      "research_time": 1272060
     },
     {
       "bonus": {
@@ -61,7 +61,7 @@
         ],
         "resources": []
       },
-      "research_time": 1884
+      "research_time": 1884300
     },
     {
       "bonus": {
@@ -96,7 +96,7 @@
         ],
         "resources": []
       },
-      "research_time": 2519
+      "research_time": 2519280
     },
     {
       "bonus": {
@@ -127,7 +127,7 @@
         ],
         "resources": []
       },
-      "research_time": 3380
+      "research_time": 3380040
     },
     {
       "bonus": {
@@ -162,7 +162,7 @@
         ],
         "resources": []
       },
-      "research_time": 4549
+      "research_time": 4549380
     },
     {
       "bonus": {
@@ -193,7 +193,7 @@
         ],
         "resources": []
       },
-      "research_time": 4529
+      "research_time": 4529160
     },
     {
       "bonus": {
@@ -223,7 +223,7 @@
         ],
         "resources": []
       },
-      "research_time": 7755
+      "research_time": 7755720
     },
     {
       "bonus": {
@@ -258,7 +258,7 @@
         ],
         "resources": []
       },
-      "research_time": 10476
+      "research_time": 10476360
     },
     {
       "bonus": {
@@ -297,7 +297,7 @@
         ],
         "resources": []
       },
-      "research_time": 18363
+      "research_time": 18363000
     },
     {
       "bonus": {

--- a/research/battleship_penetration.json
+++ b/research/battleship_penetration.json
@@ -31,15 +31,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 6670
+            "value": 6670000
           },
           {
             "type": "dilithium",
-            "value": 8890
+            "value": 8890000
           }
         ]
       },
-      "research_time": 2080
+      "research_time": 2080020
     },
     {
       "bonus": {
@@ -70,15 +70,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 14650
+            "value": 14650000
           },
           {
             "type": "dilithium",
-            "value": 19550
+            "value": 19550000
           }
         ]
       },
-      "research_time": 2787
+      "research_time": 2787180
     },
     {
       "bonus": {
@@ -128,15 +128,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 23200
+            "value": 23200000
           },
           {
             "type": "dilithium",
-            "value": 30900
+            "value": 30900000
           }
         ]
       },
-      "research_time": 4772
+      "research_time": 4772760
     },
     {
       "bonus": {
@@ -232,11 +232,11 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 1230
+            "value": 1230000
           },
           {
             "type": "dilithium",
-            "value": 1630
+            "value": 1630000
           }
         ]
       },
@@ -271,11 +271,11 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 1800
+            "value": 1800000
           },
           {
             "type": "dilithium",
-            "value": 2400
+            "value": 2400000
           }
         ]
       },
@@ -310,15 +310,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 4470
+            "value": 4470000
           },
           {
             "type": "dilithium",
-            "value": 5960
+            "value": 5960000
           }
         ]
       },
-      "research_time": 1550
+      "research_time": 1550340
     },
     {
       "bonus": {

--- a/research/battleship_regeneration.json
+++ b/research/battleship_regeneration.json
@@ -22,7 +22,7 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1210
+            "value": 1210000
           }
         ]
       },
@@ -103,7 +103,7 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 2700
+            "value": 2700000
           }
         ]
       },
@@ -151,11 +151,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 6710
+            "value": 6710000
           }
         ]
       },
-      "research_time": 1744
+      "research_time": 1744080
     },
     {
       "bonus": {

--- a/research/battleship_repair_costs.json
+++ b/research/battleship_repair_costs.json
@@ -40,11 +40,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1110
+            "value": 1110000
           }
         ]
       },
-      "research_time": 2600
+      "research_time": 2600040
     },
     {
       "bonus": {
@@ -75,11 +75,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 2440
+            "value": 2440000
           }
         ]
       },
-      "research_time": 3483
+      "research_time": 3483960
     },
     {
       "bonus": {
@@ -110,11 +110,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 3860
+            "value": 3860000
           }
         ]
       },
-      "research_time": 5965
+      "research_time": 5965920
     },
     {
       "bonus": {
@@ -145,11 +145,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 6580
+            "value": 6580000
           }
         ]
       },
-      "research_time": 8058
+      "research_time": 8058720
     },
     {
       "bonus": {
@@ -180,11 +180,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 10400
+            "value": 10400000
           }
         ]
       },
-      "research_time": 14125
+      "research_time": 14125380
     },
     {
       "bonus": {
@@ -215,11 +215,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 22450
+            "value": 22450000
           }
         ]
       },
-      "research_time": 21017
+      "research_time": 21017460
     },
     {
       "bonus": {
@@ -254,11 +254,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 49650
+            "value": 49650000
           }
         ]
       },
-      "research_time": 38934
+      "research_time": 38934120
     },
     {
       "bonus": {
@@ -289,11 +289,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 98750
+            "value": 98750000
           }
         ]
       },
-      "research_time": 68900
+      "research_time": 68900340
     },
     {
       "bonus": {
@@ -324,11 +324,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 235800
+            "value": 235800000
           }
         ]
       },
-      "research_time": 113694
+      "research_time": 113694240
     },
     {
       "bonus": {
@@ -367,11 +367,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 708800
+            "value": 708800000
           }
         ]
       },
-      "research_time": 189523
+      "research_time": 189523500
     }
   ],
   "location": {

--- a/research/battleship_retaliation.json
+++ b/research/battleship_retaliation.json
@@ -33,15 +33,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 2026
+            "value": 2026000000
           },
           {
             "type": "dilithium",
-            "value": 496500
+            "value": 496500000
           }
         ]
       },
-      "research_time": 38934
+      "research_time": 38934120
     }
   ],
   "location": {

--- a/research/battleship_shields.json
+++ b/research/battleship_shields.json
@@ -36,11 +36,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 32600
+            "value": 32600000
           }
         ]
       },
-      "research_time": 29338
+      "research_time": 29338800
     },
     {
       "bonus": {
@@ -76,11 +76,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 70800
+            "value": 70800000
           }
         ]
       },
-      "research_time": 51090
+      "research_time": 51090420
     },
     {
       "bonus": {
@@ -160,11 +160,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1110
+            "value": 1110000
           }
         ]
       },
-      "research_time": 2600
+      "research_time": 2600040
     },
     {
       "bonus": {
@@ -204,11 +204,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1660
+            "value": 1660000
           }
         ]
       },
-      "research_time": 3499
+      "research_time": 3499500
     },
     {
       "bonus": {
@@ -244,11 +244,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 2440
+            "value": 2440000
           }
         ]
       },
-      "research_time": 3483
+      "research_time": 3483960
     },
     {
       "bonus": {
@@ -292,11 +292,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 3860
+            "value": 3860000
           }
         ]
       },
-      "research_time": 5965
+      "research_time": 5965920
     },
     {
       "bonus": {
@@ -332,11 +332,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 6580
+            "value": 6580000
           }
         ]
       },
-      "research_time": 8058
+      "research_time": 8058720
     },
     {
       "bonus": {
@@ -380,11 +380,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 10400
+            "value": 10400000
           }
         ]
       },
-      "research_time": 14125
+      "research_time": 14125380
     },
     {
       "bonus": {
@@ -428,11 +428,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 15100
+            "value": 15100000
           }
         ]
       },
-      "research_time": 13456
+      "research_time": 13456140
     },
     {
       "bonus": {
@@ -463,11 +463,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 146000
+            "value": 146000000
           }
         ]
       },
-      "research_time": 88888
+      "research_time": 88888440
     },
     {
       "bonus": {
@@ -507,11 +507,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 399000
+            "value": 399000000
           }
         ]
       },
-      "research_time": 150563
+      "research_time": 150563760
     }
   ],
   "location": {

--- a/research/battleship_space_critical_resist.json
+++ b/research/battleship_space_critical_resist.json
@@ -42,15 +42,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 584000
+            "value": 584000000
           },
           {
             "type": "dilithium",
-            "value": 1460
+            "value": 1460000000
           }
         ]
       },
-      "research_time": 106666
+      "research_time": 106666140
     },
     {
       "bonus": {
@@ -72,15 +72,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 19934
+            "value": 19934000000
           },
           {
             "type": "dilithium",
-            "value": 49834
+            "value": 49834000000
           }
         ]
       },
-      "research_time": 465134
+      "research_time": 465134820
     }
   ],
   "location": {

--- a/research/battleship_tactics.json
+++ b/research/battleship_tactics.json
@@ -43,11 +43,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 14450
+            "value": 14450000
           }
         ]
       },
-      "research_time": 3380
+      "research_time": 3380040
     },
     {
       "bonus": {
@@ -82,11 +82,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 31750
+            "value": 31750000
           }
         ]
       },
-      "research_time": 4529
+      "research_time": 4529160
     },
     {
       "bonus": {
@@ -140,11 +140,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 50250
+            "value": 50250000
           }
         ]
       },
-      "research_time": 7755
+      "research_time": 7755720
     },
     {
       "bonus": {
@@ -179,11 +179,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 3900
+            "value": 3900000
           }
         ]
       },
-      "research_time": 1272
+      "research_time": 1272060
     },
     {
       "bonus": {
@@ -308,11 +308,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 2660
+            "value": 2660000
           }
         ]
       },
-      "research_time": 1235
+      "research_time": 1235700
     },
     {
       "bonus": {
@@ -347,11 +347,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 9690
+            "value": 9690000
           }
         ]
       },
-      "research_time": 2519
+      "research_time": 2519280
     },
     {
       "bonus": {

--- a/research/battleship_warfare.json
+++ b/research/battleship_warfare.json
@@ -31,11 +31,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1110
+            "value": 1110000
           }
         ]
       },
-      "research_time": 2600
+      "research_time": 2600040
     },
     {
       "bonus": {
@@ -66,11 +66,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1660
+            "value": 1660000
           }
         ]
       },
-      "research_time": 3499
+      "research_time": 3499500
     },
     {
       "bonus": {
@@ -101,11 +101,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 2440
+            "value": 2440000
           }
         ]
       },
-      "research_time": 3483
+      "research_time": 3483960
     },
     {
       "bonus": {
@@ -136,11 +136,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 3860
+            "value": 3860000
           }
         ]
       },
-      "research_time": 5965
+      "research_time": 5965920
     },
     {
       "bonus": {
@@ -171,11 +171,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 6580
+            "value": 6580000
           }
         ]
       },
-      "research_time": 8058
+      "research_time": 8058720
     },
     {
       "bonus": {
@@ -219,11 +219,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 10400
+            "value": 10400000
           }
         ]
       },
-      "research_time": 14125
+      "research_time": 14125380
     },
     {
       "bonus": {
@@ -254,11 +254,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 15100
+            "value": 15100000
           }
         ]
       },
-      "research_time": 13456
+      "research_time": 13456140
     },
     {
       "bonus": {
@@ -289,11 +289,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 32600
+            "value": 32600000
           }
         ]
       },
-      "research_time": 29338
+      "research_time": 29338800
     },
     {
       "bonus": {
@@ -324,11 +324,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 70800
+            "value": 70800000
           }
         ]
       },
-      "research_time": 51090
+      "research_time": 51090420
     },
     {
       "bonus": {
@@ -359,11 +359,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 146000
+            "value": 146000000
           }
         ]
       },
-      "research_time": 88888
+      "research_time": 88888440
     },
     {
       "bonus": {
@@ -403,11 +403,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 399000
+            "value": 399000000
           }
         ]
       },
-      "research_time": 150563
+      "research_time": 150563760
     },
     {
       "bonus": {

--- a/research/battleship_warp.json
+++ b/research/battleship_warp.json
@@ -44,11 +44,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 14650
+            "value": 14650000
           }
         ]
       },
-      "research_time": 2090
+      "research_time": 2090400
     },
     {
       "bonus": {
@@ -90,11 +90,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 23200
+            "value": 23200000
           }
         ]
       },
-      "research_time": 3579
+      "research_time": 3579540
     },
     {
       "bonus": {
@@ -128,11 +128,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 39500
+            "value": 39500000
           }
         ]
       },
-      "research_time": 4835
+      "research_time": 4835220
     },
     {
       "bonus": {
@@ -169,11 +169,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 62350
+            "value": 62350000
           }
         ]
       },
-      "research_time": 8475
+      "research_time": 8475243
     },
     {
       "bonus": {
@@ -206,11 +206,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 90450
+            "value": 90450000
           }
         ]
       },
-      "research_time": 8073
+      "research_time": 8073660
     },
     {
       "bonus": {
@@ -243,11 +243,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 195600
+            "value": 195600000
           }
         ]
       },
-      "research_time": 17603
+      "research_time": 17603280
     },
     {
       "bonus": {
@@ -287,11 +287,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 134800
+            "value": 134800000
           }
         ]
       },
-      "research_time": 12610
+      "research_time": 12610500
     },
     {
       "bonus": {
@@ -326,11 +326,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 297900
+            "value": 297900000
           }
         ]
       },
-      "research_time": 23360
+      "research_time": 23360460
     },
     {
       "bonus": {
@@ -359,11 +359,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 424800
+            "value": 424800000
           }
         ]
       },
-      "research_time": 30654
+      "research_time": 30654240
     },
     {
       "bonus": {
@@ -405,7 +405,7 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1230
+            "value": 1230000
           }
         ]
       },

--- a/research/battleships_focus.json
+++ b/research/battleships_focus.json
@@ -74,7 +74,7 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1340
+            "value": 1340000
           }
         ]
       },
@@ -100,7 +100,7 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 3000
+            "value": 3000000
           }
         ]
       },
@@ -126,11 +126,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 4650
+            "value": 4650000
           }
         ]
       },
-      "research_time": 1449
+      "research_time": 1449420
     },
     {
       "bonus": {
@@ -152,11 +152,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 11100
+            "value": 11100000
           }
         ]
       },
-      "research_time": 2600
+      "research_time": 2600040
     },
     {
       "bonus": {
@@ -178,11 +178,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 16600
+            "value": 16600000
           }
         ]
       },
-      "research_time": 3499
+      "research_time": 3499500
     },
     {
       "bonus": {
@@ -204,11 +204,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 38650
+            "value": 38650000
           }
         ]
       },
-      "research_time": 5965
+      "research_time": 5965920
     },
     {
       "bonus": {
@@ -249,11 +249,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 65800
+            "value": 65800000
           }
         ]
       },
-      "research_time": 8058
+      "research_time": 8058720
     },
     {
       "bonus": {

--- a/research/blindsided_assault.json
+++ b/research/blindsided_assault.json
@@ -60,11 +60,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1382
+            "value": 1382000000
           }
         ]
       },
-      "research_time": 96460
+      "research_time": 96460500
     },
     {
       "bonus": {
@@ -99,11 +99,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 2044
+            "value": 2044000000
           }
         ]
       },
-      "research_time": 124443
+      "research_time": 124443840
     },
     {
       "bonus": {
@@ -155,11 +155,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 3301
+            "value": 3301000000
           }
         ]
       },
-      "research_time": 159171
+      "research_time": 159171960
     },
     {
       "bonus": {
@@ -194,11 +194,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 5586
+            "value": 5586000000
           }
         ]
       },
-      "research_time": 210789
+      "research_time": 210789240
     },
     {
       "bonus": {
@@ -250,11 +250,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 9923
+            "value": 9923000000
           }
         ]
       },
-      "research_time": 265332
+      "research_time": 265332840
     }
   ],
   "location": {

--- a/research/bolstered_hulls.json
+++ b/research/bolstered_hulls.json
@@ -164,7 +164,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1500
+            "value": 1500000
           },
           {
             "type": "dilithium",
@@ -224,7 +224,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 2290
+            "value": 2290000
           },
           {
             "type": "dilithium",
@@ -280,7 +280,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 3530
+            "value": 3530000
           },
           {
             "type": "dilithium",
@@ -328,11 +328,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 5470
+            "value": 5470000
           },
           {
             "type": "dilithium",
-            "value": 1340
+            "value": 1340000
           }
         ]
       },

--- a/research/bolstered_shields.json
+++ b/research/bolstered_shields.json
@@ -164,7 +164,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1500
+            "value": 1500000
           },
           {
             "type": "dilithium",
@@ -212,11 +212,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 5470
+            "value": 5470000
           },
           {
             "type": "dilithium",
-            "value": 1340
+            "value": 1340000
           }
         ]
       },
@@ -477,7 +477,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 3530
+            "value": 3530000
           },
           {
             "type": "dilithium",
@@ -537,7 +537,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 2290
+            "value": 2290000
           },
           {
             "type": "dilithium",

--- a/research/building_efficiency.json
+++ b/research/building_efficiency.json
@@ -39,7 +39,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 3750
+            "value": 3750000
           },
           {
             "type": "dilithium",
@@ -90,11 +90,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 8820
+            "value": 8820000
           },
           {
             "type": "dilithium",
-            "value": 1730
+            "value": 1730000
           }
         ]
       },
@@ -151,15 +151,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 113300
+            "value": 113300000
           },
           {
             "type": "dilithium",
-            "value": 22200
+            "value": 22200000
           }
         ]
       },
-      "research_time": 2600
+      "research_time": 2600040
     },
     {
       "bonus": {
@@ -213,15 +213,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 249200
+            "value": 249200000
           },
           {
             "type": "dilithium",
-            "value": 48850
+            "value": 48850000
           }
         ]
       },
-      "research_time": 3483
+      "research_time": 3483960
     },
     {
       "bonus": {
@@ -258,15 +258,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1060
+            "value": 1060000000
           },
           {
             "type": "dilithium",
-            "value": 207900
+            "value": 207900000
           }
         ]
       },
-      "research_time": 14125
+      "research_time": 14125380
     },
     {
       "bonus": {
@@ -313,15 +313,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 3325
+            "value": 3325000000
           },
           {
             "type": "dilithium",
-            "value": 652000
+            "value": 652000000
           }
         ]
       },
-      "research_time": 29338
+      "research_time": 29338800
     },
     {
       "bonus": {
@@ -362,15 +362,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 10070
+            "value": 10070000000
           },
           {
             "type": "dilithium",
-            "value": 1975
+            "value": 1975000000
           }
         ]
       },
-      "research_time": 68900
+      "research_time": 68900340
     },
     {
       "bonus": {
@@ -411,15 +411,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 40698
+            "value": 40698000000
           },
           {
             "type": "dilithium",
-            "value": 7980
+            "value": 7980000000
           }
         ]
       },
-      "research_time": 150563
+      "research_time": 150563760
     },
     {
       "bonus": {
@@ -441,15 +441,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 168683
+            "value": 168683000000
           },
           {
             "type": "dilithium",
-            "value": 33075
+            "value": 33075000000
           }
         ]
       },
-      "research_time": 297588
+      "research_time": 297588180
     },
     {
       "bonus": {
@@ -489,7 +489,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1550
+            "value": 1550000
           },
           {
             "type": "dilithium",
@@ -551,11 +551,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 20850
+            "value": 20850000
           },
           {
             "type": "dilithium",
-            "value": 4090
+            "value": 4090000
           }
         ]
       },
@@ -608,15 +608,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 47400
+            "value": 47400000
           },
           {
             "type": "dilithium",
-            "value": 9290
+            "value": 9290000
           }
         ]
       },
-      "research_time": 1449
+      "research_time": 1449420
     },
     {
       "bonus": {

--- a/research/cargo_security.json
+++ b/research/cargo_security.json
@@ -84,7 +84,7 @@
           }
         ]
       },
-      "research_time": 1449
+      "research_time": 1449420
     },
     {
       "bonus": {
@@ -128,7 +128,7 @@
           }
         ]
       },
-      "research_time": 1937
+      "research_time": 1937880
     },
     {
       "bonus": {
@@ -168,11 +168,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1660
+            "value": 1660000
           }
         ]
       },
-      "research_time": 3499
+      "research_time": 3499500
     },
     {
       "bonus": {
@@ -212,11 +212,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 3860
+            "value": 3860000
           }
         ]
       },
-      "research_time": 5965
+      "research_time": 5965920
     },
     {
       "bonus": {
@@ -256,11 +256,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 10400
+            "value": 10400000
           }
         ]
       },
-      "research_time": 14125
+      "research_time": 14125380
     },
     {
       "bonus": {
@@ -300,11 +300,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 22450
+            "value": 22450000
           }
         ]
       },
-      "research_time": 21017
+      "research_time": 21017460
     },
     {
       "bonus": {
@@ -344,11 +344,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 49650
+            "value": 49650000
           }
         ]
       },
-      "research_time": 38934
+      "research_time": 38934120
     },
     {
       "bonus": {
@@ -388,11 +388,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 98750
+            "value": 98750000
           }
         ]
       },
-      "research_time": 68900
+      "research_time": 68900340
     },
     {
       "bonus": {
@@ -432,11 +432,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 235800
+            "value": 235800000
           }
         ]
       },
-      "research_time": 113694
+      "research_time": 113694240
     },
     {
       "bonus": {
@@ -472,11 +472,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 708800
+            "value": 708800000
           }
         ]
       },
-      "research_time": 189523
+      "research_time": 189523500
     },
     {
       "bonus": {

--- a/research/charismatic_orders.json
+++ b/research/charismatic_orders.json
@@ -30,7 +30,7 @@
         ],
         "resources": []
       },
-      "research_time": 2438
+      "research_time": 2438820
     },
     {
       "bonus": {
@@ -60,7 +60,7 @@
         ],
         "resources": []
       },
-      "research_time": 4176
+      "research_time": 4176180
     },
     {
       "bonus": {
@@ -99,7 +99,7 @@
         ],
         "resources": []
       },
-      "research_time": 5641
+      "research_time": 5641140
     },
     {
       "bonus": {
@@ -133,7 +133,7 @@
         ],
         "resources": []
       },
-      "research_time": 9887
+      "research_time": 9887760
     },
     {
       "bonus": {
@@ -180,7 +180,7 @@
         ],
         "resources": []
       },
-      "research_time": 1820
+      "research_time": 1820040
     }
   ],
   "location": {

--- a/research/construction_speed.json
+++ b/research/construction_speed.json
@@ -48,11 +48,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 8820
+            "value": 8820000
           },
           {
             "type": "dilithium",
-            "value": 1730
+            "value": 1730000
           }
         ]
       },
@@ -110,15 +110,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 394100
+            "value": 394100000
           },
           {
             "type": "dilithium",
-            "value": 77300
+            "value": 77300000
           }
         ]
       },
-      "research_time": 5965
+      "research_time": 5965920
     },
     {
       "bonus": {
@@ -555,7 +555,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 2460
+            "value": 2460000
           },
           {
             "type": "dilithium",
@@ -612,11 +612,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 30550
+            "value": 30550000
           },
           {
             "type": "dilithium",
-            "value": 5990
+            "value": 5990000
           }
         ]
       },
@@ -674,15 +674,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 113300
+            "value": 113300000
           },
           {
             "type": "dilithium",
-            "value": 22200
+            "value": 22200000
           }
         ]
       },
-      "research_time": 2600
+      "research_time": 2600040
     }
   ],
   "location": {

--- a/research/crafty_engineering.json
+++ b/research/crafty_engineering.json
@@ -97,7 +97,7 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1670
+            "value": 1670000
           }
         ]
       },
@@ -137,7 +137,7 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 3670
+            "value": 3670000
           }
         ]
       },
@@ -173,11 +173,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 9870
+            "value": 9870000
           }
         ]
       },
-      "research_time": 1208
+      "research_time": 1208820
     },
     {
       "bonus": {
@@ -204,11 +204,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 22600
+            "value": 22600000
           }
         ]
       },
-      "research_time": 2018
+      "research_time": 2018400
     },
     {
       "bonus": {
@@ -235,11 +235,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 48900
+            "value": 48900000
           }
         ]
       },
-      "research_time": 4400
+      "research_time": 4400820
     },
     {
       "bonus": {
@@ -271,11 +271,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 106200
+            "value": 106200000
           }
         ]
       },
-      "research_time": 7663
+      "research_time": 7663560
     },
     {
       "bonus": {
@@ -306,11 +306,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 219000
+            "value": 219000000
           }
         ]
       },
-      "research_time": 13333
+      "research_time": 13333260
     },
     {
       "bonus": {

--- a/research/critical_interceptor_hit.json
+++ b/research/critical_interceptor_hit.json
@@ -49,15 +49,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 15450
+            "value": 15450000
           },
           {
             "type": "dilithium",
-            "value": 38650
+            "value": 38650000
           }
         ]
       },
-      "research_time": 7159
+      "research_time": 7159140
     },
     {
       "bonus": {
@@ -87,15 +87,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 26350
+            "value": 26350000
           },
           {
             "type": "dilithium",
-            "value": 65800
+            "value": 65800000
           }
         ]
       },
-      "research_time": 9670
+      "research_time": 9670500
     },
     {
       "bonus": {
@@ -258,15 +258,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 1860
+            "value": 1860000
           },
           {
             "type": "dilithium",
-            "value": 4650
+            "value": 4650000
           }
         ]
       },
-      "research_time": 1739
+      "research_time": 1739340
     },
     {
       "bonus": {
@@ -305,15 +305,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 2980
+            "value": 2980000
           },
           {
             "type": "dilithium",
-            "value": 7460
+            "value": 7460000
           }
         ]
       },
-      "research_time": 2325
+      "research_time": 2325480
     },
     {
       "bonus": {

--- a/research/crystal_building_efficiency.json
+++ b/research/crystal_building_efficiency.json
@@ -52,15 +52,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 18950
+            "value": 18950000
           },
           {
             "type": "dilithium",
-            "value": 4650
+            "value": 4650000
           }
         ]
       },
-      "research_time": 1449
+      "research_time": 1449420
     },
     {
       "bonus": {
@@ -112,15 +112,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 45350
+            "value": 45350000
           },
           {
             "type": "dilithium",
-            "value": 11100
+            "value": 11100000
           }
         ]
       },
-      "research_time": 2600
+      "research_time": 2600040
     },
     {
       "bonus": {
@@ -172,15 +172,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 99700
+            "value": 99700000
           },
           {
             "type": "dilithium",
-            "value": 24450
+            "value": 24450000
           }
         ]
       },
-      "research_time": 3483
+      "research_time": 3483960
     },
     {
       "bonus": {
@@ -232,15 +232,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 268500
+            "value": 268500000
           },
           {
             "type": "dilithium",
-            "value": 65800
+            "value": 65800000
           }
         ]
       },
-      "research_time": 8058
+      "research_time": 8058720
     },
     {
       "bonus": {
@@ -284,15 +284,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 615100
+            "value": 615100000
           },
           {
             "type": "dilithium",
-            "value": 150800
+            "value": 150800000
           }
         ]
       },
-      "research_time": 13456
+      "research_time": 13456140
     },
     {
       "bonus": {
@@ -336,15 +336,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1330
+            "value": 1330000000
           },
           {
             "type": "dilithium",
-            "value": 326000
+            "value": 326000000
           }
         ]
       },
-      "research_time": 29338
+      "research_time": 29338800
     },
     {
       "bonus": {
@@ -388,15 +388,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 2889
+            "value": 2889000000
           },
           {
             "type": "dilithium",
-            "value": 708000
+            "value": 708000000
           }
         ]
       },
-      "research_time": 51090
+      "research_time": 51090420
     },
     {
       "bonus": {
@@ -427,15 +427,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 5957
+            "value": 5957000000
           },
           {
             "type": "dilithium",
-            "value": 1460
+            "value": 1460000000
           }
         ]
       },
-      "research_time": 88888
+      "research_time": 88888440
     },
     {
       "bonus": {
@@ -477,7 +477,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1500
+            "value": 1500000
           },
           {
             "type": "dilithium",
@@ -533,11 +533,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 8340
+            "value": 8340000
           },
           {
             "type": "dilithium",
-            "value": 2040
+            "value": 2040000
           }
         ]
       },

--- a/research/crystal_miner.json
+++ b/research/crystal_miner.json
@@ -159,11 +159,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 2250
+            "value": 2250000
           }
         ]
       },
-      "research_time": 1045
+      "research_time": 1045620
     },
     {
       "bonus": {
@@ -196,11 +196,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 5110
+            "value": 5110000
           }
         ]
       },
-      "research_time": 1594
+      "research_time": 1594380
     },
     {
       "bonus": {
@@ -233,11 +233,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 12200
+            "value": 12200000
           }
         ]
       },
-      "research_time": 2860
+      "research_time": 2860080
     },
     {
       "bonus": {
@@ -276,11 +276,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 26900
+            "value": 26900000
           }
         ]
       },
-      "research_time": 3832
+      "research_time": 3832380
     },
     {
       "bonus": {
@@ -314,11 +314,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 72400
+            "value": 72400000
           }
         ]
       },
-      "research_time": 8864
+      "research_time": 8864580
     },
     {
       "bonus": {

--- a/research/crystal_research_efficiency.json
+++ b/research/crystal_research_efficiency.json
@@ -52,11 +52,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 12250
+            "value": 12250000
           },
           {
             "type": "dilithium",
-            "value": 3000
+            "value": 3000000
           }
         ]
       },
@@ -112,15 +112,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 30400
+            "value": 30400000
           },
           {
             "type": "dilithium",
-            "value": 7460
+            "value": 7460000
           }
         ]
       },
-      "research_time": 1937
+      "research_time": 1937880
     },
     {
       "bonus": {
@@ -172,15 +172,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 67650
+            "value": 67650000
           },
           {
             "type": "dilithium",
-            "value": 16600
+            "value": 16600000
           }
         ]
       },
-      "research_time": 3499
+      "research_time": 3499500
     },
     {
       "bonus": {
@@ -232,15 +232,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 157700
+            "value": 157700000
           },
           {
             "type": "dilithium",
-            "value": 38650
+            "value": 38650000
           }
         ]
       },
-      "research_time": 5965
+      "research_time": 5965920
     },
     {
       "bonus": {
@@ -292,15 +292,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 424100
+            "value": 424100000
           },
           {
             "type": "dilithium",
-            "value": 104000
+            "value": 104000000
           }
         ]
       },
-      "research_time": 14125
+      "research_time": 14125380
     },
     {
       "bonus": {
@@ -352,15 +352,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 916800
+            "value": 916800000
           },
           {
             "type": "dilithium",
-            "value": 224700
+            "value": 224700000
           }
         ]
       },
-      "research_time": 21017
+      "research_time": 21017460
     },
     {
       "bonus": {
@@ -404,15 +404,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 2026
+            "value": 2026000000
           },
           {
             "type": "dilithium",
-            "value": 496500
+            "value": 496500000
           }
         ]
       },
-      "research_time": 38934
+      "research_time": 38934120
     },
     {
       "bonus": {
@@ -456,15 +456,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 4028
+            "value": 4028000000
           },
           {
             "type": "dilithium",
-            "value": 987300
+            "value": 987300000
           }
         ]
       },
-      "research_time": 68900
+      "research_time": 68900340
     },
     {
       "bonus": {
@@ -506,7 +506,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1500
+            "value": 1500000
           },
           {
             "type": "dilithium",
@@ -556,11 +556,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 5470
+            "value": 5470000
           },
           {
             "type": "dilithium",
-            "value": 1340
+            "value": 1340000
           }
         ]
       },

--- a/research/cultivated_mycelium_jump_efficiency.json
+++ b/research/cultivated_mycelium_jump_efficiency.json
@@ -194,7 +194,7 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 2037
+            "value": 2037500
           }
         ]
       },
@@ -227,7 +227,7 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 2648
+            "value": 2648750
           }
         ]
       },
@@ -260,7 +260,7 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 3056
+            "value": 3056250
           }
         ]
       },
@@ -293,7 +293,7 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 3667
+            "value": 3667500
           }
         ]
       },
@@ -331,7 +331,7 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 4278
+            "value": 4278750
           }
         ]
       },

--- a/research/data_miner.json
+++ b/research/data_miner.json
@@ -227,7 +227,7 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1430
+            "value": 1430000
           }
         ]
       },

--- a/research/data_storage.json
+++ b/research/data_storage.json
@@ -261,11 +261,11 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 1230
+            "value": 1230000
           },
           {
             "type": "dilithium",
-            "value": 1020
+            "value": 1020000
           }
         ]
       },
@@ -308,11 +308,11 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 1800
+            "value": 1800000
           },
           {
             "type": "dilithium",
-            "value": 1500
+            "value": 1500000
           }
         ]
       },

--- a/research/defense_platform_armor.json
+++ b/research/defense_platform_armor.json
@@ -33,15 +33,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 10853
+            "value": 10853000000
           },
           {
             "type": "dilithium",
-            "value": 3192
+            "value": 3192000000
           }
         ]
       },
-      "research_time": 120450
+      "research_time": 120450960
     },
     {
       "bonus": {
@@ -80,15 +80,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 29345
+            "value": 29345000000
           },
           {
             "type": "dilithium",
-            "value": 8631
+            "value": 8631000000
           }
         ]
       },
-      "research_time": 172800
+      "research_time": 172800000
     },
     {
       "bonus": {
@@ -127,15 +127,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 40163
+            "value": 40163000000
           },
           {
             "type": "dilithium",
-            "value": 11813
+            "value": 11813000000
           }
         ]
       },
-      "research_time": 223200
+      "research_time": 223200000
     }
   ],
   "location": {

--- a/research/defense_platform_health.json
+++ b/research/defense_platform_health.json
@@ -39,15 +39,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 16279
+            "value": 16279000000
           },
           {
             "type": "dilithium",
-            "value": 3990
+            "value": 3990000000
           }
         ]
       },
-      "research_time": 150563
+      "research_time": 150563760
     },
     {
       "bonus": {
@@ -76,15 +76,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 44018
+            "value": 44018000000
           },
           {
             "type": "dilithium",
-            "value": 10789
+            "value": 10789000000
           }
         ]
       },
-      "research_time": 216000
+      "research_time": 216000000
     },
     {
       "bonus": {
@@ -123,15 +123,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 60244
+            "value": 60244000000
           },
           {
             "type": "dilithium",
-            "value": 14766
+            "value": 14766000000
           }
         ]
       },
-      "research_time": 279000
+      "research_time": 279000000
     }
   ],
   "location": {

--- a/research/defense_platform_hull_ii.json
+++ b/research/defense_platform_hull_ii.json
@@ -31,7 +31,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1500
+            "value": 1500000
           },
           {
             "type": "dilithium",
@@ -70,7 +70,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 2290
+            "value": 2290000
           },
           {
             "type": "dilithium",
@@ -104,7 +104,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 3530
+            "value": 3530000
           },
           {
             "type": "dilithium",
@@ -139,11 +139,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 5470
+            "value": 5470000
           },
           {
             "type": "dilithium",
-            "value": 1340
+            "value": 1340000
           }
         ]
       },
@@ -178,11 +178,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 8340
+            "value": 8340000
           },
           {
             "type": "dilithium",
-            "value": 2040
+            "value": 2040000
           }
         ]
       },
@@ -213,11 +213,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 12250
+            "value": 12250000
           },
           {
             "type": "dilithium",
-            "value": 3000
+            "value": 3000000
           }
         ]
       },
@@ -247,15 +247,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 18950
+            "value": 18950000
           },
           {
             "type": "dilithium",
-            "value": 4650
+            "value": 4650000
           }
         ]
       },
-      "research_time": 1449
+      "research_time": 1449420
     },
     {
       "bonus": {
@@ -282,15 +282,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 30400
+            "value": 30400000
           },
           {
             "type": "dilithium",
-            "value": 7460
+            "value": 7460000
           }
         ]
       },
-      "research_time": 1937
+      "research_time": 1937880
     },
     {
       "bonus": {
@@ -316,15 +316,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 45350
+            "value": 45350000
           },
           {
             "type": "dilithium",
-            "value": 11100
+            "value": 11100000
           }
         ]
       },
-      "research_time": 2600
+      "research_time": 2600040
     },
     {
       "bonus": {

--- a/research/defense_platform_modulation.json
+++ b/research/defense_platform_modulation.json
@@ -33,15 +33,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1350
+            "value": 1350000000
           },
           {
             "type": "dilithium",
-            "value": 397200
+            "value": 397200000
           }
         ]
       },
-      "research_time": 31147
+      "research_time": 31147320
     },
     {
       "bonus": {
@@ -74,15 +74,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1926
+            "value": 1926000000
           },
           {
             "type": "dilithium",
-            "value": 566400
+            "value": 566400000
           }
         ]
       },
-      "research_time": 40872
+      "research_time": 40872300
     }
   ],
   "location": {

--- a/research/defense_platform_penetration.json
+++ b/research/defense_platform_penetration.json
@@ -37,15 +37,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1350
+            "value": 1350000000
           },
           {
             "type": "dilithium",
-            "value": 397200
+            "value": 397200000
           }
         ]
       },
-      "research_time": 31147
+      "research_time": 31147320
     }
   ],
   "location": {

--- a/research/defense_platform_shields.json
+++ b/research/defense_platform_shields.json
@@ -39,15 +39,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 135548
+            "value": 135548000000
           },
           {
             "type": "dilithium",
-            "value": 33223
+            "value": 33223000000
           }
         ]
       },
-      "research_time": 354000
+      "research_time": 354000000
     },
     {
       "bonus": {
@@ -95,15 +95,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 16279
+            "value": 16279000000
           },
           {
             "type": "dilithium",
-            "value": 3990
+            "value": 3990000000
           }
         ]
       },
-      "research_time": 150563
+      "research_time": 150563760
     },
     {
       "bonus": {
@@ -142,15 +142,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 28917
+            "value": 28917000000
           },
           {
             "type": "dilithium",
-            "value": 7088
+            "value": 7088000000
           }
         ]
       },
-      "research_time": 189523
+      "research_time": 189523500
     },
     {
       "bonus": {
@@ -193,15 +193,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 90366
+            "value": 90366000000
           },
           {
             "type": "dilithium",
-            "value": 22148
+            "value": 22148000000
           }
         ]
       },
-      "research_time": 315000
+      "research_time": 315000000
     },
     {
       "bonus": {
@@ -290,15 +290,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 44018
+            "value": 44018000000
           },
           {
             "type": "dilithium",
-            "value": 10789
+            "value": 10789000000
           }
         ]
       },
-      "research_time": 216000
+      "research_time": 216000000
     },
     {
       "bonus": {
@@ -344,15 +344,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 9621
+            "value": 9621000000
           },
           {
             "type": "dilithium",
-            "value": 2358
+            "value": 2358000000
           }
         ]
       },
-      "research_time": 113694
+      "research_time": 113694240
     },
     {
       "bonus": {
@@ -391,15 +391,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 203323
+            "value": 203323000000
           },
           {
             "type": "dilithium",
-            "value": 49834
+            "value": 49834000000
           }
         ]
       },
-      "research_time": 396000
+      "research_time": 396000000
     },
     {
       "bonus": {
@@ -446,15 +446,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 304984
+            "value": 304984000000
           },
           {
             "type": "dilithium",
-            "value": 74751
+            "value": 74751000000
           }
         ]
       },
-      "research_time": 441000
+      "research_time": 441000000
     }
   ],
   "location": {

--- a/research/defense_platforms.json
+++ b/research/defense_platforms.json
@@ -37,15 +37,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 112800
+            "value": 112800000
           },
           {
             "type": "dilithium",
-            "value": 33150
+            "value": 33150000
           }
         ]
       },
-      "research_time": 6124
+      "research_time": 6124140
     },
     {
       "increased_power": 107000,
@@ -82,15 +82,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 9928
+            "value": 9928000000
           },
           {
             "type": "dilithium",
-            "value": 2920
+            "value": 2920000000
           }
         ]
       },
-      "research_time": 155554
+      "research_time": 155554800
     },
     {
       "increased_power": 2900,
@@ -197,7 +197,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1640
+            "value": 1640000
           },
           {
             "type": "dilithium",

--- a/research/defense_strategy.json
+++ b/research/defense_strategy.json
@@ -22,11 +22,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 23200
+            "value": 23200000
           }
         ]
       },
-      "research_time": 4899
+      "research_time": 4899360
     },
     {
       "bonus": {
@@ -88,11 +88,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 6500
+            "value": 6500000
           }
         ]
       },
-      "research_time": 2029
+      "research_time": 2029200
     },
     {
       "bonus": {
@@ -114,11 +114,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 10450
+            "value": 10450000
           }
         ]
       },
-      "research_time": 2713
+      "research_time": 2713080
     },
     {
       "bonus": {
@@ -140,11 +140,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 34200
+            "value": 34200000
           }
         ]
       },
-      "research_time": 4877
+      "research_time": 4877580
     },
     {
       "bonus": {
@@ -185,11 +185,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 92150
+            "value": 92150000
           }
         ]
       },
-      "research_time": 11282
+      "research_time": 11282220
     },
     {
       "bonus": {
@@ -211,11 +211,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 145500
+            "value": 145500000
           }
         ]
       },
-      "research_time": 19775
+      "research_time": 19775580
     },
     {
       "bonus": {
@@ -256,11 +256,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 314600
+            "value": 314600000
           }
         ]
       },
-      "research_time": 29424
+      "research_time": 29424480
     },
     {
       "bonus": {
@@ -301,11 +301,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 991200
+            "value": 991200000
           }
         ]
       },
-      "research_time": 71526
+      "research_time": 71526540
     },
     {
       "bonus": {
@@ -327,11 +327,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 456400
+            "value": 456400000
           }
         ]
       },
-      "research_time": 41074
+      "research_time": 41074320
     },
     {
       "bonus": {
@@ -353,11 +353,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1382
+            "value": 1382000000
           }
         ]
       },
-      "research_time": 96460
+      "research_time": 96460500
     }
   ],
   "location": {

--- a/research/defense_strategy_ii.json
+++ b/research/defense_strategy_ii.json
@@ -124,7 +124,7 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1210
+            "value": 1210000
           }
         ]
       },
@@ -154,11 +154,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1880
+            "value": 1880000
           }
         ]
       },
-      "research_time": 1037
+      "research_time": 1037400
     },
     {
       "bonus": {
@@ -184,11 +184,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 2860
+            "value": 2860000
           }
         ]
       },
-      "research_time": 1330
+      "research_time": 1330800
     },
     {
       "bonus": {
@@ -214,11 +214,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 4200
+            "value": 4200000
           }
         ]
       },
-      "research_time": 1369
+      "research_time": 1369920
     },
     {
       "bonus": {
@@ -245,11 +245,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 6500
+            "value": 6500000
           }
         ]
       },
-      "research_time": 2029
+      "research_time": 2029200
     },
     {
       "bonus": {
@@ -275,11 +275,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 10450
+            "value": 10450000
           }
         ]
       },
-      "research_time": 2713
+      "research_time": 2713080
     },
     {
       "bonus": {
@@ -306,11 +306,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 15550
+            "value": 15550000
           }
         ]
       },
-      "research_time": 3640
+      "research_time": 3640080
     },
     {
       "bonus": {

--- a/research/defense_training.json
+++ b/research/defense_training.json
@@ -48,7 +48,7 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1020
+            "value": 1020000
           }
         ]
       },
@@ -91,11 +91,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 19300
+            "value": 19300000
           }
         ]
       },
-      "research_time": 2982
+      "research_time": 2982960
     },
     {
       "bonus": {
@@ -130,11 +130,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 32900
+            "value": 32900000
           }
         ]
       },
-      "research_time": 4029
+      "research_time": 4029360
     },
     {
       "bonus": {
@@ -163,11 +163,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 52000
+            "value": 52000000
           }
         ]
       },
-      "research_time": 7062
+      "research_time": 7062720
     },
     {
       "bonus": {
@@ -196,11 +196,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 75400
+            "value": 75400000
           }
         ]
       },
-      "research_time": 6728
+      "research_time": 6728040
     },
     {
       "bonus": {
@@ -239,11 +239,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 112400
+            "value": 112400000
           }
         ]
       },
-      "research_time": 10508
+      "research_time": 10508760
     },
     {
       "bonus": {
@@ -283,11 +283,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 163000
+            "value": 163000000
           }
         ]
       },
-      "research_time": 14669
+      "research_time": 14669400
     },
     {
       "bonus": {
@@ -326,11 +326,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 248300
+            "value": 248300000
           }
         ]
       },
-      "research_time": 19467
+      "research_time": 19467060
     },
     {
       "bonus": {
@@ -365,11 +365,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 354000
+            "value": 354000000
           }
         ]
       },
-      "research_time": 25545
+      "research_time": 25545180
     },
     {
       "bonus": {
@@ -404,11 +404,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 493600
+            "value": 493600000
           }
         ]
       },
-      "research_time": 34450
+      "research_time": 34450200
     }
   ],
   "location": {

--- a/research/defensive_strategies.json
+++ b/research/defensive_strategies.json
@@ -54,15 +54,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 566400
+            "value": 566400000
           },
           {
             "type": "dilithium",
-            "value": 708000
+            "value": 708000000
           }
         ]
       },
-      "research_time": 61308
+      "research_time": 61308480
     },
     {
       "bonus": {
@@ -112,15 +112,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 789800
+            "value": 789800000
           },
           {
             "type": "dilithium",
-            "value": 987300
+            "value": 987300000
           }
         ]
       },
-      "research_time": 82680
+      "research_time": 82680420
     }
   ],
   "location": {

--- a/research/depart_for_the_planet.json
+++ b/research/depart_for_the_planet.json
@@ -26,7 +26,7 @@
         ],
         "resources": []
       },
-      "research_time": 4400
+      "research_time": 4400820
     }
   ],
   "location": {

--- a/research/dilithium_accelerator.json
+++ b/research/dilithium_accelerator.json
@@ -35,11 +35,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 12650
+            "value": 12650000
           },
           {
             "type": "dilithium",
-            "value": 2790
+            "value": 2790000
           }
         ]
       },
@@ -82,15 +82,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 30200
+            "value": 30200000
           },
           {
             "type": "dilithium",
-            "value": 6670
+            "value": 6670000
           }
         ]
       },
-      "research_time": 1560
+      "research_time": 1560000
     },
     {
       "bonus": {
@@ -125,15 +125,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 45100
+            "value": 45100000
           },
           {
             "type": "dilithium",
-            "value": 9950
+            "value": 9950000
           }
         ]
       },
-      "research_time": 2099
+      "research_time": 2099700
     },
     {
       "bonus": {
@@ -160,15 +160,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 105100
+            "value": 105100000
           },
           {
             "type": "dilithium",
-            "value": 23200
+            "value": 23200000
           }
         ]
       },
-      "research_time": 3579
+      "research_time": 3579540
     },
     {
       "bonus": {
@@ -203,15 +203,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 179000
+            "value": 179000000
           },
           {
             "type": "dilithium",
-            "value": 39500
+            "value": 39500000
           }
         ]
       },
-      "research_time": 4835
+      "research_time": 4835220
     },
     {
       "bonus": {
@@ -246,15 +246,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 410000
+            "value": 410000000
           },
           {
             "type": "dilithium",
-            "value": 90450
+            "value": 90450000
           }
         ]
       },
-      "research_time": 8073
+      "research_time": 8073660
     },
     {
       "bonus": {
@@ -293,15 +293,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 611200
+            "value": 611200000
           },
           {
             "type": "dilithium",
-            "value": 134800
+            "value": 134800000
           }
         ]
       },
-      "research_time": 12610
+      "research_time": 12610500
     },
     {
       "bonus": {
@@ -361,7 +361,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1520
+            "value": 1520000
           },
           {
             "type": "dilithium",
@@ -400,7 +400,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 3650
+            "value": 3650000
           },
           {
             "type": "dilithium",
@@ -435,11 +435,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 8150
+            "value": 8150000
           },
           {
             "type": "dilithium",
-            "value": 1800
+            "value": 1800000
           }
         ]
       },

--- a/research/dilithium_fortification.json
+++ b/research/dilithium_fortification.json
@@ -42,15 +42,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 565500
+            "value": 565500000
           },
           {
             "type": "dilithium",
-            "value": 104000
+            "value": 104000000
           }
         ]
       },
-      "research_time": 17656
+      "research_time": 17656740
     },
     {
       "bonus": {
@@ -87,15 +87,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 820100
+            "value": 820100000
           },
           {
             "type": "dilithium",
-            "value": 150800
+            "value": 150800000
           }
         ]
       },
-      "research_time": 16820
+      "research_time": 16820160
     },
     {
       "bonus": {
@@ -143,15 +143,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1222
+            "value": 1222000000
           },
           {
             "type": "dilithium",
-            "value": 224700
+            "value": 224700000
           }
         ]
       },
-      "research_time": 26271
+      "research_time": 26271840
     },
     {
       "bonus": {
@@ -194,15 +194,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1773
+            "value": 1773000000
           },
           {
             "type": "dilithium",
-            "value": 326000
+            "value": 326000000
           }
         ]
       },
-      "research_time": 36673
+      "research_time": 36673500
     },
     {
       "bonus": {
@@ -245,15 +245,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 2701
+            "value": 2701000000
           },
           {
             "type": "dilithium",
-            "value": 496500
+            "value": 496500000
           }
         ]
       },
-      "research_time": 48667
+      "research_time": 48667680
     },
     {
       "bonus": {
@@ -296,15 +296,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 3852
+            "value": 3852000000
           },
           {
             "type": "dilithium",
-            "value": 708000
+            "value": 708000000
           }
         ]
       },
-      "research_time": 63862
+      "research_time": 63862980
     },
     {
       "bonus": {
@@ -352,15 +352,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 5371
+            "value": 5371000000
           },
           {
             "type": "dilithium",
-            "value": 987300
+            "value": 987300000
           }
         ]
       },
-      "research_time": 86125
+      "research_time": 86125440
     },
     {
       "bonus": {
@@ -403,15 +403,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 7942
+            "value": 7942000000
           },
           {
             "type": "dilithium",
-            "value": 1460
+            "value": 1460000000
           }
         ]
       },
-      "research_time": 111110
+      "research_time": 111110580
     },
     {
       "bonus": {
@@ -459,15 +459,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 12828
+            "value": 12828000000
           },
           {
             "type": "dilithium",
-            "value": 2358
+            "value": 2358000000
           }
         ]
       },
-      "research_time": 142117
+      "research_time": 142117800
     },
     {
       "bonus": {
@@ -504,15 +504,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 21706
+            "value": 21706000000
           },
           {
             "type": "dilithium",
-            "value": 3990
+            "value": 3990000000
           }
         ]
       },
-      "research_time": 188204
+      "research_time": 188204640
     }
   ],
   "location": {

--- a/research/dilithium_holding.json
+++ b/research/dilithium_holding.json
@@ -35,11 +35,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 9480
+            "value": 9480000
           },
           {
             "type": "dilithium",
-            "value": 1860
+            "value": 1860000
           }
         ]
       },
@@ -70,11 +70,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 15200
+            "value": 15200000
           },
           {
             "type": "dilithium",
-            "value": 2980
+            "value": 2980000
           }
         ]
       },
@@ -109,15 +109,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 33850
+            "value": 33850000
           },
           {
             "type": "dilithium",
-            "value": 6630
+            "value": 6630000
           }
         ]
       },
-      "research_time": 1399
+      "research_time": 1399800
     },
     {
       "bonus": {
@@ -152,15 +152,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 49850
+            "value": 49850000
           },
           {
             "type": "dilithium",
-            "value": 9770
+            "value": 9770000
           }
         ]
       },
-      "research_time": 1393
+      "research_time": 1393620
     },
     {
       "bonus": {
@@ -187,15 +187,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 134300
+            "value": 134300000
           },
           {
             "type": "dilithium",
-            "value": 26350
+            "value": 26350000
           }
         ]
       },
-      "research_time": 3223
+      "research_time": 3223500
     },
     {
       "bonus": {
@@ -221,15 +221,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 212100
+            "value": 212100000
           },
           {
             "type": "dilithium",
-            "value": 41600
+            "value": 41600000
           }
         ]
       },
-      "research_time": 5650
+      "research_time": 5650140
     },
     {
       "bonus": {
@@ -256,15 +256,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 458400
+            "value": 458400000
           },
           {
             "type": "dilithium",
-            "value": 89900
+            "value": 89900000
           }
         ]
       },
-      "research_time": 8407
+      "research_time": 8407020
     },
     {
       "bonus": {
@@ -291,15 +291,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 665000
+            "value": 665000000
           },
           {
             "type": "dilithium",
-            "value": 130400
+            "value": 130400000
           }
         ]
       },
-      "research_time": 11735
+      "research_time": 11735520
     },
     {
       "bonus": {
@@ -353,7 +353,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 2740
+            "value": 2740000
           },
           {
             "type": "dilithium",
@@ -396,7 +396,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 4170
+            "value": 4170000
           },
           {
             "type": "dilithium",

--- a/research/dilithium_hunter.json
+++ b/research/dilithium_hunter.json
@@ -270,7 +270,7 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1070
+            "value": 1070000
           }
         ]
       },
@@ -312,7 +312,7 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1630
+            "value": 1630000
           }
         ]
       },
@@ -366,7 +366,7 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 2400
+            "value": 2400000
           }
         ]
       },

--- a/research/dilithium_miner.json
+++ b/research/dilithium_miner.json
@@ -175,7 +175,7 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1480
+            "value": 1480000
           }
         ]
       },
@@ -210,11 +210,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 2250
+            "value": 2250000
           }
         ]
       },
-      "research_time": 1045
+      "research_time": 1045620
     },
     {
       "bonus": {
@@ -241,11 +241,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 3300
+            "value": 3300000
           }
         ]
       },
-      "research_time": 1076
+      "research_time": 1076400
     },
     {
       "bonus": {
@@ -276,11 +276,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 8200
+            "value": 8200000
           }
         ]
       },
-      "research_time": 2131
+      "research_time": 2131680
     },
     {
       "bonus": {
@@ -311,11 +311,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 18250
+            "value": 18250000
           }
         ]
       },
-      "research_time": 3849
+      "research_time": 3849480
     },
     {
       "bonus": {
@@ -342,11 +342,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 114300
+            "value": 114300000
           }
         ]
       },
-      "research_time": 15537
+      "research_time": 15537960
     },
     {
       "bonus": {
@@ -377,11 +377,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 42500
+            "value": 42500000
           }
         ]
       },
-      "research_time": 6562
+      "research_time": 6562560
     },
     {
       "bonus": {

--- a/research/dilithium_safeguard.json
+++ b/research/dilithium_safeguard.json
@@ -142,7 +142,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1310
+            "value": 1310000
           },
           {
             "type": "dilithium",
@@ -177,7 +177,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 2000
+            "value": 2000000
           },
           {
             "type": "dilithium",

--- a/research/dilithium_security.json
+++ b/research/dilithium_security.json
@@ -54,15 +54,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 16300
+            "value": 16300000
           },
           {
             "type": "dilithium",
-            "value": 3000
+            "value": 3000000
           }
         ]
       },
-      "research_time": 1223
+      "research_time": 1223160
     },
     {
       "bonus": {
@@ -84,15 +84,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 25250
+            "value": 25250000
           },
           {
             "type": "dilithium",
-            "value": 4650
+            "value": 4650000
           }
         ]
       },
-      "research_time": 1811
+      "research_time": 1811820
     },
     {
       "bonus": {
@@ -114,15 +114,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 60450
+            "value": 60450000
           },
           {
             "type": "dilithium",
-            "value": 11100
+            "value": 11100000
           }
         ]
       },
-      "research_time": 3250
+      "research_time": 3250080
     },
     {
       "bonus": {
@@ -157,15 +157,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 90200
+            "value": 90200000
           },
           {
             "type": "dilithium",
-            "value": 16600
+            "value": 16600000
           }
         ]
       },
-      "research_time": 4374
+      "research_time": 4374420
     },
     {
       "bonus": {
@@ -187,15 +187,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 210200
+            "value": 210200000
           },
           {
             "type": "dilithium",
-            "value": 38650
+            "value": 38650000
           }
         ]
       },
-      "research_time": 7457
+      "research_time": 7457400
     },
     {
       "bonus": {
@@ -217,15 +217,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 358000
+            "value": 358000000
           },
           {
             "type": "dilithium",
-            "value": 65800
+            "value": 65800000
           }
         ]
       },
-      "research_time": 10073
+      "research_time": 10073400
     },
     {
       "bonus": {
@@ -255,15 +255,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 820100
+            "value": 820100000
           },
           {
             "type": "dilithium",
-            "value": 150800
+            "value": 150800000
           }
         ]
       },
-      "research_time": 16820
+      "research_time": 16820160
     },
     {
       "bonus": {
@@ -290,15 +290,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1222
+            "value": 1222000000
           },
           {
             "type": "dilithium",
-            "value": 224700
+            "value": 224700000
           }
         ]
       },
-      "research_time": 26271
+      "research_time": 26271840
     },
     {
       "bonus": {
@@ -320,15 +320,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 2701
+            "value": 2701000000
           },
           {
             "type": "dilithium",
-            "value": 496500
+            "value": 496500000
           }
         ]
       },
-      "research_time": 48667
+      "research_time": 48667680
     },
     {
       "bonus": {
@@ -358,15 +358,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 3852
+            "value": 3852000000
           },
           {
             "type": "dilithium",
-            "value": 708000
+            "value": 708000000
           }
         ]
       },
-      "research_time": 63862
+      "research_time": 63862980
     }
   ],
   "location": {

--- a/research/dilithium_stockpile.json
+++ b/research/dilithium_stockpile.json
@@ -54,11 +54,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 8340
+            "value": 8340000
           },
           {
             "type": "dilithium",
-            "value": 1530
+            "value": 1530000
           }
         ]
       },
@@ -84,11 +84,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 12250
+            "value": 12250000
           },
           {
             "type": "dilithium",
-            "value": 2250
+            "value": 2250000
           }
         ]
       },
@@ -122,15 +122,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 30400
+            "value": 30400000
           },
           {
             "type": "dilithium",
-            "value": 5590
+            "value": 5590000
           }
         ]
       },
-      "research_time": 1453
+      "research_time": 1453440
     },
     {
       "bonus": {
@@ -161,15 +161,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 45350
+            "value": 45350000
           },
           {
             "type": "dilithium",
-            "value": 8330
+            "value": 8330000
           }
         ]
       },
-      "research_time": 1950
+      "research_time": 1950060
     },
     {
       "bonus": {
@@ -191,15 +191,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 99700
+            "value": 99700000
           },
           {
             "type": "dilithium",
-            "value": 18350
+            "value": 18350000
           }
         ]
       },
-      "research_time": 2613
+      "research_time": 2613000
     },
     {
       "bonus": {
@@ -229,15 +229,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 157700
+            "value": 157700000
           },
           {
             "type": "dilithium",
-            "value": 29000
+            "value": 29000000
           }
         ]
       },
-      "research_time": 4474
+      "research_time": 4474440
     },
     {
       "bonus": {
@@ -264,15 +264,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 424100
+            "value": 424100000
           },
           {
             "type": "dilithium",
-            "value": 77950
+            "value": 77950000
           }
         ]
       },
-      "research_time": 10594
+      "research_time": 10594080
     },
     {
       "bonus": {
@@ -299,15 +299,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 615100
+            "value": 615100000
           },
           {
             "type": "dilithium",
-            "value": 113100
+            "value": 113100000
           }
         ]
       },
-      "research_time": 10092
+      "research_time": 10092120
     },
     {
       "bonus": {
@@ -337,15 +337,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1330
+            "value": 1330000000
           },
           {
             "type": "dilithium",
-            "value": 244500
+            "value": 244500000
           }
         ]
       },
-      "research_time": 22004
+      "research_time": 22004100
     },
     {
       "bonus": {
@@ -372,15 +372,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 2026
+            "value": 2026000000
           },
           {
             "type": "dilithium",
-            "value": 372400
+            "value": 372400000
           }
         ]
       },
-      "research_time": 29200
+      "research_time": 29200620
     }
   ],
   "location": {

--- a/research/dilithium_upgrades.json
+++ b/research/dilithium_upgrades.json
@@ -42,15 +42,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1330
+            "value": 1330000000
           },
           {
             "type": "dilithium",
-            "value": 326000
+            "value": 326000000
           }
         ]
       },
-      "research_time": 46942
+      "research_time": 46942080
     },
     {
       "bonus": {
@@ -84,15 +84,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 2026
+            "value": 2026000000
           },
           {
             "type": "dilithium",
-            "value": 496500
+            "value": 496500000
           }
         ]
       },
-      "research_time": 62294
+      "research_time": 62294640
     },
     {
       "bonus": {
@@ -134,15 +134,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 2889
+            "value": 2889000000
           },
           {
             "type": "dilithium",
-            "value": 708000
+            "value": 708000000
           }
         ]
       },
-      "research_time": 81744
+      "research_time": 81744660
     },
     {
       "bonus": {
@@ -182,15 +182,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 4028
+            "value": 4028000000
           },
           {
             "type": "dilithium",
-            "value": 987300
+            "value": 987300000
           }
         ]
       },
-      "research_time": 110240
+      "research_time": 110240520
     },
     {
       "bonus": {
@@ -242,15 +242,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 5957
+            "value": 5957000000
           },
           {
             "type": "dilithium",
-            "value": 1460
+            "value": 1460000000
           }
         ]
       },
-      "research_time": 142221
+      "research_time": 142221540
     },
     {
       "bonus": {
@@ -294,15 +294,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 9621
+            "value": 9621000000
           },
           {
             "type": "dilithium",
-            "value": 2358
+            "value": 2358000000
           }
         ]
       },
-      "research_time": 181910
+      "research_time": 181910760
     },
     {
       "bonus": {
@@ -354,15 +354,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 16279
+            "value": 16279000000
           },
           {
             "type": "dilithium",
-            "value": 3990
+            "value": 3990000000
           }
         ]
       },
-      "research_time": 240901
+      "research_time": 240901980
     },
     {
       "bonus": {
@@ -402,15 +402,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 28917
+            "value": 28917000000
           },
           {
             "type": "dilithium",
-            "value": 7088
+            "value": 7088000000
           }
         ]
       },
-      "research_time": 303237
+      "research_time": 303237540
     },
     {
       "bonus": {
@@ -437,15 +437,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 44018
+            "value": 44018000000
           },
           {
             "type": "dilithium",
-            "value": 10789
+            "value": 10789000000
           }
         ]
       },
-      "research_time": 369866
+      "research_time": 369866760
     },
     {
       "bonus": {
@@ -472,15 +472,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 67473
+            "value": 67473000000
           },
           {
             "type": "dilithium",
-            "value": 16538
+            "value": 16538000000
           }
         ]
       },
-      "research_time": 476141
+      "research_time": 476141100
     }
   ],
   "location": {

--- a/research/eclipse_defenses.json
+++ b/research/eclipse_defenses.json
@@ -40,15 +40,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 2980
+            "value": 2980000
           },
           {
             "type": "dilithium",
-            "value": 7460
+            "value": 7460000
           }
         ]
       },
-      "research_time": 1937
+      "research_time": 1937880
     },
     {
       "bonus": {
@@ -88,15 +88,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 4440
+            "value": 4440000
           },
           {
             "type": "dilithium",
-            "value": 11100
+            "value": 11100000
           }
         ]
       },
-      "research_time": 2600
+      "research_time": 2600040
     },
     {
       "bonus": {
@@ -132,15 +132,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 6630
+            "value": 6630000
           },
           {
             "type": "dilithium",
-            "value": 16600
+            "value": 16600000
           }
         ]
       },
-      "research_time": 3499
+      "research_time": 3499500
     },
     {
       "bonus": {
@@ -167,15 +167,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 9770
+            "value": 9770000
           },
           {
             "type": "dilithium",
-            "value": 24450
+            "value": 24450000
           }
         ]
       },
-      "research_time": 3483
+      "research_time": 3483960
     },
     {
       "bonus": {
@@ -211,15 +211,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 15450
+            "value": 15450000
           },
           {
             "type": "dilithium",
-            "value": 38650
+            "value": 38650000
           }
         ]
       },
-      "research_time": 5965
+      "research_time": 5965920
     },
     {
       "bonus": {
@@ -255,15 +255,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 26350
+            "value": 26350000
           },
           {
             "type": "dilithium",
-            "value": 65800
+            "value": 65800000
           }
         ]
       },
-      "research_time": 8058
+      "research_time": 8058720
     },
     {
       "bonus": {
@@ -299,15 +299,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 41600
+            "value": 41600000
           },
           {
             "type": "dilithium",
-            "value": 104000
+            "value": 104000000
           }
         ]
       },
-      "research_time": 14125
+      "research_time": 14125380
     },
     {
       "bonus": {
@@ -339,11 +339,11 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 1200
+            "value": 1200000
           },
           {
             "type": "dilithium",
-            "value": 3000
+            "value": 3000000
           }
         ]
       },
@@ -402,7 +402,7 @@
           },
           {
             "type": "dilithium",
-            "value": 2040
+            "value": 2040000
           }
         ]
       },
@@ -442,15 +442,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 1860
+            "value": 1860000
           },
           {
             "type": "dilithium",
-            "value": 4650
+            "value": 4650000
           }
         ]
       },
-      "research_time": 1449
+      "research_time": 1449420
     }
   ],
   "location": {

--- a/research/eclipse_targeting.json
+++ b/research/eclipse_targeting.json
@@ -40,15 +40,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 2980
+            "value": 2980000
           },
           {
             "type": "dilithium",
-            "value": 7460
+            "value": 7460000
           }
         ]
       },
-      "research_time": 1937
+      "research_time": 1937880
     },
     {
       "bonus": {
@@ -96,15 +96,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 6630
+            "value": 6630000
           },
           {
             "type": "dilithium",
-            "value": 16600
+            "value": 16600000
           }
         ]
       },
-      "research_time": 3499
+      "research_time": 3499500
     },
     {
       "bonus": {
@@ -148,15 +148,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 15450
+            "value": 15450000
           },
           {
             "type": "dilithium",
-            "value": 38650
+            "value": 38650000
           }
         ]
       },
-      "research_time": 5965
+      "research_time": 5965920
     },
     {
       "bonus": {
@@ -208,15 +208,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 41600
+            "value": 41600000
           },
           {
             "type": "dilithium",
-            "value": 104000
+            "value": 104000000
           }
         ]
       },
-      "research_time": 14125
+      "research_time": 14125380
     },
     {
       "bonus": {
@@ -271,7 +271,7 @@
           },
           {
             "type": "dilithium",
-            "value": 2040
+            "value": 2040000
           }
         ]
       },

--- a/research/eclipse_weakpoints.json
+++ b/research/eclipse_weakpoints.json
@@ -51,7 +51,7 @@
           },
           {
             "type": "dilithium",
-            "value": 2040
+            "value": 2040000
           }
         ]
       },
@@ -91,15 +91,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 2980
+            "value": 2980000
           },
           {
             "type": "dilithium",
-            "value": 7460
+            "value": 7460000
           }
         ]
       },
-      "research_time": 1937
+      "research_time": 1937880
     },
     {
       "bonus": {
@@ -147,15 +147,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 6630
+            "value": 6630000
           },
           {
             "type": "dilithium",
-            "value": 16600
+            "value": 16600000
           }
         ]
       },
-      "research_time": 3499
+      "research_time": 3499500
     },
     {
       "bonus": {
@@ -195,15 +195,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 15450
+            "value": 15450000
           },
           {
             "type": "dilithium",
-            "value": 38650
+            "value": 38650000
           }
         ]
       },
-      "research_time": 5965
+      "research_time": 5965920
     },
     {
       "bonus": {
@@ -251,15 +251,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 41600
+            "value": 41600000
           },
           {
             "type": "dilithium",
-            "value": 104000
+            "value": 104000000
           }
         ]
       },
-      "research_time": 14125
+      "research_time": 14125380
     }
   ],
   "location": {

--- a/research/effective_construction.json
+++ b/research/effective_construction.json
@@ -40,11 +40,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1110
+            "value": 1110000
           }
         ]
       },
-      "research_time": 2600
+      "research_time": 2600040
     },
     {
       "bonus": {
@@ -75,11 +75,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 3860
+            "value": 3860000
           }
         ]
       },
-      "research_time": 5965
+      "research_time": 5965920
     },
     {
       "bonus": {
@@ -110,11 +110,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 6580
+            "value": 6580000
           }
         ]
       },
-      "research_time": 8058
+      "research_time": 8058720
     },
     {
       "bonus": {
@@ -145,11 +145,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 10400
+            "value": 10400000
           }
         ]
       },
-      "research_time": 14125
+      "research_time": 14125380
     },
     {
       "bonus": {
@@ -180,11 +180,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 15100
+            "value": 15100000
           }
         ]
       },
-      "research_time": 13456
+      "research_time": 13456140
     },
     {
       "bonus": {
@@ -224,11 +224,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 22450
+            "value": 22450000
           }
         ]
       },
-      "research_time": 21017
+      "research_time": 21017460
     },
     {
       "bonus": {
@@ -259,11 +259,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 32600
+            "value": 32600000
           }
         ]
       },
-      "research_time": 29338
+      "research_time": 29338800
     },
     {
       "bonus": {
@@ -294,11 +294,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 70800
+            "value": 70800000
           }
         ]
       },
-      "research_time": 51090
+      "research_time": 51090420
     },
     {
       "bonus": {
@@ -329,11 +329,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 146000
+            "value": 146000000
           }
         ]
       },
-      "research_time": 88888
+      "research_time": 88888440
     },
     {
       "bonus": {
@@ -373,11 +373,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 399000
+            "value": 399000000
           }
         ]
       },
-      "research_time": 150563
+      "research_time": 150563760
     }
   ],
   "location": {

--- a/research/efficient_construction.json
+++ b/research/efficient_construction.json
@@ -75,11 +75,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1660
+            "value": 1660000
           }
         ]
       },
-      "research_time": 3499
+      "research_time": 3499500
     },
     {
       "bonus": {
@@ -110,11 +110,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 3860
+            "value": 3860000
           }
         ]
       },
-      "research_time": 5965
+      "research_time": 5965920
     },
     {
       "bonus": {
@@ -149,11 +149,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 10400
+            "value": 10400000
           }
         ]
       },
-      "research_time": 14125
+      "research_time": 14125380
     },
     {
       "bonus": {
@@ -184,11 +184,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 22450
+            "value": 22450000
           }
         ]
       },
-      "research_time": 21017
+      "research_time": 21017460
     },
     {
       "bonus": {
@@ -219,11 +219,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 49650
+            "value": 49650000
           }
         ]
       },
-      "research_time": 38934
+      "research_time": 38934120
     },
     {
       "bonus": {
@@ -254,11 +254,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 98750
+            "value": 98750000
           }
         ]
       },
-      "research_time": 68900
+      "research_time": 68900340
     },
     {
       "bonus": {
@@ -289,11 +289,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 235800
+            "value": 235800000
           }
         ]
       },
-      "research_time": 113694
+      "research_time": 113694240
     },
     {
       "bonus": {
@@ -328,11 +328,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 708800
+            "value": 708800000
           }
         ]
       },
-      "research_time": 189523
+      "research_time": 189523500
     },
     {
       "bonus": {
@@ -367,7 +367,7 @@
           }
         ]
       },
-      "research_time": 1449
+      "research_time": 1449420
     },
     {
       "bonus": {
@@ -402,7 +402,7 @@
           }
         ]
       },
-      "research_time": 1937
+      "research_time": 1937880
     },
     {
       "bonus": {

--- a/research/efficient_research.json
+++ b/research/efficient_research.json
@@ -110,11 +110,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1660
+            "value": 1660000
           }
         ]
       },
-      "research_time": 3499
+      "research_time": 3499500
     },
     {
       "bonus": {
@@ -145,11 +145,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 3860
+            "value": 3860000
           }
         ]
       },
-      "research_time": 5965
+      "research_time": 5965920
     },
     {
       "bonus": {
@@ -184,11 +184,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 10400
+            "value": 10400000
           }
         ]
       },
-      "research_time": 14125
+      "research_time": 14125380
     },
     {
       "bonus": {
@@ -219,11 +219,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 22450
+            "value": 22450000
           }
         ]
       },
-      "research_time": 21017
+      "research_time": 21017460
     },
     {
       "bonus": {
@@ -254,11 +254,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 49650
+            "value": 49650000
           }
         ]
       },
-      "research_time": 38934
+      "research_time": 38934120
     },
     {
       "bonus": {
@@ -289,11 +289,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 98750
+            "value": 98750000
           }
         ]
       },
-      "research_time": 68900
+      "research_time": 68900340
     },
     {
       "bonus": {
@@ -324,11 +324,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 235800
+            "value": 235800000
           }
         ]
       },
-      "research_time": 113694
+      "research_time": 113694240
     },
     {
       "bonus": {
@@ -363,11 +363,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 708800
+            "value": 708800000
           }
         ]
       },
-      "research_time": 189523
+      "research_time": 189523500
     },
     {
       "bonus": {
@@ -402,7 +402,7 @@
           }
         ]
       },
-      "research_time": 1449
+      "research_time": 1449420
     },
     {
       "bonus": {
@@ -437,7 +437,7 @@
           }
         ]
       },
-      "research_time": 1937
+      "research_time": 1937880
     }
   ],
   "location": {

--- a/research/efficient_ship_upgrades.json
+++ b/research/efficient_ship_upgrades.json
@@ -31,11 +31,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1660
+            "value": 1660000
           }
         ]
       },
-      "research_time": 3499
+      "research_time": 3499500
     },
     {
       "bonus": {
@@ -66,11 +66,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 3860
+            "value": 3860000
           }
         ]
       },
-      "research_time": 5965
+      "research_time": 5965920
     },
     {
       "bonus": {
@@ -105,11 +105,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 10400
+            "value": 10400000
           }
         ]
       },
-      "research_time": 14125
+      "research_time": 14125380
     },
     {
       "bonus": {
@@ -140,11 +140,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 22450
+            "value": 22450000
           }
         ]
       },
-      "research_time": 21017
+      "research_time": 21017460
     },
     {
       "bonus": {
@@ -175,11 +175,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 49650
+            "value": 49650000
           }
         ]
       },
-      "research_time": 38934
+      "research_time": 38934120
     },
     {
       "bonus": {
@@ -210,11 +210,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 98750
+            "value": 98750000
           }
         ]
       },
-      "research_time": 68900
+      "research_time": 68900340
     },
     {
       "bonus": {
@@ -245,11 +245,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 235800
+            "value": 235800000
           }
         ]
       },
-      "research_time": 113694
+      "research_time": 113694240
     },
     {
       "bonus": {
@@ -284,11 +284,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 708800
+            "value": 708800000
           }
         ]
       },
-      "research_time": 189523
+      "research_time": 189523500
     },
     {
       "bonus": {
@@ -402,7 +402,7 @@
           }
         ]
       },
-      "research_time": 1449
+      "research_time": 1449420
     },
     {
       "bonus": {
@@ -437,7 +437,7 @@
           }
         ]
       },
-      "research_time": 1937
+      "research_time": 1937880
     }
   ],
   "location": {

--- a/research/emergency_defenses.json
+++ b/research/emergency_defenses.json
@@ -120,7 +120,7 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1210
+            "value": 1210000
           }
         ]
       },
@@ -168,11 +168,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1880
+            "value": 1880000
           }
         ]
       },
-      "research_time": 1037
+      "research_time": 1037400
     },
     {
       "bonus": {
@@ -206,11 +206,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 2860
+            "value": 2860000
           }
         ]
       },
-      "research_time": 1330
+      "research_time": 1330800
     },
     {
       "bonus": {

--- a/research/energy_guerilla_warfare.json
+++ b/research/energy_guerilla_warfare.json
@@ -32,7 +32,7 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1341
+            "value": 1341900
           }
         ]
       },
@@ -71,7 +71,7 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 2490
+            "value": 2490000
           }
         ]
       },
@@ -102,7 +102,7 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 2985
+            "value": 2985300
           }
         ]
       },
@@ -141,7 +141,7 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 5800
+            "value": 5800000
           }
         ]
       },
@@ -177,11 +177,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 6955
+            "value": 6955200
           }
         ]
       },
-      "research_time": 1073
+      "research_time": 1073880
     },
     {
       "bonus": {
@@ -216,11 +216,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 15600
+            "value": 15600000
           }
         ]
       },
-      "research_time": 2118
+      "research_time": 2118840
     },
     {
       "bonus": {
@@ -247,11 +247,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 18711
+            "value": 18711000
           }
         ]
       },
-      "research_time": 2542
+      "research_time": 2542560
     },
     {
       "bonus": {
@@ -291,11 +291,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 33700
+            "value": 33700000
           }
         ]
       },
-      "research_time": 3152
+      "research_time": 3152640
     },
     {
       "bonus": {
@@ -322,11 +322,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 40446
+            "value": 40446000
           }
         ]
       },
-      "research_time": 3783
+      "research_time": 3783120
     },
     {
       "bonus": {
@@ -353,11 +353,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 74500
+            "value": 74500000
           }
         ]
       },
-      "research_time": 5840
+      "research_time": 5840100
     },
     {
       "bonus": {
@@ -401,11 +401,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 148100
+            "value": 148100000
           }
         ]
       },
-      "research_time": 10335
+      "research_time": 10335060
     },
     {
       "bonus": {
@@ -546,7 +546,7 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1120
+            "value": 1120000
           }
         ]
       },

--- a/research/enhanced_defenses.json
+++ b/research/enhanced_defenses.json
@@ -36,11 +36,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1660
+            "value": 1660000
           }
         ]
       },
-      "research_time": 3499
+      "research_time": 3499500
     },
     {
       "bonus": {
@@ -76,11 +76,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 3860
+            "value": 3860000
           }
         ]
       },
-      "research_time": 5965
+      "research_time": 5965920
     },
     {
       "bonus": {
@@ -116,11 +116,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 10400
+            "value": 10400000
           }
         ]
       },
-      "research_time": 14125
+      "research_time": 14125380
     },
     {
       "bonus": {
@@ -156,11 +156,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 22450
+            "value": 22450000
           }
         ]
       },
-      "research_time": 21017
+      "research_time": 21017460
     },
     {
       "bonus": {
@@ -196,11 +196,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 49650
+            "value": 49650000
           }
         ]
       },
-      "research_time": 38934
+      "research_time": 38934120
     },
     {
       "bonus": {
@@ -236,11 +236,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 98750
+            "value": 98750000
           }
         ]
       },
-      "research_time": 68900
+      "research_time": 68900340
     },
     {
       "bonus": {
@@ -276,11 +276,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 235800
+            "value": 235800000
           }
         ]
       },
-      "research_time": 113694
+      "research_time": 113694240
     },
     {
       "bonus": {
@@ -316,11 +316,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 708800
+            "value": 708800000
           }
         ]
       },
-      "research_time": 189523
+      "research_time": 189523500
     },
     {
       "bonus": {
@@ -476,7 +476,7 @@
           }
         ]
       },
-      "research_time": 1937
+      "research_time": 1937880
     },
     {
       "bonus": {

--- a/research/enhanced_piercing.json
+++ b/research/enhanced_piercing.json
@@ -36,11 +36,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1660
+            "value": 1660000
           }
         ]
       },
-      "research_time": 3499
+      "research_time": 3499500
     },
     {
       "bonus": {
@@ -76,11 +76,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 3860
+            "value": 3860000
           }
         ]
       },
-      "research_time": 5965
+      "research_time": 5965920
     },
     {
       "bonus": {
@@ -116,11 +116,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 10400
+            "value": 10400000
           }
         ]
       },
-      "research_time": 14125
+      "research_time": 14125380
     },
     {
       "bonus": {
@@ -156,11 +156,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 22450
+            "value": 22450000
           }
         ]
       },
-      "research_time": 21017
+      "research_time": 21017460
     },
     {
       "bonus": {
@@ -196,11 +196,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 49650
+            "value": 49650000
           }
         ]
       },
-      "research_time": 38934
+      "research_time": 38934120
     },
     {
       "bonus": {
@@ -236,11 +236,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 98750
+            "value": 98750000
           }
         ]
       },
-      "research_time": 68900
+      "research_time": 68900340
     },
     {
       "bonus": {
@@ -276,11 +276,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 235800
+            "value": 235800000
           }
         ]
       },
-      "research_time": 113694
+      "research_time": 113694240
     },
     {
       "bonus": {
@@ -316,11 +316,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 708800
+            "value": 708800000
           }
         ]
       },
-      "research_time": 189523
+      "research_time": 189523500
     },
     {
       "bonus": {
@@ -440,7 +440,7 @@
           }
         ]
       },
-      "research_time": 1937
+      "research_time": 1937880
     },
     {
       "bonus": {

--- a/research/enhanced_warp_cores.json
+++ b/research/enhanced_warp_cores.json
@@ -38,11 +38,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 187100
+            "value": 187100000
           }
         ]
       },
-      "research_time": 28250
+      "research_time": 28250820
     },
     {
       "bonus": {
@@ -71,11 +71,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 404500
+            "value": 404500000
           }
         ]
       },
-      "research_time": 42034
+      "research_time": 42034980
     },
     {
       "bonus": {
@@ -104,11 +104,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 893700
+            "value": 893700000
           }
         ]
       },
-      "research_time": 77868
+      "research_time": 77868300
     },
     {
       "bonus": {
@@ -137,11 +137,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1777
+            "value": 1777000000
           }
         ]
       },
-      "research_time": 137800
+      "research_time": 137800680
     },
     {
       "bonus": {
@@ -170,11 +170,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 4244
+            "value": 4244000000
           }
         ]
       },
-      "research_time": 227388
+      "research_time": 227388480
     }
   ],
   "location": {

--- a/research/enhanced_weaponry.json
+++ b/research/enhanced_weaponry.json
@@ -38,11 +38,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 12200
+            "value": 12200000
           }
         ]
       },
-      "research_time": 5200
+      "research_time": 5200080
     },
     {
       "bonus": {
@@ -86,11 +86,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 18250
+            "value": 18250000
           }
         ]
       },
-      "research_time": 6999
+      "research_time": 6999060
     },
     {
       "bonus": {
@@ -134,11 +134,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 26900
+            "value": 26900000
           }
         ]
       },
-      "research_time": 6967
+      "research_time": 6967980
     },
     {
       "bonus": {
@@ -186,11 +186,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 42500
+            "value": 42500000
           }
         ]
       },
-      "research_time": 11931
+      "research_time": 11931900
     },
     {
       "bonus": {
@@ -238,11 +238,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 72400
+            "value": 72400000
           }
         ]
       },
-      "research_time": 16117
+      "research_time": 16117440
     },
     {
       "bonus": {
@@ -290,11 +290,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 114300
+            "value": 114300000
           }
         ]
       },
-      "research_time": 28250
+      "research_time": 28250820
     },
     {
       "bonus": {
@@ -338,11 +338,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 165800
+            "value": 165800000
           }
         ]
       },
-      "research_time": 26912
+      "research_time": 26912280
     },
     {
       "bonus": {
@@ -386,11 +386,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 247200
+            "value": 247200000
           }
         ]
       },
-      "research_time": 42034
+      "research_time": 42034980
     },
     {
       "bonus": {
@@ -434,11 +434,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 358600
+            "value": 358600000
           }
         ]
       },
-      "research_time": 58677
+      "research_time": 58677600
     },
     {
       "bonus": {
@@ -494,11 +494,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 546200
+            "value": 546200000
           }
         ]
       },
-      "research_time": 77868
+      "research_time": 77868300
     }
   ],
   "location": {

--- a/research/evasive_klingons.json
+++ b/research/evasive_klingons.json
@@ -26,15 +26,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 5960
+            "value": 5960000
           },
           {
             "type": "dilithium",
-            "value": 7460
+            "value": 7460000
           }
         ]
       },
-      "research_time": 2713
+      "research_time": 2713080
     },
     {
       "bonus": {
@@ -112,15 +112,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 1070
+            "value": 1070000
           },
           {
             "type": "dilithium",
-            "value": 1340
+            "value": 1340000
           }
         ]
       },
-      "research_time": 1037
+      "research_time": 1037400
     },
     {
       "bonus": {
@@ -165,15 +165,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 2400
+            "value": 2400000
           },
           {
             "type": "dilithium",
-            "value": 3000
+            "value": 3000000
           }
         ]
       },
-      "research_time": 1369
+      "research_time": 1369920
     },
     {
       "bonus": {
@@ -218,15 +218,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 13250
+            "value": 13250000
           },
           {
             "type": "dilithium",
-            "value": 16600
+            "value": 16600000
           }
         ]
       },
-      "research_time": 4899
+      "research_time": 4899360
     },
     {
       "bonus": {
@@ -271,15 +271,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 30900
+            "value": 30900000
           },
           {
             "type": "dilithium",
-            "value": 38650
+            "value": 38650000
           }
         ]
       },
-      "research_time": 8352
+      "research_time": 8352300
     },
     {
       "bonus": {
@@ -312,15 +312,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 83150
+            "value": 83150000
           },
           {
             "type": "dilithium",
-            "value": 104000
+            "value": 104000000
           }
         ]
       },
-      "research_time": 19775
+      "research_time": 19775580
     },
     {
       "bonus": {
@@ -365,15 +365,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 179800
+            "value": 179800000
           },
           {
             "type": "dilithium",
-            "value": 224700
+            "value": 224700000
           }
         ]
       },
-      "research_time": 29424
+      "research_time": 29424480
     },
     {
       "bonus": {
@@ -418,15 +418,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 397200
+            "value": 397200000
           },
           {
             "type": "dilithium",
-            "value": 496500
+            "value": 496500000
           }
         ]
       },
-      "research_time": 54507
+      "research_time": 54507780
     },
     {
       "bonus": {

--- a/research/expert_repairs.json
+++ b/research/expert_repairs.json
@@ -40,11 +40,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1110
+            "value": 1110000
           }
         ]
       },
-      "research_time": 2600
+      "research_time": 2600040
     },
     {
       "bonus": {
@@ -75,11 +75,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 3860
+            "value": 3860000
           }
         ]
       },
-      "research_time": 5965
+      "research_time": 5965920
     },
     {
       "bonus": {
@@ -110,11 +110,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 6580
+            "value": 6580000
           }
         ]
       },
-      "research_time": 8058
+      "research_time": 8058720
     },
     {
       "bonus": {
@@ -145,11 +145,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 10400
+            "value": 10400000
           }
         ]
       },
-      "research_time": 14125
+      "research_time": 14125380
     },
     {
       "bonus": {
@@ -184,11 +184,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 15100
+            "value": 15100000
           }
         ]
       },
-      "research_time": 13456
+      "research_time": 13456140
     },
     {
       "bonus": {
@@ -224,11 +224,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 22450
+            "value": 22450000
           }
         ]
       },
-      "research_time": 21017
+      "research_time": 21017460
     },
     {
       "bonus": {
@@ -259,11 +259,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 32600
+            "value": 32600000
           }
         ]
       },
-      "research_time": 29338
+      "research_time": 29338800
     },
     {
       "bonus": {
@@ -294,11 +294,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 70800
+            "value": 70800000
           }
         ]
       },
-      "research_time": 51090
+      "research_time": 51090420
     },
     {
       "bonus": {
@@ -333,11 +333,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 146000
+            "value": 146000000
           }
         ]
       },
-      "research_time": 88888
+      "research_time": 88888440
     },
     {
       "bonus": {
@@ -373,11 +373,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 399000
+            "value": 399000000
           }
         ]
       },
-      "research_time": 150563
+      "research_time": 150563760
     }
   ],
   "location": {

--- a/research/exploit_weakpoints_ii.json
+++ b/research/exploit_weakpoints_ii.json
@@ -44,15 +44,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 6630
+            "value": 6630000
           },
           {
             "type": "dilithium",
-            "value": 16600
+            "value": 16600000
           }
         ]
       },
-      "research_time": 4199
+      "research_time": 4199400
     },
     {
       "bonus": {
@@ -90,15 +90,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 15450
+            "value": 15450000
           },
           {
             "type": "dilithium",
-            "value": 38650
+            "value": 38650000
           }
         ]
       },
-      "research_time": 7159
+      "research_time": 7159140
     },
     {
       "bonus": {
@@ -136,15 +136,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 41600
+            "value": 41600000
           },
           {
             "type": "dilithium",
-            "value": 104000
+            "value": 104000000
           }
         ]
       },
-      "research_time": 16950
+      "research_time": 16950480
     },
     {
       "bonus": {
@@ -184,15 +184,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 89900
+            "value": 89900000
           },
           {
             "type": "dilithium",
-            "value": 224700
+            "value": 224700000
           }
         ]
       },
-      "research_time": 25221
+      "research_time": 25221000
     },
     {
       "bonus": {
@@ -235,11 +235,11 @@
           },
           {
             "type": "dilithium",
-            "value": 2040
+            "value": 2040000
           }
         ]
       },
-      "research_time": 1140
+      "research_time": 1140660
     }
   ],
   "location": {

--- a/research/explorer_advanced_piercing.json
+++ b/research/explorer_advanced_piercing.json
@@ -35,7 +35,7 @@
         ],
         "resources": []
       },
-      "research_time": 2600
+      "research_time": 2600040
     },
     {
       "bonus": {
@@ -65,7 +65,7 @@
         ],
         "resources": []
       },
-      "research_time": 8058
+      "research_time": 8058720
     },
     {
       "bonus": {
@@ -104,7 +104,7 @@
         ],
         "resources": []
       },
-      "research_time": 14125
+      "research_time": 14125380
     },
     {
       "bonus": {
@@ -139,7 +139,7 @@
         ],
         "resources": []
       },
-      "research_time": 13456
+      "research_time": 13456140
     },
     {
       "bonus": {
@@ -178,7 +178,7 @@
         ],
         "resources": []
       },
-      "research_time": 21017
+      "research_time": 21017460
     },
     {
       "bonus": {
@@ -213,7 +213,7 @@
         ],
         "resources": []
       },
-      "research_time": 29338
+      "research_time": 29338800
     },
     {
       "bonus": {
@@ -252,7 +252,7 @@
         ],
         "resources": []
       },
-      "research_time": 38934
+      "research_time": 38934120
     },
     {
       "bonus": {
@@ -278,7 +278,7 @@
         "others": [
           {
             "type": "Service\u00a0Award",
-            "value": 1259
+            "value": 1259626
           },
           {
             "type": "Merit\u00a0of\u00a0Honor",
@@ -287,7 +287,7 @@
         ],
         "resources": []
       },
-      "research_time": 51090
+      "research_time": 51090420
     },
     {
       "bonus": {
@@ -317,7 +317,7 @@
         "others": [
           {
             "type": "Service\u00a0Award",
-            "value": 1796
+            "value": 1796553
           },
           {
             "type": "Merit\u00a0of\u00a0Honor",
@@ -326,7 +326,7 @@
         ],
         "resources": []
       },
-      "research_time": 68900
+      "research_time": 68900340
     },
     {
       "bonus": {
@@ -352,7 +352,7 @@
         "others": [
           {
             "type": "Service\u00a0Award",
-            "value": 2669
+            "value": 2669728
           },
           {
             "type": "Merit\u00a0of\u00a0Honor",
@@ -361,7 +361,7 @@
         ],
         "resources": []
       },
-      "research_time": 88888
+      "research_time": 88888440
     }
   ],
   "location": {

--- a/research/explorer_barrage.json
+++ b/research/explorer_barrage.json
@@ -27,11 +27,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 674100
+            "value": 674100000
           }
         ]
       },
-      "research_time": 42034
+      "research_time": 42034980
     }
   ],
   "location": {

--- a/research/explorer_bartering.json
+++ b/research/explorer_bartering.json
@@ -35,11 +35,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 20300
+            "value": 20300000
           },
           {
             "type": "dilithium",
-            "value": 2240
+            "value": 2240000
           }
         ]
       },
@@ -82,7 +82,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 8150
+            "value": 8150000
           },
           {
             "type": "dilithium",
@@ -125,15 +125,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 45100
+            "value": 45100000
           },
           {
             "type": "dilithium",
-            "value": 4980
+            "value": 4980000
           }
         ]
       },
-      "research_time": 1049
+      "research_time": 1049880
     },
     {
       "bonus": {
@@ -168,15 +168,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 105100
+            "value": 105100000
           },
           {
             "type": "dilithium",
-            "value": 11600
+            "value": 11600000
           }
         ]
       },
-      "research_time": 1789
+      "research_time": 1789800
     },
     {
       "bonus": {
@@ -211,15 +211,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 282700
+            "value": 282700000
           },
           {
             "type": "dilithium",
-            "value": 31200
+            "value": 31200000
           }
         ]
       },
-      "research_time": 4237
+      "research_time": 4237620
     },
     {
       "bonus": {
@@ -254,15 +254,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 611200
+            "value": 611200000
           },
           {
             "type": "dilithium",
-            "value": 67400
+            "value": 67400000
           }
         ]
       },
-      "research_time": 6305
+      "research_time": 6305220
     },
     {
       "bonus": {
@@ -314,7 +314,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 3650
+            "value": 3650000
           },
           {
             "type": "dilithium",
@@ -424,7 +424,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1520
+            "value": 1520000
           },
           {
             "type": "dilithium",

--- a/research/explorer_firepower.json
+++ b/research/explorer_firepower.json
@@ -49,15 +49,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 15450
+            "value": 15450000
           },
           {
             "type": "dilithium",
-            "value": 38650
+            "value": 38650000
           }
         ]
       },
-      "research_time": 7159
+      "research_time": 7159140
     },
     {
       "bonus": {
@@ -87,15 +87,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 26350
+            "value": 26350000
           },
           {
             "type": "dilithium",
-            "value": 65800
+            "value": 65800000
           }
         ]
       },
-      "research_time": 9670
+      "research_time": 9670500
     },
     {
       "bonus": {
@@ -219,7 +219,7 @@
           },
           {
             "type": "dilithium",
-            "value": 1340
+            "value": 1340000
           }
         ]
       },
@@ -266,11 +266,11 @@
           },
           {
             "type": "dilithium",
-            "value": 2040
+            "value": 2040000
           }
         ]
       },
-      "research_time": 1140
+      "research_time": 1140660
     },
     {
       "bonus": {
@@ -300,15 +300,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 2980
+            "value": 2980000
           },
           {
             "type": "dilithium",
-            "value": 7460
+            "value": 7460000
           }
         ]
       },
-      "research_time": 2325
+      "research_time": 2325480
     },
     {
       "bonus": {
@@ -347,15 +347,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 4440
+            "value": 4440000
           },
           {
             "type": "dilithium",
-            "value": 11100
+            "value": 11100000
           }
         ]
       },
-      "research_time": 3120
+      "research_time": 3120060
     },
     {
       "bonus": {

--- a/research/explorer_focus_shot.json
+++ b/research/explorer_focus_shot.json
@@ -38,7 +38,7 @@
         ],
         "resources": []
       },
-      "research_time": 50614
+      "research_time": 50614380
     },
     {
       "bonus": {
@@ -72,12 +72,12 @@
           },
           {
             "type": "Service\u00a0Award",
-            "value": 1259
+            "value": 1259626
           }
         ],
         "resources": []
       },
-      "research_time": 66417
+      "research_time": 66417540
     },
     {
       "bonus": {
@@ -106,12 +106,12 @@
           },
           {
             "type": "Service\u00a0Award",
-            "value": 1796
+            "value": 1796553
           }
         ],
         "resources": []
       },
-      "research_time": 89570
+      "research_time": 89570460
     },
     {
       "bonus": {
@@ -145,12 +145,12 @@
           },
           {
             "type": "Service\u00a0Award",
-            "value": 2669
+            "value": 2669728
           }
         ],
         "resources": []
       },
-      "research_time": 115554
+      "research_time": 115554960
     },
     {
       "bonus": {
@@ -171,7 +171,7 @@
         "others": [
           {
             "type": "Service\u00a0Award",
-            "value": 4412
+            "value": 4412607
           },
           {
             "type": "Merit\u00a0of\u00a0Honor",
@@ -180,7 +180,7 @@
         ],
         "resources": []
       },
-      "research_time": 147802
+      "research_time": 147802500
     },
     {
       "bonus": {
@@ -214,12 +214,12 @@
           },
           {
             "type": "Service\u00a0Award",
-            "value": 7673
+            "value": 7673146
           }
         ],
         "resources": []
       },
-      "research_time": 195732
+      "research_time": 195732840
     },
     {
       "bonus": {
@@ -240,7 +240,7 @@
         "others": [
           {
             "type": "Service\u00a0Award",
-            "value": 12766
+            "value": 12766604
           },
           {
             "type": "Merit\u00a0of\u00a0Honor",
@@ -249,7 +249,7 @@
         ],
         "resources": []
       },
-      "research_time": 246380
+      "research_time": 246380520
     },
     {
       "bonus": {
@@ -279,7 +279,7 @@
         "others": [
           {
             "type": "Service\u00a0Award",
-            "value": 14185
+            "value": 14185115
           },
           {
             "type": "Merit\u00a0of\u00a0Honor",
@@ -288,7 +288,7 @@
         ],
         "resources": []
       },
-      "research_time": 300516
+      "research_time": 300516720
     },
     {
       "bonus": {
@@ -309,7 +309,7 @@
         "others": [
           {
             "type": "Service\u00a0Award",
-            "value": 14185
+            "value": 14185115
           },
           {
             "type": "Merit\u00a0of\u00a0Honor",
@@ -318,7 +318,7 @@
         ],
         "resources": []
       },
-      "research_time": 300516
+      "research_time": 300516720
     },
     {
       "bonus": {
@@ -348,7 +348,7 @@
         "others": [
           {
             "type": "Service\u00a0Award",
-            "value": 17022
+            "value": 17022138
           },
           {
             "type": "Merit\u00a0of\u00a0Honor",
@@ -357,7 +357,7 @@
         ],
         "resources": []
       },
-      "research_time": 265945
+      "research_time": 265945140
     }
   ],
   "location": {

--- a/research/explorer_hull_boost.json
+++ b/research/explorer_hull_boost.json
@@ -49,15 +49,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 38650
+            "value": 38650000
           },
           {
             "type": "dilithium",
-            "value": 23200
+            "value": 23200000
           }
         ]
       },
-      "research_time": 5965
+      "research_time": 5965920
     },
     {
       "bonus": {
@@ -87,15 +87,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 65800
+            "value": 65800000
           },
           {
             "type": "dilithium",
-            "value": 39500
+            "value": 39500000
           }
         ]
       },
-      "research_time": 8058
+      "research_time": 8058720
     },
     {
       "bonus": {
@@ -125,15 +125,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 7460
+            "value": 7460000
           },
           {
             "type": "dilithium",
-            "value": 4470
+            "value": 4470000
           }
         ]
       },
-      "research_time": 1937
+      "research_time": 1937880
     },
     {
       "bonus": {
@@ -168,7 +168,7 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 1340
+            "value": 1340000
           },
           {
             "type": "dilithium",
@@ -254,11 +254,11 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 2040
+            "value": 2040000
           },
           {
             "type": "dilithium",
-            "value": 1230
+            "value": 1230000
           }
         ]
       },
@@ -301,15 +301,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 11100
+            "value": 11100000
           },
           {
             "type": "dilithium",
-            "value": 6670
+            "value": 6670000
           }
         ]
       },
-      "research_time": 2600
+      "research_time": 2600040
     },
     {
       "bonus": {

--- a/research/explorer_hull_integrity.json
+++ b/research/explorer_hull_integrity.json
@@ -31,11 +31,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1110
+            "value": 1110000
           }
         ]
       },
-      "research_time": 2600
+      "research_time": 2600040
     },
     {
       "bonus": {
@@ -66,11 +66,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1660
+            "value": 1660000
           }
         ]
       },
-      "research_time": 3499
+      "research_time": 3499500
     },
     {
       "bonus": {
@@ -101,11 +101,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 2440
+            "value": 2440000
           }
         ]
       },
-      "research_time": 3483
+      "research_time": 3483960
     },
     {
       "bonus": {
@@ -145,11 +145,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 6580
+            "value": 6580000
           }
         ]
       },
-      "research_time": 8058
+      "research_time": 8058720
     },
     {
       "bonus": {
@@ -180,11 +180,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 15100
+            "value": 15100000
           }
         ]
       },
-      "research_time": 13456
+      "research_time": 13456140
     },
     {
       "bonus": {
@@ -215,11 +215,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 32600
+            "value": 32600000
           }
         ]
       },
-      "research_time": 29338
+      "research_time": 29338800
     },
     {
       "bonus": {
@@ -250,11 +250,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 70800
+            "value": 70800000
           }
         ]
       },
-      "research_time": 51090
+      "research_time": 51090420
     },
     {
       "bonus": {
@@ -285,11 +285,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 146000
+            "value": 146000000
           }
         ]
       },
-      "research_time": 88888
+      "research_time": 88888440
     },
     {
       "bonus": {
@@ -329,11 +329,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 399000
+            "value": 399000000
           }
         ]
       },
-      "research_time": 150563
+      "research_time": 150563760
     },
     {
       "bonus": {
@@ -368,7 +368,7 @@
           }
         ]
       },
-      "research_time": 1937
+      "research_time": 1937880
     },
     {
       "bonus": {
@@ -403,7 +403,7 @@
           }
         ]
       },
-      "research_time": 1449
+      "research_time": 1449420
     },
     {
       "bonus": {

--- a/research/explorer_nacelles.json
+++ b/research/explorer_nacelles.json
@@ -96,7 +96,7 @@
         ],
         "resources": []
       },
-      "research_time": 1162
+      "research_time": 1162740
     },
     {
       "bonus": {

--- a/research/explorer_overcharge.json
+++ b/research/explorer_overcharge.json
@@ -35,7 +35,7 @@
         ],
         "resources": []
       },
-      "research_time": 2519
+      "research_time": 2519280
     },
     {
       "bonus": {
@@ -65,7 +65,7 @@
         ],
         "resources": []
       },
-      "research_time": 1272
+      "research_time": 1272060
     },
     {
       "bonus": {
@@ -96,7 +96,7 @@
         ],
         "resources": []
       },
-      "research_time": 1884
+      "research_time": 1884300
     },
     {
       "bonus": {
@@ -127,7 +127,7 @@
         ],
         "resources": []
       },
-      "research_time": 3380
+      "research_time": 3380040
     },
     {
       "bonus": {
@@ -157,7 +157,7 @@
         ],
         "resources": []
       },
-      "research_time": 4549
+      "research_time": 4549380
     },
     {
       "bonus": {
@@ -192,7 +192,7 @@
         ],
         "resources": []
       },
-      "research_time": 4529
+      "research_time": 4529160
     },
     {
       "bonus": {
@@ -222,7 +222,7 @@
         ],
         "resources": []
       },
-      "research_time": 7755
+      "research_time": 7755720
     },
     {
       "bonus": {
@@ -257,7 +257,7 @@
         ],
         "resources": []
       },
-      "research_time": 10476
+      "research_time": 10476360
     },
     {
       "bonus": {
@@ -296,7 +296,7 @@
         ],
         "resources": []
       },
-      "research_time": 18363
+      "research_time": 18363000
     },
     {
       "bonus": {

--- a/research/explorer_regeneration.json
+++ b/research/explorer_regeneration.json
@@ -55,7 +55,7 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1210
+            "value": 1210000
           }
         ]
       },
@@ -103,7 +103,7 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 2700
+            "value": 2700000
           }
         ]
       },
@@ -151,11 +151,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 6710
+            "value": 6710000
           }
         ]
       },
-      "research_time": 1744
+      "research_time": 1744080
     },
     {
       "bonus": {

--- a/research/explorer_repair_costs.json
+++ b/research/explorer_repair_costs.json
@@ -40,11 +40,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1110
+            "value": 1110000
           }
         ]
       },
-      "research_time": 2600
+      "research_time": 2600040
     },
     {
       "bonus": {
@@ -75,11 +75,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 2440
+            "value": 2440000
           }
         ]
       },
-      "research_time": 3483
+      "research_time": 3483960
     },
     {
       "bonus": {
@@ -110,11 +110,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 3860
+            "value": 3860000
           }
         ]
       },
-      "research_time": 5965
+      "research_time": 5965920
     },
     {
       "bonus": {
@@ -145,11 +145,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 6580
+            "value": 6580000
           }
         ]
       },
-      "research_time": 8058
+      "research_time": 8058720
     },
     {
       "bonus": {
@@ -180,11 +180,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 10400
+            "value": 10400000
           }
         ]
       },
-      "research_time": 14125
+      "research_time": 14125380
     },
     {
       "bonus": {
@@ -219,11 +219,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 22450
+            "value": 22450000
           }
         ]
       },
-      "research_time": 21017
+      "research_time": 21017460
     },
     {
       "bonus": {
@@ -254,11 +254,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 49650
+            "value": 49650000
           }
         ]
       },
-      "research_time": 38934
+      "research_time": 38934120
     },
     {
       "bonus": {
@@ -289,11 +289,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 98750
+            "value": 98750000
           }
         ]
       },
-      "research_time": 68900
+      "research_time": 68900340
     },
     {
       "bonus": {
@@ -324,11 +324,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 235800
+            "value": 235800000
           }
         ]
       },
-      "research_time": 113694
+      "research_time": 113694240
     },
     {
       "bonus": {
@@ -367,11 +367,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 708800
+            "value": 708800000
           }
         ]
       },
-      "research_time": 189523
+      "research_time": 189523500
     }
   ],
   "location": {

--- a/research/explorer_retaliation.json
+++ b/research/explorer_retaliation.json
@@ -33,15 +33,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 2026
+            "value": 2026000000
           },
           {
             "type": "dilithium",
-            "value": 496500
+            "value": 496500000
           }
         ]
       },
-      "research_time": 38934
+      "research_time": 38934120
     }
   ],
   "location": {

--- a/research/explorer_shields.json
+++ b/research/explorer_shields.json
@@ -36,11 +36,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 32600
+            "value": 32600000
           }
         ]
       },
-      "research_time": 29338
+      "research_time": 29338800
     },
     {
       "bonus": {
@@ -76,11 +76,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 70800
+            "value": 70800000
           }
         ]
       },
-      "research_time": 51090
+      "research_time": 51090420
     },
     {
       "bonus": {
@@ -120,11 +120,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1110
+            "value": 1110000
           }
         ]
       },
-      "research_time": 2600
+      "research_time": 2600040
     },
     {
       "bonus": {
@@ -160,11 +160,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1660
+            "value": 1660000
           }
         ]
       },
-      "research_time": 3499
+      "research_time": 3499500
     },
     {
       "bonus": {
@@ -208,11 +208,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 2440
+            "value": 2440000
           }
         ]
       },
-      "research_time": 3483
+      "research_time": 3483960
     },
     {
       "bonus": {
@@ -252,11 +252,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 6580
+            "value": 6580000
           }
         ]
       },
-      "research_time": 8058
+      "research_time": 8058720
     },
     {
       "bonus": {
@@ -300,11 +300,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 15100
+            "value": 15100000
           }
         ]
       },
-      "research_time": 13456
+      "research_time": 13456140
     },
     {
       "bonus": {
@@ -335,11 +335,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 146000
+            "value": 146000000
           }
         ]
       },
-      "research_time": 88888
+      "research_time": 88888440
     },
     {
       "bonus": {
@@ -379,11 +379,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 399000
+            "value": 399000000
           }
         ]
       },
-      "research_time": 150563
+      "research_time": 150563760
     },
     {
       "bonus": {
@@ -471,7 +471,7 @@
           }
         ]
       },
-      "research_time": 1449
+      "research_time": 1449420
     },
     {
       "bonus": {
@@ -515,7 +515,7 @@
           }
         ]
       },
-      "research_time": 1937
+      "research_time": 1937880
     }
   ],
   "location": {

--- a/research/explorer_space_critical_resist.json
+++ b/research/explorer_space_critical_resist.json
@@ -54,15 +54,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 584000
+            "value": 584000000
           },
           {
             "type": "dilithium",
-            "value": 1460
+            "value": 1460000000
           }
         ]
       },
-      "research_time": 106666
+      "research_time": 106666140
     }
   ],
   "location": {

--- a/research/explorer_tactics.json
+++ b/research/explorer_tactics.json
@@ -43,11 +43,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 9690
+            "value": 9690000
           }
         ]
       },
-      "research_time": 2519
+      "research_time": 2519280
     },
     {
       "bonus": {
@@ -82,11 +82,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 31750
+            "value": 31750000
           }
         ]
       },
-      "research_time": 4529
+      "research_time": 4529160
     },
     {
       "bonus": {
@@ -140,11 +140,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 50250
+            "value": 50250000
           }
         ]
       },
-      "research_time": 7755
+      "research_time": 7755720
     },
     {
       "bonus": {
@@ -179,7 +179,7 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1120
+            "value": 1120000
           }
         ]
       },
@@ -226,7 +226,7 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1740
+            "value": 1740000
           }
         ]
       },
@@ -265,11 +265,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 6040
+            "value": 6040000
           }
         ]
       },
-      "research_time": 1884
+      "research_time": 1884300
     },
     {
       "bonus": {

--- a/research/explorer_targeting_array.json
+++ b/research/explorer_targeting_array.json
@@ -31,15 +31,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 4470
+            "value": 4470000
           },
           {
             "type": "dilithium",
-            "value": 5960
+            "value": 5960000
           }
         ]
       },
-      "research_time": 1550
+      "research_time": 1550340
     },
     {
       "bonus": {
@@ -89,15 +89,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 14650
+            "value": 14650000
           },
           {
             "type": "dilithium",
-            "value": 19550
+            "value": 19550000
           }
         ]
       },
-      "research_time": 2787
+      "research_time": 2787180
     },
     {
       "bonus": {
@@ -147,15 +147,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 23200
+            "value": 23200000
           },
           {
             "type": "dilithium",
-            "value": 30900
+            "value": 30900000
           }
         ]
       },
-      "research_time": 4772
+      "research_time": 4772760
     },
     {
       "bonus": {
@@ -186,15 +186,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 2790
+            "value": 2790000
           },
           {
             "type": "dilithium",
-            "value": 3720
+            "value": 3720000
           }
         ]
       },
-      "research_time": 1159
+      "research_time": 1159560
     },
     {
       "bonus": {
@@ -363,7 +363,7 @@
           },
           {
             "type": "dilithium",
-            "value": 1070
+            "value": 1070000
           }
         ]
       },

--- a/research/explorer_warfare.json
+++ b/research/explorer_warfare.json
@@ -31,11 +31,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1110
+            "value": 1110000
           }
         ]
       },
-      "research_time": 2600
+      "research_time": 2600040
     },
     {
       "bonus": {
@@ -66,11 +66,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1660
+            "value": 1660000
           }
         ]
       },
-      "research_time": 3499
+      "research_time": 3499500
     },
     {
       "bonus": {
@@ -101,11 +101,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 2440
+            "value": 2440000
           }
         ]
       },
-      "research_time": 3483
+      "research_time": 3483960
     },
     {
       "bonus": {
@@ -145,11 +145,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 6580
+            "value": 6580000
           }
         ]
       },
-      "research_time": 8058
+      "research_time": 8058720
     },
     {
       "bonus": {
@@ -180,11 +180,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 15100
+            "value": 15100000
           }
         ]
       },
-      "research_time": 13456
+      "research_time": 13456140
     },
     {
       "bonus": {
@@ -215,11 +215,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 32600
+            "value": 32600000
           }
         ]
       },
-      "research_time": 29338
+      "research_time": 29338800
     },
     {
       "bonus": {
@@ -250,11 +250,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 70800
+            "value": 70800000
           }
         ]
       },
-      "research_time": 51090
+      "research_time": 51090420
     },
     {
       "bonus": {
@@ -285,11 +285,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 146000
+            "value": 146000000
           }
         ]
       },
-      "research_time": 88888
+      "research_time": 88888440
     },
     {
       "bonus": {
@@ -329,11 +329,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 399000
+            "value": 399000000
           }
         ]
       },
-      "research_time": 150563
+      "research_time": 150563760
     },
     {
       "bonus": {
@@ -416,7 +416,7 @@
           }
         ]
       },
-      "research_time": 1937
+      "research_time": 1937880
     },
     {
       "bonus": {
@@ -451,7 +451,7 @@
           }
         ]
       },
-      "research_time": 1449
+      "research_time": 1449420
     }
   ],
   "location": {

--- a/research/explorer_warp.json
+++ b/research/explorer_warp.json
@@ -50,7 +50,7 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1230
+            "value": 1230000
           }
         ]
       },
@@ -98,11 +98,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 14650
+            "value": 14650000
           }
         ]
       },
-      "research_time": 2090
+      "research_time": 2090400
     },
     {
       "bonus": {
@@ -144,11 +144,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 23200
+            "value": 23200000
           }
         ]
       },
-      "research_time": 3579
+      "research_time": 3579540
     },
     {
       "bonus": {
@@ -182,11 +182,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 39500
+            "value": 39500000
           }
         ]
       },
-      "research_time": 4835
+      "research_time": 4835220
     },
     {
       "bonus": {
@@ -223,11 +223,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 62350
+            "value": 62350000
           }
         ]
       },
-      "research_time": 8475
+      "research_time": 8475243
     },
     {
       "bonus": {
@@ -260,11 +260,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 90450
+            "value": 90450000
           }
         ]
       },
-      "research_time": 8073
+      "research_time": 8073660
     },
     {
       "bonus": {
@@ -304,11 +304,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 134800
+            "value": 134800000
           }
         ]
       },
-      "research_time": 12610
+      "research_time": 12610500
     },
     {
       "bonus": {
@@ -341,11 +341,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 195600
+            "value": 195600000
           }
         ]
       },
-      "research_time": 17603
+      "research_time": 17603280
     },
     {
       "bonus": {
@@ -380,11 +380,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 297900
+            "value": 297900000
           }
         ]
       },
-      "research_time": 23360
+      "research_time": 23360460
     },
     {
       "bonus": {
@@ -413,11 +413,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 424800
+            "value": 424800000
           }
         ]
       },
-      "research_time": 30654
+      "research_time": 30654240
     }
   ],
   "location": {

--- a/research/explorers_focus.json
+++ b/research/explorers_focus.json
@@ -74,7 +74,7 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1340
+            "value": 1340000
           }
         ]
       },
@@ -100,7 +100,7 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 3000
+            "value": 3000000
           }
         ]
       },
@@ -126,11 +126,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 4650
+            "value": 4650000
           }
         ]
       },
-      "research_time": 1449
+      "research_time": 1449420
     },
     {
       "bonus": {
@@ -152,11 +152,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 11100
+            "value": 11100000
           }
         ]
       },
-      "research_time": 2600
+      "research_time": 2600040
     },
     {
       "bonus": {
@@ -178,11 +178,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 16600
+            "value": 16600000
           }
         ]
       },
-      "research_time": 3499
+      "research_time": 3499500
     },
     {
       "bonus": {
@@ -204,11 +204,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 38650
+            "value": 38650000
           }
         ]
       },
-      "research_time": 5965
+      "research_time": 5965920
     },
     {
       "bonus": {
@@ -249,11 +249,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 65800
+            "value": 65800000
           }
         ]
       },
-      "research_time": 8058
+      "research_time": 8058720
     },
     {
       "bonus": {

--- a/research/factory_line.json
+++ b/research/factory_line.json
@@ -47,7 +47,7 @@
         ],
         "resources": []
       },
-      "research_time": 13456
+      "research_time": 13456140
     },
     {
       "bonus": {
@@ -81,7 +81,7 @@
         ],
         "resources": []
       },
-      "research_time": 21017
+      "research_time": 21017460
     },
     {
       "bonus": {
@@ -111,7 +111,7 @@
         ],
         "resources": []
       },
-      "research_time": 29338
+      "research_time": 29338800
     },
     {
       "bonus": {
@@ -146,7 +146,7 @@
         ],
         "resources": []
       },
-      "research_time": 38934
+      "research_time": 38934120
     },
     {
       "bonus": {
@@ -175,12 +175,12 @@
           },
           {
             "type": "Service\u00a0Award",
-            "value": 1259
+            "value": 1259626
           }
         ],
         "resources": []
       },
-      "research_time": 51090
+      "research_time": 51090420
     },
     {
       "bonus": {
@@ -222,12 +222,12 @@
           },
           {
             "type": "Service\u00a0Award",
-            "value": 1796
+            "value": 1796553
           }
         ],
         "resources": []
       },
-      "research_time": 68900
+      "research_time": 68900340
     },
     {
       "bonus": {
@@ -252,7 +252,7 @@
         "others": [
           {
             "type": "Service\u00a0Award",
-            "value": 2669
+            "value": 2669728
           },
           {
             "type": "Merit\u00a0of\u00a0Honor",
@@ -261,7 +261,7 @@
         ],
         "resources": []
       },
-      "research_time": 88888
+      "research_time": 88888440
     },
     {
       "bonus": {
@@ -287,7 +287,7 @@
         "others": [
           {
             "type": "Service\u00a0Award",
-            "value": 4412
+            "value": 4412607
           },
           {
             "type": "Merit\u00a0of\u00a0Honor",
@@ -296,7 +296,7 @@
         ],
         "resources": []
       },
-      "research_time": 113694
+      "research_time": 113694240
     },
     {
       "bonus": {
@@ -325,12 +325,12 @@
           },
           {
             "type": "Service\u00a0Award",
-            "value": 7673
+            "value": 7673146
           }
         ],
         "resources": []
       },
-      "research_time": 150563
+      "research_time": 150563760
     },
     {
       "bonus": {
@@ -356,7 +356,7 @@
         "others": [
           {
             "type": "Service\u00a0Award",
-            "value": 12766
+            "value": 12766604
           },
           {
             "type": "Merit\u00a0of\u00a0Honor",
@@ -365,7 +365,7 @@
         ],
         "resources": []
       },
-      "research_time": 189523
+      "research_time": 189523500
     }
   ],
   "location": {

--- a/research/federation_apprentice.json
+++ b/research/federation_apprentice.json
@@ -29,7 +29,7 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 2320
+            "value": 2320000
           }
         ]
       },
@@ -66,7 +66,7 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 3730
+            "value": 3730000
           }
         ]
       },
@@ -99,11 +99,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 5560
+            "value": 5560000
           }
         ]
       },
-      "research_time": 1300
+      "research_time": 1300020
     },
     {
       "bonus": {
@@ -136,11 +136,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 8290
+            "value": 8290000
           }
         ]
       },
-      "research_time": 1749
+      "research_time": 1749780
     },
     {
       "bonus": {
@@ -169,11 +169,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 12200
+            "value": 12200000
           }
         ]
       },
-      "research_time": 1741
+      "research_time": 1741980
     },
     {
       "bonus": {
@@ -206,11 +206,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 19300
+            "value": 19300000
           }
         ]
       },
-      "research_time": 2982
+      "research_time": 2982960
     },
     {
       "bonus": {
@@ -239,11 +239,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 32900
+            "value": 32900000
           }
         ]
       },
-      "research_time": 4029
+      "research_time": 4029360
     },
     {
       "bonus": {
@@ -276,11 +276,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 52000
+            "value": 52000000
           }
         ]
       },
-      "research_time": 7062
+      "research_time": 7062720
     },
     {
       "bonus": {
@@ -309,11 +309,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 75400
+            "value": 75400000
           }
         ]
       },
-      "research_time": 6728
+      "research_time": 6728040
     },
     {
       "bonus": {
@@ -361,7 +361,7 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1020
+            "value": 1020000
           }
         ]
       },

--- a/research/federation_armada_defects.json
+++ b/research/federation_armada_defects.json
@@ -48,11 +48,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 3990
+            "value": 3990000000
           }
         ]
       },
-      "research_time": 150563
+      "research_time": 150563760
     }
   ],
   "location": {

--- a/research/federation_demolition.json
+++ b/research/federation_demolition.json
@@ -39,7 +39,7 @@
         ],
         "resources": []
       },
-      "research_time": 15537
+      "research_time": 15537960
     },
     {
       "bonus": {
@@ -73,7 +73,7 @@
         ],
         "resources": []
       },
-      "research_time": 14801
+      "research_time": 14801760
     },
     {
       "bonus": {
@@ -103,7 +103,7 @@
         ],
         "resources": []
       },
-      "research_time": 23119
+      "research_time": 23119200
     },
     {
       "bonus": {
@@ -137,7 +137,7 @@
         ],
         "resources": []
       },
-      "research_time": 32272
+      "research_time": 32272680
     },
     {
       "bonus": {
@@ -162,7 +162,7 @@
         "others": [
           {
             "type": "Service\u00a0Award",
-            "value": 1259
+            "value": 1259626
           },
           {
             "type": "Merit\u00a0of\u00a0Honor",
@@ -171,7 +171,7 @@
         ],
         "resources": []
       },
-      "research_time": 56199
+      "research_time": 56199420
     },
     {
       "bonus": {
@@ -201,7 +201,7 @@
         ],
         "resources": []
       },
-      "research_time": 42827
+      "research_time": 42827580
     },
     {
       "bonus": {
@@ -230,12 +230,12 @@
           },
           {
             "type": "Service\u00a0Award",
-            "value": 2669
+            "value": 2669728
           }
         ],
         "resources": []
       },
-      "research_time": 97777
+      "research_time": 97777320
     },
     {
       "bonus": {
@@ -264,12 +264,12 @@
           },
           {
             "type": "Service\u00a0Award",
-            "value": 4412
+            "value": 4412607
           }
         ],
         "resources": []
       },
-      "research_time": 125063
+      "research_time": 125063640
     },
     {
       "bonus": {
@@ -298,12 +298,12 @@
           },
           {
             "type": "Service\u00a0Award",
-            "value": 7673
+            "value": 7673146
           }
         ],
         "resources": []
       },
-      "research_time": 165620
+      "research_time": 165620100
     },
     {
       "bonus": {
@@ -328,7 +328,7 @@
         "others": [
           {
             "type": "Service\u00a0Award",
-            "value": 12766
+            "value": 12766604
           },
           {
             "type": "Merit\u00a0of\u00a0Honor",
@@ -337,7 +337,7 @@
         ],
         "resources": []
       },
-      "research_time": 208475
+      "research_time": 208475820
     }
   ],
   "location": {

--- a/research/federation_devotion.json
+++ b/research/federation_devotion.json
@@ -70,11 +70,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1020
+            "value": 1020000
           }
         ]
       },
-      "research_time": 1330
+      "research_time": 1330800
     },
     {
       "bonus": {
@@ -107,11 +107,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 2320
+            "value": 2320000
           }
         ]
       },
-      "research_time": 2029
+      "research_time": 2029200
     },
     {
       "bonus": {
@@ -144,11 +144,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 5560
+            "value": 5560000
           }
         ]
       },
-      "research_time": 3640
+      "research_time": 3640080
     },
     {
       "bonus": {
@@ -181,11 +181,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 12200
+            "value": 12200000
           }
         ]
       },
-      "research_time": 4877
+      "research_time": 4877580
     },
     {
       "bonus": {
@@ -218,11 +218,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 32900
+            "value": 32900000
           }
         ]
       },
-      "research_time": 11282
+      "research_time": 11282220
     },
     {
       "bonus": {
@@ -255,11 +255,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 75400
+            "value": 75400000
           }
         ]
       },
-      "research_time": 18838
+      "research_time": 18838560
     },
     {
       "bonus": {
@@ -292,11 +292,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 163000
+            "value": 163000000
           }
         ]
       },
-      "research_time": 41074
+      "research_time": 41074320
     },
     {
       "bonus": {
@@ -329,11 +329,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 354000
+            "value": 354000000
           }
         ]
       },
-      "research_time": 71526
+      "research_time": 71526540
     },
     {
       "bonus": {

--- a/research/federation_firepower.json
+++ b/research/federation_firepower.json
@@ -45,11 +45,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 77300
+            "value": 77300000
           }
         ]
       },
-      "research_time": 14914
+      "research_time": 14914860
     },
     {
       "bonus": {
@@ -82,11 +82,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 207900
+            "value": 207900000
           }
         ]
       },
-      "research_time": 35313
+      "research_time": 35313540
     },
     {
       "bonus": {
@@ -131,11 +131,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 449400
+            "value": 449400000
           }
         ]
       },
-      "research_time": 52543
+      "research_time": 52543680
     },
     {
       "bonus": {
@@ -190,11 +190,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 75000
+            "value": 75000000
           }
         ]
       },
-      "research_time": 4844
+      "research_time": 4844760
     },
     {
       "bonus": {
@@ -239,11 +239,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 33150
+            "value": 33150000
           }
         ]
       },
-      "research_time": 8748
+      "research_time": 8748780
     }
   ],
   "location": {

--- a/research/federation_gas_miner.json
+++ b/research/federation_gas_miner.json
@@ -33,11 +33,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 18250
+            "value": 18250000
           }
         ]
       },
-      "research_time": 6299
+      "research_time": 6299160
     },
     {
       "bonus": {
@@ -70,11 +70,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 42500
+            "value": 42500000
           }
         ]
       },
-      "research_time": 10738
+      "research_time": 10738680
     },
     {
       "bonus": {
@@ -107,11 +107,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 114300
+            "value": 114300000
           }
         ]
       },
-      "research_time": 25425
+      "research_time": 25425720
     },
     {
       "bonus": {
@@ -144,11 +144,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 247200
+            "value": 247200000
           }
         ]
       },
-      "research_time": 37831
+      "research_time": 37831440
     },
     {
       "bonus": {
@@ -181,11 +181,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 546200
+            "value": 546200000
           }
         ]
       },
-      "research_time": 70081
+      "research_time": 70081440
     },
     {
       "bonus": {
@@ -218,11 +218,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1086
+            "value": 1086000000
           }
         ]
       },
-      "research_time": 124020
+      "research_time": 124020600
     },
     {
       "bonus": {
@@ -255,11 +255,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1480
+            "value": 1480000
           }
         ]
       },
-      "research_time": 1333
+      "research_time": 1333800
     },
     {
       "bonus": {
@@ -292,11 +292,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 3300
+            "value": 3300000
           }
         ]
       },
-      "research_time": 1761
+      "research_time": 1761360
     },
     {
       "bonus": {
@@ -329,11 +329,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 8200
+            "value": 8200000
           }
         ]
       },
-      "research_time": 3488
+      "research_time": 3488220
     },
     {
       "bonus": {
@@ -379,7 +379,7 @@
           }
         ]
       },
-      "research_time": 1039
+      "research_time": 1039980
     }
   ],
   "location": {

--- a/research/federation_graviton_shields.json
+++ b/research/federation_graviton_shields.json
@@ -30,7 +30,7 @@
         ],
         "resources": []
       },
-      "research_time": 1937
+      "research_time": 1937880
     },
     {
       "bonus": {
@@ -60,7 +60,7 @@
         ],
         "resources": []
       },
-      "research_time": 2600
+      "research_time": 2600040
     },
     {
       "bonus": {
@@ -91,7 +91,7 @@
         ],
         "resources": []
       },
-      "research_time": 3499
+      "research_time": 3499500
     },
     {
       "bonus": {
@@ -126,7 +126,7 @@
         ],
         "resources": []
       },
-      "research_time": 3483
+      "research_time": 3483960
     },
     {
       "bonus": {
@@ -157,7 +157,7 @@
         ],
         "resources": []
       },
-      "research_time": 5965
+      "research_time": 5965920
     },
     {
       "bonus": {
@@ -192,7 +192,7 @@
         ],
         "resources": []
       },
-      "research_time": 8058
+      "research_time": 8058720
     },
     {
       "bonus": {
@@ -231,7 +231,7 @@
         ],
         "resources": []
       },
-      "research_time": 14125
+      "research_time": 14125380
     },
     {
       "bonus": {
@@ -266,7 +266,7 @@
         ],
         "resources": []
       },
-      "research_time": 13456
+      "research_time": 13456140
     },
     {
       "bonus": {
@@ -300,7 +300,7 @@
         ],
         "resources": []
       },
-      "research_time": 21017
+      "research_time": 21017460
     },
     {
       "bonus": {

--- a/research/federation_hauler.json
+++ b/research/federation_hauler.json
@@ -39,7 +39,7 @@
         ],
         "resources": []
       },
-      "research_time": 16147
+      "research_time": 16147380
     },
     {
       "bonus": {
@@ -73,7 +73,7 @@
         ],
         "resources": []
       },
-      "research_time": 25221
+      "research_time": 25221000
     },
     {
       "bonus": {
@@ -112,7 +112,7 @@
         ],
         "resources": []
       },
-      "research_time": 35206
+      "research_time": 35206560
     },
     {
       "bonus": {
@@ -147,7 +147,7 @@
         ],
         "resources": []
       },
-      "research_time": 46720
+      "research_time": 46720980
     },
     {
       "bonus": {
@@ -172,12 +172,12 @@
           },
           {
             "type": "Service\u00a0Award",
-            "value": 1259
+            "value": 1259626
           }
         ],
         "resources": []
       },
-      "research_time": 61308
+      "research_time": 61308480
     },
     {
       "bonus": {
@@ -206,12 +206,12 @@
           },
           {
             "type": "Service\u00a0Award",
-            "value": 1796
+            "value": 1796553
           }
         ],
         "resources": []
       },
-      "research_time": 82680
+      "research_time": 82680420
     },
     {
       "bonus": {
@@ -236,12 +236,12 @@
           },
           {
             "type": "Service\u00a0Award",
-            "value": 2669
+            "value": 2669728
           }
         ],
         "resources": []
       },
-      "research_time": 106666
+      "research_time": 106666140
     },
     {
       "bonus": {
@@ -270,12 +270,12 @@
           },
           {
             "type": "Service\u00a0Award",
-            "value": 4412
+            "value": 4412607
           }
         ],
         "resources": []
       },
-      "research_time": 136433
+      "research_time": 136433100
     },
     {
       "bonus": {
@@ -300,12 +300,12 @@
           },
           {
             "type": "Service\u00a0Award",
-            "value": 7673
+            "value": 7673146
           }
         ],
         "resources": []
       },
-      "research_time": 180676
+      "research_time": 180676500
     },
     {
       "bonus": {
@@ -334,12 +334,12 @@
           },
           {
             "type": "Service\u00a0Award",
-            "value": 12766
+            "value": 12766604
           }
         ],
         "resources": []
       },
-      "research_time": 227428
+      "research_time": 227428200
     }
   ],
   "location": {

--- a/research/federation_notoriety.json
+++ b/research/federation_notoriety.json
@@ -30,7 +30,7 @@
         ],
         "resources": []
       },
-      "research_time": 2449
+      "research_time": 2449680
     },
     {
       "bonus": {
@@ -60,7 +60,7 @@
         ],
         "resources": []
       },
-      "research_time": 2438
+      "research_time": 2438820
     },
     {
       "bonus": {
@@ -90,7 +90,7 @@
         ],
         "resources": []
       },
-      "research_time": 4176
+      "research_time": 4176180
     },
     {
       "bonus": {
@@ -120,7 +120,7 @@
         ],
         "resources": []
       },
-      "research_time": 5641
+      "research_time": 5641140
     },
     {
       "bonus": {
@@ -154,7 +154,7 @@
         ],
         "resources": []
       },
-      "research_time": 9887
+      "research_time": 9887760
     },
     {
       "bonus": {
@@ -188,7 +188,7 @@
         ],
         "resources": []
       },
-      "research_time": 9419
+      "research_time": 9419280
     },
     {
       "bonus": {
@@ -227,7 +227,7 @@
         ],
         "resources": []
       },
-      "research_time": 14712
+      "research_time": 14712240
     },
     {
       "bonus": {
@@ -261,7 +261,7 @@
         ],
         "resources": []
       },
-      "research_time": 20537
+      "research_time": 20537160
     },
     {
       "bonus": {
@@ -291,7 +291,7 @@
         ],
         "resources": []
       },
-      "research_time": 27253
+      "research_time": 27253920
     },
     {
       "bonus": {
@@ -326,7 +326,7 @@
         ],
         "resources": []
       },
-      "research_time": 1820
+      "research_time": 1820040
     }
   ],
   "location": {

--- a/research/federation_pure_gas.json
+++ b/research/federation_pure_gas.json
@@ -33,15 +33,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 99700
+            "value": 99700000
           },
           {
             "type": "dilithium",
-            "value": 24450
+            "value": 24450000
           }
         ]
       },
-      "research_time": 5574
+      "research_time": 5574360
     },
     {
       "bonus": {
@@ -74,15 +74,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 45350
+            "value": 45350000
           },
           {
             "type": "dilithium",
-            "value": 11100
+            "value": 11100000
           }
         ]
       },
-      "research_time": 4160
+      "research_time": 4160100
     },
     {
       "bonus": {
@@ -115,15 +115,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 268500
+            "value": 268500000
           },
           {
             "type": "dilithium",
-            "value": 65800
+            "value": 65800000
           }
         ]
       },
-      "research_time": 12893
+      "research_time": 12893940
     },
     {
       "bonus": {
@@ -156,15 +156,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 615100
+            "value": 615100000
           },
           {
             "type": "dilithium",
-            "value": 150800
+            "value": 150800000
           }
         ]
       },
-      "research_time": 21529
+      "research_time": 21529800
     },
     {
       "bonus": {
@@ -197,15 +197,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1330
+            "value": 1330000000
           },
           {
             "type": "dilithium",
-            "value": 326000
+            "value": 326000000
           }
         ]
       },
-      "research_time": 46942
+      "research_time": 46942080
     },
     {
       "bonus": {
@@ -238,15 +238,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 2889
+            "value": 2889000000
           },
           {
             "type": "dilithium",
-            "value": 708000
+            "value": 708000000
           }
         ]
       },
-      "research_time": 81744
+      "research_time": 81744660
     },
     {
       "bonus": {
@@ -279,15 +279,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 5957
+            "value": 5957000000
           },
           {
             "type": "dilithium",
-            "value": 1460
+            "value": 1460000000
           }
         ]
       },
-      "research_time": 142221
+      "research_time": 142221540
     },
     {
       "bonus": {
@@ -324,7 +324,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 3530
+            "value": 3530000
           },
           {
             "type": "dilithium",
@@ -332,7 +332,7 @@
           }
         ]
       },
-      "research_time": 1039
+      "research_time": 1039440
     },
     {
       "bonus": {
@@ -365,15 +365,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 8340
+            "value": 8340000
           },
           {
             "type": "dilithium",
-            "value": 2040
+            "value": 2040000
           }
         ]
       },
-      "research_time": 1520
+      "research_time": 1520880
     },
     {
       "bonus": {
@@ -406,15 +406,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 18950
+            "value": 18950000
           },
           {
             "type": "dilithium",
-            "value": 4650
+            "value": 4650000
           }
         ]
       },
-      "research_time": 2319
+      "research_time": 2319120
     }
   ],
   "location": {

--- a/research/federation_repair_costs.json
+++ b/research/federation_repair_costs.json
@@ -54,15 +54,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 5470
+            "value": 5470000
           },
           {
             "type": "dilithium",
-            "value": 1480
+            "value": 1480000
           }
         ]
       },
-      "research_time": 1333
+      "research_time": 1333800
     },
     {
       "bonus": {
@@ -107,15 +107,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 12250
+            "value": 12250000
           },
           {
             "type": "dilithium",
-            "value": 3300
+            "value": 3300000
           }
         ]
       },
-      "research_time": 1761
+      "research_time": 1761360
     },
     {
       "bonus": {
@@ -141,15 +141,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 30400
+            "value": 30400000
           },
           {
             "type": "dilithium",
-            "value": 8200
+            "value": 8200000
           }
         ]
       },
-      "research_time": 3488
+      "research_time": 3488220
     },
     {
       "bonus": {
@@ -194,15 +194,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 67650
+            "value": 67650000
           },
           {
             "type": "dilithium",
-            "value": 18250
+            "value": 18250000
           }
         ]
       },
-      "research_time": 6299
+      "research_time": 6299160
     },
     {
       "bonus": {
@@ -247,15 +247,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 157700
+            "value": 157700000
           },
           {
             "type": "dilithium",
-            "value": 42500
+            "value": 42500000
           }
         ]
       },
-      "research_time": 10738
+      "research_time": 10738680
     },
     {
       "bonus": {
@@ -288,15 +288,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 424100
+            "value": 424100000
           },
           {
             "type": "dilithium",
-            "value": 114300
+            "value": 114300000
           }
         ]
       },
-      "research_time": 25425
+      "research_time": 25425720
     },
     {
       "bonus": {
@@ -341,15 +341,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 916800
+            "value": 916800000
           },
           {
             "type": "dilithium",
-            "value": 247200
+            "value": 247200000
           }
         ]
       },
-      "research_time": 37831
+      "research_time": 37831440
     },
     {
       "bonus": {
@@ -394,15 +394,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 2026
+            "value": 2026000000
           },
           {
             "type": "dilithium",
-            "value": 546200
+            "value": 546200000
           }
         ]
       },
-      "research_time": 70081
+      "research_time": 70081440
     },
     {
       "bonus": {
@@ -447,15 +447,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 4028
+            "value": 4028000000
           },
           {
             "type": "dilithium",
-            "value": 1086
+            "value": 1086000000
           }
         ]
       },
-      "research_time": 124020
+      "research_time": 124020600
     },
     {
       "bonus": {
@@ -500,15 +500,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 9621
+            "value": 9621000000
           },
           {
             "type": "dilithium",
-            "value": 2594
+            "value": 2594000000
           }
         ]
       },
-      "research_time": 204649
+      "research_time": 204649620
     }
   ],
   "location": {

--- a/research/federation_repair_speed.json
+++ b/research/federation_repair_speed.json
@@ -49,15 +49,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 45350
+            "value": 45350000
           },
           {
             "type": "dilithium",
-            "value": 22200
+            "value": 22200000
           }
         ]
       },
-      "research_time": 6500
+      "research_time": 6500100
     },
     {
       "bonus": {
@@ -102,15 +102,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 99700
+            "value": 99700000
           },
           {
             "type": "dilithium",
-            "value": 48850
+            "value": 48850000
           }
         ]
       },
-      "research_time": 8709
+      "research_time": 8709960
     },
     {
       "bonus": {
@@ -155,15 +155,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 268500
+            "value": 268500000
           },
           {
             "type": "dilithium",
-            "value": 131600
+            "value": 131600000
           }
         ]
       },
-      "research_time": 20146
+      "research_time": 20146800
     },
     {
       "bonus": {
@@ -196,15 +196,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 615100
+            "value": 615100000
           },
           {
             "type": "dilithium",
-            "value": 301500
+            "value": 301500000
           }
         ]
       },
-      "research_time": 33640
+      "research_time": 33640320
     },
     {
       "bonus": {
@@ -249,15 +249,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1330
+            "value": 1330000000
           },
           {
             "type": "dilithium",
-            "value": 652000
+            "value": 652000000
           }
         ]
       },
-      "research_time": 73347
+      "research_time": 73347000
     },
     {
       "bonus": {
@@ -302,15 +302,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 2889
+            "value": 2889000000
           },
           {
             "type": "dilithium",
-            "value": 1416
+            "value": 1416000000
           }
         ]
       },
-      "research_time": 127726
+      "research_time": 127726020
     },
     {
       "bonus": {
@@ -355,15 +355,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 5957
+            "value": 5957000000
           },
           {
             "type": "dilithium",
-            "value": 2920
+            "value": 2920000000
           }
         ]
       },
-      "research_time": 222221
+      "research_time": 222221100
     },
     {
       "bonus": {
@@ -408,15 +408,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 16279
+            "value": 16279000000
           },
           {
             "type": "dilithium",
-            "value": 7980
+            "value": 7980000000
           }
         ]
       },
-      "research_time": 376409
+      "research_time": 376409340
     },
     {
       "bonus": {
@@ -442,15 +442,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 44018
+            "value": 44018000000
           },
           {
             "type": "dilithium",
-            "value": 21578
+            "value": 21578000000
           }
         ]
       },
-      "research_time": 577916
+      "research_time": 577916820
     },
     {
       "bonus": {
@@ -476,15 +476,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 60244
+            "value": 60244000000
           },
           {
             "type": "dilithium",
-            "value": 29531
+            "value": 29531000000
           }
         ]
       },
-      "research_time": 511432
+      "research_time": 511432980
     }
   ],
   "location": {

--- a/research/federation_ship_structure.json
+++ b/research/federation_ship_structure.json
@@ -39,7 +39,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1500
+            "value": 1500000
           },
           {
             "type": "dilithium",
@@ -86,7 +86,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 3530
+            "value": 3530000
           },
           {
             "type": "dilithium",
@@ -139,15 +139,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 8340
+            "value": 8340000
           },
           {
             "type": "dilithium",
-            "value": 2040
+            "value": 2040000
           }
         ]
       },
-      "research_time": 1330
+      "research_time": 1330800
     },
     {
       "bonus": {
@@ -192,15 +192,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 18950
+            "value": 18950000
           },
           {
             "type": "dilithium",
-            "value": 4650
+            "value": 4650000
           }
         ]
       },
-      "research_time": 2029
+      "research_time": 2029200
     },
     {
       "bonus": {
@@ -245,15 +245,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 45350
+            "value": 45350000
           },
           {
             "type": "dilithium",
-            "value": 11100
+            "value": 11100000
           }
         ]
       },
-      "research_time": 3640
+      "research_time": 3640080
     },
     {
       "bonus": {
@@ -298,15 +298,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 99700
+            "value": 99700000
           },
           {
             "type": "dilithium",
-            "value": 24450
+            "value": 24450000
           }
         ]
       },
-      "research_time": 4877
+      "research_time": 4877580
     },
     {
       "bonus": {
@@ -351,15 +351,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 268500
+            "value": 268500000
           },
           {
             "type": "dilithium",
-            "value": 65800
+            "value": 65800000
           }
         ]
       },
-      "research_time": 11282
+      "research_time": 11282220
     },
     {
       "bonus": {
@@ -398,15 +398,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 615100
+            "value": 615100000
           },
           {
             "type": "dilithium",
-            "value": 150800
+            "value": 150800000
           }
         ]
       },
-      "research_time": 18838
+      "research_time": 18838560
     },
     {
       "bonus": {
@@ -451,15 +451,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1330
+            "value": 1330000000
           },
           {
             "type": "dilithium",
-            "value": 326000
+            "value": 326000000
           }
         ]
       },
-      "research_time": 41074
+      "research_time": 41074320
     },
     {
       "bonus": {

--- a/research/federation_vulnerability.json
+++ b/research/federation_vulnerability.json
@@ -50,11 +50,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 9214
+            "value": 9214000000
           }
         ]
       },
-      "research_time": 246380
+      "research_time": 246380520
     }
   ],
   "location": {

--- a/research/federation_weakpoints.json
+++ b/research/federation_weakpoints.json
@@ -46,7 +46,7 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1120
+            "value": 1120000
           }
         ]
       },
@@ -91,11 +91,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 2660
+            "value": 2660000
           }
         ]
       },
-      "research_time": 1235
+      "research_time": 1235700
     },
     {
       "bonus": {
@@ -136,11 +136,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 3900
+            "value": 3900000
           }
         ]
       },
-      "research_time": 1272
+      "research_time": 1272060
     },
     {
       "bonus": {
@@ -162,11 +162,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 9690
+            "value": 9690000
           }
         ]
       },
-      "research_time": 2519
+      "research_time": 2519280
     },
     {
       "bonus": {
@@ -207,11 +207,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 14450
+            "value": 14450000
           }
         ]
       },
-      "research_time": 3380
+      "research_time": 3380040
     },
     {
       "bonus": {
@@ -252,11 +252,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 31750
+            "value": 31750000
           }
         ]
       },
-      "research_time": 4529
+      "research_time": 4529160
     },
     {
       "bonus": {
@@ -278,11 +278,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 50250
+            "value": 50250000
           }
         ]
       },
-      "research_time": 7755
+      "research_time": 7755720
     },
     {
       "bonus": {
@@ -311,11 +311,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 135100
+            "value": 135100000
           }
         ]
       },
-      "research_time": 18363
+      "research_time": 18363000
     },
     {
       "bonus": {
@@ -350,11 +350,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 196000
+            "value": 196000000
           }
         ]
       },
-      "research_time": 17492
+      "research_time": 17492940
     },
     {
       "bonus": {

--- a/research/fighting_dirty.json
+++ b/research/fighting_dirty.json
@@ -256,7 +256,7 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1210
+            "value": 1210000
           }
         ]
       },

--- a/research/fleet_commander.json
+++ b/research/fleet_commander.json
@@ -25,15 +25,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 3810
+            "value": 3810000
           },
           {
             "type": "dilithium",
-            "value": 1120
+            "value": 1120000
           }
         ]
       },
-      "research_time": 1011
+      "research_time": 1011120
     },
     {
       "increased_power": 66000,
@@ -70,15 +70,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 447500
+            "value": 447500000
           },
           {
             "type": "dilithium",
-            "value": 131600
+            "value": 131600000
           }
         ]
       },
-      "research_time": 14102
+      "research_time": 14102760
     },
     {
       "increased_power": 97000,
@@ -115,15 +115,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 16034
+            "value": 16034000000
           },
           {
             "type": "dilithium",
-            "value": 4716
+            "value": 4716000000
           }
         ]
       },
-      "research_time": 198964
+      "research_time": 198964920
     },
     {
       "increased_power": 725,

--- a/research/fortified_romulans.json
+++ b/research/fortified_romulans.json
@@ -73,15 +73,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 1070
+            "value": 1070000
           },
           {
             "type": "dilithium",
-            "value": 1340
+            "value": 1340000
           }
         ]
       },
-      "research_time": 1037
+      "research_time": 1037400
     },
     {
       "bonus": {
@@ -126,15 +126,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 2400
+            "value": 2400000
           },
           {
             "type": "dilithium",
-            "value": 3000
+            "value": 3000000
           }
         ]
       },
-      "research_time": 1369
+      "research_time": 1369920
     },
     {
       "bonus": {
@@ -160,15 +160,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 5960
+            "value": 5960000
           },
           {
             "type": "dilithium",
-            "value": 7460
+            "value": 7460000
           }
         ]
       },
-      "research_time": 2713
+      "research_time": 2713080
     },
     {
       "bonus": {
@@ -213,15 +213,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 13250
+            "value": 13250000
           },
           {
             "type": "dilithium",
-            "value": 16600
+            "value": 16600000
           }
         ]
       },
-      "research_time": 4899
+      "research_time": 4899360
     },
     {
       "bonus": {
@@ -266,15 +266,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 30900
+            "value": 30900000
           },
           {
             "type": "dilithium",
-            "value": 38650
+            "value": 38650000
           }
         ]
       },
-      "research_time": 8352
+      "research_time": 8352300
     },
     {
       "bonus": {
@@ -307,15 +307,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 83150
+            "value": 83150000
           },
           {
             "type": "dilithium",
-            "value": 104000
+            "value": 104000000
           }
         ]
       },
-      "research_time": 19775
+      "research_time": 19775580
     },
     {
       "bonus": {
@@ -360,15 +360,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 179800
+            "value": 179800000
           },
           {
             "type": "dilithium",
-            "value": 224700
+            "value": 224700000
           }
         ]
       },
-      "research_time": 29424
+      "research_time": 29424480
     },
     {
       "bonus": {
@@ -413,15 +413,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 397200
+            "value": 397200000
           },
           {
             "type": "dilithium",
-            "value": 496500
+            "value": 496500000
           }
         ]
       },
-      "research_time": 54507
+      "research_time": 54507780
     },
     {
       "bonus": {

--- a/research/frequency_modulator_cost_efficiency.json
+++ b/research/frequency_modulator_cost_efficiency.json
@@ -222,7 +222,7 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1100
+            "value": 1100000
           }
         ]
       },

--- a/research/g4_impulse.json
+++ b/research/g4_impulse.json
@@ -48,11 +48,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 337100
+            "value": 337100000
           }
         ]
       },
-      "research_time": 31526
+      "research_time": 31526220
     },
     {
       "bonus": {
@@ -100,11 +100,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 489000
+            "value": 489000000
           }
         ]
       },
-      "research_time": 44008
+      "research_time": 44008200
     },
     {
       "bonus": {
@@ -144,11 +144,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 744800
+            "value": 744800000
           }
         ]
       },
-      "research_time": 58401
+      "research_time": 58401240
     },
     {
       "bonus": {
@@ -196,11 +196,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1062
+            "value": 1062000000
           }
         ]
       },
-      "research_time": 76635
+      "research_time": 76635600
     },
     {
       "bonus": {
@@ -240,11 +240,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1481
+            "value": 1481000000
           }
         ]
       },
-      "research_time": 103350
+      "research_time": 103350540
     },
     {
       "bonus": {
@@ -296,11 +296,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 2190
+            "value": 2190000000
           }
         ]
       },
-      "research_time": 133332
+      "research_time": 133332660
     },
     {
       "bonus": {
@@ -344,11 +344,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 2628
+            "value": 2628000000
           }
         ]
       },
-      "research_time": 159999
+      "research_time": 159999240
     },
     {
       "bonus": {
@@ -392,11 +392,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 3537
+            "value": 3537000000
           }
         ]
       },
-      "research_time": 170541
+      "research_time": 170541360
     },
     {
       "bonus": {
@@ -440,11 +440,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 4244
+            "value": 4244400000
           }
         ]
       },
-      "research_time": 204649
+      "research_time": 204649620
     },
     {
       "bonus": {
@@ -496,11 +496,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 5985
+            "value": 5985000000
           }
         ]
       },
-      "research_time": 225845
+      "research_time": 225845580
     }
   ],
   "location": {

--- a/research/g4_ship_repairs.json
+++ b/research/g4_ship_repairs.json
@@ -52,15 +52,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 268500
+            "value": 268500000
           },
           {
             "type": "dilithium",
-            "value": 79000
+            "value": 79000000
           }
         ]
       },
-      "research_time": 12088
+      "research_time": 12088080
     },
     {
       "bonus": {
@@ -116,15 +116,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 424100
+            "value": 424100000
           },
           {
             "type": "dilithium",
-            "value": 124700
+            "value": 124700000
           }
         ]
       },
-      "research_time": 21188
+      "research_time": 21188100
     },
     {
       "bonus": {
@@ -180,15 +180,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 615100
+            "value": 615100000
           },
           {
             "type": "dilithium",
-            "value": 180900
+            "value": 180900000
           }
         ]
       },
-      "research_time": 20184
+      "research_time": 20184180
     },
     {
       "bonus": {
@@ -244,15 +244,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 916800
+            "value": 916800000
           },
           {
             "type": "dilithium",
-            "value": 269600
+            "value": 269600000
           }
         ]
       },
-      "research_time": 31526
+      "research_time": 31526220
     },
     {
       "bonus": {
@@ -308,15 +308,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1330
+            "value": 1330000000
           },
           {
             "type": "dilithium",
-            "value": 391200
+            "value": 391200000
           }
         ]
       },
-      "research_time": 44008
+      "research_time": 44008200
     },
     {
       "bonus": {
@@ -372,15 +372,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 2026
+            "value": 2026000000
           },
           {
             "type": "dilithium",
-            "value": 595800
+            "value": 595800000
           }
         ]
       },
-      "research_time": 58401
+      "research_time": 58401240
     },
     {
       "bonus": {
@@ -436,15 +436,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 2889
+            "value": 2889000000
           },
           {
             "type": "dilithium",
-            "value": 849600
+            "value": 849600000
           }
         ]
       },
-      "research_time": 76635
+      "research_time": 76635600
     },
     {
       "bonus": {
@@ -500,15 +500,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 4028
+            "value": 4028000000
           },
           {
             "type": "dilithium",
-            "value": 1185
+            "value": 1185000000
           }
         ]
       },
-      "research_time": 103350
+      "research_time": 103350540
     },
     {
       "bonus": {
@@ -564,15 +564,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 5957
+            "value": 5957000000
           },
           {
             "type": "dilithium",
-            "value": 1752
+            "value": 1752000000
           }
         ]
       },
-      "research_time": 133332
+      "research_time": 133332660
     },
     {
       "bonus": {
@@ -616,15 +616,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 9621
+            "value": 9621000000
           },
           {
             "type": "dilithium",
-            "value": 2830
+            "value": 2830000000
           }
         ]
       },
-      "research_time": 170541
+      "research_time": 170541360
     }
   ],
   "location": {

--- a/research/gas_building_efficiency.json
+++ b/research/gas_building_efficiency.json
@@ -38,15 +38,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 45350
+            "value": 45350000
           },
           {
             "type": "dilithium",
-            "value": 11100
+            "value": 11100000
           }
         ]
       },
-      "research_time": 2600
+      "research_time": 2600040
     },
     {
       "bonus": {
@@ -90,15 +90,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 99700
+            "value": 99700000
           },
           {
             "type": "dilithium",
-            "value": 24450
+            "value": 24450000
           }
         ]
       },
-      "research_time": 3483
+      "research_time": 3483960
     },
     {
       "bonus": {
@@ -146,15 +146,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 268500
+            "value": 268500000
           },
           {
             "type": "dilithium",
-            "value": 65800
+            "value": 65800000
           }
         ]
       },
-      "research_time": 8058
+      "research_time": 8058720
     },
     {
       "bonus": {
@@ -202,15 +202,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 615100
+            "value": 615100000
           },
           {
             "type": "dilithium",
-            "value": 150800
+            "value": 150800000
           }
         ]
       },
-      "research_time": 13456
+      "research_time": 13456140
     },
     {
       "bonus": {
@@ -254,15 +254,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 916800
+            "value": 916800000
           },
           {
             "type": "dilithium",
-            "value": 224700
+            "value": 224700000
           }
         ]
       },
-      "research_time": 21017
+      "research_time": 21017460
     },
     {
       "bonus": {
@@ -306,15 +306,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1330
+            "value": 1330000000
           },
           {
             "type": "dilithium",
-            "value": 326000
+            "value": 326000000
           }
         ]
       },
-      "research_time": 29338
+      "research_time": 29338800
     },
     {
       "bonus": {
@@ -358,15 +358,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 2026
+            "value": 2026000000
           },
           {
             "type": "dilithium",
-            "value": 496500
+            "value": 496500000
           }
         ]
       },
-      "research_time": 38934
+      "research_time": 38934120
     },
     {
       "bonus": {
@@ -410,15 +410,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 2889
+            "value": 2889000000
           },
           {
             "type": "dilithium",
-            "value": 708000
+            "value": 708000000
           }
         ]
       },
-      "research_time": 51090
+      "research_time": 51090420
     },
     {
       "bonus": {
@@ -462,15 +462,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 4028
+            "value": 4028000000
           },
           {
             "type": "dilithium",
-            "value": 987300
+            "value": 987300000
           }
         ]
       },
-      "research_time": 68900
+      "research_time": 68900340
     },
     {
       "bonus": {
@@ -508,11 +508,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 8340
+            "value": 8340000
           },
           {
             "type": "dilithium",
-            "value": 2040
+            "value": 2040000
           }
         ]
       },

--- a/research/gas_miner.json
+++ b/research/gas_miner.json
@@ -192,7 +192,7 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1480
+            "value": 1480000
           }
         ]
       },
@@ -234,11 +234,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 2250
+            "value": 2250000
           }
         ]
       },
-      "research_time": 1045
+      "research_time": 1045620
     },
     {
       "bonus": {
@@ -272,11 +272,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 5110
+            "value": 5110000
           }
         ]
       },
-      "research_time": 1594
+      "research_time": 1594380
     },
     {
       "bonus": {
@@ -309,11 +309,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 12200
+            "value": 12200000
           }
         ]
       },
-      "research_time": 2860
+      "research_time": 2860080
     },
     {
       "bonus": {
@@ -352,11 +352,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 26900
+            "value": 26900000
           }
         ]
       },
-      "research_time": 3832
+      "research_time": 3832380
     },
     {
       "bonus": {
@@ -394,11 +394,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 72400
+            "value": 72400000
           }
         ]
       },
-      "research_time": 8864
+      "research_time": 8864580
     },
     {
       "bonus": {

--- a/research/gas_research_efficiency.json
+++ b/research/gas_research_efficiency.json
@@ -42,11 +42,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 8340
+            "value": 8340000
           },
           {
             "type": "dilithium",
-            "value": 2040
+            "value": 2040000
           }
         ]
       },
@@ -98,15 +98,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 67650
+            "value": 67650000
           },
           {
             "type": "dilithium",
-            "value": 16600
+            "value": 16600000
           }
         ]
       },
-      "research_time": 3499
+      "research_time": 3499500
     },
     {
       "bonus": {
@@ -158,15 +158,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 157700
+            "value": 157700000
           },
           {
             "type": "dilithium",
-            "value": 38650
+            "value": 38650000
           }
         ]
       },
-      "research_time": 5965
+      "research_time": 5965920
     },
     {
       "bonus": {
@@ -218,15 +218,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 424100
+            "value": 424100000
           },
           {
             "type": "dilithium",
-            "value": 104000
+            "value": 104000000
           }
         ]
       },
-      "research_time": 14125
+      "research_time": 14125380
     },
     {
       "bonus": {
@@ -278,15 +278,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 615100
+            "value": 615100000
           },
           {
             "type": "dilithium",
-            "value": 150800
+            "value": 150800000
           }
         ]
       },
-      "research_time": 13456
+      "research_time": 13456140
     },
     {
       "bonus": {
@@ -330,15 +330,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 916800
+            "value": 916800000
           },
           {
             "type": "dilithium",
-            "value": 224700
+            "value": 224700000
           }
         ]
       },
-      "research_time": 21017
+      "research_time": 21017460
     },
     {
       "bonus": {
@@ -382,15 +382,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1330
+            "value": 1330000000
           },
           {
             "type": "dilithium",
-            "value": 326000
+            "value": 326000000
           }
         ]
       },
-      "research_time": 29338
+      "research_time": 29338800
     },
     {
       "bonus": {
@@ -434,15 +434,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 2026
+            "value": 2026000000
           },
           {
             "type": "dilithium",
-            "value": 496500
+            "value": 496500000
           }
         ]
       },
-      "research_time": 38934
+      "research_time": 38934120
     },
     {
       "bonus": {
@@ -486,15 +486,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 2889
+            "value": 2889000000
           },
           {
             "type": "dilithium",
-            "value": 708000
+            "value": 708000000
           }
         ]
       },
-      "research_time": 51090
+      "research_time": 51090420
     },
     {
       "bonus": {
@@ -525,15 +525,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 5957
+            "value": 5957000000
           },
           {
             "type": "dilithium",
-            "value": 1460
+            "value": 1460000000
           }
         ]
       },
-      "research_time": 88888
+      "research_time": 88888440
     }
   ],
   "location": {

--- a/research/getaway_pilots_ii.json
+++ b/research/getaway_pilots_ii.json
@@ -47,11 +47,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 150800
+            "value": 150800000
           }
         ]
       },
-      "research_time": 13456
+      "research_time": 13456140
     },
     {
       "bonus": {
@@ -94,11 +94,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 326000
+            "value": 326000000
           }
         ]
       },
-      "research_time": 29338
+      "research_time": 29338800
     },
     {
       "bonus": {
@@ -147,11 +147,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 708000
+            "value": 708000000
           }
         ]
       },
-      "research_time": 51090
+      "research_time": 51090420
     },
     {
       "bonus": {
@@ -204,11 +204,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1460
+            "value": 1460000000
           }
         ]
       },
-      "research_time": 88888
+      "research_time": 88888440
     },
     {
       "bonus": {
@@ -261,11 +261,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 3990
+            "value": 3990000000
           }
         ]
       },
-      "research_time": 150563
+      "research_time": 150563760
     }
   ],
   "location": {

--- a/research/grade_4_ship_research.json
+++ b/research/grade_4_ship_research.json
@@ -31,11 +31,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 98700
+            "value": 98700000
           }
         ]
       },
-      "research_time": 16117
+      "research_time": 16117440
     }
   ],
   "location": {

--- a/research/hideout_defenses.json
+++ b/research/hideout_defenses.json
@@ -65,15 +65,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 18950
+            "value": 18950000
           },
           {
             "type": "dilithium",
-            "value": 4650
+            "value": 4650000
           }
         ]
       },
-      "research_time": 1449
+      "research_time": 1449420
     },
     {
       "bonus": {
@@ -130,15 +130,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 30400
+            "value": 30400000
           },
           {
             "type": "dilithium",
-            "value": 7460
+            "value": 7460000
           }
         ]
       },
-      "research_time": 1937
+      "research_time": 1937880
     },
     {
       "bonus": {
@@ -199,15 +199,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 45350
+            "value": 45350000
           },
           {
             "type": "dilithium",
-            "value": 11100
+            "value": 11100000
           }
         ]
       },
-      "research_time": 2600
+      "research_time": 2600040
     },
     {
       "bonus": {
@@ -264,15 +264,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 67650
+            "value": 67650000
           },
           {
             "type": "dilithium",
-            "value": 16600
+            "value": 16600000
           }
         ]
       },
-      "research_time": 3499
+      "research_time": 3499500
     },
     {
       "bonus": {
@@ -325,15 +325,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 99700
+            "value": 99700000
           },
           {
             "type": "dilithium",
-            "value": 24450
+            "value": 24450000
           }
         ]
       },
-      "research_time": 3483
+      "research_time": 3483960
     },
     {
       "bonus": {
@@ -394,15 +394,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 157700
+            "value": 157700000
           },
           {
             "type": "dilithium",
-            "value": 38650
+            "value": 38650000
           }
         ]
       },
-      "research_time": 5965
+      "research_time": 5965920
     },
     {
       "bonus": {
@@ -459,11 +459,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 12250
+            "value": 12250000
           },
           {
             "type": "dilithium",
-            "value": 3000
+            "value": 3000000
           }
         ]
       },
@@ -509,11 +509,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 5470
+            "value": 5470000
           },
           {
             "type": "dilithium",
-            "value": 1340
+            "value": 1340000
           }
         ]
       },
@@ -570,11 +570,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 8340
+            "value": 8340000
           },
           {
             "type": "dilithium",
-            "value": 2040
+            "value": 2040000
           }
         ]
       },
@@ -635,7 +635,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1500
+            "value": 1500000
           },
           {
             "type": "dilithium",

--- a/research/hideout_weaponry.json
+++ b/research/hideout_weaponry.json
@@ -57,15 +57,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 18950
+            "value": 18950000
           },
           {
             "type": "dilithium",
-            "value": 4650
+            "value": 4650000
           }
         ]
       },
-      "research_time": 1449
+      "research_time": 1449420
     },
     {
       "bonus": {
@@ -122,15 +122,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 30400
+            "value": 30400000
           },
           {
             "type": "dilithium",
-            "value": 7460
+            "value": 7460000
           }
         ]
       },
-      "research_time": 1937
+      "research_time": 1937880
     },
     {
       "bonus": {
@@ -187,15 +187,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 45350
+            "value": 45350000
           },
           {
             "type": "dilithium",
-            "value": 11100
+            "value": 11100000
           }
         ]
       },
-      "research_time": 2600
+      "research_time": 2600040
     },
     {
       "bonus": {
@@ -252,15 +252,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 67650
+            "value": 67650000
           },
           {
             "type": "dilithium",
-            "value": 16600
+            "value": 16600000
           }
         ]
       },
-      "research_time": 3499
+      "research_time": 3499500
     },
     {
       "bonus": {
@@ -309,15 +309,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 99700
+            "value": 99700000
           },
           {
             "type": "dilithium",
-            "value": 24450
+            "value": 24450000
           }
         ]
       },
-      "research_time": 3483
+      "research_time": 3483960
     },
     {
       "bonus": {
@@ -374,15 +374,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 157700
+            "value": 157700000
           },
           {
             "type": "dilithium",
-            "value": 38650
+            "value": 38650000
           }
         ]
       },
-      "research_time": 5965
+      "research_time": 5965920
     },
     {
       "bonus": {
@@ -431,7 +431,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1500
+            "value": 1500000
           },
           {
             "type": "dilithium",
@@ -496,11 +496,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 12250
+            "value": 12250000
           },
           {
             "type": "dilithium",
-            "value": 3000
+            "value": 3000000
           }
         ]
       },
@@ -542,11 +542,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 5470
+            "value": 5470000
           },
           {
             "type": "dilithium",
-            "value": 1340
+            "value": 1340000
           }
         ]
       },
@@ -599,11 +599,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 8340
+            "value": 8340000
           },
           {
             "type": "dilithium",
-            "value": 2040
+            "value": 2040000
           }
         ]
       },

--- a/research/highway_robbery.json
+++ b/research/highway_robbery.json
@@ -167,7 +167,7 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1670
+            "value": 1670000
           }
         ]
       },
@@ -198,7 +198,7 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1999
+            "value": 1999800
           }
         ]
       },
@@ -234,7 +234,7 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 3670
+            "value": 3670000
           }
         ]
       },
@@ -265,7 +265,7 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 4398
+            "value": 4398300
           }
         ]
       },
@@ -304,11 +304,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 9870
+            "value": 9870000
           }
         ]
       },
-      "research_time": 1208
+      "research_time": 1208820
     },
     {
       "bonus": {
@@ -335,11 +335,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 11846
+            "value": 11846250
           }
         ]
       },
-      "research_time": 1450
+      "research_time": 1450560
     },
     {
       "bonus": {
@@ -371,11 +371,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 22600
+            "value": 22600000
           }
         ]
       },
-      "research_time": 2018
+      "research_time": 2018400
     },
     {
       "bonus": {
@@ -410,11 +410,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 48900
+            "value": 48900000
           }
         ]
       },
-      "research_time": 4400
+      "research_time": 4400820
     },
     {
       "bonus": {
@@ -441,11 +441,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 106200
+            "value": 106200000
           }
         ]
       },
-      "research_time": 7663
+      "research_time": 7663560
     },
     {
       "bonus": {
@@ -480,11 +480,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 219000
+            "value": 219000000
           }
         ]
       },
-      "research_time": 13333
+      "research_time": 13333260
     },
     {
       "bonus": {
@@ -511,11 +511,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 598500
+            "value": 598500000
           }
         ]
       },
-      "research_time": 22584
+      "research_time": 22584540
     }
   ],
   "location": {

--- a/research/hostile_tactics.json
+++ b/research/hostile_tactics.json
@@ -36,11 +36,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1110
+            "value": 1110000
           }
         ]
       },
-      "research_time": 2600
+      "research_time": 2600040
     },
     {
       "bonus": {
@@ -76,11 +76,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 2440
+            "value": 2440000
           }
         ]
       },
-      "research_time": 3483
+      "research_time": 3483960
     },
     {
       "bonus": {
@@ -116,11 +116,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 6580
+            "value": 6580000
           }
         ]
       },
-      "research_time": 8058
+      "research_time": 8058720
     },
     {
       "bonus": {
@@ -156,11 +156,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 15100
+            "value": 15100000
           }
         ]
       },
-      "research_time": 13456
+      "research_time": 13456140
     },
     {
       "bonus": {
@@ -196,11 +196,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 32600
+            "value": 32600000
           }
         ]
       },
-      "research_time": 29338
+      "research_time": 29338800
     },
     {
       "bonus": {
@@ -236,11 +236,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 70800
+            "value": 70800000
           }
         ]
       },
-      "research_time": 51090
+      "research_time": 51090420
     },
     {
       "bonus": {
@@ -276,11 +276,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 146000
+            "value": 146000000
           }
         ]
       },
-      "research_time": 88888
+      "research_time": 88888440
     },
     {
       "bonus": {
@@ -316,11 +316,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 399000
+            "value": 399000000
           }
         ]
       },
-      "research_time": 150563
+      "research_time": 150563760
     },
     {
       "bonus": {
@@ -546,7 +546,7 @@
           }
         ]
       },
-      "research_time": 1449
+      "research_time": 1449420
     },
     {
       "bonus": {

--- a/research/hull_durability.json
+++ b/research/hull_durability.json
@@ -40,11 +40,11 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 3000
+            "value": 3000000
           },
           {
             "type": "dilithium",
-            "value": 1800
+            "value": 1800000
           }
         ]
       },
@@ -87,15 +87,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 4650
+            "value": 4650000
           },
           {
             "type": "dilithium",
-            "value": 2790
+            "value": 2790000
           }
         ]
       },
-      "research_time": 1449
+      "research_time": 1449420
     },
     {
       "bonus": {
@@ -129,15 +129,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 7460
+            "value": 7460000
           },
           {
             "type": "dilithium",
-            "value": 4470
+            "value": 4470000
           }
         ]
       },
-      "research_time": 1937
+      "research_time": 1937880
     },
     {
       "bonus": {
@@ -181,15 +181,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 11100
+            "value": 11100000
           },
           {
             "type": "dilithium",
-            "value": 6670
+            "value": 6670000
           }
         ]
       },
-      "research_time": 2600
+      "research_time": 2600040
     },
     {
       "bonus": {
@@ -237,15 +237,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 16600
+            "value": 16600000
           },
           {
             "type": "dilithium",
-            "value": 9950
+            "value": 9950000
           }
         ]
       },
-      "research_time": 3499
+      "research_time": 3499500
     },
     {
       "bonus": {
@@ -283,15 +283,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 24450
+            "value": 24450000
           },
           {
             "type": "dilithium",
-            "value": 14650
+            "value": 14650000
           }
         ]
       },
-      "research_time": 3483
+      "research_time": 3483960
     },
     {
       "bonus": {
@@ -324,15 +324,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 38650
+            "value": 38650000
           },
           {
             "type": "dilithium",
-            "value": 23200
+            "value": 23200000
           }
         ]
       },
-      "research_time": 5965
+      "research_time": 5965920
     },
     {
       "bonus": {
@@ -363,15 +363,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 65800
+            "value": 65800000
           },
           {
             "type": "dilithium",
-            "value": 39500
+            "value": 39500000
           }
         ]
       },
-      "research_time": 8058
+      "research_time": 8058720
     },
     {
       "bonus": {
@@ -409,15 +409,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 104000
+            "value": 104000000
           },
           {
             "type": "dilithium",
-            "value": 62350
+            "value": 62350000
           }
         ]
       },
-      "research_time": 14125
+      "research_time": 14125380
     },
     {
       "bonus": {

--- a/research/hull_stability.json
+++ b/research/hull_stability.json
@@ -44,11 +44,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1110
+            "value": 1110000
           }
         ]
       },
-      "research_time": 2600
+      "research_time": 2600040
     },
     {
       "bonus": {
@@ -83,11 +83,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 10400
+            "value": 10400000
           }
         ]
       },
-      "research_time": 14125
+      "research_time": 14125380
     },
     {
       "bonus": {
@@ -122,11 +122,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 15100
+            "value": 15100000
           }
         ]
       },
-      "research_time": 13456
+      "research_time": 13456140
     },
     {
       "bonus": {
@@ -170,11 +170,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 22450
+            "value": 22450000
           }
         ]
       },
-      "research_time": 21017
+      "research_time": 21017460
     },
     {
       "bonus": {
@@ -209,11 +209,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 32600
+            "value": 32600000
           }
         ]
       },
-      "research_time": 29338
+      "research_time": 29338800
     },
     {
       "bonus": {
@@ -248,11 +248,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 49650
+            "value": 49650000
           }
         ]
       },
-      "research_time": 38934
+      "research_time": 38934120
     },
     {
       "bonus": {
@@ -287,11 +287,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 70800
+            "value": 70800000
           }
         ]
       },
-      "research_time": 51090
+      "research_time": 51090420
     },
     {
       "bonus": {
@@ -326,11 +326,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 98750
+            "value": 98750000
           }
         ]
       },
-      "research_time": 68900
+      "research_time": 68900340
     },
     {
       "bonus": {
@@ -365,11 +365,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 146000
+            "value": 146000000
           }
         ]
       },
-      "research_time": 88888
+      "research_time": 88888440
     },
     {
       "bonus": {
@@ -413,11 +413,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 399000
+            "value": 399000000
           }
         ]
       },
-      "research_time": 150563
+      "research_time": 150563760
     }
   ],
   "location": {

--- a/research/hypospray_technology.json
+++ b/research/hypospray_technology.json
@@ -39,7 +39,7 @@
         ],
         "resources": []
       },
-      "research_time": 8475
+      "research_time": 8475240
     },
     {
       "bonus": {
@@ -74,7 +74,7 @@
         ],
         "resources": []
       },
-      "research_time": 3579
+      "research_time": 3579540
     },
     {
       "bonus": {
@@ -144,7 +144,7 @@
         ],
         "resources": []
       },
-      "research_time": 1162
+      "research_time": 1162740
     },
     {
       "bonus": {
@@ -175,7 +175,7 @@
         ],
         "resources": []
       },
-      "research_time": 2099
+      "research_time": 2099700
     }
   ],
   "location": {

--- a/research/immovable_object.json
+++ b/research/immovable_object.json
@@ -53,11 +53,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 16650
+            "value": 16650000
           }
         ]
       },
-      "research_time": 3900
+      "research_time": 3900060
     },
     {
       "bonus": {
@@ -109,11 +109,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 98700
+            "value": 98700000
           }
         ]
       },
-      "research_time": 12088
+      "research_time": 12088080
     },
     {
       "bonus": {
@@ -165,11 +165,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 155900
+            "value": 155900000
           }
         ]
       },
-      "research_time": 21188
+      "research_time": 21188100
     },
     {
       "bonus": {
@@ -221,11 +221,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 226100
+            "value": 226100000
           }
         ]
       },
-      "research_time": 20184
+      "research_time": 20184180
     },
     {
       "bonus": {
@@ -277,11 +277,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 337100
+            "value": 337100000
           }
         ]
       },
-      "research_time": 31526
+      "research_time": 31526220
     },
     {
       "bonus": {
@@ -333,11 +333,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 489000
+            "value": 489000000
           }
         ]
       },
-      "research_time": 44008
+      "research_time": 44008200
     },
     {
       "bonus": {
@@ -389,11 +389,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 744800
+            "value": 744800000
           }
         ]
       },
-      "research_time": 58401
+      "research_time": 58401240
     },
     {
       "bonus": {
@@ -445,11 +445,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1062
+            "value": 1062000000
           }
         ]
       },
-      "research_time": 76635
+      "research_time": 76635600
     },
     {
       "bonus": {
@@ -501,11 +501,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1481
+            "value": 1481000000
           }
         ]
       },
-      "research_time": 103350
+      "research_time": 103350540
     },
     {
       "bonus": {
@@ -549,11 +549,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 2190
+            "value": 2190000000
           }
         ]
       },
-      "research_time": 133332
+      "research_time": 133332660
     }
   ],
   "location": {

--- a/research/infamy_and_heroism.json
+++ b/research/infamy_and_heroism.json
@@ -47,7 +47,7 @@
         ],
         "resources": []
       },
-      "research_time": 2080
+      "research_time": 2080020
     },
     {
       "bonus": {
@@ -81,7 +81,7 @@
         ],
         "resources": []
       },
-      "research_time": 6447
+      "research_time": 6447000
     },
     {
       "bonus": {
@@ -124,7 +124,7 @@
         ],
         "resources": []
       },
-      "research_time": 10764
+      "research_time": 10764900
     },
     {
       "bonus": {
@@ -167,7 +167,7 @@
         ],
         "resources": []
       },
-      "research_time": 23471
+      "research_time": 23471040
     },
     {
       "bonus": {
@@ -221,12 +221,12 @@
           },
           {
             "type": "Service\u00a0Award",
-            "value": 1259
+            "value": 1259626
           }
         ],
         "resources": []
       },
-      "research_time": 40872
+      "research_time": 40872300
     }
   ],
   "location": {

--- a/research/interceptor_advanced_piercing.json
+++ b/research/interceptor_advanced_piercing.json
@@ -30,7 +30,7 @@
         ],
         "resources": []
       },
-      "research_time": 8058
+      "research_time": 8058720
     },
     {
       "bonus": {
@@ -69,7 +69,7 @@
         ],
         "resources": []
       },
-      "research_time": 14125
+      "research_time": 14125380
     },
     {
       "bonus": {
@@ -104,7 +104,7 @@
         ],
         "resources": []
       },
-      "research_time": 13456
+      "research_time": 13456140
     },
     {
       "bonus": {
@@ -143,7 +143,7 @@
         ],
         "resources": []
       },
-      "research_time": 21017
+      "research_time": 21017460
     },
     {
       "bonus": {
@@ -178,7 +178,7 @@
         ],
         "resources": []
       },
-      "research_time": 29338
+      "research_time": 29338800
     },
     {
       "bonus": {
@@ -217,7 +217,7 @@
         ],
         "resources": []
       },
-      "research_time": 38934
+      "research_time": 38934120
     },
     {
       "bonus": {
@@ -247,12 +247,12 @@
           },
           {
             "type": "Service\u00a0Award",
-            "value": 1259
+            "value": 1259626
           }
         ],
         "resources": []
       },
-      "research_time": 51090
+      "research_time": 51090420
     },
     {
       "bonus": {
@@ -286,12 +286,12 @@
           },
           {
             "type": "Service\u00a0Award",
-            "value": 1796
+            "value": 1796553
           }
         ],
         "resources": []
       },
-      "research_time": 68900
+      "research_time": 68900340
     },
     {
       "bonus": {
@@ -321,12 +321,12 @@
           },
           {
             "type": "Service\u00a0Award",
-            "value": 2669
+            "value": 2669728
           }
         ],
         "resources": []
       },
-      "research_time": 88888
+      "research_time": 88888440
     },
     {
       "bonus": {
@@ -365,7 +365,7 @@
         ],
         "resources": []
       },
-      "research_time": 2600
+      "research_time": 2600040
     }
   ],
   "location": {

--- a/research/interceptor_armor_piercing.json
+++ b/research/interceptor_armor_piercing.json
@@ -31,15 +31,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 14650
+            "value": 14650000
           },
           {
             "type": "dilithium",
-            "value": 19550
+            "value": 19550000
           }
         ]
       },
-      "research_time": 2787
+      "research_time": 2787180
     },
     {
       "bonus": {
@@ -89,15 +89,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 23200
+            "value": 23200000
           },
           {
             "type": "dilithium",
-            "value": 30900
+            "value": 30900000
           }
         ]
       },
-      "research_time": 4772
+      "research_time": 4772760
     },
     {
       "bonus": {
@@ -249,11 +249,11 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 1800
+            "value": 1800000
           },
           {
             "type": "dilithium",
-            "value": 2400
+            "value": 2400000
           }
         ]
       },
@@ -288,15 +288,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 2790
+            "value": 2790000
           },
           {
             "type": "dilithium",
-            "value": 3720
+            "value": 3720000
           }
         ]
       },
-      "research_time": 1159
+      "research_time": 1159560
     },
     {
       "bonus": {

--- a/research/interceptor_barrage.json
+++ b/research/interceptor_barrage.json
@@ -27,11 +27,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 674100
+            "value": 674100000
           }
         ]
       },
-      "research_time": 42034
+      "research_time": 42034980
     }
   ],
   "location": {

--- a/research/interceptor_bartering.json
+++ b/research/interceptor_bartering.json
@@ -102,7 +102,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1520
+            "value": 1520000
           },
           {
             "type": "dilithium",
@@ -162,7 +162,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 3650
+            "value": 3650000
           },
           {
             "type": "dilithium",
@@ -209,7 +209,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 8150
+            "value": 8150000
           },
           {
             "type": "dilithium",
@@ -252,11 +252,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 20300
+            "value": 20300000
           },
           {
             "type": "dilithium",
-            "value": 2240
+            "value": 2240000
           }
         ]
       },
@@ -295,15 +295,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 45100
+            "value": 45100000
           },
           {
             "type": "dilithium",
-            "value": 4980
+            "value": 4980000
           }
         ]
       },
-      "research_time": 1049
+      "research_time": 1049880
     },
     {
       "bonus": {
@@ -338,15 +338,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 105100
+            "value": 105100000
           },
           {
             "type": "dilithium",
-            "value": 11600
+            "value": 11600000
           }
         ]
       },
-      "research_time": 1789
+      "research_time": 1789800
     },
     {
       "bonus": {
@@ -381,15 +381,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 282700
+            "value": 282700000
           },
           {
             "type": "dilithium",
-            "value": 31200
+            "value": 31200000
           }
         ]
       },
-      "research_time": 4237
+      "research_time": 4237620
     },
     {
       "bonus": {
@@ -424,15 +424,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 611200
+            "value": 611200000
           },
           {
             "type": "dilithium",
-            "value": 67400
+            "value": 67400000
           }
         ]
       },
-      "research_time": 6305
+      "research_time": 6305220
     },
     {
       "bonus": {

--- a/research/interceptor_focus.json
+++ b/research/interceptor_focus.json
@@ -74,7 +74,7 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1340
+            "value": 1340000
           }
         ]
       },
@@ -100,7 +100,7 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 3000
+            "value": 3000000
           }
         ]
       },
@@ -126,11 +126,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 4650
+            "value": 4650000
           }
         ]
       },
-      "research_time": 1449
+      "research_time": 1449420
     },
     {
       "bonus": {
@@ -152,11 +152,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 11100
+            "value": 11100000
           }
         ]
       },
-      "research_time": 2600
+      "research_time": 2600040
     },
     {
       "bonus": {
@@ -178,11 +178,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 16600
+            "value": 16600000
           }
         ]
       },
-      "research_time": 3499
+      "research_time": 3499500
     },
     {
       "bonus": {
@@ -204,11 +204,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 38650
+            "value": 38650000
           }
         ]
       },
-      "research_time": 5965
+      "research_time": 5965920
     },
     {
       "bonus": {
@@ -249,11 +249,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 65800
+            "value": 65800000
           }
         ]
       },
-      "research_time": 8058
+      "research_time": 8058720
     },
     {
       "bonus": {

--- a/research/interceptor_focus_shot.json
+++ b/research/interceptor_focus_shot.json
@@ -38,7 +38,7 @@
         ],
         "resources": []
       },
-      "research_time": 50614
+      "research_time": 50614380
     },
     {
       "bonus": {
@@ -68,7 +68,7 @@
         "others": [
           {
             "type": "Service\u00a0Award",
-            "value": 1259
+            "value": 1259626
           },
           {
             "type": "Merit\u00a0of\u00a0Honor",
@@ -77,7 +77,7 @@
         ],
         "resources": []
       },
-      "research_time": 66417
+      "research_time": 66417540
     },
     {
       "bonus": {
@@ -106,12 +106,12 @@
           },
           {
             "type": "Service\u00a0Award",
-            "value": 1796
+            "value": 1796553
           }
         ],
         "resources": []
       },
-      "research_time": 89570
+      "research_time": 89570460
     },
     {
       "bonus": {
@@ -141,7 +141,7 @@
         "others": [
           {
             "type": "Service\u00a0Award",
-            "value": 2669
+            "value": 2669728
           },
           {
             "type": "Merit\u00a0of\u00a0Honor",
@@ -150,7 +150,7 @@
         ],
         "resources": []
       },
-      "research_time": 115554
+      "research_time": 115554960
     },
     {
       "bonus": {
@@ -171,7 +171,7 @@
         "others": [
           {
             "type": "Service\u00a0Award",
-            "value": 4412
+            "value": 4412607
           },
           {
             "type": "Merit\u00a0of\u00a0Honor",
@@ -180,7 +180,7 @@
         ],
         "resources": []
       },
-      "research_time": 147802
+      "research_time": 147802500
     },
     {
       "bonus": {
@@ -210,7 +210,7 @@
         "others": [
           {
             "type": "Service\u00a0Award",
-            "value": 7673
+            "value": 7673146
           },
           {
             "type": "Merit\u00a0of\u00a0Honor",
@@ -219,7 +219,7 @@
         ],
         "resources": []
       },
-      "research_time": 195732
+      "research_time": 195732840
     },
     {
       "bonus": {
@@ -244,12 +244,12 @@
           },
           {
             "type": "Service\u00a0Award",
-            "value": 12766
+            "value": 12766604
           }
         ],
         "resources": []
       },
-      "research_time": 246380
+      "research_time": 246380520
     },
     {
       "bonus": {
@@ -279,7 +279,7 @@
         "others": [
           {
             "type": "Service\u00a0Award",
-            "value": 14185
+            "value": 14185115
           },
           {
             "type": "Merit\u00a0of\u00a0Honor",
@@ -288,7 +288,7 @@
         ],
         "resources": []
       },
-      "research_time": 300516
+      "research_time": 300516720
     },
     {
       "bonus": {
@@ -309,7 +309,7 @@
         "others": [
           {
             "type": "Service\u00a0Award",
-            "value": 14185
+            "value": 14185115
           },
           {
             "type": "Merit\u00a0of\u00a0Honor",
@@ -318,7 +318,7 @@
         ],
         "resources": []
       },
-      "research_time": 300516
+      "research_time": 300516720
     },
     {
       "bonus": {
@@ -352,12 +352,12 @@
           },
           {
             "type": "Service\u00a0Award",
-            "value": 17022
+            "value": 17022138
           }
         ],
         "resources": []
       },
-      "research_time": 265945
+      "research_time": 265945140
     }
   ],
   "location": {

--- a/research/interceptor_hull_boost.json
+++ b/research/interceptor_hull_boost.json
@@ -30,15 +30,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 65800
+            "value": 65800000
           },
           {
             "type": "dilithium",
-            "value": 39500
+            "value": 39500000
           }
         ]
       },
-      "research_time": 8058
+      "research_time": 8058720
     },
     {
       "bonus": {
@@ -87,15 +87,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 38650
+            "value": 38650000
           },
           {
             "type": "dilithium",
-            "value": 23200
+            "value": 23200000
           }
         ]
       },
-      "research_time": 5965
+      "research_time": 5965920
     },
     {
       "bonus": {
@@ -172,15 +172,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 4650
+            "value": 4650000
           },
           {
             "type": "dilithium",
-            "value": 2790
+            "value": 2790000
           }
         ]
       },
-      "research_time": 1449
+      "research_time": 1449420
     },
     {
       "bonus": {
@@ -219,15 +219,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 7460
+            "value": 7460000
           },
           {
             "type": "dilithium",
-            "value": 4470
+            "value": 4470000
           }
         ]
       },
-      "research_time": 1937
+      "research_time": 1937880
     },
     {
       "bonus": {

--- a/research/interceptor_hull_integrity.json
+++ b/research/interceptor_hull_integrity.json
@@ -31,11 +31,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1110
+            "value": 1110000
           }
         ]
       },
-      "research_time": 2600
+      "research_time": 2600040
     },
     {
       "bonus": {
@@ -66,11 +66,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1660
+            "value": 1660000
           }
         ]
       },
-      "research_time": 3499
+      "research_time": 3499500
     },
     {
       "bonus": {
@@ -101,11 +101,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 2440
+            "value": 2440000
           }
         ]
       },
-      "research_time": 3483
+      "research_time": 3483960
     },
     {
       "bonus": {
@@ -136,11 +136,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 3860
+            "value": 3860000
           }
         ]
       },
-      "research_time": 5965
+      "research_time": 5965920
     },
     {
       "bonus": {
@@ -180,11 +180,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 10400
+            "value": 10400000
           }
         ]
       },
-      "research_time": 14125
+      "research_time": 14125380
     },
     {
       "bonus": {
@@ -215,11 +215,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 22450
+            "value": 22450000
           }
         ]
       },
-      "research_time": 21017
+      "research_time": 21017460
     },
     {
       "bonus": {
@@ -250,11 +250,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 49650
+            "value": 49650000
           }
         ]
       },
-      "research_time": 38934
+      "research_time": 38934120
     },
     {
       "bonus": {
@@ -285,11 +285,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 98750
+            "value": 98750000
           }
         ]
       },
-      "research_time": 68900
+      "research_time": 68900340
     },
     {
       "bonus": {
@@ -320,11 +320,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 235800
+            "value": 235800000
           }
         ]
       },
-      "research_time": 113694
+      "research_time": 113694240
     },
     {
       "bonus": {
@@ -368,11 +368,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 708800
+            "value": 708800000
           }
         ]
       },
-      "research_time": 189523
+      "research_time": 189523500
     },
     {
       "bonus": {
@@ -407,7 +407,7 @@
           }
         ]
       },
-      "research_time": 1937
+      "research_time": 1937880
     },
     {
       "bonus": {

--- a/research/interceptor_nacelles.json
+++ b/research/interceptor_nacelles.json
@@ -127,7 +127,7 @@
         ],
         "resources": []
       },
-      "research_time": 1162
+      "research_time": 1162740
     },
     {
       "bonus": {

--- a/research/interceptor_overcharge.json
+++ b/research/interceptor_overcharge.json
@@ -65,7 +65,7 @@
         ],
         "resources": []
       },
-      "research_time": 1272
+      "research_time": 1272060
     },
     {
       "bonus": {
@@ -96,7 +96,7 @@
         ],
         "resources": []
       },
-      "research_time": 1884
+      "research_time": 1884300
     },
     {
       "bonus": {
@@ -131,7 +131,7 @@
         ],
         "resources": []
       },
-      "research_time": 2519
+      "research_time": 2519280
     },
     {
       "bonus": {
@@ -162,7 +162,7 @@
         ],
         "resources": []
       },
-      "research_time": 3380
+      "research_time": 3380040
     },
     {
       "bonus": {
@@ -193,7 +193,7 @@
         ],
         "resources": []
       },
-      "research_time": 4549
+      "research_time": 4549380
     },
     {
       "bonus": {
@@ -228,7 +228,7 @@
         ],
         "resources": []
       },
-      "research_time": 4529
+      "research_time": 4529160
     },
     {
       "bonus": {
@@ -258,7 +258,7 @@
         ],
         "resources": []
       },
-      "research_time": 7755
+      "research_time": 7755720
     },
     {
       "bonus": {
@@ -293,7 +293,7 @@
         ],
         "resources": []
       },
-      "research_time": 10476
+      "research_time": 10476360
     },
     {
       "bonus": {
@@ -332,7 +332,7 @@
         ],
         "resources": []
       },
-      "research_time": 18363
+      "research_time": 18363000
     }
   ],
   "location": {

--- a/research/interceptor_regeneration.json
+++ b/research/interceptor_regeneration.json
@@ -64,7 +64,7 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1210
+            "value": 1210000
           }
         ]
       },
@@ -145,7 +145,7 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 2700
+            "value": 2700000
           }
         ]
       },
@@ -193,11 +193,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 6710
+            "value": 6710000
           }
         ]
       },
-      "research_time": 1744
+      "research_time": 1744080
     }
   ],
   "location": {

--- a/research/interceptor_repair_costs.json
+++ b/research/interceptor_repair_costs.json
@@ -40,11 +40,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1110
+            "value": 1110000
           }
         ]
       },
-      "research_time": 2600
+      "research_time": 2600040
     },
     {
       "bonus": {
@@ -75,11 +75,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 2440
+            "value": 2440000
           }
         ]
       },
-      "research_time": 3483
+      "research_time": 3483960
     },
     {
       "bonus": {
@@ -110,11 +110,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 3860
+            "value": 3860000
           }
         ]
       },
-      "research_time": 5965
+      "research_time": 5965920
     },
     {
       "bonus": {
@@ -145,11 +145,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 6580
+            "value": 6580000
           }
         ]
       },
-      "research_time": 8058
+      "research_time": 8058720
     },
     {
       "bonus": {
@@ -180,11 +180,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 10400
+            "value": 10400000
           }
         ]
       },
-      "research_time": 14125
+      "research_time": 14125380
     },
     {
       "bonus": {
@@ -219,11 +219,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 22450
+            "value": 22450000
           }
         ]
       },
-      "research_time": 21017
+      "research_time": 21017460
     },
     {
       "bonus": {
@@ -254,11 +254,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 49650
+            "value": 49650000
           }
         ]
       },
-      "research_time": 38934
+      "research_time": 38934120
     },
     {
       "bonus": {
@@ -289,11 +289,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 98750
+            "value": 98750000
           }
         ]
       },
-      "research_time": 68900
+      "research_time": 68900340
     },
     {
       "bonus": {
@@ -324,11 +324,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 235800
+            "value": 235800000
           }
         ]
       },
-      "research_time": 113694
+      "research_time": 113694240
     },
     {
       "bonus": {
@@ -367,11 +367,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 708800
+            "value": 708800000
           }
         ]
       },
-      "research_time": 189523
+      "research_time": 189523500
     }
   ],
   "location": {

--- a/research/interceptor_retaliation.json
+++ b/research/interceptor_retaliation.json
@@ -33,15 +33,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 2026
+            "value": 2026000000
           },
           {
             "type": "dilithium",
-            "value": 496500
+            "value": 496500000
           }
         ]
       },
-      "research_time": 38934
+      "research_time": 38934120
     },
     {
       "bonus": {
@@ -83,15 +83,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 2889
+            "value": 2889000000
           },
           {
             "type": "dilithium",
-            "value": 708000
+            "value": 708000000
           }
         ]
       },
-      "research_time": 51090
+      "research_time": 51090420
     },
     {
       "bonus": {
@@ -130,15 +130,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 60244
+            "value": 60244000000
           },
           {
             "type": "dilithium",
-            "value": 14766
+            "value": 14766000000
           }
         ]
       },
-      "research_time": 279000
+      "research_time": 279000000
     }
   ],
   "location": {

--- a/research/interceptor_shields.json
+++ b/research/interceptor_shields.json
@@ -36,11 +36,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 49650
+            "value": 49650000
           }
         ]
       },
-      "research_time": 38934
+      "research_time": 38934120
     },
     {
       "bonus": {
@@ -76,11 +76,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 98750
+            "value": 98750000
           }
         ]
       },
-      "research_time": 68900
+      "research_time": 68900340
     },
     {
       "bonus": {
@@ -116,11 +116,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1110
+            "value": 1110000
           }
         ]
       },
-      "research_time": 2600
+      "research_time": 2600040
     },
     {
       "bonus": {
@@ -164,11 +164,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1660
+            "value": 1660000
           }
         ]
       },
-      "research_time": 3499
+      "research_time": 3499500
     },
     {
       "bonus": {
@@ -208,11 +208,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 2440
+            "value": 2440000
           }
         ]
       },
-      "research_time": 3483
+      "research_time": 3483960
     },
     {
       "bonus": {
@@ -256,11 +256,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 3860
+            "value": 3860000
           }
         ]
       },
-      "research_time": 5965
+      "research_time": 5965920
     },
     {
       "bonus": {
@@ -300,11 +300,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 10400
+            "value": 10400000
           }
         ]
       },
-      "research_time": 14125
+      "research_time": 14125380
     },
     {
       "bonus": {
@@ -335,11 +335,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 235800
+            "value": 235800000
           }
         ]
       },
-      "research_time": 113694
+      "research_time": 113694240
     },
     {
       "bonus": {
@@ -383,11 +383,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 708800
+            "value": 708800000
           }
         ]
       },
-      "research_time": 189523
+      "research_time": 189523500
     },
     {
       "bonus": {
@@ -431,11 +431,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 22450
+            "value": 22450000
           }
         ]
       },
-      "research_time": 21017
+      "research_time": 21017460
     },
     {
       "bonus": {
@@ -479,7 +479,7 @@
           }
         ]
       },
-      "research_time": 1937
+      "research_time": 1937880
     },
     {
       "bonus": {

--- a/research/interceptor_space_critical_resist.json
+++ b/research/interceptor_space_critical_resist.json
@@ -42,15 +42,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 584000
+            "value": 584000000
           },
           {
             "type": "dilithium",
-            "value": 1460
+            "value": 1460000000
           }
         ]
       },
-      "research_time": 106666
+      "research_time": 106666140
     },
     {
       "bonus": {
@@ -94,15 +94,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 943200
+            "value": 943200000
           },
           {
             "type": "dilithium",
-            "value": 2358
+            "value": 2358000000
           }
         ]
       },
-      "research_time": 136433
+      "research_time": 136433100
     },
     {
       "bonus": {
@@ -140,15 +140,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 1596
+            "value": 1596000000
           },
           {
             "type": "dilithium",
-            "value": 3990
+            "value": 3990000000
           }
         ]
       },
-      "research_time": 180676
+      "research_time": 180676500
     },
     {
       "bonus": {
@@ -192,15 +192,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 2835
+            "value": 2835000000
           },
           {
             "type": "dilithium",
-            "value": 7088
+            "value": 7088000000
           }
         ]
       },
-      "research_time": 227428
+      "research_time": 227428200
     },
     {
       "bonus": {
@@ -222,15 +222,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 4316
+            "value": 4316000000
           },
           {
             "type": "dilithium",
-            "value": 10789
+            "value": 10789000000
           }
         ]
       },
-      "research_time": 277400
+      "research_time": 277400040
     },
     {
       "bonus": {
@@ -252,15 +252,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 6615
+            "value": 6615000000
           },
           {
             "type": "dilithium",
-            "value": 16538
+            "value": 16538000000
           }
         ]
       },
-      "research_time": 357105
+      "research_time": 357105840
     },
     {
       "bonus": {
@@ -282,15 +282,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 5906
+            "value": 5906000000
           },
           {
             "type": "dilithium",
-            "value": 14766
+            "value": 14766000000
           }
         ]
       },
-      "research_time": 245487
+      "research_time": 245487840
     },
     {
       "bonus": {
@@ -312,15 +312,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 8859
+            "value": 8859000000
           },
           {
             "type": "dilithium",
-            "value": 22148
+            "value": 22148000000
           }
         ]
       },
-      "research_time": 294585
+      "research_time": 294585420
     },
     {
       "bonus": {
@@ -342,15 +342,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 13289
+            "value": 13289000000
           },
           {
             "type": "dilithium",
-            "value": 33223
+            "value": 33223000000
           }
         ]
       },
-      "research_time": 387612
+      "research_time": 387612360
     },
     {
       "bonus": {
@@ -372,15 +372,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 19934
+            "value": 19934000000
           },
           {
             "type": "dilithium",
-            "value": 49834
+            "value": 49834000000
           }
         ]
       },
-      "research_time": 465134
+      "research_time": 465134820
     }
   ],
   "location": {

--- a/research/interceptor_tactics.json
+++ b/research/interceptor_tactics.json
@@ -35,11 +35,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 31750
+            "value": 31750000
           }
         ]
       },
-      "research_time": 4529
+      "research_time": 4529160
     },
     {
       "bonus": {
@@ -93,11 +93,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 50250
+            "value": 50250000
           }
         ]
       },
-      "research_time": 7755
+      "research_time": 7755720
     },
     {
       "bonus": {
@@ -226,11 +226,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 3900
+            "value": 3900000
           }
         ]
       },
-      "research_time": 1272
+      "research_time": 1272060
     },
     {
       "bonus": {
@@ -273,11 +273,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 6040
+            "value": 6040000
           }
         ]
       },
-      "research_time": 1884
+      "research_time": 1884300
     },
     {
       "bonus": {

--- a/research/interceptor_warfare.json
+++ b/research/interceptor_warfare.json
@@ -31,11 +31,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1110
+            "value": 1110000
           }
         ]
       },
-      "research_time": 2600
+      "research_time": 2600040
     },
     {
       "bonus": {
@@ -66,11 +66,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1660
+            "value": 1660000
           }
         ]
       },
-      "research_time": 3499
+      "research_time": 3499500
     },
     {
       "bonus": {
@@ -101,11 +101,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 2440
+            "value": 2440000
           }
         ]
       },
-      "research_time": 3483
+      "research_time": 3483960
     },
     {
       "bonus": {
@@ -136,11 +136,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 3860
+            "value": 3860000
           }
         ]
       },
-      "research_time": 5965
+      "research_time": 5965920
     },
     {
       "bonus": {
@@ -180,11 +180,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 10400
+            "value": 10400000
           }
         ]
       },
-      "research_time": 14125
+      "research_time": 14125380
     },
     {
       "bonus": {
@@ -215,11 +215,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 22450
+            "value": 22450000
           }
         ]
       },
-      "research_time": 21017
+      "research_time": 21017460
     },
     {
       "bonus": {
@@ -250,11 +250,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 49650
+            "value": 49650000
           }
         ]
       },
-      "research_time": 38934
+      "research_time": 38934120
     },
     {
       "bonus": {
@@ -285,11 +285,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 98750
+            "value": 98750000
           }
         ]
       },
-      "research_time": 68900
+      "research_time": 68900340
     },
     {
       "bonus": {
@@ -320,11 +320,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 235800
+            "value": 235800000
           }
         ]
       },
-      "research_time": 113694
+      "research_time": 113694240
     },
     {
       "bonus": {
@@ -368,11 +368,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 708800
+            "value": 708800000
           }
         ]
       },
-      "research_time": 189523
+      "research_time": 189523500
     },
     {
       "bonus": {
@@ -451,7 +451,7 @@
           }
         ]
       },
-      "research_time": 1937
+      "research_time": 1937880
     }
   ],
   "location": {

--- a/research/interceptor_warp.json
+++ b/research/interceptor_warp.json
@@ -44,11 +44,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 14650
+            "value": 14650000
           }
         ]
       },
-      "research_time": 2090
+      "research_time": 2090400
     },
     {
       "bonus": {
@@ -90,11 +90,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 23200
+            "value": 23200000
           }
         ]
       },
-      "research_time": 3579
+      "research_time": 3579540
     },
     {
       "bonus": {
@@ -128,11 +128,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 39500
+            "value": 39500000
           }
         ]
       },
-      "research_time": 4835
+      "research_time": 4835220
     },
     {
       "bonus": {
@@ -169,11 +169,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 62350
+            "value": 62350000
           }
         ]
       },
-      "research_time": 8475
+      "research_time": 8475243
     },
     {
       "bonus": {
@@ -206,11 +206,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 90450
+            "value": 90450000
           }
         ]
       },
-      "research_time": 8073
+      "research_time": 8073660
     },
     {
       "bonus": {
@@ -250,11 +250,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 134800
+            "value": 134800000
           }
         ]
       },
-      "research_time": 12610
+      "research_time": 12610500
     },
     {
       "bonus": {
@@ -287,11 +287,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 195600
+            "value": 195600000
           }
         ]
       },
-      "research_time": 17603
+      "research_time": 17603280
     },
     {
       "bonus": {
@@ -326,11 +326,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 297900
+            "value": 297900000
           }
         ]
       },
-      "research_time": 23360
+      "research_time": 23360460
     },
     {
       "bonus": {
@@ -359,11 +359,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 424800
+            "value": 424800000
           }
         ]
       },
-      "research_time": 30654
+      "research_time": 30654240
     },
     {
       "bonus": {
@@ -405,7 +405,7 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1230
+            "value": 1230000
           }
         ]
       },

--- a/research/kinetic_guerilla_warfare.json
+++ b/research/kinetic_guerilla_warfare.json
@@ -133,7 +133,7 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1120
+            "value": 1120000
           }
         ]
       },
@@ -169,7 +169,7 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1341
+            "value": 1341900
           }
         ]
       },
@@ -208,7 +208,7 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 2490
+            "value": 2490000
           }
         ]
       },
@@ -239,7 +239,7 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 2985
+            "value": 2985300
           }
         ]
       },
@@ -278,7 +278,7 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 5800
+            "value": 5800000
           }
         ]
       },
@@ -314,11 +314,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 6955
+            "value": 6955200
           }
         ]
       },
-      "research_time": 1073
+      "research_time": 1073880
     },
     {
       "bonus": {
@@ -353,11 +353,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 15600
+            "value": 15600000
           }
         ]
       },
-      "research_time": 2118
+      "research_time": 2118840
     },
     {
       "bonus": {
@@ -384,11 +384,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 18711
+            "value": 18711000
           }
         ]
       },
-      "research_time": 2542
+      "research_time": 2542560
     },
     {
       "bonus": {
@@ -428,11 +428,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 33700
+            "value": 33700000
           }
         ]
       },
-      "research_time": 3152
+      "research_time": 3152640
     },
     {
       "bonus": {
@@ -459,11 +459,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 40446
+            "value": 40446000
           }
         ]
       },
-      "research_time": 3783
+      "research_time": 3783120
     },
     {
       "bonus": {
@@ -490,11 +490,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 74500
+            "value": 74500000
           }
         ]
       },
-      "research_time": 5840
+      "research_time": 5840100
     },
     {
       "bonus": {
@@ -538,11 +538,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 148100
+            "value": 148100000
           }
         ]
       },
-      "research_time": 10335
+      "research_time": 10335060
     }
   ],
   "location": {

--- a/research/klingon_apprentice.json
+++ b/research/klingon_apprentice.json
@@ -44,7 +44,7 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1020
+            "value": 1020000
           }
         ]
       },
@@ -77,7 +77,7 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 2320
+            "value": 2320000
           }
         ]
       },
@@ -114,7 +114,7 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 3730
+            "value": 3730000
           }
         ]
       },
@@ -147,11 +147,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 5560
+            "value": 5560000
           }
         ]
       },
-      "research_time": 1300
+      "research_time": 1300020
     },
     {
       "bonus": {
@@ -184,11 +184,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 8290
+            "value": 8290000
           }
         ]
       },
-      "research_time": 1749
+      "research_time": 1749780
     },
     {
       "bonus": {
@@ -217,11 +217,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 12200
+            "value": 12200000
           }
         ]
       },
-      "research_time": 1741
+      "research_time": 1741980
     },
     {
       "bonus": {
@@ -254,11 +254,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 19300
+            "value": 19300000
           }
         ]
       },
-      "research_time": 2982
+      "research_time": 2982960
     },
     {
       "bonus": {
@@ -287,11 +287,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 32900
+            "value": 32900000
           }
         ]
       },
-      "research_time": 4029
+      "research_time": 4029360
     },
     {
       "bonus": {
@@ -324,11 +324,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 52000
+            "value": 52000000
           }
         ]
       },
-      "research_time": 7062
+      "research_time": 7062720
     },
     {
       "bonus": {
@@ -357,11 +357,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 75400
+            "value": 75400000
           }
         ]
       },
-      "research_time": 6728
+      "research_time": 6728040
     }
   ],
   "location": {

--- a/research/klingon_armada_defects.json
+++ b/research/klingon_armada_defects.json
@@ -48,11 +48,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 3990
+            "value": 3990000000
           }
         ]
       },
-      "research_time": 150563
+      "research_time": 150563760
     },
     {
       "bonus": {
@@ -74,11 +74,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 112126
+            "value": 112126000000
           }
         ]
       },
-      "research_time": 558161
+      "research_time": 558161820
     }
   ],
   "location": {

--- a/research/klingon_crystal_miner.json
+++ b/research/klingon_crystal_miner.json
@@ -33,11 +33,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 18250
+            "value": 18250000
           }
         ]
       },
-      "research_time": 6299
+      "research_time": 6299160
     },
     {
       "bonus": {
@@ -70,11 +70,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 42500
+            "value": 42500000
           }
         ]
       },
-      "research_time": 10738
+      "research_time": 10738680
     },
     {
       "bonus": {
@@ -107,11 +107,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 114300
+            "value": 114300000
           }
         ]
       },
-      "research_time": 25425
+      "research_time": 25425720
     },
     {
       "bonus": {
@@ -144,11 +144,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 247200
+            "value": 247200000
           }
         ]
       },
-      "research_time": 37831
+      "research_time": 37831440
     },
     {
       "bonus": {
@@ -181,11 +181,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 546200
+            "value": 546200000
           }
         ]
       },
-      "research_time": 70081
+      "research_time": 70081440
     },
     {
       "bonus": {
@@ -218,11 +218,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1086
+            "value": 1086000000
           }
         ]
       },
-      "research_time": 124020
+      "research_time": 124020600
     },
     {
       "bonus": {
@@ -255,11 +255,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1480
+            "value": 1480000
           }
         ]
       },
-      "research_time": 1333
+      "research_time": 1333800
     },
     {
       "bonus": {
@@ -292,11 +292,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 3300
+            "value": 3300000
           }
         ]
       },
-      "research_time": 1761
+      "research_time": 1761360
     },
     {
       "bonus": {
@@ -329,11 +329,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 8200
+            "value": 8200000
           }
         ]
       },
-      "research_time": 3488
+      "research_time": 3488220
     },
     {
       "bonus": {
@@ -379,7 +379,7 @@
           }
         ]
       },
-      "research_time": 1039
+      "research_time": 1039980
     }
   ],
   "location": {

--- a/research/klingon_demolition.json
+++ b/research/klingon_demolition.json
@@ -39,7 +39,7 @@
         ],
         "resources": []
       },
-      "research_time": 15537
+      "research_time": 15537960
     },
     {
       "bonus": {
@@ -73,7 +73,7 @@
         ],
         "resources": []
       },
-      "research_time": 14801
+      "research_time": 14801760
     },
     {
       "bonus": {
@@ -103,7 +103,7 @@
         ],
         "resources": []
       },
-      "research_time": 23119
+      "research_time": 23119200
     },
     {
       "bonus": {
@@ -137,7 +137,7 @@
         ],
         "resources": []
       },
-      "research_time": 32272
+      "research_time": 32272680
     },
     {
       "bonus": {
@@ -167,7 +167,7 @@
         ],
         "resources": []
       },
-      "research_time": 42827
+      "research_time": 42827580
     },
     {
       "bonus": {
@@ -196,12 +196,12 @@
           },
           {
             "type": "Service\u00a0Award",
-            "value": 1259
+            "value": 1259626
           }
         ],
         "resources": []
       },
-      "research_time": 56199
+      "research_time": 56199420
     },
     {
       "bonus": {
@@ -230,12 +230,12 @@
           },
           {
             "type": "Service\u00a0Award",
-            "value": 2669
+            "value": 2669728
           }
         ],
         "resources": []
       },
-      "research_time": 97777
+      "research_time": 97777320
     },
     {
       "bonus": {
@@ -264,12 +264,12 @@
           },
           {
             "type": "Service\u00a0Award",
-            "value": 4412
+            "value": 4412607
           }
         ],
         "resources": []
       },
-      "research_time": 125063
+      "research_time": 125063640
     },
     {
       "bonus": {
@@ -298,12 +298,12 @@
           },
           {
             "type": "Service\u00a0Award",
-            "value": 7673
+            "value": 7673146
           }
         ],
         "resources": []
       },
-      "research_time": 165620
+      "research_time": 165620100
     },
     {
       "bonus": {
@@ -332,12 +332,12 @@
           },
           {
             "type": "Service\u00a0Award",
-            "value": 12766
+            "value": 12766604
           }
         ],
         "resources": []
       },
-      "research_time": 208475
+      "research_time": 208475820
     }
   ],
   "location": {

--- a/research/klingon_devotion.json
+++ b/research/klingon_devotion.json
@@ -70,11 +70,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1020
+            "value": 1020000
           }
         ]
       },
-      "research_time": 1330
+      "research_time": 1330800
     },
     {
       "bonus": {
@@ -107,11 +107,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 2320
+            "value": 2320000
           }
         ]
       },
-      "research_time": 2029
+      "research_time": 2029200
     },
     {
       "bonus": {
@@ -144,11 +144,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 5560
+            "value": 5560000
           }
         ]
       },
-      "research_time": 3640
+      "research_time": 3640080
     },
     {
       "bonus": {
@@ -181,11 +181,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 12200
+            "value": 12200000
           }
         ]
       },
-      "research_time": 4877
+      "research_time": 4877580
     },
     {
       "bonus": {
@@ -218,11 +218,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 32900
+            "value": 32900000
           }
         ]
       },
-      "research_time": 11282
+      "research_time": 11282220
     },
     {
       "bonus": {
@@ -255,11 +255,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 75400
+            "value": 75400000
           }
         ]
       },
-      "research_time": 18838
+      "research_time": 18838560
     },
     {
       "bonus": {
@@ -292,11 +292,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 163000
+            "value": 163000000
           }
         ]
       },
-      "research_time": 41074
+      "research_time": 41074320
     },
     {
       "bonus": {
@@ -329,11 +329,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 354000
+            "value": 354000000
           }
         ]
       },
-      "research_time": 71526
+      "research_time": 71526540
     },
     {
       "bonus": {

--- a/research/klingon_firepower.json
+++ b/research/klingon_firepower.json
@@ -45,11 +45,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 77300
+            "value": 77300000
           }
         ]
       },
-      "research_time": 14914
+      "research_time": 14914860
     },
     {
       "bonus": {
@@ -82,11 +82,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 207900
+            "value": 207900000
           }
         ]
       },
-      "research_time": 35313
+      "research_time": 35313540
     },
     {
       "bonus": {
@@ -131,11 +131,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 449400
+            "value": 449400000
           }
         ]
       },
-      "research_time": 52543
+      "research_time": 52543680
     },
     {
       "bonus": {
@@ -180,11 +180,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 33150
+            "value": 33150000
           }
         ]
       },
-      "research_time": 8748
+      "research_time": 8748780
     },
     {
       "bonus": {
@@ -239,11 +239,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 75000
+            "value": 75000000
           }
         ]
       },
-      "research_time": 4844
+      "research_time": 4844760
     }
   ],
   "location": {

--- a/research/klingon_graviton_shields.json
+++ b/research/klingon_graviton_shields.json
@@ -30,7 +30,7 @@
         ],
         "resources": []
       },
-      "research_time": 1937
+      "research_time": 1937880
     },
     {
       "bonus": {
@@ -60,7 +60,7 @@
         ],
         "resources": []
       },
-      "research_time": 2600
+      "research_time": 2600040
     },
     {
       "bonus": {
@@ -91,7 +91,7 @@
         ],
         "resources": []
       },
-      "research_time": 3499
+      "research_time": 3499500
     },
     {
       "bonus": {
@@ -126,7 +126,7 @@
         ],
         "resources": []
       },
-      "research_time": 3483
+      "research_time": 3483960
     },
     {
       "bonus": {
@@ -157,7 +157,7 @@
         ],
         "resources": []
       },
-      "research_time": 5965
+      "research_time": 5965920
     },
     {
       "bonus": {
@@ -192,7 +192,7 @@
         ],
         "resources": []
       },
-      "research_time": 8058
+      "research_time": 8058720
     },
     {
       "bonus": {
@@ -231,7 +231,7 @@
         ],
         "resources": []
       },
-      "research_time": 14125
+      "research_time": 14125380
     },
     {
       "bonus": {
@@ -266,7 +266,7 @@
         ],
         "resources": []
       },
-      "research_time": 13456
+      "research_time": 13456140
     },
     {
       "bonus": {
@@ -300,7 +300,7 @@
         ],
         "resources": []
       },
-      "research_time": 21017
+      "research_time": 21017460
     },
     {
       "bonus": {

--- a/research/klingon_hauler.json
+++ b/research/klingon_hauler.json
@@ -51,7 +51,7 @@
         ],
         "resources": []
       },
-      "research_time": 16147
+      "research_time": 16147380
     },
     {
       "bonus": {
@@ -85,7 +85,7 @@
         ],
         "resources": []
       },
-      "research_time": 25221
+      "research_time": 25221000
     },
     {
       "bonus": {
@@ -124,7 +124,7 @@
         ],
         "resources": []
       },
-      "research_time": 35206
+      "research_time": 35206560
     },
     {
       "bonus": {
@@ -163,7 +163,7 @@
         ],
         "resources": []
       },
-      "research_time": 46720
+      "research_time": 46720980
     },
     {
       "bonus": {
@@ -188,12 +188,12 @@
           },
           {
             "type": "Service\u00a0Award",
-            "value": 1259
+            "value": 1259626
           }
         ],
         "resources": []
       },
-      "research_time": 61308
+      "research_time": 61308480
     },
     {
       "bonus": {
@@ -218,7 +218,7 @@
         "others": [
           {
             "type": "Service\u00a0Award",
-            "value": 1796
+            "value": 1796553
           },
           {
             "type": "Merit\u00a0of\u00a0Honor",
@@ -227,7 +227,7 @@
         ],
         "resources": []
       },
-      "research_time": 82680
+      "research_time": 82680420
     },
     {
       "bonus": {
@@ -252,12 +252,12 @@
           },
           {
             "type": "Service\u00a0Award",
-            "value": 2669
+            "value": 2669728
           }
         ],
         "resources": []
       },
-      "research_time": 106666
+      "research_time": 106666140
     },
     {
       "bonus": {
@@ -286,12 +286,12 @@
           },
           {
             "type": "Service\u00a0Award",
-            "value": 4412
+            "value": 4412607
           }
         ],
         "resources": []
       },
-      "research_time": 136433
+      "research_time": 136433100
     },
     {
       "bonus": {
@@ -316,12 +316,12 @@
           },
           {
             "type": "Service\u00a0Award",
-            "value": 7673
+            "value": 7673146
           }
         ],
         "resources": []
       },
-      "research_time": 180676
+      "research_time": 180676500
     },
     {
       "bonus": {
@@ -350,12 +350,12 @@
           },
           {
             "type": "Service\u00a0Award",
-            "value": 12766
+            "value": 12766604
           }
         ],
         "resources": []
       },
-      "research_time": 227428
+      "research_time": 227428200
     }
   ],
   "location": {

--- a/research/klingon_notoriety.json
+++ b/research/klingon_notoriety.json
@@ -30,7 +30,7 @@
         ],
         "resources": []
       },
-      "research_time": 2449
+      "research_time": 2449680
     },
     {
       "bonus": {
@@ -60,7 +60,7 @@
         ],
         "resources": []
       },
-      "research_time": 2438
+      "research_time": 2438820
     },
     {
       "bonus": {
@@ -90,7 +90,7 @@
         ],
         "resources": []
       },
-      "research_time": 4176
+      "research_time": 4176180
     },
     {
       "bonus": {
@@ -120,7 +120,7 @@
         ],
         "resources": []
       },
-      "research_time": 5641
+      "research_time": 5641140
     },
     {
       "bonus": {
@@ -154,7 +154,7 @@
         ],
         "resources": []
       },
-      "research_time": 9887
+      "research_time": 9887760
     },
     {
       "bonus": {
@@ -193,7 +193,7 @@
         ],
         "resources": []
       },
-      "research_time": 14712
+      "research_time": 14712240
     },
     {
       "bonus": {
@@ -227,7 +227,7 @@
         ],
         "resources": []
       },
-      "research_time": 9419
+      "research_time": 9419280
     },
     {
       "bonus": {
@@ -261,7 +261,7 @@
         ],
         "resources": []
       },
-      "research_time": 20537
+      "research_time": 20537160
     },
     {
       "bonus": {
@@ -295,7 +295,7 @@
         ],
         "resources": []
       },
-      "research_time": 27253
+      "research_time": 27253920
     },
     {
       "bonus": {
@@ -338,7 +338,7 @@
         ],
         "resources": []
       },
-      "research_time": 1820
+      "research_time": 1820040
     }
   ],
   "location": {

--- a/research/klingon_pure_crystal.json
+++ b/research/klingon_pure_crystal.json
@@ -33,15 +33,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 45350
+            "value": 45350000
           },
           {
             "type": "dilithium",
-            "value": 11100
+            "value": 11100000
           }
         ]
       },
-      "research_time": 4160
+      "research_time": 4160100
     },
     {
       "bonus": {
@@ -74,15 +74,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 99700
+            "value": 99700000
           },
           {
             "type": "dilithium",
-            "value": 24450
+            "value": 24450000
           }
         ]
       },
-      "research_time": 5574
+      "research_time": 5574360
     },
     {
       "bonus": {
@@ -115,15 +115,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 268500
+            "value": 268500000
           },
           {
             "type": "dilithium",
-            "value": 65800
+            "value": 65800000
           }
         ]
       },
-      "research_time": 12893
+      "research_time": 12893940
     },
     {
       "bonus": {
@@ -156,15 +156,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 615100
+            "value": 615100000
           },
           {
             "type": "dilithium",
-            "value": 150800
+            "value": 150800000
           }
         ]
       },
-      "research_time": 21529
+      "research_time": 21529800
     },
     {
       "bonus": {
@@ -197,15 +197,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1330
+            "value": 1330000000
           },
           {
             "type": "dilithium",
-            "value": 326000
+            "value": 326000000
           }
         ]
       },
-      "research_time": 46942
+      "research_time": 46942080
     },
     {
       "bonus": {
@@ -238,15 +238,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 2889
+            "value": 2889000000
           },
           {
             "type": "dilithium",
-            "value": 708000
+            "value": 708000000
           }
         ]
       },
-      "research_time": 81744
+      "research_time": 81744660
     },
     {
       "bonus": {
@@ -279,15 +279,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 5957
+            "value": 5957000000
           },
           {
             "type": "dilithium",
-            "value": 1460
+            "value": 1460000000
           }
         ]
       },
-      "research_time": 142221
+      "research_time": 142221540
     },
     {
       "bonus": {
@@ -324,7 +324,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 3530
+            "value": 3530000
           },
           {
             "type": "dilithium",
@@ -332,7 +332,7 @@
           }
         ]
       },
-      "research_time": 1039
+      "research_time": 1039440
     },
     {
       "bonus": {
@@ -365,15 +365,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 8340
+            "value": 8340000
           },
           {
             "type": "dilithium",
-            "value": 2040
+            "value": 2040000
           }
         ]
       },
-      "research_time": 1520
+      "research_time": 1520880
     },
     {
       "bonus": {
@@ -406,15 +406,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 18950
+            "value": 18950000
           },
           {
             "type": "dilithium",
-            "value": 4650
+            "value": 4650000
           }
         ]
       },
-      "research_time": 2319
+      "research_time": 2319120
     }
   ],
   "location": {

--- a/research/klingon_repair_costs.json
+++ b/research/klingon_repair_costs.json
@@ -54,15 +54,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 5470
+            "value": 5470000
           },
           {
             "type": "dilithium",
-            "value": 1480
+            "value": 1480000
           }
         ]
       },
-      "research_time": 1333
+      "research_time": 1333800
     },
     {
       "bonus": {
@@ -107,15 +107,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 12250
+            "value": 12250000
           },
           {
             "type": "dilithium",
-            "value": 3300
+            "value": 3300000
           }
         ]
       },
-      "research_time": 1761
+      "research_time": 1761360
     },
     {
       "bonus": {
@@ -141,15 +141,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 30400
+            "value": 30400000
           },
           {
             "type": "dilithium",
-            "value": 8200
+            "value": 8200000
           }
         ]
       },
-      "research_time": 3488
+      "research_time": 3488220
     },
     {
       "bonus": {
@@ -194,15 +194,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 67650
+            "value": 67650000
           },
           {
             "type": "dilithium",
-            "value": 18250
+            "value": 18250000
           }
         ]
       },
-      "research_time": 6299
+      "research_time": 6299160
     },
     {
       "bonus": {
@@ -247,15 +247,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 157700
+            "value": 157700000
           },
           {
             "type": "dilithium",
-            "value": 42500
+            "value": 42500000
           }
         ]
       },
-      "research_time": 10738
+      "research_time": 10738680
     },
     {
       "bonus": {
@@ -288,15 +288,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 424100
+            "value": 424100000
           },
           {
             "type": "dilithium",
-            "value": 114300
+            "value": 114300000
           }
         ]
       },
-      "research_time": 25425
+      "research_time": 25425720
     },
     {
       "bonus": {
@@ -341,15 +341,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 916800
+            "value": 916800000
           },
           {
             "type": "dilithium",
-            "value": 247200
+            "value": 247200000
           }
         ]
       },
-      "research_time": 37831
+      "research_time": 37831440
     },
     {
       "bonus": {
@@ -394,15 +394,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 2026
+            "value": 2026000000
           },
           {
             "type": "dilithium",
-            "value": 546200
+            "value": 546200000
           }
         ]
       },
-      "research_time": 70081
+      "research_time": 70081440
     },
     {
       "bonus": {
@@ -447,15 +447,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 4028
+            "value": 4028000000
           },
           {
             "type": "dilithium",
-            "value": 1086
+            "value": 1086000000
           }
         ]
       },
-      "research_time": 124020
+      "research_time": 124020600
     },
     {
       "bonus": {
@@ -500,15 +500,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 9621
+            "value": 9621000000
           },
           {
             "type": "dilithium",
-            "value": 2594
+            "value": 2594000000
           }
         ]
       },
-      "research_time": 204649
+      "research_time": 204649620
     }
   ],
   "location": {

--- a/research/klingon_repair_speed.json
+++ b/research/klingon_repair_speed.json
@@ -49,15 +49,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 45350
+            "value": 45350000
           },
           {
             "type": "dilithium",
-            "value": 22200
+            "value": 22200000
           }
         ]
       },
-      "research_time": 6500
+      "research_time": 6500100
     },
     {
       "bonus": {
@@ -102,15 +102,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 99700
+            "value": 99700000
           },
           {
             "type": "dilithium",
-            "value": 48850
+            "value": 48850000
           }
         ]
       },
-      "research_time": 8709
+      "research_time": 8709960
     },
     {
       "bonus": {
@@ -155,15 +155,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 268500
+            "value": 268500000
           },
           {
             "type": "dilithium",
-            "value": 131600
+            "value": 131600000
           }
         ]
       },
-      "research_time": 20146
+      "research_time": 20146800
     },
     {
       "bonus": {
@@ -196,15 +196,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 615100
+            "value": 615100000
           },
           {
             "type": "dilithium",
-            "value": 301500
+            "value": 301500000
           }
         ]
       },
-      "research_time": 33640
+      "research_time": 33640320
     },
     {
       "bonus": {
@@ -249,15 +249,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1330
+            "value": 1330000000
           },
           {
             "type": "dilithium",
-            "value": 652000
+            "value": 652000000
           }
         ]
       },
-      "research_time": 73347
+      "research_time": 73347000
     },
     {
       "bonus": {
@@ -302,15 +302,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 2889
+            "value": 2889000000
           },
           {
             "type": "dilithium",
-            "value": 1416
+            "value": 1416000000
           }
         ]
       },
-      "research_time": 127726
+      "research_time": 127726020
     },
     {
       "bonus": {
@@ -355,15 +355,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 5957
+            "value": 5957000000
           },
           {
             "type": "dilithium",
-            "value": 2920
+            "value": 2920000000
           }
         ]
       },
-      "research_time": 222221
+      "research_time": 222221100
     },
     {
       "bonus": {
@@ -408,15 +408,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 16279
+            "value": 16279000000
           },
           {
             "type": "dilithium",
-            "value": 7980
+            "value": 7980000000
           }
         ]
       },
-      "research_time": 376409
+      "research_time": 376409340
     },
     {
       "bonus": {
@@ -442,15 +442,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 44018
+            "value": 44018000000
           },
           {
             "type": "dilithium",
-            "value": 21578
+            "value": 21578000000
           }
         ]
       },
-      "research_time": 577916
+      "research_time": 577916820
     },
     {
       "bonus": {
@@ -476,15 +476,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 60244
+            "value": 60244000000
           },
           {
             "type": "dilithium",
-            "value": 29531
+            "value": 29531000000
           }
         ]
       },
-      "research_time": 511432
+      "research_time": 511432980
     }
   ],
   "location": {

--- a/research/klingon_ship_structure.json
+++ b/research/klingon_ship_structure.json
@@ -39,7 +39,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1500
+            "value": 1500000
           },
           {
             "type": "dilithium",
@@ -86,7 +86,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 3530
+            "value": 3530000
           },
           {
             "type": "dilithium",
@@ -139,15 +139,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 8340
+            "value": 8340000
           },
           {
             "type": "dilithium",
-            "value": 2040
+            "value": 2040000
           }
         ]
       },
-      "research_time": 1330
+      "research_time": 1330800
     },
     {
       "bonus": {
@@ -192,15 +192,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 18950
+            "value": 18950000
           },
           {
             "type": "dilithium",
-            "value": 4650
+            "value": 4650000
           }
         ]
       },
-      "research_time": 2029
+      "research_time": 2029200
     },
     {
       "bonus": {
@@ -245,15 +245,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 45350
+            "value": 45350000
           },
           {
             "type": "dilithium",
-            "value": 11100
+            "value": 11100000
           }
         ]
       },
-      "research_time": 3640
+      "research_time": 3640080
     },
     {
       "bonus": {
@@ -298,15 +298,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 99700
+            "value": 99700000
           },
           {
             "type": "dilithium",
-            "value": 24450
+            "value": 24450000
           }
         ]
       },
-      "research_time": 4877
+      "research_time": 4877580
     },
     {
       "bonus": {
@@ -351,15 +351,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 268500
+            "value": 268500000
           },
           {
             "type": "dilithium",
-            "value": 65800
+            "value": 65800000
           }
         ]
       },
-      "research_time": 11282
+      "research_time": 11282220
     },
     {
       "bonus": {
@@ -398,15 +398,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 615100
+            "value": 615100000
           },
           {
             "type": "dilithium",
-            "value": 150800
+            "value": 150800000
           }
         ]
       },
-      "research_time": 18838
+      "research_time": 18838560
     },
     {
       "bonus": {
@@ -451,15 +451,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1330
+            "value": 1330000000
           },
           {
             "type": "dilithium",
-            "value": 326000
+            "value": 326000000
           }
         ]
       },
-      "research_time": 41074
+      "research_time": 41074320
     },
     {
       "bonus": {

--- a/research/klingon_vulnerability.json
+++ b/research/klingon_vulnerability.json
@@ -50,11 +50,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 9214
+            "value": 9214000000
           }
         ]
       },
-      "research_time": 246380
+      "research_time": 246380520
     }
   ],
   "location": {

--- a/research/klingon_weakpoints.json
+++ b/research/klingon_weakpoints.json
@@ -46,7 +46,7 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1120
+            "value": 1120000
           }
         ]
       },
@@ -91,11 +91,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 2660
+            "value": 2660000
           }
         ]
       },
-      "research_time": 1235
+      "research_time": 1235700
     },
     {
       "bonus": {
@@ -136,11 +136,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 3900
+            "value": 3900000
           }
         ]
       },
-      "research_time": 1272
+      "research_time": 1272060
     },
     {
       "bonus": {
@@ -162,11 +162,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 9690
+            "value": 9690000
           }
         ]
       },
-      "research_time": 2519
+      "research_time": 2519280
     },
     {
       "bonus": {
@@ -207,11 +207,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 14450
+            "value": 14450000
           }
         ]
       },
-      "research_time": 3380
+      "research_time": 3380040
     },
     {
       "bonus": {
@@ -252,11 +252,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 31750
+            "value": 31750000
           }
         ]
       },
-      "research_time": 4529
+      "research_time": 4529160
     },
     {
       "bonus": {
@@ -278,11 +278,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 50250
+            "value": 50250000
           }
         ]
       },
-      "research_time": 7755
+      "research_time": 7755720
     },
     {
       "bonus": {
@@ -311,11 +311,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 135100
+            "value": 135100000
           }
         ]
       },
-      "research_time": 18363
+      "research_time": 18363000
     },
     {
       "bonus": {
@@ -350,11 +350,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 196000
+            "value": 196000000
           }
         ]
       },
-      "research_time": 17492
+      "research_time": 17492940
     },
     {
       "bonus": {

--- a/research/merciless_outlaw.json
+++ b/research/merciless_outlaw.json
@@ -44,7 +44,7 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1670
+            "value": 1670000
           }
         ]
       },
@@ -75,7 +75,7 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 2490
+            "value": 2490000
           }
         ]
       },
@@ -119,7 +119,7 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 3670
+            "value": 3670000
           }
         ]
       },
@@ -155,11 +155,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 9870
+            "value": 9870000
           }
         ]
       },
-      "research_time": 1208
+      "research_time": 1208820
     },
     {
       "bonus": {
@@ -199,11 +199,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 22600
+            "value": 22600000
           }
         ]
       },
-      "research_time": 2018
+      "research_time": 2018400
     },
     {
       "bonus": {
@@ -235,11 +235,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 27135
+            "value": 27135000
           }
         ]
       },
-      "research_time": 2422
+      "research_time": 2422080
     },
     {
       "bonus": {
@@ -266,11 +266,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 48900
+            "value": 48900000
           }
         ]
       },
-      "research_time": 4400
+      "research_time": 4400820
     },
     {
       "bonus": {
@@ -302,11 +302,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 58680
+            "value": 58680000
           }
         ]
       },
-      "research_time": 5280
+      "research_time": 5280960
     },
     {
       "bonus": {
@@ -338,11 +338,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 106200
+            "value": 106200000
           }
         ]
       },
-      "research_time": 7663
+      "research_time": 7663560
     },
     {
       "bonus": {
@@ -369,11 +369,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 219000
+            "value": 219000000
           }
         ]
       },
-      "research_time": 13333
+      "research_time": 13333260
     }
   ],
   "location": {

--- a/research/miner_offense.json
+++ b/research/miner_offense.json
@@ -39,7 +39,7 @@
         ],
         "resources": []
       },
-      "research_time": 3900
+      "research_time": 3900060
     },
     {
       "bonus": {
@@ -74,7 +74,7 @@
         ],
         "resources": []
       },
-      "research_time": 5249
+      "research_time": 5249280
     },
     {
       "bonus": {
@@ -109,7 +109,7 @@
         ],
         "resources": []
       },
-      "research_time": 5226
+      "research_time": 5226000
     },
     {
       "bonus": {
@@ -139,7 +139,7 @@
         ],
         "resources": []
       },
-      "research_time": 8948
+      "research_time": 8948940
     },
     {
       "bonus": {
@@ -170,7 +170,7 @@
         ],
         "resources": []
       },
-      "research_time": 12088
+      "research_time": 12088080
     },
     {
       "bonus": {
@@ -209,7 +209,7 @@
         ],
         "resources": []
       },
-      "research_time": 21188
+      "research_time": 21188100
     },
     {
       "bonus": {
@@ -248,7 +248,7 @@
         ],
         "resources": []
       },
-      "research_time": 20184
+      "research_time": 20184180
     },
     {
       "bonus": {
@@ -287,7 +287,7 @@
         ],
         "resources": []
       },
-      "research_time": 31526
+      "research_time": 31526220
     },
     {
       "bonus": {
@@ -322,7 +322,7 @@
         ],
         "resources": []
       },
-      "research_time": 44008
+      "research_time": 44008200
     },
     {
       "bonus": {
@@ -361,7 +361,7 @@
         ],
         "resources": []
       },
-      "research_time": 1111
+      "research_time": 1111500
     }
   ],
   "location": {

--- a/research/mining_bunker.json
+++ b/research/mining_bunker.json
@@ -39,7 +39,7 @@
         ],
         "resources": []
       },
-      "research_time": 3900
+      "research_time": 3900060
     },
     {
       "bonus": {
@@ -70,7 +70,7 @@
         ],
         "resources": []
       },
-      "research_time": 5249
+      "research_time": 5249280
     },
     {
       "bonus": {
@@ -100,7 +100,7 @@
         ],
         "resources": []
       },
-      "research_time": 5226
+      "research_time": 5226000
     },
     {
       "bonus": {
@@ -135,7 +135,7 @@
         ],
         "resources": []
       },
-      "research_time": 8948
+      "research_time": 8948940
     },
     {
       "bonus": {
@@ -170,7 +170,7 @@
         ],
         "resources": []
       },
-      "research_time": 12088
+      "research_time": 12088080
     },
     {
       "bonus": {
@@ -200,7 +200,7 @@
         ],
         "resources": []
       },
-      "research_time": 20184
+      "research_time": 20184180
     },
     {
       "bonus": {
@@ -239,7 +239,7 @@
         ],
         "resources": []
       },
-      "research_time": 21188
+      "research_time": 21188100
     },
     {
       "bonus": {
@@ -273,7 +273,7 @@
         ],
         "resources": []
       },
-      "research_time": 31526
+      "research_time": 31526220
     },
     {
       "bonus": {
@@ -307,7 +307,7 @@
         ],
         "resources": []
       },
-      "research_time": 44008
+      "research_time": 44008200
     },
     {
       "bonus": {
@@ -346,7 +346,7 @@
         ],
         "resources": []
       },
-      "research_time": 1111
+      "research_time": 1111500
     }
   ],
   "location": {

--- a/research/modulated_federation.json
+++ b/research/modulated_federation.json
@@ -26,15 +26,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 1070
+            "value": 1070000
           },
           {
             "type": "dilithium",
-            "value": 1340
+            "value": 1340000
           }
         ]
       },
-      "research_time": 1037
+      "research_time": 1037400
     },
     {
       "bonus": {
@@ -79,15 +79,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 2400
+            "value": 2400000
           },
           {
             "type": "dilithium",
-            "value": 3000
+            "value": 3000000
           }
         ]
       },
-      "research_time": 1369
+      "research_time": 1369920
     },
     {
       "bonus": {
@@ -113,15 +113,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 5960
+            "value": 5960000
           },
           {
             "type": "dilithium",
-            "value": 7460
+            "value": 7460000
           }
         ]
       },
-      "research_time": 2713
+      "research_time": 2713080
     },
     {
       "bonus": {
@@ -166,15 +166,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 13250
+            "value": 13250000
           },
           {
             "type": "dilithium",
-            "value": 16600
+            "value": 16600000
           }
         ]
       },
-      "research_time": 4899
+      "research_time": 4899360
     },
     {
       "bonus": {
@@ -219,15 +219,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 30900
+            "value": 30900000
           },
           {
             "type": "dilithium",
-            "value": 38650
+            "value": 38650000
           }
         ]
       },
-      "research_time": 8352
+      "research_time": 8352300
     },
     {
       "bonus": {
@@ -260,15 +260,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 83150
+            "value": 83150000
           },
           {
             "type": "dilithium",
-            "value": 104000
+            "value": 104000000
           }
         ]
       },
-      "research_time": 19775
+      "research_time": 19775580
     },
     {
       "bonus": {
@@ -313,15 +313,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 179800
+            "value": 179800000
           },
           {
             "type": "dilithium",
-            "value": 224700
+            "value": 224700000
           }
         ]
       },
-      "research_time": 29424
+      "research_time": 29424480
     },
     {
       "bonus": {
@@ -366,15 +366,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 397200
+            "value": 397200000
           },
           {
             "type": "dilithium",
-            "value": 496500
+            "value": 496500000
           }
         ]
       },
-      "research_time": 54507
+      "research_time": 54507780
     },
     {
       "bonus": {

--- a/research/mudd_s_mudd.json
+++ b/research/mudd_s_mudd.json
@@ -43,11 +43,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 259900
+            "value": 259900000
           }
         ]
       },
-      "research_time": 35313,
+      "research_time": 35313540,
       "reward": {
         "type": "Gamma\u00a0Particle\u00a0",
         "value": 1

--- a/research/multi_adaptive_shielding.json
+++ b/research/multi_adaptive_shielding.json
@@ -45,11 +45,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 3065
+            "value": 3065000000
           }
         ]
       },
-      "research_time": 147802
+      "research_time": 147802500
     },
     {
       "bonus": {
@@ -95,11 +95,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 9214
+            "value": 9214000000
           }
         ]
       },
-      "research_time": 246380
+      "research_time": 246380520
     },
     {
       "bonus": {
@@ -134,11 +134,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 14025
+            "value": 14025000000
           }
         ]
       },
-      "research_time": 300516
+      "research_time": 300516720
     },
     {
       "bonus": {
@@ -173,11 +173,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 19195
+            "value": 19195000000
           }
         ]
       },
-      "research_time": 265945
+      "research_time": 265945140
     },
     {
       "bonus": {
@@ -212,11 +212,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 28793
+            "value": 28793000000
           }
         ]
       },
-      "research_time": 319134
+      "research_time": 319134180
     },
     {
       "bonus": {
@@ -251,11 +251,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 43189
+            "value": 43189000000
           }
         ]
       },
-      "research_time": 419913
+      "research_time": 419913420
     }
   ],
   "location": {

--- a/research/offensive_strategies.json
+++ b/research/offensive_strategies.json
@@ -48,15 +48,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 566400
+            "value": 566400000
           },
           {
             "type": "dilithium",
-            "value": 708000
+            "value": 708000000
           }
         ]
       },
-      "research_time": 61308
+      "research_time": 61308480
     },
     {
       "bonus": {
@@ -100,15 +100,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 789800
+            "value": 789800000
           },
           {
             "type": "dilithium",
-            "value": 987300
+            "value": 987300000
           }
         ]
       },
-      "research_time": 82680
+      "research_time": 82680420
     },
     {
       "bonus": {
@@ -152,15 +152,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 1168
+            "value": 1168000000
           },
           {
             "type": "dilithium",
-            "value": 1460
+            "value": 1460000000
           }
         ]
       },
-      "research_time": 106666
+      "research_time": 106666140
     },
     {
       "bonus": {
@@ -200,15 +200,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 1886
+            "value": 1886000000
           },
           {
             "type": "dilithium",
-            "value": 2358
+            "value": 2358000000
           }
         ]
       },
-      "research_time": 136433
+      "research_time": 136433100
     },
     {
       "bonus": {
@@ -256,15 +256,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 3192
+            "value": 3192000000
           },
           {
             "type": "dilithium",
-            "value": 3990
+            "value": 3990000000
           }
         ]
       },
-      "research_time": 180676
+      "research_time": 180676500
     },
     {
       "bonus": {
@@ -308,15 +308,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 5670
+            "value": 5670000000
           },
           {
             "type": "dilithium",
-            "value": 7088
+            "value": 7088000000
           }
         ]
       },
-      "research_time": 227428
+      "research_time": 227428200
     },
     {
       "bonus": {
@@ -338,15 +338,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 8631
+            "value": 8631000000
           },
           {
             "type": "dilithium",
-            "value": 10789
+            "value": 10789000000
           }
         ]
       },
-      "research_time": 277400
+      "research_time": 277400040
     },
     {
       "bonus": {
@@ -368,15 +368,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 13230
+            "value": 13230000000
           },
           {
             "type": "dilithium",
-            "value": 16538
+            "value": 16538000000
           }
         ]
       },
-      "research_time": 357105
+      "research_time": 357105840
     },
     {
       "bonus": {
@@ -398,15 +398,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 11813
+            "value": 11813000000
           },
           {
             "type": "dilithium",
-            "value": 14766
+            "value": 14766000000
           }
         ]
       },
-      "research_time": 245487
+      "research_time": 245487840
     },
     {
       "bonus": {
@@ -428,15 +428,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 17719
+            "value": 17719000000
           },
           {
             "type": "dilithium",
-            "value": 22148
+            "value": 22148000000
           }
         ]
       },
-      "research_time": 294585
+      "research_time": 294585420
     }
   ],
   "location": {

--- a/research/officer_conditioning.json
+++ b/research/officer_conditioning.json
@@ -36,11 +36,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 2440
+            "value": 2440000
           }
         ]
       },
-      "research_time": 3483
+      "research_time": 3483960
     },
     {
       "bonus": {
@@ -76,11 +76,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1110
+            "value": 1110000
           }
         ]
       },
-      "research_time": 2600
+      "research_time": 2600040
     },
     {
       "bonus": {
@@ -116,11 +116,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 6580
+            "value": 6580000
           }
         ]
       },
-      "research_time": 8058
+      "research_time": 8058720
     },
     {
       "bonus": {
@@ -156,11 +156,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 15100
+            "value": 15100000
           }
         ]
       },
-      "research_time": 13456
+      "research_time": 13456140
     },
     {
       "bonus": {
@@ -196,11 +196,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 32600
+            "value": 32600000
           }
         ]
       },
-      "research_time": 29338
+      "research_time": 29338800
     },
     {
       "bonus": {
@@ -236,11 +236,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 70800
+            "value": 70800000
           }
         ]
       },
-      "research_time": 51090
+      "research_time": 51090420
     },
     {
       "bonus": {
@@ -276,11 +276,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 146000
+            "value": 146000000
           }
         ]
       },
-      "research_time": 88888
+      "research_time": 88888440
     },
     {
       "bonus": {
@@ -316,11 +316,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 399000
+            "value": 399000000
           }
         ]
       },
-      "research_time": 150563
+      "research_time": 150563760
     },
     {
       "bonus": {
@@ -600,7 +600,7 @@
           }
         ]
       },
-      "research_time": 1449
+      "research_time": 1449420
     }
   ],
   "location": {

--- a/research/optimized_construction.json
+++ b/research/optimized_construction.json
@@ -40,11 +40,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1110
+            "value": 1110000
           }
         ]
       },
-      "research_time": 2600
+      "research_time": 2600040
     },
     {
       "bonus": {
@@ -75,11 +75,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 6580
+            "value": 6580000
           }
         ]
       },
-      "research_time": 8058
+      "research_time": 8058720
     },
     {
       "bonus": {
@@ -110,11 +110,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 10400
+            "value": 10400000
           }
         ]
       },
-      "research_time": 14125
+      "research_time": 14125380
     },
     {
       "bonus": {
@@ -145,11 +145,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 15100
+            "value": 15100000
           }
         ]
       },
-      "research_time": 13456
+      "research_time": 13456140
     },
     {
       "bonus": {
@@ -184,11 +184,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 22450
+            "value": 22450000
           }
         ]
       },
-      "research_time": 21017
+      "research_time": 21017460
     },
     {
       "bonus": {
@@ -219,11 +219,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 32600
+            "value": 32600000
           }
         ]
       },
-      "research_time": 29338
+      "research_time": 29338800
     },
     {
       "bonus": {
@@ -254,11 +254,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 49650
+            "value": 49650000
           }
         ]
       },
-      "research_time": 38934
+      "research_time": 38934120
     },
     {
       "bonus": {
@@ -289,11 +289,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 98750
+            "value": 98750000
           }
         ]
       },
-      "research_time": 68900
+      "research_time": 68900340
     },
     {
       "bonus": {
@@ -324,11 +324,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 235800
+            "value": 235800000
           }
         ]
       },
-      "research_time": 113694
+      "research_time": 113694240
     },
     {
       "bonus": {
@@ -368,11 +368,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 708800
+            "value": 708800000
           }
         ]
       },
-      "research_time": 189523
+      "research_time": 189523500
     }
   ],
   "location": {

--- a/research/optimized_research.json
+++ b/research/optimized_research.json
@@ -40,11 +40,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1110
+            "value": 1110000
           }
         ]
       },
-      "research_time": 2600
+      "research_time": 2600040
     },
     {
       "bonus": {
@@ -75,11 +75,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 6580
+            "value": 6580000
           }
         ]
       },
-      "research_time": 8058
+      "research_time": 8058720
     },
     {
       "bonus": {
@@ -110,11 +110,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 10400
+            "value": 10400000
           }
         ]
       },
-      "research_time": 14125
+      "research_time": 14125380
     },
     {
       "bonus": {
@@ -145,11 +145,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 15100
+            "value": 15100000
           }
         ]
       },
-      "research_time": 13456
+      "research_time": 13456140
     },
     {
       "bonus": {
@@ -189,11 +189,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 22450
+            "value": 22450000
           }
         ]
       },
-      "research_time": 21017
+      "research_time": 21017460
     },
     {
       "bonus": {
@@ -224,11 +224,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 32600
+            "value": 32600000
           }
         ]
       },
-      "research_time": 29338
+      "research_time": 29338800
     },
     {
       "bonus": {
@@ -259,11 +259,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 49650
+            "value": 49650000
           }
         ]
       },
-      "research_time": 38934
+      "research_time": 38934120
     },
     {
       "bonus": {
@@ -294,11 +294,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 98750
+            "value": 98750000
           }
         ]
       },
-      "research_time": 68900
+      "research_time": 68900340
     },
     {
       "bonus": {
@@ -329,11 +329,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 235800
+            "value": 235800000
           }
         ]
       },
-      "research_time": 113694
+      "research_time": 113694240
     },
     {
       "bonus": {
@@ -385,11 +385,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 708800
+            "value": 708800000
           }
         ]
       },
-      "research_time": 189523
+      "research_time": 189523500
     }
   ],
   "location": {

--- a/research/optimized_ship_upgrades.json
+++ b/research/optimized_ship_upgrades.json
@@ -40,11 +40,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1110
+            "value": 1110000
           }
         ]
       },
-      "research_time": 2600
+      "research_time": 2600040
     },
     {
       "bonus": {
@@ -75,11 +75,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 6580
+            "value": 6580000
           }
         ]
       },
-      "research_time": 8058
+      "research_time": 8058720
     },
     {
       "bonus": {
@@ -110,11 +110,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 10400
+            "value": 10400000
           }
         ]
       },
-      "research_time": 14125
+      "research_time": 14125380
     },
     {
       "bonus": {
@@ -145,11 +145,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 15100
+            "value": 15100000
           }
         ]
       },
-      "research_time": 13456
+      "research_time": 13456140
     },
     {
       "bonus": {
@@ -193,11 +193,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 22450
+            "value": 22450000
           }
         ]
       },
-      "research_time": 21017
+      "research_time": 21017460
     },
     {
       "bonus": {
@@ -228,11 +228,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 32600
+            "value": 32600000
           }
         ]
       },
-      "research_time": 29338
+      "research_time": 29338800
     },
     {
       "bonus": {
@@ -263,11 +263,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 49650
+            "value": 49650000
           }
         ]
       },
-      "research_time": 38934
+      "research_time": 38934120
     },
     {
       "bonus": {
@@ -298,11 +298,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 98750
+            "value": 98750000
           }
         ]
       },
-      "research_time": 68900
+      "research_time": 68900340
     },
     {
       "bonus": {
@@ -333,11 +333,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 235800
+            "value": 235800000
           }
         ]
       },
-      "research_time": 113694
+      "research_time": 113694240
     },
     {
       "bonus": {
@@ -377,11 +377,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 708800
+            "value": 708800000
           }
         ]
       },
-      "research_time": 189523
+      "research_time": 189523500
     }
   ],
   "location": {

--- a/research/ore_building_efficiency.json
+++ b/research/ore_building_efficiency.json
@@ -42,15 +42,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 45350
+            "value": 45350000
           },
           {
             "type": "dilithium",
-            "value": 11100
+            "value": 11100000
           }
         ]
       },
-      "research_time": 2600
+      "research_time": 2600040
     },
     {
       "bonus": {
@@ -92,15 +92,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 157700
+            "value": 157700000
           },
           {
             "type": "dilithium",
-            "value": 38650
+            "value": 38650000
           }
         ]
       },
-      "research_time": 5965
+      "research_time": 5965920
     },
     {
       "bonus": {
@@ -152,15 +152,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 268500
+            "value": 268500000
           },
           {
             "type": "dilithium",
-            "value": 65800
+            "value": 65800000
           }
         ]
       },
-      "research_time": 8058
+      "research_time": 8058720
     },
     {
       "bonus": {
@@ -212,15 +212,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 424100
+            "value": 424100000
           },
           {
             "type": "dilithium",
-            "value": 104000
+            "value": 104000000
           }
         ]
       },
-      "research_time": 14125
+      "research_time": 14125380
     },
     {
       "bonus": {
@@ -272,15 +272,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 615100
+            "value": 615100000
           },
           {
             "type": "dilithium",
-            "value": 150800
+            "value": 150800000
           }
         ]
       },
-      "research_time": 13456
+      "research_time": 13456140
     },
     {
       "bonus": {
@@ -332,15 +332,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 916800
+            "value": 916800000
           },
           {
             "type": "dilithium",
-            "value": 224700
+            "value": 224700000
           }
         ]
       },
-      "research_time": 21017
+      "research_time": 21017460
     },
     {
       "bonus": {
@@ -392,15 +392,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1330
+            "value": 1330000000
           },
           {
             "type": "dilithium",
-            "value": 326000
+            "value": 326000000
           }
         ]
       },
-      "research_time": 29338
+      "research_time": 29338800
     },
     {
       "bonus": {
@@ -452,15 +452,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 2026
+            "value": 2026000000
           },
           {
             "type": "dilithium",
-            "value": 496500
+            "value": 496500000
           }
         ]
       },
-      "research_time": 38934
+      "research_time": 38934120
     },
     {
       "bonus": {
@@ -512,15 +512,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 2889
+            "value": 2889000000
           },
           {
             "type": "dilithium",
-            "value": 708000
+            "value": 708000000
           }
         ]
       },
-      "research_time": 51090
+      "research_time": 51090420
     },
     {
       "bonus": {
@@ -564,15 +564,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 4028
+            "value": 4028000000
           },
           {
             "type": "dilithium",
-            "value": 987300
+            "value": 987300000
           }
         ]
       },
-      "research_time": 68900
+      "research_time": 68900340
     }
   ],
   "location": {

--- a/research/ore_miner.json
+++ b/research/ore_miner.json
@@ -131,11 +131,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 2250
+            "value": 2250000
           }
         ]
       },
-      "research_time": 1045
+      "research_time": 1045620
     },
     {
       "bonus": {
@@ -179,7 +179,7 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1480
+            "value": 1480000
           }
         ]
       },
@@ -218,11 +218,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 3300
+            "value": 3300000
           }
         ]
       },
-      "research_time": 1076
+      "research_time": 1076400
     },
     {
       "bonus": {
@@ -260,11 +260,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 5110
+            "value": 5110000
           }
         ]
       },
-      "research_time": 1594
+      "research_time": 1594380
     },
     {
       "bonus": {
@@ -297,11 +297,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 12200
+            "value": 12200000
           }
         ]
       },
-      "research_time": 2860
+      "research_time": 2860080
     },
     {
       "bonus": {
@@ -340,11 +340,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 26900
+            "value": 26900000
           }
         ]
       },
-      "research_time": 3832
+      "research_time": 3832380
     },
     {
       "bonus": {
@@ -377,11 +377,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 72400
+            "value": 72400000
           }
         ]
       },
-      "research_time": 8864
+      "research_time": 8864580
     },
     {
       "bonus": {

--- a/research/ore_research.json
+++ b/research/ore_research.json
@@ -42,15 +42,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 45350
+            "value": 45350000
           },
           {
             "type": "dilithium",
-            "value": 11100
+            "value": 11100000
           }
         ]
       },
-      "research_time": 2600
+      "research_time": 2600040
     },
     {
       "bonus": {
@@ -88,15 +88,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 157700
+            "value": 157700000
           },
           {
             "type": "dilithium",
-            "value": 38650
+            "value": 38650000
           }
         ]
       },
-      "research_time": 5965
+      "research_time": 5965920
     },
     {
       "bonus": {
@@ -152,15 +152,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 268500
+            "value": 268500000
           },
           {
             "type": "dilithium",
-            "value": 65800
+            "value": 65800000
           }
         ]
       },
-      "research_time": 8058
+      "research_time": 8058720
     },
     {
       "bonus": {
@@ -208,15 +208,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 424100
+            "value": 424100000
           },
           {
             "type": "dilithium",
-            "value": 104000
+            "value": 104000000
           }
         ]
       },
-      "research_time": 14125
+      "research_time": 14125380
     },
     {
       "bonus": {
@@ -268,15 +268,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 615100
+            "value": 615100000
           },
           {
             "type": "dilithium",
-            "value": 150800
+            "value": 150800000
           }
         ]
       },
-      "research_time": 13456
+      "research_time": 13456140
     },
     {
       "bonus": {
@@ -320,15 +320,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 916800
+            "value": 916800000
           },
           {
             "type": "dilithium",
-            "value": 224700
+            "value": 224700000
           }
         ]
       },
-      "research_time": 21017
+      "research_time": 21017460
     },
     {
       "bonus": {
@@ -380,15 +380,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1330
+            "value": 1330000000
           },
           {
             "type": "dilithium",
-            "value": 326000
+            "value": 326000000
           }
         ]
       },
-      "research_time": 29338
+      "research_time": 29338800
     },
     {
       "bonus": {
@@ -432,15 +432,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 2026
+            "value": 2026000000
           },
           {
             "type": "dilithium",
-            "value": 496500
+            "value": 496500000
           }
         ]
       },
-      "research_time": 38934
+      "research_time": 38934120
     },
     {
       "bonus": {
@@ -492,15 +492,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 2889
+            "value": 2889000000
           },
           {
             "type": "dilithium",
-            "value": 708000
+            "value": 708000000
           }
         ]
       },
-      "research_time": 51090
+      "research_time": 51090420
     },
     {
       "bonus": {
@@ -552,15 +552,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 4028
+            "value": 4028000000
           },
           {
             "type": "dilithium",
-            "value": 987300
+            "value": 987300000
           }
         ]
       },
-      "research_time": 68900
+      "research_time": 68900340
     }
   ],
   "location": {

--- a/research/out_of_the_darkness.json
+++ b/research/out_of_the_darkness.json
@@ -43,11 +43,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 259900
+            "value": 259900000
           }
         ]
       },
-      "research_time": 35313,
+      "research_time": 35313540,
       "reward": {
         "type": "Mission\u00a0Token\u00a0",
         "value": 1

--- a/research/outlaw_mechanics.json
+++ b/research/outlaw_mechanics.json
@@ -92,7 +92,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1500
+            "value": 1500000
           },
           {
             "type": "dilithium",
@@ -148,7 +148,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 2290
+            "value": 2290000
           },
           {
             "type": "dilithium",

--- a/research/parsteel_accelerator.json
+++ b/research/parsteel_accelerator.json
@@ -35,15 +35,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 45100
+            "value": 45100000
           },
           {
             "type": "dilithium",
-            "value": 9950
+            "value": 9950000
           }
         ]
       },
-      "research_time": 2099
+      "research_time": 2099700
     },
     {
       "bonus": {
@@ -70,15 +70,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 105100
+            "value": 105100000
           },
           {
             "type": "dilithium",
-            "value": 23200
+            "value": 23200000
           }
         ]
       },
-      "research_time": 3579
+      "research_time": 3579540
     },
     {
       "bonus": {
@@ -109,15 +109,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 179000
+            "value": 179000000
           },
           {
             "type": "dilithium",
-            "value": 39500
+            "value": 39500000
           }
         ]
       },
-      "research_time": 4835
+      "research_time": 4835220
     },
     {
       "bonus": {
@@ -147,15 +147,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 410000
+            "value": 410000000
           },
           {
             "type": "dilithium",
-            "value": 90450
+            "value": 90450000
           }
         ]
       },
-      "research_time": 8073
+      "research_time": 8073660
     },
     {
       "bonus": {
@@ -190,15 +190,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 611200
+            "value": 611200000
           },
           {
             "type": "dilithium",
-            "value": 134800
+            "value": 134800000
           }
         ]
       },
-      "research_time": 12610
+      "research_time": 12610500
     },
     {
       "bonus": {
@@ -225,11 +225,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 8150
+            "value": 8150000
           },
           {
             "type": "dilithium",
-            "value": 1800
+            "value": 1800000
           }
         ]
       },
@@ -289,7 +289,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1520
+            "value": 1520000
           },
           {
             "type": "dilithium",
@@ -324,7 +324,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 3650
+            "value": 3650000
           },
           {
             "type": "dilithium",
@@ -363,11 +363,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 12650
+            "value": 12650000
           },
           {
             "type": "dilithium",
-            "value": 2790
+            "value": 2790000
           }
         ]
       },
@@ -410,15 +410,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 30200
+            "value": 30200000
           },
           {
             "type": "dilithium",
-            "value": 6670
+            "value": 6670000
           }
         ]
       },
-      "research_time": 1560
+      "research_time": 1560000
     }
   ],
   "location": {

--- a/research/parsteel_fortification.json
+++ b/research/parsteel_fortification.json
@@ -42,15 +42,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 565500
+            "value": 565500000
           },
           {
             "type": "dilithium",
-            "value": 104000
+            "value": 104000000
           }
         ]
       },
-      "research_time": 17656
+      "research_time": 17656740
     },
     {
       "bonus": {
@@ -87,15 +87,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 820100
+            "value": 820100000
           },
           {
             "type": "dilithium",
-            "value": 150800
+            "value": 150800000
           }
         ]
       },
-      "research_time": 16820
+      "research_time": 16820160
     },
     {
       "bonus": {
@@ -143,15 +143,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1222
+            "value": 1222000000
           },
           {
             "type": "dilithium",
-            "value": 224700
+            "value": 224700000
           }
         ]
       },
-      "research_time": 26271
+      "research_time": 26271840
     },
     {
       "bonus": {
@@ -194,15 +194,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1773
+            "value": 1773000000
           },
           {
             "type": "dilithium",
-            "value": 326000
+            "value": 326000000
           }
         ]
       },
-      "research_time": 36673
+      "research_time": 36673500
     },
     {
       "bonus": {
@@ -245,15 +245,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 2701
+            "value": 2701000000
           },
           {
             "type": "dilithium",
-            "value": 496500
+            "value": 496500000
           }
         ]
       },
-      "research_time": 48667
+      "research_time": 48667680
     },
     {
       "bonus": {
@@ -296,15 +296,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 3852
+            "value": 3852000000
           },
           {
             "type": "dilithium",
-            "value": 708000
+            "value": 708000000
           }
         ]
       },
-      "research_time": 63862
+      "research_time": 63862980
     },
     {
       "bonus": {
@@ -352,15 +352,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 5371
+            "value": 5371000000
           },
           {
             "type": "dilithium",
-            "value": 987300
+            "value": 987300000
           }
         ]
       },
-      "research_time": 86125
+      "research_time": 86125440
     },
     {
       "bonus": {
@@ -403,15 +403,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 7942
+            "value": 7942000000
           },
           {
             "type": "dilithium",
-            "value": 1460
+            "value": 1460000000
           }
         ]
       },
-      "research_time": 111110
+      "research_time": 111110580
     },
     {
       "bonus": {
@@ -459,15 +459,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 12828
+            "value": 12828000000
           },
           {
             "type": "dilithium",
-            "value": 2358
+            "value": 2358000000
           }
         ]
       },
-      "research_time": 142117
+      "research_time": 142117800
     },
     {
       "bonus": {
@@ -504,15 +504,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 21706
+            "value": 21706000000
           },
           {
             "type": "dilithium",
-            "value": 3990
+            "value": 3990000000
           }
         ]
       },
-      "research_time": 188204
+      "research_time": 188204640
     }
   ],
   "location": {

--- a/research/parsteel_holding.json
+++ b/research/parsteel_holding.json
@@ -27,11 +27,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 15200
+            "value": 15200000
           },
           {
             "type": "dilithium",
-            "value": 2980
+            "value": 2980000
           }
         ]
       },
@@ -61,15 +61,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 33850
+            "value": 33850000
           },
           {
             "type": "dilithium",
-            "value": 6630
+            "value": 6630000
           }
         ]
       },
-      "research_time": 1399
+      "research_time": 1399800
     },
     {
       "bonus": {
@@ -96,15 +96,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 49850
+            "value": 49850000
           },
           {
             "type": "dilithium",
-            "value": 9770
+            "value": 9770000
           }
         ]
       },
-      "research_time": 1393
+      "research_time": 1393620
     },
     {
       "bonus": {
@@ -131,15 +131,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 134300
+            "value": 134300000
           },
           {
             "type": "dilithium",
-            "value": 26350
+            "value": 26350000
           }
         ]
       },
-      "research_time": 3223
+      "research_time": 3223500
     },
     {
       "bonus": {
@@ -170,15 +170,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 212100
+            "value": 212100000
           },
           {
             "type": "dilithium",
-            "value": 41600
+            "value": 41600000
           }
         ]
       },
-      "research_time": 5650
+      "research_time": 5650140
     },
     {
       "bonus": {
@@ -205,15 +205,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 458400
+            "value": 458400000
           },
           {
             "type": "dilithium",
-            "value": 89900
+            "value": 89900000
           }
         ]
       },
-      "research_time": 8407
+      "research_time": 8407020
     },
     {
       "bonus": {
@@ -240,15 +240,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 665000
+            "value": 665000000
           },
           {
             "type": "dilithium",
-            "value": 130400
+            "value": 130400000
           }
         ]
       },
-      "research_time": 11735
+      "research_time": 11735520
     },
     {
       "bonus": {
@@ -298,7 +298,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 2740
+            "value": 2740000
           },
           {
             "type": "dilithium",
@@ -337,7 +337,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 4170
+            "value": 4170000
           },
           {
             "type": "dilithium",
@@ -376,11 +376,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 9480
+            "value": 9480000
           },
           {
             "type": "dilithium",
-            "value": 1860
+            "value": 1860000
           }
         ]
       },

--- a/research/parsteel_hunter.json
+++ b/research/parsteel_hunter.json
@@ -160,7 +160,7 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1070
+            "value": 1070000
           }
         ]
       },
@@ -198,7 +198,7 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1630
+            "value": 1630000
           }
         ]
       },
@@ -252,7 +252,7 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 2400
+            "value": 2400000
           }
         ]
       },

--- a/research/parsteel_miner.json
+++ b/research/parsteel_miner.json
@@ -144,7 +144,7 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1340
+            "value": 1340000
           }
         ]
       },
@@ -179,7 +179,7 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 3000
+            "value": 3000000
           }
         ]
       },
@@ -209,11 +209,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 7460
+            "value": 7460000
           }
         ]
       },
-      "research_time": 1937
+      "research_time": 1937880
     },
     {
       "bonus": {
@@ -239,11 +239,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 16600
+            "value": 16600000
           }
         ]
       },
-      "research_time": 3499
+      "research_time": 3499500
     },
     {
       "bonus": {
@@ -270,11 +270,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 38650
+            "value": 38650000
           }
         ]
       },
-      "research_time": 5965
+      "research_time": 5965920
     },
     {
       "bonus": {

--- a/research/parsteel_security.json
+++ b/research/parsteel_security.json
@@ -54,15 +54,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 16300
+            "value": 16300000
           },
           {
             "type": "dilithium",
-            "value": 3000
+            "value": 3000000
           }
         ]
       },
-      "research_time": 1223
+      "research_time": 1223160
     },
     {
       "bonus": {
@@ -84,15 +84,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 25250
+            "value": 25250000
           },
           {
             "type": "dilithium",
-            "value": 4650
+            "value": 4650000
           }
         ]
       },
-      "research_time": 1811
+      "research_time": 1811820
     },
     {
       "bonus": {
@@ -114,15 +114,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 60450
+            "value": 60450000
           },
           {
             "type": "dilithium",
-            "value": 11100
+            "value": 11100000
           }
         ]
       },
-      "research_time": 3250
+      "research_time": 3250080
     },
     {
       "bonus": {
@@ -157,15 +157,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 90200
+            "value": 90200000
           },
           {
             "type": "dilithium",
-            "value": 16600
+            "value": 16600000
           }
         ]
       },
-      "research_time": 4374
+      "research_time": 4374420
     },
     {
       "bonus": {
@@ -187,15 +187,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 210200
+            "value": 210200000
           },
           {
             "type": "dilithium",
-            "value": 38650
+            "value": 38650000
           }
         ]
       },
-      "research_time": 7457
+      "research_time": 7457400
     },
     {
       "bonus": {
@@ -217,15 +217,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 358000
+            "value": 358000000
           },
           {
             "type": "dilithium",
-            "value": 65800
+            "value": 65800000
           }
         ]
       },
-      "research_time": 10073
+      "research_time": 10073400
     },
     {
       "bonus": {
@@ -255,15 +255,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 820100
+            "value": 820100000
           },
           {
             "type": "dilithium",
-            "value": 150800
+            "value": 150800000
           }
         ]
       },
-      "research_time": 16820
+      "research_time": 16820160
     },
     {
       "bonus": {
@@ -290,15 +290,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1222
+            "value": 1222000000
           },
           {
             "type": "dilithium",
-            "value": 224700
+            "value": 224700000
           }
         ]
       },
-      "research_time": 26271
+      "research_time": 26271840
     },
     {
       "bonus": {
@@ -320,15 +320,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 2701
+            "value": 2701000000
           },
           {
             "type": "dilithium",
-            "value": 496500
+            "value": 496500000
           }
         ]
       },
-      "research_time": 48667
+      "research_time": 48667680
     },
     {
       "bonus": {
@@ -358,15 +358,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 3852
+            "value": 3852000000
           },
           {
             "type": "dilithium",
-            "value": 708000
+            "value": 708000000
           }
         ]
       },
-      "research_time": 63862
+      "research_time": 63862980
     }
   ],
   "location": {

--- a/research/parsteel_stockpile.json
+++ b/research/parsteel_stockpile.json
@@ -54,11 +54,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 8340
+            "value": 8340000
           },
           {
             "type": "dilithium",
-            "value": 1530
+            "value": 1530000
           }
         ]
       },
@@ -84,11 +84,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 12250
+            "value": 12250000
           },
           {
             "type": "dilithium",
-            "value": 2250
+            "value": 2250000
           }
         ]
       },
@@ -122,15 +122,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 30400
+            "value": 30400000
           },
           {
             "type": "dilithium",
-            "value": 5590
+            "value": 5590000
           }
         ]
       },
-      "research_time": 1453
+      "research_time": 1453440
     },
     {
       "bonus": {
@@ -161,15 +161,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 45350
+            "value": 45350000
           },
           {
             "type": "dilithium",
-            "value": 8330
+            "value": 8330000
           }
         ]
       },
-      "research_time": 1950
+      "research_time": 1950060
     },
     {
       "bonus": {
@@ -191,15 +191,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 99700
+            "value": 99700000
           },
           {
             "type": "dilithium",
-            "value": 18350
+            "value": 18350000
           }
         ]
       },
-      "research_time": 2613
+      "research_time": 2613000
     },
     {
       "bonus": {
@@ -229,15 +229,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 157700
+            "value": 157700000
           },
           {
             "type": "dilithium",
-            "value": 29000
+            "value": 29000000
           }
         ]
       },
-      "research_time": 4474
+      "research_time": 4474440
     },
     {
       "bonus": {
@@ -264,15 +264,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 424100
+            "value": 424100000
           },
           {
             "type": "dilithium",
-            "value": 77950
+            "value": 77950000
           }
         ]
       },
-      "research_time": 10594
+      "research_time": 10594080
     },
     {
       "bonus": {
@@ -299,15 +299,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 615100
+            "value": 615100000
           },
           {
             "type": "dilithium",
-            "value": 113100
+            "value": 113100000
           }
         ]
       },
-      "research_time": 10092
+      "research_time": 10092120
     },
     {
       "bonus": {
@@ -337,15 +337,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1330
+            "value": 1330000000
           },
           {
             "type": "dilithium",
-            "value": 244500
+            "value": 244500000
           }
         ]
       },
-      "research_time": 22004
+      "research_time": 22004100
     },
     {
       "bonus": {
@@ -372,15 +372,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 2026
+            "value": 2026000000
           },
           {
             "type": "dilithium",
-            "value": 372400
+            "value": 372400000
           }
         ]
       },
-      "research_time": 29200
+      "research_time": 29200620
     }
   ],
   "location": {

--- a/research/plutonium_bartering_ii.json
+++ b/research/plutonium_bartering_ii.json
@@ -104,7 +104,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1000
+            "value": 1000000
           },
           {
             "type": "dilithium",
@@ -159,7 +159,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1520
+            "value": 1520000
           },
           {
             "type": "dilithium",
@@ -219,7 +219,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 2350
+            "value": 2350000
           },
           {
             "type": "dilithium",

--- a/research/plutonium_bartering_iii.json
+++ b/research/plutonium_bartering_iii.json
@@ -42,11 +42,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 12650
+            "value": 12650000
           },
           {
             "type": "dilithium",
-            "value": 1390
+            "value": 1390000
           }
         ]
       },
@@ -92,7 +92,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 8150
+            "value": 8150000
           },
           {
             "type": "dilithium",
@@ -152,11 +152,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 20300
+            "value": 20300000
           },
           {
             "type": "dilithium",
-            "value": 2240
+            "value": 2240000
           }
         ]
       },
@@ -206,11 +206,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 30200
+            "value": 30200000
           },
           {
             "type": "dilithium",
-            "value": 3330
+            "value": 3330000
           }
         ]
       },
@@ -256,7 +256,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 5560
+            "value": 5560000
           },
           {
             "type": "dilithium",

--- a/research/prime_3_crystal_refining.json
+++ b/research/prime_3_crystal_refining.json
@@ -29,11 +29,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 64900
+            "value": 64900000
           }
         ]
       },
-      "research_time": 1624,
+      "research_time": 1624080,
       "reward": {
         "type": "Relocation\u00a0Token\u00a0",
         "value": 1

--- a/research/prime_3_gas_refining.json
+++ b/research/prime_3_gas_refining.json
@@ -29,11 +29,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 100600
+            "value": 100600000
           }
         ]
       },
-      "research_time": 1852,
+      "research_time": 1852500,
       "reward": {
         "type": "Relocation\u00a0Token\u00a0",
         "value": 1

--- a/research/prime_3_ore_refining.json
+++ b/research/prime_3_ore_refining.json
@@ -29,11 +29,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 224700
+            "value": 224700000
           }
         ]
       },
-      "research_time": 2446,
+      "research_time": 2446320,
       "reward": {
         "type": "Relocation\u00a0Token\u00a0",
         "value": 1

--- a/research/prime_active_nanoprobes_refining.json
+++ b/research/prime_active_nanoprobes_refining.json
@@ -29,11 +29,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 11250
+            "value": 11250000
           }
         ]
       },
-      "research_time": 1045,
+      "research_time": 1045020,
       "reward": {
         "type": "Relocation\u00a0Token\u00a0",
         "value": 1

--- a/research/prime_armada_damage.json
+++ b/research/prime_armada_damage.json
@@ -33,11 +33,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 753800
+            "value": 753800000
           }
         ]
       },
-      "research_time": 33640
+      "research_time": 33640320
     }
   ],
   "location": {

--- a/research/prime_augment_favor.json
+++ b/research/prime_augment_favor.json
@@ -34,11 +34,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 12050
+            "value": 12050000
           }
         ]
       },
-      "research_time": 1045,
+      "research_time": 1045020,
       "reward": {
         "type": "Mission\u00a0Token\u00a0",
         "value": 1

--- a/research/prime_battleship_manufacturing.json
+++ b/research/prime_battleship_manufacturing.json
@@ -25,11 +25,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1630
+            "value": 1630000000
           }
         ]
       },
-      "research_time": 73347,
+      "research_time": 73347000,
       "reward": {
         "type": "Mission\u00a0Token\u00a0",
         "value": 1

--- a/research/prime_borg_rewards.json
+++ b/research/prime_borg_rewards.json
@@ -29,7 +29,7 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 3000
+            "value": 3000000
           }
         ]
       },

--- a/research/prime_capture_node_damage.json
+++ b/research/prime_capture_node_damage.json
@@ -27,11 +27,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 555500
+            "value": 555500000
           }
         ]
       },
-      "research_time": 6500
+      "research_time": 6500100
     }
   ],
   "location": {

--- a/research/prime_critical_hit_chance.json
+++ b/research/prime_critical_hit_chance.json
@@ -33,11 +33,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 2124
+            "value": 2124000000
           }
         ]
       },
-      "research_time": 127726
+      "research_time": 127726020
     }
   ],
   "location": {

--- a/research/prime_critical_hit_damage.json
+++ b/research/prime_critical_hit_damage.json
@@ -33,11 +33,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1124
+            "value": 1124000000
           }
         ]
       },
-      "research_time": 52543
+      "research_time": 52543680
     }
   ],
   "location": {

--- a/research/prime_damage_vs_players.json
+++ b/research/prime_damage_vs_players.json
@@ -27,7 +27,7 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 7600
+            "value": 7600000
           }
         ]
       },

--- a/research/prime_defenses.json
+++ b/research/prime_defenses.json
@@ -33,7 +33,7 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 2200
+            "value": 2200000
           }
         ]
       },

--- a/research/prime_explorer_manufacturing.json
+++ b/research/prime_explorer_manufacturing.json
@@ -25,11 +25,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1630
+            "value": 1630000000
           }
         ]
       },
-      "research_time": 73347,
+      "research_time": 73347000,
       "reward": {
         "type": "Mission\u00a0Token\u00a0",
         "value": 1

--- a/research/prime_interceptor_manufacturing.json
+++ b/research/prime_interceptor_manufacturing.json
@@ -25,11 +25,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1630
+            "value": 1630000000
           }
         ]
       },
-      "research_time": 73347,
+      "research_time": 73347000,
       "reward": {
         "type": "Mission\u00a0Token\u00a0",
         "value": 1

--- a/research/prime_latinum_refining.json
+++ b/research/prime_latinum_refining.json
@@ -33,11 +33,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 18000
+            "value": 18000000
           }
         ]
       },
-      "research_time": 1444,
+      "research_time": 1444440,
       "reward": {
         "type": "Relocation\u00a0Token\u00a0",
         "value": 1

--- a/research/prime_materials_extractor.json
+++ b/research/prime_materials_extractor.json
@@ -30,7 +30,7 @@
         ],
         "resources": []
       },
-      "research_time": 1852
+      "research_time": 1852500
     }
   ],
   "location": {

--- a/research/prime_maximum_warp.json
+++ b/research/prime_maximum_warp.json
@@ -34,7 +34,7 @@
         ],
         "resources": []
       },
-      "research_time": 33640
+      "research_time": 33640320
     }
   ],
   "location": {

--- a/research/prime_officers.json
+++ b/research/prime_officers.json
@@ -37,7 +37,7 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1660
+            "value": 1660000
           }
         ]
       },

--- a/research/prime_piercing.json
+++ b/research/prime_piercing.json
@@ -33,7 +33,7 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 2600
+            "value": 2600000
           }
         ]
       },

--- a/research/prime_protected_cargo.json
+++ b/research/prime_protected_cargo.json
@@ -27,7 +27,7 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 7600
+            "value": 7600000
           }
         ]
       },

--- a/research/prime_repair_costs.json
+++ b/research/prime_repair_costs.json
@@ -33,7 +33,7 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1000
+            "value": 1000000
           }
         ]
       },

--- a/research/prime_repair_speed.json
+++ b/research/prime_repair_speed.json
@@ -33,7 +33,7 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1250
+            "value": 1250000
           }
         ]
       },

--- a/research/prime_rogue_credit_yield.json
+++ b/research/prime_rogue_credit_yield.json
@@ -34,11 +34,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 222200
+            "value": 222200000
           }
         ]
       },
-      "research_time": 6500,
+      "research_time": 6500100,
       "reward": {
         "type": "Mission\u00a0Token\u00a0",
         "value": 1

--- a/research/prime_stella_efficiency.json
+++ b/research/prime_stella_efficiency.json
@@ -34,11 +34,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 102200
+            "value": 102200000
           }
         ]
       },
-      "research_time": 2376
+      "research_time": 2376360
     }
   ],
   "location": {

--- a/research/prime_survey_manufacturing.json
+++ b/research/prime_survey_manufacturing.json
@@ -25,11 +25,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 753800
+            "value": 753800000
           }
         ]
       },
-      "research_time": 33640,
+      "research_time": 33640320,
       "reward": {
         "type": "Mission\u00a0Token\u00a0",
         "value": 1

--- a/research/protected_cargo_extension.json
+++ b/research/protected_cargo_extension.json
@@ -39,7 +39,7 @@
         ],
         "resources": []
       },
-      "research_time": 3120
+      "research_time": 3120060
     },
     {
       "bonus": {
@@ -78,7 +78,7 @@
         ],
         "resources": []
       },
-      "research_time": 4199
+      "research_time": 4199400
     },
     {
       "bonus": {
@@ -113,7 +113,7 @@
         ],
         "resources": []
       },
-      "research_time": 4180
+      "research_time": 4180800
     },
     {
       "bonus": {
@@ -144,7 +144,7 @@
         ],
         "resources": []
       },
-      "research_time": 7159
+      "research_time": 7159140
     },
     {
       "bonus": {
@@ -179,7 +179,7 @@
         ],
         "resources": []
       },
-      "research_time": 9670
+      "research_time": 9670500
     },
     {
       "bonus": {
@@ -214,7 +214,7 @@
         ],
         "resources": []
       },
-      "research_time": 16950
+      "research_time": 16950480
     },
     {
       "bonus": {
@@ -248,7 +248,7 @@
         ],
         "resources": []
       },
-      "research_time": 16147
+      "research_time": 16147380
     },
     {
       "bonus": {
@@ -291,7 +291,7 @@
         ],
         "resources": []
       },
-      "research_time": 25221
+      "research_time": 25221000
     },
     {
       "bonus": {
@@ -342,7 +342,7 @@
         ],
         "resources": []
       },
-      "research_time": 35206
+      "research_time": 35206560
     },
     {
       "bonus": {

--- a/research/pure_crystal.json
+++ b/research/pure_crystal.json
@@ -38,15 +38,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 45350
+            "value": 45350000
           },
           {
             "type": "dilithium",
-            "value": 11100
+            "value": 11100000
           }
         ]
       },
-      "research_time": 2600
+      "research_time": 2600040
     },
     {
       "bonus": {
@@ -77,15 +77,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 67650
+            "value": 67650000
           },
           {
             "type": "dilithium",
-            "value": 16600
+            "value": 16600000
           }
         ]
       },
-      "research_time": 3499
+      "research_time": 3499500
     },
     {
       "bonus": {
@@ -120,15 +120,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 99700
+            "value": 99700000
           },
           {
             "type": "dilithium",
-            "value": 24450
+            "value": 24450000
           }
         ]
       },
-      "research_time": 3483
+      "research_time": 3483960
     },
     {
       "bonus": {
@@ -155,15 +155,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 157700
+            "value": 157700000
           },
           {
             "type": "dilithium",
-            "value": 38650
+            "value": 38650000
           }
         ]
       },
-      "research_time": 5965
+      "research_time": 5965920
     },
     {
       "bonus": {
@@ -197,15 +197,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 268500
+            "value": 268500000
           },
           {
             "type": "dilithium",
-            "value": 65800
+            "value": 65800000
           }
         ]
       },
-      "research_time": 8058
+      "research_time": 8058720
     },
     {
       "bonus": {
@@ -236,15 +236,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 424100
+            "value": 424100000
           },
           {
             "type": "dilithium",
-            "value": 104000
+            "value": 104000000
           }
         ]
       },
-      "research_time": 14125
+      "research_time": 14125380
     },
     {
       "bonus": {
@@ -277,15 +277,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 615100
+            "value": 615100000
           },
           {
             "type": "dilithium",
-            "value": 150800
+            "value": 150800000
           }
         ]
       },
-      "research_time": 13456
+      "research_time": 13456140
     },
     {
       "bonus": {
@@ -312,15 +312,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 916800
+            "value": 916800000
           },
           {
             "type": "dilithium",
-            "value": 224700
+            "value": 224700000
           }
         ]
       },
-      "research_time": 21017
+      "research_time": 21017460
     },
     {
       "bonus": {
@@ -349,15 +349,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1330
+            "value": 1330000000
           },
           {
             "type": "dilithium",
-            "value": 326000
+            "value": 326000000
           }
         ]
       },
-      "research_time": 29338
+      "research_time": 29338800
     },
     {
       "bonus": {
@@ -395,11 +395,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 8340
+            "value": 8340000
           },
           {
             "type": "dilithium",
-            "value": 2040
+            "value": 2040000
           }
         ]
       },

--- a/research/pure_dilithium.json
+++ b/research/pure_dilithium.json
@@ -54,15 +54,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 18950
+            "value": 18950000
           },
           {
             "type": "dilithium",
-            "value": 4650
+            "value": 4650000
           }
         ]
       },
-      "research_time": 1449
+      "research_time": 1449420
     },
     {
       "bonus": {
@@ -115,15 +115,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 45350
+            "value": 45350000
           },
           {
             "type": "dilithium",
-            "value": 11100
+            "value": 11100000
           }
         ]
       },
-      "research_time": 2600
+      "research_time": 2600040
     },
     {
       "bonus": {
@@ -176,15 +176,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 99700
+            "value": 99700000
           },
           {
             "type": "dilithium",
-            "value": 24450
+            "value": 24450000
           }
         ]
       },
-      "research_time": 3483
+      "research_time": 3483960
     },
     {
       "bonus": {
@@ -312,7 +312,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1500
+            "value": 1500000
           },
           {
             "type": "dilithium",
@@ -363,7 +363,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 3530
+            "value": 3530000
           },
           {
             "type": "dilithium",
@@ -405,11 +405,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 8340
+            "value": 8340000
           },
           {
             "type": "dilithium",
-            "value": 2040
+            "value": 2040000
           }
         ]
       },

--- a/research/pure_gas.json
+++ b/research/pure_gas.json
@@ -38,15 +38,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 45350
+            "value": 45350000
           },
           {
             "type": "dilithium",
-            "value": 11100
+            "value": 11100000
           }
         ]
       },
-      "research_time": 2600
+      "research_time": 2600040
     },
     {
       "bonus": {
@@ -77,15 +77,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 67650
+            "value": 67650000
           },
           {
             "type": "dilithium",
-            "value": 16600
+            "value": 16600000
           }
         ]
       },
-      "research_time": 3499
+      "research_time": 3499500
     },
     {
       "bonus": {
@@ -120,15 +120,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 99700
+            "value": 99700000
           },
           {
             "type": "dilithium",
-            "value": 24450
+            "value": 24450000
           }
         ]
       },
-      "research_time": 3483
+      "research_time": 3483960
     },
     {
       "bonus": {
@@ -155,15 +155,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 157700
+            "value": 157700000
           },
           {
             "type": "dilithium",
-            "value": 38650
+            "value": 38650000
           }
         ]
       },
-      "research_time": 5965
+      "research_time": 5965920
     },
     {
       "bonus": {
@@ -197,15 +197,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 268500
+            "value": 268500000
           },
           {
             "type": "dilithium",
-            "value": 65800
+            "value": 65800000
           }
         ]
       },
-      "research_time": 8058
+      "research_time": 8058720
     },
     {
       "bonus": {
@@ -236,15 +236,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 424100
+            "value": 424100000
           },
           {
             "type": "dilithium",
-            "value": 104000
+            "value": 104000000
           }
         ]
       },
-      "research_time": 14125
+      "research_time": 14125380
     },
     {
       "bonus": {
@@ -277,15 +277,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 615100
+            "value": 615100000
           },
           {
             "type": "dilithium",
-            "value": 150800
+            "value": 150800000
           }
         ]
       },
-      "research_time": 13456
+      "research_time": 13456140
     },
     {
       "bonus": {
@@ -312,15 +312,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 916800
+            "value": 916800000
           },
           {
             "type": "dilithium",
-            "value": 224700
+            "value": 224700000
           }
         ]
       },
-      "research_time": 21017
+      "research_time": 21017460
     },
     {
       "bonus": {
@@ -349,15 +349,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1330
+            "value": 1330000000
           },
           {
             "type": "dilithium",
-            "value": 326000
+            "value": 326000000
           }
         ]
       },
-      "research_time": 29338
+      "research_time": 29338800
     },
     {
       "bonus": {
@@ -399,11 +399,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 8340
+            "value": 8340000
           },
           {
             "type": "dilithium",
-            "value": 2040
+            "value": 2040000
           }
         ]
       },

--- a/research/pure_ore.json
+++ b/research/pure_ore.json
@@ -38,15 +38,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 45350
+            "value": 45350000
           },
           {
             "type": "dilithium",
-            "value": 11100
+            "value": 11100000
           }
         ]
       },
-      "research_time": 2600
+      "research_time": 2600040
     },
     {
       "bonus": {
@@ -77,15 +77,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 67650
+            "value": 67650000
           },
           {
             "type": "dilithium",
-            "value": 16600
+            "value": 16600000
           }
         ]
       },
-      "research_time": 3499
+      "research_time": 3499500
     },
     {
       "bonus": {
@@ -120,15 +120,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 99700
+            "value": 99700000
           },
           {
             "type": "dilithium",
-            "value": 24450
+            "value": 24450000
           }
         ]
       },
-      "research_time": 3483
+      "research_time": 3483960
     },
     {
       "bonus": {
@@ -155,15 +155,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 157700
+            "value": 157700000
           },
           {
             "type": "dilithium",
-            "value": 38650
+            "value": 38650000
           }
         ]
       },
-      "research_time": 5965
+      "research_time": 5965920
     },
     {
       "bonus": {
@@ -197,15 +197,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 268500
+            "value": 268500000
           },
           {
             "type": "dilithium",
-            "value": 65800
+            "value": 65800000
           }
         ]
       },
-      "research_time": 8058
+      "research_time": 8058720
     },
     {
       "bonus": {
@@ -236,15 +236,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 424100
+            "value": 424100000
           },
           {
             "type": "dilithium",
-            "value": 104000
+            "value": 104000000
           }
         ]
       },
-      "research_time": 14125
+      "research_time": 14125380
     },
     {
       "bonus": {
@@ -277,15 +277,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 615100
+            "value": 615100000
           },
           {
             "type": "dilithium",
-            "value": 150800
+            "value": 150800000
           }
         ]
       },
-      "research_time": 13456
+      "research_time": 13456140
     },
     {
       "bonus": {
@@ -312,15 +312,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 916800
+            "value": 916800000
           },
           {
             "type": "dilithium",
-            "value": 224700
+            "value": 224700000
           }
         ]
       },
-      "research_time": 21017
+      "research_time": 21017460
     },
     {
       "bonus": {
@@ -349,15 +349,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1330
+            "value": 1330000000
           },
           {
             "type": "dilithium",
-            "value": 326000
+            "value": 326000000
           }
         ]
       },
-      "research_time": 29338
+      "research_time": 29338800
     },
     {
       "bonus": {
@@ -395,11 +395,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 8340
+            "value": 8340000
           },
           {
             "type": "dilithium",
-            "value": 2040
+            "value": 2040000
           }
         ]
       },

--- a/research/pure_parts_battleship.json
+++ b/research/pure_parts_battleship.json
@@ -29,7 +29,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 5560
+            "value": 5560000
           },
           {
             "type": "dilithium",
@@ -70,7 +70,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 8150
+            "value": 8150000
           },
           {
             "type": "dilithium",
@@ -107,11 +107,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 12650
+            "value": 12650000
           },
           {
             "type": "dilithium",
-            "value": 1390
+            "value": 1390000
           }
         ]
       },
@@ -141,11 +141,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 20300
+            "value": 20300000
           },
           {
             "type": "dilithium",
-            "value": 2240
+            "value": 2240000
           }
         ]
       },
@@ -182,11 +182,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 30200
+            "value": 30200000
           },
           {
             "type": "dilithium",
-            "value": 3330
+            "value": 3330000
           }
         ]
       },
@@ -224,15 +224,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 45100
+            "value": 45100000
           },
           {
             "type": "dilithium",
-            "value": 4980
+            "value": 4980000
           }
         ]
       },
-      "research_time": 1049
+      "research_time": 1049880
     },
     {
       "bonus": {
@@ -258,15 +258,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 66450
+            "value": 66450000
           },
           {
             "type": "dilithium",
-            "value": 7330
+            "value": 7330000
           }
         ]
       },
-      "research_time": 1045
+      "research_time": 1045200
     },
     {
       "bonus": {
@@ -292,15 +292,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 105100
+            "value": 105100000
           },
           {
             "type": "dilithium",
-            "value": 11600
+            "value": 11600000
           }
         ]
       },
-      "research_time": 1789
+      "research_time": 1789800
     },
     {
       "bonus": {
@@ -326,15 +326,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 179000
+            "value": 179000000
           },
           {
             "type": "dilithium",
-            "value": 19750
+            "value": 19750000
           }
         ]
       },
-      "research_time": 2417
+      "research_time": 2417640
     },
     {
       "bonus": {

--- a/research/pure_parts_explorer.json
+++ b/research/pure_parts_explorer.json
@@ -29,7 +29,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 5560
+            "value": 5560000
           },
           {
             "type": "dilithium",
@@ -70,7 +70,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 8150
+            "value": 8150000
           },
           {
             "type": "dilithium",
@@ -107,11 +107,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 12650
+            "value": 12650000
           },
           {
             "type": "dilithium",
-            "value": 1390
+            "value": 1390000
           }
         ]
       },
@@ -141,11 +141,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 20300
+            "value": 20300000
           },
           {
             "type": "dilithium",
-            "value": 2240
+            "value": 2240000
           }
         ]
       },
@@ -175,11 +175,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 30200
+            "value": 30200000
           },
           {
             "type": "dilithium",
-            "value": 3330
+            "value": 3330000
           }
         ]
       },
@@ -217,15 +217,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 45100
+            "value": 45100000
           },
           {
             "type": "dilithium",
-            "value": 4980
+            "value": 4980000
           }
         ]
       },
-      "research_time": 1049
+      "research_time": 1049880
     },
     {
       "bonus": {
@@ -251,15 +251,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 66450
+            "value": 66450000
           },
           {
             "type": "dilithium",
-            "value": 7330
+            "value": 7330000
           }
         ]
       },
-      "research_time": 1045
+      "research_time": 1045200
     },
     {
       "bonus": {
@@ -285,15 +285,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 105100
+            "value": 105100000
           },
           {
             "type": "dilithium",
-            "value": 11600
+            "value": 11600000
           }
         ]
       },
-      "research_time": 1789
+      "research_time": 1789800
     },
     {
       "bonus": {
@@ -319,15 +319,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 179000
+            "value": 179000000
           },
           {
             "type": "dilithium",
-            "value": 19750
+            "value": 19750000
           }
         ]
       },
-      "research_time": 2417
+      "research_time": 2417640
     },
     {
       "bonus": {

--- a/research/pure_parts_interceptor.json
+++ b/research/pure_parts_interceptor.json
@@ -29,7 +29,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 5560
+            "value": 5560000
           },
           {
             "type": "dilithium",
@@ -70,7 +70,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 8150
+            "value": 8150000
           },
           {
             "type": "dilithium",
@@ -107,11 +107,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 12650
+            "value": 12650000
           },
           {
             "type": "dilithium",
-            "value": 1390
+            "value": 1390000
           }
         ]
       },
@@ -141,11 +141,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 20300
+            "value": 20300000
           },
           {
             "type": "dilithium",
-            "value": 2240
+            "value": 2240000
           }
         ]
       },
@@ -175,11 +175,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 30200
+            "value": 30200000
           },
           {
             "type": "dilithium",
-            "value": 3330
+            "value": 3330000
           }
         ]
       },
@@ -217,15 +217,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 45100
+            "value": 45100000
           },
           {
             "type": "dilithium",
-            "value": 4980
+            "value": 4980000
           }
         ]
       },
-      "research_time": 1049
+      "research_time": 1049880
     },
     {
       "bonus": {
@@ -251,15 +251,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 66450
+            "value": 66450000
           },
           {
             "type": "dilithium",
-            "value": 7330
+            "value": 7330000
           }
         ]
       },
-      "research_time": 1045
+      "research_time": 1045200
     },
     {
       "bonus": {
@@ -285,15 +285,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 105100
+            "value": 105100000
           },
           {
             "type": "dilithium",
-            "value": 11600
+            "value": 11600000
           }
         ]
       },
-      "research_time": 1789
+      "research_time": 1789800
     },
     {
       "bonus": {
@@ -319,15 +319,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 179000
+            "value": 179000000
           },
           {
             "type": "dilithium",
-            "value": 19750
+            "value": 19750000
           }
         ]
       },
-      "research_time": 2417
+      "research_time": 2417640
     },
     {
       "bonus": {

--- a/research/pure_tritanium.json
+++ b/research/pure_tritanium.json
@@ -53,15 +53,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 18950
+            "value": 18950000
           },
           {
             "type": "dilithium",
-            "value": 4650
+            "value": 4650000
           }
         ]
       },
-      "research_time": 1449
+      "research_time": 1449420
     },
     {
       "bonus": {
@@ -115,15 +115,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 45350
+            "value": 45350000
           },
           {
             "type": "dilithium",
-            "value": 11100
+            "value": 11100000
           }
         ]
       },
-      "research_time": 2600
+      "research_time": 2600040
     },
     {
       "bonus": {
@@ -177,15 +177,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 99700
+            "value": 99700000
           },
           {
             "type": "dilithium",
-            "value": 24450
+            "value": 24450000
           }
         ]
       },
-      "research_time": 3483
+      "research_time": 3483960
     },
     {
       "bonus": {
@@ -310,7 +310,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1500
+            "value": 1500000
           },
           {
             "type": "dilithium",
@@ -366,7 +366,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 3530
+            "value": 3530000
           },
           {
             "type": "dilithium",
@@ -413,11 +413,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 8340
+            "value": 8340000
           },
           {
             "type": "dilithium",
-            "value": 2040
+            "value": 2040000
           }
         ]
       },

--- a/research/rapid_construction.json
+++ b/research/rapid_construction.json
@@ -48,11 +48,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 404500
+            "value": 404500000
           }
         ]
       },
-      "research_time": 21017
+      "research_time": 21017460
     },
     {
       "bonus": {
@@ -100,11 +100,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 586800
+            "value": 586800000
           }
         ]
       },
-      "research_time": 29338
+      "research_time": 29338800
     },
     {
       "bonus": {
@@ -152,11 +152,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 893700
+            "value": 893700000
           }
         ]
       },
-      "research_time": 38934
+      "research_time": 38934120
     },
     {
       "bonus": {
@@ -204,11 +204,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1274
+            "value": 1274000000
           }
         ]
       },
-      "research_time": 51090
+      "research_time": 51090420
     },
     {
       "bonus": {
@@ -256,11 +256,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1777
+            "value": 1777000000
           }
         ]
       },
-      "research_time": 68900
+      "research_time": 68900340
     },
     {
       "bonus": {
@@ -308,11 +308,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 4244
+            "value": 4244000000
           }
         ]
       },
-      "research_time": 113694
+      "research_time": 113694240
     },
     {
       "bonus": {
@@ -360,11 +360,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 2628
+            "value": 2628000000
           }
         ]
       },
-      "research_time": 88888
+      "research_time": 88888440
     },
     {
       "bonus": {
@@ -406,11 +406,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 7182
+            "value": 7182000000
           }
         ]
       },
-      "research_time": 150563
+      "research_time": 150563760
     },
     {
       "bonus": {
@@ -456,11 +456,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 187100
+            "value": 187100000
           }
         ]
       },
-      "research_time": 14125
+      "research_time": 14125380
     },
     {
       "bonus": {
@@ -502,11 +502,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 271400
+            "value": 271400000
           }
         ]
       },
-      "research_time": 13456
+      "research_time": 13456140
     }
   ],
   "location": {

--- a/research/rapid_research.json
+++ b/research/rapid_research.json
@@ -58,11 +58,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1770
+            "value": 1770000000
           }
         ]
       },
-      "research_time": 56199
+      "research_time": 56199420
     }
   ],
   "location": {

--- a/research/reactive_damage.json
+++ b/research/reactive_damage.json
@@ -50,11 +50,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 226100
+            "value": 226100000
           }
         ]
       },
-      "research_time": 20184
+      "research_time": 20184180
     },
     {
       "bonus": {
@@ -104,11 +104,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 337100
+            "value": 337100000
           }
         ]
       },
-      "research_time": 31526
+      "research_time": 31526220
     },
     {
       "bonus": {
@@ -158,11 +158,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 489000
+            "value": 489000000
           }
         ]
       },
-      "research_time": 44008
+      "research_time": 44008200
     },
     {
       "bonus": {
@@ -212,11 +212,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 744800
+            "value": 744800000
           }
         ]
       },
-      "research_time": 58401
+      "research_time": 58401240
     },
     {
       "bonus": {
@@ -261,11 +261,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1062
+            "value": 1062000000
           }
         ]
       },
-      "research_time": 76635
+      "research_time": 76635600
     },
     {
       "bonus": {
@@ -310,11 +310,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1481
+            "value": 1481000000
           }
         ]
       },
-      "research_time": 103350
+      "research_time": 103350540
     },
     {
       "bonus": {
@@ -359,11 +359,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 2190
+            "value": 2190000000
           }
         ]
       },
-      "research_time": 133332
+      "research_time": 133332660
     },
     {
       "bonus": {
@@ -413,11 +413,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 3537
+            "value": 3537000000
           }
         ]
       },
-      "research_time": 170541
+      "research_time": 170541360
     },
     {
       "bonus": {
@@ -467,11 +467,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 5985
+            "value": 5985000000
           }
         ]
       },
-      "research_time": 225845
+      "research_time": 225845580
     },
     {
       "bonus": {
@@ -516,11 +516,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 10631
+            "value": 10631000000
           }
         ]
       },
-      "research_time": 284285
+      "research_time": 284285220
     }
   ],
   "location": {

--- a/research/reactive_defenses.json
+++ b/research/reactive_defenses.json
@@ -50,11 +50,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 226100
+            "value": 226100000
           }
         ]
       },
-      "research_time": 20184
+      "research_time": 20184180
     },
     {
       "bonus": {
@@ -104,11 +104,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 337100
+            "value": 337100000
           }
         ]
       },
-      "research_time": 31526
+      "research_time": 31526220
     },
     {
       "bonus": {
@@ -158,11 +158,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 489000
+            "value": 489000000
           }
         ]
       },
-      "research_time": 44008
+      "research_time": 44008200
     },
     {
       "bonus": {
@@ -212,11 +212,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 744800
+            "value": 744800000
           }
         ]
       },
-      "research_time": 58401
+      "research_time": 58401240
     },
     {
       "bonus": {
@@ -266,11 +266,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1062
+            "value": 1062000000
           }
         ]
       },
-      "research_time": 76635
+      "research_time": 76635600
     },
     {
       "bonus": {
@@ -320,11 +320,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1481
+            "value": 1481000000
           }
         ]
       },
-      "research_time": 103350
+      "research_time": 103350540
     },
     {
       "bonus": {
@@ -374,11 +374,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 2190
+            "value": 2190000000
           }
         ]
       },
-      "research_time": 133332
+      "research_time": 133332660
     },
     {
       "bonus": {
@@ -428,11 +428,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 3537
+            "value": 3537000000
           }
         ]
       },
-      "research_time": 170541
+      "research_time": 170541360
     },
     {
       "bonus": {
@@ -478,11 +478,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 5985
+            "value": 5985000000
           }
         ]
       },
-      "research_time": 225845
+      "research_time": 225845580
     },
     {
       "bonus": {
@@ -532,11 +532,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 10631
+            "value": 10631000000
           }
         ]
       },
-      "research_time": 284285
+      "research_time": 284285220
     }
   ],
   "location": {

--- a/research/reactive_survey_damage.json
+++ b/research/reactive_survey_damage.json
@@ -54,11 +54,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 269600
+            "value": 269600000
           }
         ]
       },
-      "research_time": 25221
+      "research_time": 25221000
     },
     {
       "bonus": {
@@ -104,11 +104,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 391200
+            "value": 391200000
           }
         ]
       },
-      "research_time": 35206
+      "research_time": 35206560
     },
     {
       "bonus": {
@@ -154,11 +154,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 595800
+            "value": 595800000
           }
         ]
       },
-      "research_time": 46720
+      "research_time": 46720980
     },
     {
       "bonus": {
@@ -208,11 +208,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 849600
+            "value": 849600000
           }
         ]
       },
-      "research_time": 61308
+      "research_time": 61308480
     },
     {
       "bonus": {
@@ -262,11 +262,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1185
+            "value": 1185000000
           }
         ]
       },
-      "research_time": 82680
+      "research_time": 82680420
     },
     {
       "bonus": {
@@ -312,11 +312,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1752
+            "value": 1752000000
           }
         ]
       },
-      "research_time": 106666
+      "research_time": 106666140
     },
     {
       "bonus": {
@@ -366,11 +366,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 2830
+            "value": 2830000000
           }
         ]
       },
-      "research_time": 136433
+      "research_time": 136433100
     },
     {
       "bonus": {
@@ -420,11 +420,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 4788
+            "value": 4788000000
           }
         ]
       },
-      "research_time": 180676
+      "research_time": 180676500
     },
     {
       "bonus": {
@@ -470,11 +470,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 8505
+            "value": 8505000000
           }
         ]
       },
-      "research_time": 227428
+      "research_time": 227428200
     },
     {
       "bonus": {
@@ -496,11 +496,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 12947
+            "value": 12947000000
           }
         ]
       },
-      "research_time": 277400
+      "research_time": 277400040
     }
   ],
   "location": {

--- a/research/reactive_survey_defense.json
+++ b/research/reactive_survey_defense.json
@@ -48,11 +48,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 269600
+            "value": 269600000
           }
         ]
       },
-      "research_time": 25221
+      "research_time": 25221000
     },
     {
       "bonus": {
@@ -96,11 +96,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 391200
+            "value": 391200000
           }
         ]
       },
-      "research_time": 35206
+      "research_time": 35206560
     },
     {
       "bonus": {
@@ -144,11 +144,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 595800
+            "value": 595800000
           }
         ]
       },
-      "research_time": 46720
+      "research_time": 46720980
     },
     {
       "bonus": {
@@ -192,11 +192,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 849600
+            "value": 849600000
           }
         ]
       },
-      "research_time": 61308
+      "research_time": 61308480
     },
     {
       "bonus": {
@@ -240,11 +240,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1185
+            "value": 1185000000
           }
         ]
       },
-      "research_time": 82680
+      "research_time": 82680420
     },
     {
       "bonus": {
@@ -288,11 +288,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1752
+            "value": 1752000000
           }
         ]
       },
-      "research_time": 106666
+      "research_time": 106666140
     },
     {
       "bonus": {
@@ -332,11 +332,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 2830
+            "value": 2830000000
           }
         ]
       },
-      "research_time": 136433
+      "research_time": 136433100
     },
     {
       "bonus": {
@@ -380,11 +380,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 4788
+            "value": 4788000000
           }
         ]
       },
-      "research_time": 180676
+      "research_time": 180676500
     },
     {
       "bonus": {
@@ -428,11 +428,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 8505
+            "value": 8505000000
           }
         ]
       },
-      "research_time": 227428
+      "research_time": 227428200
     },
     {
       "bonus": {
@@ -454,11 +454,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 12947
+            "value": 12947000000
           }
         ]
       },
-      "research_time": 277400
+      "research_time": 277400040
     }
   ],
   "location": {

--- a/research/rerouting_to_shields.json
+++ b/research/rerouting_to_shields.json
@@ -35,7 +35,7 @@
         ],
         "resources": []
       },
-      "research_time": 3579
+      "research_time": 3579540
     },
     {
       "bonus": {
@@ -65,7 +65,7 @@
         ],
         "resources": []
       },
-      "research_time": 1162
+      "research_time": 1162740
     },
     {
       "bonus": {
@@ -100,7 +100,7 @@
         ],
         "resources": []
       },
-      "research_time": 2099
+      "research_time": 2099700
     },
     {
       "bonus": {
@@ -135,7 +135,7 @@
         ],
         "resources": []
       },
-      "research_time": 8475
+      "research_time": 8475240
     },
     {
       "bonus": {

--- a/research/research_expert.json
+++ b/research/research_expert.json
@@ -57,11 +57,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1241
+            "value": 1241000000
           }
         ]
       },
-      "research_time": 38934
+      "research_time": 38934120
     },
     {
       "bonus": {
@@ -106,11 +106,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 3650
+            "value": 3650000000
           }
         ]
       },
-      "research_time": 88888
+      "research_time": 88888440
     },
     {
       "bonus": {
@@ -132,11 +132,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 36914
+            "value": 36914000000
           }
         ]
       },
-      "research_time": 204573
+      "research_time": 204573180
     },
     {
       "bonus": {
@@ -189,11 +189,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 18650
+            "value": 18650000
           }
         ]
       },
-      "research_time": 1937
+      "research_time": 1937880
     },
     {
       "bonus": {
@@ -247,11 +247,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 41450
+            "value": 41450000
           }
         ]
       },
-      "research_time": 3499
+      "research_time": 3499500
     },
     {
       "bonus": {
@@ -285,11 +285,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 96600
+            "value": 96600000
           }
         ]
       },
-      "research_time": 5965
+      "research_time": 5965920
     },
     {
       "bonus": {
@@ -331,11 +331,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 376900
+            "value": 376900000
           }
         ]
       },
-      "research_time": 13456
+      "research_time": 13456140
     },
     {
       "bonus": {
@@ -357,11 +357,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 17719
+            "value": 17719000000
           }
         ]
       },
-      "research_time": 189523
+      "research_time": 189523500
     },
     {
       "bonus": {
@@ -447,7 +447,7 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1400
+            "value": 1400000
           }
         ]
       },
@@ -505,7 +505,7 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 3350
+            "value": 3350000
           }
         ]
       },
@@ -558,7 +558,7 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 7490
+            "value": 7490000
           }
         ]
       },

--- a/research/research_optimization.json
+++ b/research/research_optimization.json
@@ -54,11 +54,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 18650
+            "value": 18650000
           }
         ]
       },
-      "research_time": 1937
+      "research_time": 1937880
     },
     {
       "bonus": {
@@ -108,11 +108,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 61100
+            "value": 61100000
           }
         ]
       },
-      "research_time": 3483
+      "research_time": 3483960
     },
     {
       "bonus": {
@@ -149,11 +149,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 259900
+            "value": 259900000
           }
         ]
       },
-      "research_time": 14125
+      "research_time": 14125380
     },
     {
       "bonus": {
@@ -203,11 +203,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 815000
+            "value": 815000000
           }
         ]
       },
-      "research_time": 29338
+      "research_time": 29338800
     },
     {
       "bonus": {
@@ -261,11 +261,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 2468
+            "value": 2468000000
           }
         ]
       },
-      "research_time": 68900
+      "research_time": 68900340
     },
     {
       "bonus": {
@@ -313,7 +313,7 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1400
+            "value": 1400000
           }
         ]
       },
@@ -367,7 +367,7 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 5110
+            "value": 5110000
           }
         ]
       },

--- a/research/research_pure_resources.json
+++ b/research/research_pure_resources.json
@@ -50,11 +50,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 993000
+            "value": 993000000
           }
         ]
       },
-      "research_time": 38934
+      "research_time": 38934120
     },
     {
       "bonus": {
@@ -93,11 +93,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1975
+            "value": 1975000000
           }
         ]
       },
-      "research_time": 68900
+      "research_time": 68900340
     },
     {
       "bonus": {
@@ -149,11 +149,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 2920
+            "value": 2920000000
           }
         ]
       },
-      "research_time": 88888
+      "research_time": 88888440
     },
     {
       "bonus": {
@@ -192,11 +192,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 4716
+            "value": 4716000000
           }
         ]
       },
-      "research_time": 113694
+      "research_time": 113694240
     },
     {
       "bonus": {
@@ -244,11 +244,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1416
+            "value": 1416000000
           }
         ]
       },
-      "research_time": 51090
+      "research_time": 51090420
     },
     {
       "bonus": {
@@ -300,11 +300,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 14175
+            "value": 14175000000
           }
         ]
       },
-      "research_time": 189523
+      "research_time": 189523500
     },
     {
       "bonus": {
@@ -352,11 +352,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 21578
+            "value": 21578000000
           }
         ]
       },
-      "research_time": 216000
+      "research_time": 216000000
     }
   ],
   "location": {

--- a/research/rogue_hulls.json
+++ b/research/rogue_hulls.json
@@ -52,11 +52,11 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 3000
+            "value": 3000000
           },
           {
             "type": "dilithium",
-            "value": 1800
+            "value": 1800000
           }
         ]
       },
@@ -112,15 +112,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 4650
+            "value": 4650000
           },
           {
             "type": "dilithium",
-            "value": 2790
+            "value": 2790000
           }
         ]
       },
-      "research_time": 1449
+      "research_time": 1449420
     },
     {
       "bonus": {
@@ -172,15 +172,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 7460
+            "value": 7460000
           },
           {
             "type": "dilithium",
-            "value": 4470
+            "value": 4470000
           }
         ]
       },
-      "research_time": 1937
+      "research_time": 1937880
     },
     {
       "bonus": {
@@ -232,15 +232,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 11100
+            "value": 11100000
           },
           {
             "type": "dilithium",
-            "value": 6670
+            "value": 6670000
           }
         ]
       },
-      "research_time": 2600
+      "research_time": 2600040
     },
     {
       "bonus": {
@@ -292,15 +292,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 16600
+            "value": 16600000
           },
           {
             "type": "dilithium",
-            "value": 9950
+            "value": 9950000
           }
         ]
       },
-      "research_time": 3499
+      "research_time": 3499500
     },
     {
       "bonus": {
@@ -352,15 +352,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 24450
+            "value": 24450000
           },
           {
             "type": "dilithium",
-            "value": 14650
+            "value": 14650000
           }
         ]
       },
-      "research_time": 3483
+      "research_time": 3483960
     },
     {
       "bonus": {
@@ -412,15 +412,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 38650
+            "value": 38650000
           },
           {
             "type": "dilithium",
-            "value": 23200
+            "value": 23200000
           }
         ]
       },
-      "research_time": 5965
+      "research_time": 5965920
     },
     {
       "bonus": {
@@ -464,15 +464,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 65800
+            "value": 65800000
           },
           {
             "type": "dilithium",
-            "value": 39500
+            "value": 39500000
           }
         ]
       },
-      "research_time": 8058
+      "research_time": 8058720
     },
     {
       "bonus": {
@@ -524,15 +524,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 104000
+            "value": 104000000
           },
           {
             "type": "dilithium",
-            "value": 62350
+            "value": 62350000
           }
         ]
       },
-      "research_time": 14125
+      "research_time": 14125380
     },
     {
       "bonus": {

--- a/research/rogue_shields.json
+++ b/research/rogue_shields.json
@@ -57,15 +57,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 4650
+            "value": 4650000
           },
           {
             "type": "dilithium",
-            "value": 2790
+            "value": 2790000
           }
         ]
       },
-      "research_time": 1449
+      "research_time": 1449420
     },
     {
       "bonus": {
@@ -117,15 +117,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 7460
+            "value": 7460000
           },
           {
             "type": "dilithium",
-            "value": 4470
+            "value": 4470000
           }
         ]
       },
-      "research_time": 1937
+      "research_time": 1937880
     },
     {
       "bonus": {
@@ -177,15 +177,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 11100
+            "value": 11100000
           },
           {
             "type": "dilithium",
-            "value": 6670
+            "value": 6670000
           }
         ]
       },
-      "research_time": 2600
+      "research_time": 2600040
     },
     {
       "bonus": {
@@ -237,15 +237,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 16600
+            "value": 16600000
           },
           {
             "type": "dilithium",
-            "value": 9950
+            "value": 9950000
           }
         ]
       },
-      "research_time": 3499
+      "research_time": 3499500
     },
     {
       "bonus": {
@@ -297,15 +297,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 24450
+            "value": 24450000
           },
           {
             "type": "dilithium",
-            "value": 14650
+            "value": 14650000
           }
         ]
       },
-      "research_time": 3483
+      "research_time": 3483960
     },
     {
       "bonus": {
@@ -357,15 +357,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 38650
+            "value": 38650000
           },
           {
             "type": "dilithium",
-            "value": 23200
+            "value": 23200000
           }
         ]
       },
-      "research_time": 5965
+      "research_time": 5965920
     },
     {
       "bonus": {
@@ -409,15 +409,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 65800
+            "value": 65800000
           },
           {
             "type": "dilithium",
-            "value": 39500
+            "value": 39500000
           }
         ]
       },
-      "research_time": 8058
+      "research_time": 8058720
     },
     {
       "bonus": {
@@ -469,15 +469,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 104000
+            "value": 104000000
           },
           {
             "type": "dilithium",
-            "value": 62350
+            "value": 62350000
           }
         ]
       },
-      "research_time": 14125
+      "research_time": 14125380
     },
     {
       "bonus": {
@@ -529,11 +529,11 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 3000
+            "value": 3000000
           },
           {
             "type": "dilithium",
-            "value": 1800
+            "value": 1800000
           }
         ]
       },

--- a/research/rogue_tactics.json
+++ b/research/rogue_tactics.json
@@ -34,15 +34,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 4440
+            "value": 4440000
           },
           {
             "type": "dilithium",
-            "value": 13332
+            "value": 13332000
           }
         ]
       },
-      "research_time": 3120
+      "research_time": 3120060
     },
     {
       "bonus": {
@@ -93,15 +93,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 4440
+            "value": 4440000
           },
           {
             "type": "dilithium",
-            "value": 11100
+            "value": 11100000
           }
         ]
       },
-      "research_time": 2600,
+      "research_time": 2600040,
       "reward": {
         "type": "Beta\u00a0Particle\u00a0",
         "value": 1
@@ -137,15 +137,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 6630
+            "value": 6630000
           },
           {
             "type": "dilithium",
-            "value": 16600
+            "value": 16600000
           }
         ]
       },
-      "research_time": 3499
+      "research_time": 3499500
     },
     {
       "bonus": {
@@ -172,15 +172,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 6630
+            "value": 6630000
           },
           {
             "type": "dilithium",
-            "value": 19902
+            "value": 19902000
           }
         ]
       },
-      "research_time": 4199
+      "research_time": 4199400
     },
     {
       "bonus": {
@@ -224,15 +224,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 9770
+            "value": 9770000
           },
           {
             "type": "dilithium",
-            "value": 24450
+            "value": 24450000
           }
         ]
       },
-      "research_time": 3483
+      "research_time": 3483960
     },
     {
       "bonus": {
@@ -259,15 +259,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 9770
+            "value": 9770000
           },
           {
             "type": "dilithium",
-            "value": 29322
+            "value": 29322000
           }
         ]
       },
-      "research_time": 4180
+      "research_time": 4180800
     },
     {
       "bonus": {
@@ -315,15 +315,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 15450
+            "value": 15450000
           },
           {
             "type": "dilithium",
-            "value": 38650
+            "value": 38650000
           }
         ]
       },
-      "research_time": 5965
+      "research_time": 5965920
     },
     {
       "bonus": {
@@ -350,15 +350,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 15450
+            "value": 15450000
           },
           {
             "type": "dilithium",
-            "value": 46368
+            "value": 46368000
           }
         ]
       },
-      "research_time": 7159
+      "research_time": 7159140
     },
     {
       "bonus": {
@@ -402,15 +402,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 26350
+            "value": 26350000
           },
           {
             "type": "dilithium",
-            "value": 65800
+            "value": 65800000
           }
         ]
       },
-      "research_time": 8058
+      "research_time": 8058720
     },
     {
       "bonus": {
@@ -462,15 +462,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 41600
+            "value": 41600000
           },
           {
             "type": "dilithium",
-            "value": 104000
+            "value": 104000000
           }
         ]
       },
-      "research_time": 14125
+      "research_time": 14125380
     }
   ],
   "location": {

--- a/research/romulan_apprentice.json
+++ b/research/romulan_apprentice.json
@@ -29,11 +29,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 12200
+            "value": 12200000
           }
         ]
       },
-      "research_time": 1741
+      "research_time": 1741980
     },
     {
       "bonus": {
@@ -62,7 +62,7 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 2320
+            "value": 2320000
           }
         ]
       },
@@ -99,7 +99,7 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 3730
+            "value": 3730000
           }
         ]
       },
@@ -132,11 +132,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 5560
+            "value": 5560000
           }
         ]
       },
-      "research_time": 1300
+      "research_time": 1300020
     },
     {
       "bonus": {
@@ -169,11 +169,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 8290
+            "value": 8290000
           }
         ]
       },
-      "research_time": 1749
+      "research_time": 1749780
     },
     {
       "bonus": {
@@ -206,11 +206,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 19300
+            "value": 19300000
           }
         ]
       },
-      "research_time": 2982
+      "research_time": 2982960
     },
     {
       "bonus": {
@@ -239,11 +239,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 32900
+            "value": 32900000
           }
         ]
       },
-      "research_time": 4029
+      "research_time": 4029360
     },
     {
       "bonus": {
@@ -276,11 +276,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 52000
+            "value": 52000000
           }
         ]
       },
-      "research_time": 7062
+      "research_time": 7062720
     },
     {
       "bonus": {
@@ -309,11 +309,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 75400
+            "value": 75400000
           }
         ]
       },
-      "research_time": 6728
+      "research_time": 6728040
     },
     {
       "bonus": {
@@ -357,7 +357,7 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1020
+            "value": 1020000
           }
         ]
       },

--- a/research/romulan_armada_defects.json
+++ b/research/romulan_armada_defects.json
@@ -48,11 +48,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 3990
+            "value": 3990000000
           }
         ]
       },
-      "research_time": 150563
+      "research_time": 150563760
     }
   ],
   "location": {

--- a/research/romulan_demolition.json
+++ b/research/romulan_demolition.json
@@ -39,7 +39,7 @@
         ],
         "resources": []
       },
-      "research_time": 15537
+      "research_time": 15537960
     },
     {
       "bonus": {
@@ -73,7 +73,7 @@
         ],
         "resources": []
       },
-      "research_time": 14801
+      "research_time": 14801760
     },
     {
       "bonus": {
@@ -103,7 +103,7 @@
         ],
         "resources": []
       },
-      "research_time": 23119
+      "research_time": 23119200
     },
     {
       "bonus": {
@@ -137,7 +137,7 @@
         ],
         "resources": []
       },
-      "research_time": 32272
+      "research_time": 32272680
     },
     {
       "bonus": {
@@ -167,7 +167,7 @@
         ],
         "resources": []
       },
-      "research_time": 42827
+      "research_time": 42827580
     },
     {
       "bonus": {
@@ -192,7 +192,7 @@
         "others": [
           {
             "type": "Service\u00a0Award",
-            "value": 1259
+            "value": 1259626
           },
           {
             "type": "Merit\u00a0of\u00a0Honor",
@@ -201,7 +201,7 @@
         ],
         "resources": []
       },
-      "research_time": 56199
+      "research_time": 56199420
     },
     {
       "bonus": {
@@ -230,12 +230,12 @@
           },
           {
             "type": "Service\u00a0Award",
-            "value": 2669
+            "value": 2669728
           }
         ],
         "resources": []
       },
-      "research_time": 97777
+      "research_time": 97777320
     },
     {
       "bonus": {
@@ -264,12 +264,12 @@
           },
           {
             "type": "Service\u00a0Award",
-            "value": 7673
+            "value": 7673146
           }
         ],
         "resources": []
       },
-      "research_time": 165620
+      "research_time": 165620100
     },
     {
       "bonus": {
@@ -298,12 +298,12 @@
           },
           {
             "type": "Service\u00a0Award",
-            "value": 12766
+            "value": 12766604
           }
         ],
         "resources": []
       },
-      "research_time": 208475
+      "research_time": 208475820
     },
     {
       "bonus": {
@@ -332,12 +332,12 @@
           },
           {
             "type": "Service\u00a0Award",
-            "value": 4412
+            "value": 4412607
           }
         ],
         "resources": []
       },
-      "research_time": 125063
+      "research_time": 125063640
     }
   ],
   "location": {

--- a/research/romulan_devotion.json
+++ b/research/romulan_devotion.json
@@ -70,11 +70,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1020
+            "value": 1020000
           }
         ]
       },
-      "research_time": 1330
+      "research_time": 1330800
     },
     {
       "bonus": {
@@ -107,11 +107,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 2320
+            "value": 2320000
           }
         ]
       },
-      "research_time": 2029
+      "research_time": 2029200
     },
     {
       "bonus": {
@@ -144,11 +144,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 5560
+            "value": 5560000
           }
         ]
       },
-      "research_time": 3640
+      "research_time": 3640080
     },
     {
       "bonus": {
@@ -181,11 +181,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 12200
+            "value": 12200000
           }
         ]
       },
-      "research_time": 4877
+      "research_time": 4877580
     },
     {
       "bonus": {
@@ -218,11 +218,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 32900
+            "value": 32900000
           }
         ]
       },
-      "research_time": 11282
+      "research_time": 11282220
     },
     {
       "bonus": {
@@ -255,11 +255,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 75400
+            "value": 75400000
           }
         ]
       },
-      "research_time": 18838
+      "research_time": 18838560
     },
     {
       "bonus": {
@@ -292,11 +292,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 163000
+            "value": 163000000
           }
         ]
       },
-      "research_time": 41074
+      "research_time": 41074320
     },
     {
       "bonus": {
@@ -329,11 +329,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 354000
+            "value": 354000000
           }
         ]
       },
-      "research_time": 71526
+      "research_time": 71526540
     },
     {
       "bonus": {

--- a/research/romulan_firepower.json
+++ b/research/romulan_firepower.json
@@ -55,11 +55,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 75000
+            "value": 75000000
           }
         ]
       },
-      "research_time": 4844
+      "research_time": 4844760
     },
     {
       "bonus": {
@@ -104,11 +104,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 77300
+            "value": 77300000
           }
         ]
       },
-      "research_time": 14914
+      "research_time": 14914860
     },
     {
       "bonus": {
@@ -141,11 +141,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 207900
+            "value": 207900000
           }
         ]
       },
-      "research_time": 35313
+      "research_time": 35313540
     },
     {
       "bonus": {
@@ -190,11 +190,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 449400
+            "value": 449400000
           }
         ]
       },
-      "research_time": 52543
+      "research_time": 52543680
     },
     {
       "bonus": {
@@ -239,11 +239,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 33150
+            "value": 33150000
           }
         ]
       },
-      "research_time": 8748
+      "research_time": 8748780
     }
   ],
   "location": {

--- a/research/romulan_fortitude.json
+++ b/research/romulan_fortitude.json
@@ -39,15 +39,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 6500
+            "value": 6500000
           },
           {
             "type": "dilithium",
-            "value": 5110
+            "value": 5110000
           }
         ]
       },
-      "research_time": 2608
+      "research_time": 2608980
     },
     {
       "bonus": {
@@ -92,15 +92,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 15550
+            "value": 15550000
           },
           {
             "type": "dilithium",
-            "value": 12200
+            "value": 12200000
           }
         ]
       },
-      "research_time": 4680
+      "research_time": 4680060
     },
     {
       "bonus": {
@@ -145,15 +145,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 34200
+            "value": 34200000
           },
           {
             "type": "dilithium",
-            "value": 26900
+            "value": 26900000
           }
         ]
       },
-      "research_time": 6271
+      "research_time": 6271200
     },
     {
       "bonus": {
@@ -198,15 +198,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 92150
+            "value": 92150000
           },
           {
             "type": "dilithium",
-            "value": 72400
+            "value": 72400000
           }
         ]
       },
-      "research_time": 14505
+      "research_time": 14505720
     },
     {
       "bonus": {
@@ -239,15 +239,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 211100
+            "value": 211100000
           },
           {
             "type": "dilithium",
-            "value": 165800
+            "value": 165800000
           }
         ]
       },
-      "research_time": 24221
+      "research_time": 24221040
     },
     {
       "bonus": {
@@ -286,15 +286,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 456400
+            "value": 456400000
           },
           {
             "type": "dilithium",
-            "value": 358600
+            "value": 358600000
           }
         ]
       },
-      "research_time": 52809
+      "research_time": 52809840
     },
     {
       "bonus": {
@@ -339,15 +339,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 991200
+            "value": 991200000
           },
           {
             "type": "dilithium",
-            "value": 778800
+            "value": 778800000
           }
         ]
       },
-      "research_time": 91962
+      "research_time": 91962720
     },
     {
       "bonus": {
@@ -392,15 +392,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 2044
+            "value": 2044000000
           },
           {
             "type": "dilithium",
-            "value": 1606
+            "value": 1606000000
           }
         ]
       },
-      "research_time": 159999
+      "research_time": 159999240
     },
     {
       "bonus": {
@@ -439,15 +439,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 2860
+            "value": 2860000
           },
           {
             "type": "dilithium",
-            "value": 2250
+            "value": 2250000
           }
         ]
       },
-      "research_time": 1711
+      "research_time": 1711020
     },
     {
       "bonus": {
@@ -495,7 +495,7 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 1210
+            "value": 1210000
           },
           {
             "type": "dilithium",
@@ -503,7 +503,7 @@
           }
         ]
       },
-      "research_time": 1169
+      "research_time": 1169340
     }
   ],
   "location": {

--- a/research/romulan_graviton_shields.json
+++ b/research/romulan_graviton_shields.json
@@ -30,7 +30,7 @@
         ],
         "resources": []
       },
-      "research_time": 1937
+      "research_time": 1937880
     },
     {
       "bonus": {
@@ -60,7 +60,7 @@
         ],
         "resources": []
       },
-      "research_time": 2600
+      "research_time": 2600040
     },
     {
       "bonus": {
@@ -91,7 +91,7 @@
         ],
         "resources": []
       },
-      "research_time": 3499
+      "research_time": 3499500
     },
     {
       "bonus": {
@@ -126,7 +126,7 @@
         ],
         "resources": []
       },
-      "research_time": 3483
+      "research_time": 3483960
     },
     {
       "bonus": {
@@ -157,7 +157,7 @@
         ],
         "resources": []
       },
-      "research_time": 5965
+      "research_time": 5965920
     },
     {
       "bonus": {
@@ -192,7 +192,7 @@
         ],
         "resources": []
       },
-      "research_time": 8058
+      "research_time": 8058720
     },
     {
       "bonus": {
@@ -231,7 +231,7 @@
         ],
         "resources": []
       },
-      "research_time": 14125
+      "research_time": 14125380
     },
     {
       "bonus": {
@@ -266,7 +266,7 @@
         ],
         "resources": []
       },
-      "research_time": 13456
+      "research_time": 13456140
     },
     {
       "bonus": {
@@ -300,7 +300,7 @@
         ],
         "resources": []
       },
-      "research_time": 21017
+      "research_time": 21017460
     },
     {
       "bonus": {

--- a/research/romulan_hauler.json
+++ b/research/romulan_hauler.json
@@ -39,7 +39,7 @@
         ],
         "resources": []
       },
-      "research_time": 16147
+      "research_time": 16147380
     },
     {
       "bonus": {
@@ -73,7 +73,7 @@
         ],
         "resources": []
       },
-      "research_time": 25221
+      "research_time": 25221000
     },
     {
       "bonus": {
@@ -112,7 +112,7 @@
         ],
         "resources": []
       },
-      "research_time": 35206
+      "research_time": 35206560
     },
     {
       "bonus": {
@@ -151,7 +151,7 @@
         ],
         "resources": []
       },
-      "research_time": 46720
+      "research_time": 46720980
     },
     {
       "bonus": {
@@ -176,12 +176,12 @@
           },
           {
             "type": "Service\u00a0Award",
-            "value": 1259
+            "value": 1259626
           }
         ],
         "resources": []
       },
-      "research_time": 61308
+      "research_time": 61308480
     },
     {
       "bonus": {
@@ -210,12 +210,12 @@
           },
           {
             "type": "Service\u00a0Award",
-            "value": 1796
+            "value": 1796553
           }
         ],
         "resources": []
       },
-      "research_time": 82680
+      "research_time": 82680420
     },
     {
       "bonus": {
@@ -240,12 +240,12 @@
           },
           {
             "type": "Service\u00a0Award",
-            "value": 2669
+            "value": 2669728
           }
         ],
         "resources": []
       },
-      "research_time": 106666
+      "research_time": 106666140
     },
     {
       "bonus": {
@@ -274,12 +274,12 @@
           },
           {
             "type": "Service\u00a0Award",
-            "value": 4412
+            "value": 4412607
           }
         ],
         "resources": []
       },
-      "research_time": 136433
+      "research_time": 136433100
     },
     {
       "bonus": {
@@ -304,12 +304,12 @@
           },
           {
             "type": "Service\u00a0Award",
-            "value": 7673
+            "value": 7673146
           }
         ],
         "resources": []
       },
-      "research_time": 180676
+      "research_time": 180676500
     },
     {
       "bonus": {
@@ -338,12 +338,12 @@
           },
           {
             "type": "Service\u00a0Award",
-            "value": 12766
+            "value": 12766604
           }
         ],
         "resources": []
       },
-      "research_time": 227428
+      "research_time": 227428200
     }
   ],
   "location": {

--- a/research/romulan_notoriety.json
+++ b/research/romulan_notoriety.json
@@ -30,7 +30,7 @@
         ],
         "resources": []
       },
-      "research_time": 2449
+      "research_time": 2449680
     },
     {
       "bonus": {
@@ -60,7 +60,7 @@
         ],
         "resources": []
       },
-      "research_time": 2438
+      "research_time": 2438820
     },
     {
       "bonus": {
@@ -90,7 +90,7 @@
         ],
         "resources": []
       },
-      "research_time": 4176
+      "research_time": 4176180
     },
     {
       "bonus": {
@@ -120,7 +120,7 @@
         ],
         "resources": []
       },
-      "research_time": 5641
+      "research_time": 5641140
     },
     {
       "bonus": {
@@ -154,7 +154,7 @@
         ],
         "resources": []
       },
-      "research_time": 9887
+      "research_time": 9887760
     },
     {
       "bonus": {
@@ -188,7 +188,7 @@
         ],
         "resources": []
       },
-      "research_time": 9419
+      "research_time": 9419280
     },
     {
       "bonus": {
@@ -227,7 +227,7 @@
         ],
         "resources": []
       },
-      "research_time": 14712
+      "research_time": 14712240
     },
     {
       "bonus": {
@@ -261,7 +261,7 @@
         ],
         "resources": []
       },
-      "research_time": 20537
+      "research_time": 20537160
     },
     {
       "bonus": {
@@ -295,7 +295,7 @@
         ],
         "resources": []
       },
-      "research_time": 27253
+      "research_time": 27253920
     },
     {
       "bonus": {
@@ -330,7 +330,7 @@
         ],
         "resources": []
       },
-      "research_time": 1820
+      "research_time": 1820040
     }
   ],
   "location": {

--- a/research/romulan_ore_miner.json
+++ b/research/romulan_ore_miner.json
@@ -33,11 +33,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 18250
+            "value": 18250000
           }
         ]
       },
-      "research_time": 6299
+      "research_time": 6299160
     },
     {
       "bonus": {
@@ -70,11 +70,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 42500
+            "value": 42500000
           }
         ]
       },
-      "research_time": 10738
+      "research_time": 10738680
     },
     {
       "bonus": {
@@ -107,11 +107,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 114300
+            "value": 114300000
           }
         ]
       },
-      "research_time": 25425
+      "research_time": 25425720
     },
     {
       "bonus": {
@@ -144,11 +144,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 247200
+            "value": 247200000
           }
         ]
       },
-      "research_time": 37831
+      "research_time": 37831440
     },
     {
       "bonus": {
@@ -181,11 +181,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 546200
+            "value": 546200000
           }
         ]
       },
-      "research_time": 70081
+      "research_time": 70081440
     },
     {
       "bonus": {
@@ -218,11 +218,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1086
+            "value": 1086000000
           }
         ]
       },
-      "research_time": 124020
+      "research_time": 124020600
     },
     {
       "bonus": {
@@ -255,11 +255,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1480
+            "value": 1480000
           }
         ]
       },
-      "research_time": 1333
+      "research_time": 1333800
     },
     {
       "bonus": {
@@ -292,11 +292,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 8200
+            "value": 8200000
           }
         ]
       },
-      "research_time": 3488
+      "research_time": 3488220
     },
     {
       "bonus": {
@@ -342,7 +342,7 @@
           }
         ]
       },
-      "research_time": 1039
+      "research_time": 1039980
     },
     {
       "bonus": {
@@ -375,11 +375,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 3300
+            "value": 3300000
           }
         ]
       },
-      "research_time": 1761
+      "research_time": 1761360
     }
   ],
   "location": {

--- a/research/romulan_pure_ore.json
+++ b/research/romulan_pure_ore.json
@@ -33,15 +33,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 45350
+            "value": 45350000
           },
           {
             "type": "dilithium",
-            "value": 11100
+            "value": 11100000
           }
         ]
       },
-      "research_time": 4160
+      "research_time": 4160100
     },
     {
       "bonus": {
@@ -74,15 +74,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 99700
+            "value": 99700000
           },
           {
             "type": "dilithium",
-            "value": 24450
+            "value": 24450000
           }
         ]
       },
-      "research_time": 5574
+      "research_time": 5574360
     },
     {
       "bonus": {
@@ -115,15 +115,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 268500
+            "value": 268500000
           },
           {
             "type": "dilithium",
-            "value": 65800
+            "value": 65800000
           }
         ]
       },
-      "research_time": 12893
+      "research_time": 12893940
     },
     {
       "bonus": {
@@ -156,15 +156,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 615100
+            "value": 615100000
           },
           {
             "type": "dilithium",
-            "value": 150800
+            "value": 150800000
           }
         ]
       },
-      "research_time": 21529
+      "research_time": 21529800
     },
     {
       "bonus": {
@@ -197,15 +197,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1330
+            "value": 1330000000
           },
           {
             "type": "dilithium",
-            "value": 326000
+            "value": 326000000
           }
         ]
       },
-      "research_time": 46942
+      "research_time": 46942080
     },
     {
       "bonus": {
@@ -238,15 +238,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 2889
+            "value": 2889000000
           },
           {
             "type": "dilithium",
-            "value": 708000
+            "value": 708000000
           }
         ]
       },
-      "research_time": 81744
+      "research_time": 81744660
     },
     {
       "bonus": {
@@ -279,15 +279,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 5957
+            "value": 5957000000
           },
           {
             "type": "dilithium",
-            "value": 1460
+            "value": 1460000000
           }
         ]
       },
-      "research_time": 142221
+      "research_time": 142221540
     },
     {
       "bonus": {
@@ -320,15 +320,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 8340
+            "value": 8340000
           },
           {
             "type": "dilithium",
-            "value": 2040
+            "value": 2040000
           }
         ]
       },
-      "research_time": 1520
+      "research_time": 1520880
     },
     {
       "bonus": {
@@ -361,15 +361,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 18950
+            "value": 18950000
           },
           {
             "type": "dilithium",
-            "value": 4650
+            "value": 4650000
           }
         ]
       },
-      "research_time": 2319
+      "research_time": 2319120
     },
     {
       "bonus": {
@@ -406,7 +406,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 3530
+            "value": 3530000
           },
           {
             "type": "dilithium",
@@ -414,7 +414,7 @@
           }
         ]
       },
-      "research_time": 1039
+      "research_time": 1039440
     }
   ],
   "location": {

--- a/research/romulan_repair_costs.json
+++ b/research/romulan_repair_costs.json
@@ -54,15 +54,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 5470
+            "value": 5470000
           },
           {
             "type": "dilithium",
-            "value": 1480
+            "value": 1480000
           }
         ]
       },
-      "research_time": 1333
+      "research_time": 1333800
     },
     {
       "bonus": {
@@ -107,15 +107,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 12250
+            "value": 12250000
           },
           {
             "type": "dilithium",
-            "value": 3300
+            "value": 3300000
           }
         ]
       },
-      "research_time": 1761
+      "research_time": 1761360
     },
     {
       "bonus": {
@@ -141,15 +141,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 30400
+            "value": 30400000
           },
           {
             "type": "dilithium",
-            "value": 8200
+            "value": 8200000
           }
         ]
       },
-      "research_time": 3488
+      "research_time": 3488220
     },
     {
       "bonus": {
@@ -194,15 +194,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 67650
+            "value": 67650000
           },
           {
             "type": "dilithium",
-            "value": 18250
+            "value": 18250000
           }
         ]
       },
-      "research_time": 6299
+      "research_time": 6299160
     },
     {
       "bonus": {
@@ -247,15 +247,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 157700
+            "value": 157700000
           },
           {
             "type": "dilithium",
-            "value": 42500
+            "value": 42500000
           }
         ]
       },
-      "research_time": 10738
+      "research_time": 10738680
     },
     {
       "bonus": {
@@ -288,15 +288,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 424100
+            "value": 424100000
           },
           {
             "type": "dilithium",
-            "value": 114300
+            "value": 114300000
           }
         ]
       },
-      "research_time": 25425
+      "research_time": 25425720
     },
     {
       "bonus": {
@@ -341,15 +341,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 916800
+            "value": 916800000
           },
           {
             "type": "dilithium",
-            "value": 247200
+            "value": 247200000
           }
         ]
       },
-      "research_time": 37831
+      "research_time": 37831440
     },
     {
       "bonus": {
@@ -394,15 +394,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 2026
+            "value": 2026000000
           },
           {
             "type": "dilithium",
-            "value": 546200
+            "value": 546200000
           }
         ]
       },
-      "research_time": 70081
+      "research_time": 70081440
     },
     {
       "bonus": {
@@ -447,15 +447,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 4028
+            "value": 4028000000
           },
           {
             "type": "dilithium",
-            "value": 1086
+            "value": 1086000000
           }
         ]
       },
-      "research_time": 124020
+      "research_time": 124020600
     },
     {
       "bonus": {
@@ -500,15 +500,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 9621
+            "value": 9621000000
           },
           {
             "type": "dilithium",
-            "value": 2594
+            "value": 2594000000
           }
         ]
       },
-      "research_time": 204649
+      "research_time": 204649620
     }
   ],
   "location": {

--- a/research/romulan_repair_speed.json
+++ b/research/romulan_repair_speed.json
@@ -49,15 +49,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 45350
+            "value": 45350000
           },
           {
             "type": "dilithium",
-            "value": 22200
+            "value": 22200000
           }
         ]
       },
-      "research_time": 6500
+      "research_time": 6500100
     },
     {
       "bonus": {
@@ -102,15 +102,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 99700
+            "value": 99700000
           },
           {
             "type": "dilithium",
-            "value": 48850
+            "value": 48850000
           }
         ]
       },
-      "research_time": 8709
+      "research_time": 8709960
     },
     {
       "bonus": {
@@ -155,15 +155,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 268500
+            "value": 268500000
           },
           {
             "type": "dilithium",
-            "value": 131600
+            "value": 131600000
           }
         ]
       },
-      "research_time": 20146
+      "research_time": 20146800
     },
     {
       "bonus": {
@@ -196,15 +196,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 615100
+            "value": 615100000
           },
           {
             "type": "dilithium",
-            "value": 301500
+            "value": 301500000
           }
         ]
       },
-      "research_time": 33640
+      "research_time": 33640320
     },
     {
       "bonus": {
@@ -249,15 +249,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1330
+            "value": 1330000000
           },
           {
             "type": "dilithium",
-            "value": 652000
+            "value": 652000000
           }
         ]
       },
-      "research_time": 73347
+      "research_time": 73347000
     },
     {
       "bonus": {
@@ -302,15 +302,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 2889
+            "value": 2889000000
           },
           {
             "type": "dilithium",
-            "value": 1416
+            "value": 1416000000
           }
         ]
       },
-      "research_time": 127726
+      "research_time": 127726020
     },
     {
       "bonus": {
@@ -355,15 +355,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 5957
+            "value": 5957000000
           },
           {
             "type": "dilithium",
-            "value": 2920
+            "value": 2920000000
           }
         ]
       },
-      "research_time": 222221
+      "research_time": 222221100
     },
     {
       "bonus": {
@@ -408,15 +408,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 16279
+            "value": 16279000000
           },
           {
             "type": "dilithium",
-            "value": 7980
+            "value": 7980000000
           }
         ]
       },
-      "research_time": 376409
+      "research_time": 376409340
     },
     {
       "bonus": {
@@ -442,15 +442,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 44018
+            "value": 44018000000
           },
           {
             "type": "dilithium",
-            "value": 21578
+            "value": 21578000000
           }
         ]
       },
-      "research_time": 577916
+      "research_time": 577916820
     },
     {
       "bonus": {
@@ -476,15 +476,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 60244
+            "value": 60244000000
           },
           {
             "type": "dilithium",
-            "value": 29531
+            "value": 29531000000
           }
         ]
       },
-      "research_time": 511432
+      "research_time": 511432980
     }
   ],
   "location": {

--- a/research/romulan_ship_structure.json
+++ b/research/romulan_ship_structure.json
@@ -39,7 +39,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1500
+            "value": 1500000
           },
           {
             "type": "dilithium",
@@ -86,7 +86,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 3530
+            "value": 3530000
           },
           {
             "type": "dilithium",
@@ -139,15 +139,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 8340
+            "value": 8340000
           },
           {
             "type": "dilithium",
-            "value": 2040
+            "value": 2040000
           }
         ]
       },
-      "research_time": 1330
+      "research_time": 1330800
     },
     {
       "bonus": {
@@ -192,15 +192,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 18950
+            "value": 18950000
           },
           {
             "type": "dilithium",
-            "value": 4650
+            "value": 4650000
           }
         ]
       },
-      "research_time": 2029
+      "research_time": 2029200
     },
     {
       "bonus": {
@@ -245,15 +245,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 45350
+            "value": 45350000
           },
           {
             "type": "dilithium",
-            "value": 11100
+            "value": 11100000
           }
         ]
       },
-      "research_time": 3640
+      "research_time": 3640080
     },
     {
       "bonus": {
@@ -298,15 +298,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 99700
+            "value": 99700000
           },
           {
             "type": "dilithium",
-            "value": 24450
+            "value": 24450000
           }
         ]
       },
-      "research_time": 4877
+      "research_time": 4877580
     },
     {
       "bonus": {
@@ -351,15 +351,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 268500
+            "value": 268500000
           },
           {
             "type": "dilithium",
-            "value": 65800
+            "value": 65800000
           }
         ]
       },
-      "research_time": 11282
+      "research_time": 11282220
     },
     {
       "bonus": {
@@ -398,15 +398,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 615100
+            "value": 615100000
           },
           {
             "type": "dilithium",
-            "value": 150800
+            "value": 150800000
           }
         ]
       },
-      "research_time": 18838
+      "research_time": 18838560
     },
     {
       "bonus": {
@@ -451,15 +451,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1330
+            "value": 1330000000
           },
           {
             "type": "dilithium",
-            "value": 326000
+            "value": 326000000
           }
         ]
       },
-      "research_time": 41074
+      "research_time": 41074320
     },
     {
       "bonus": {

--- a/research/romulan_vulnerability.json
+++ b/research/romulan_vulnerability.json
@@ -50,11 +50,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 9214
+            "value": 9214000000
           }
         ]
       },
-      "research_time": 246380
+      "research_time": 246380520
     }
   ],
   "location": {

--- a/research/romulan_weakpoints.json
+++ b/research/romulan_weakpoints.json
@@ -22,11 +22,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 9690
+            "value": 9690000
           }
         ]
       },
-      "research_time": 2519
+      "research_time": 2519280
     },
     {
       "bonus": {
@@ -72,7 +72,7 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1120
+            "value": 1120000
           }
         ]
       },
@@ -117,11 +117,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 2660
+            "value": 2660000
           }
         ]
       },
-      "research_time": 1235
+      "research_time": 1235700
     },
     {
       "bonus": {
@@ -162,11 +162,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 3900
+            "value": 3900000
           }
         ]
       },
-      "research_time": 1272
+      "research_time": 1272060
     },
     {
       "bonus": {
@@ -207,11 +207,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 14450
+            "value": 14450000
           }
         ]
       },
-      "research_time": 3380
+      "research_time": 3380040
     },
     {
       "bonus": {
@@ -252,11 +252,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 31750
+            "value": 31750000
           }
         ]
       },
-      "research_time": 4529
+      "research_time": 4529160
     },
     {
       "bonus": {
@@ -278,11 +278,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 50250
+            "value": 50250000
           }
         ]
       },
-      "research_time": 7755
+      "research_time": 7755720
     },
     {
       "bonus": {
@@ -311,11 +311,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 135100
+            "value": 135100000
           }
         ]
       },
-      "research_time": 18363
+      "research_time": 18363000
     },
     {
       "bonus": {
@@ -350,11 +350,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 196000
+            "value": 196000000
           }
         ]
       },
-      "research_time": 17492
+      "research_time": 17492940
     },
     {
       "bonus": {

--- a/research/rotating_frequencies.json
+++ b/research/rotating_frequencies.json
@@ -45,11 +45,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 3065
+            "value": 3065000000
           }
         ]
       },
-      "research_time": 147802
+      "research_time": 147802500
     },
     {
       "bonus": {
@@ -84,11 +84,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 14025
+            "value": 14025000000
           }
         ]
       },
-      "research_time": 300516
+      "research_time": 300516720
     },
     {
       "bonus": {
@@ -117,11 +117,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 21499
+            "value": 21499000000
           }
         ]
       },
-      "research_time": 386864
+      "research_time": 386864640
     },
     {
       "bonus": {
@@ -156,11 +156,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 19195
+            "value": 19195000000
           }
         ]
       },
-      "research_time": 265945
+      "research_time": 265945140
     },
     {
       "bonus": {
@@ -195,11 +195,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 28793
+            "value": 28793000000
           }
         ]
       },
-      "research_time": 319134
+      "research_time": 319134180
     },
     {
       "bonus": {
@@ -234,11 +234,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 43189
+            "value": 43189000000
           }
         ]
       },
-      "research_time": 419913
+      "research_time": 419913420
     }
   ],
   "location": {

--- a/research/self_replicating_systems.json
+++ b/research/self_replicating_systems.json
@@ -47,7 +47,7 @@
         ],
         "resources": []
       },
-      "research_time": 13456
+      "research_time": 13456140
     },
     {
       "bonus": {
@@ -81,7 +81,7 @@
         ],
         "resources": []
       },
-      "research_time": 21017
+      "research_time": 21017460
     },
     {
       "bonus": {
@@ -111,7 +111,7 @@
         ],
         "resources": []
       },
-      "research_time": 29338
+      "research_time": 29338800
     },
     {
       "bonus": {
@@ -158,7 +158,7 @@
         ],
         "resources": []
       },
-      "research_time": 38934
+      "research_time": 38934120
     },
     {
       "bonus": {
@@ -188,12 +188,12 @@
           },
           {
             "type": "Service\u00a0Award",
-            "value": 1259
+            "value": 1259626
           }
         ],
         "resources": []
       },
-      "research_time": 51090
+      "research_time": 51090420
     },
     {
       "bonus": {
@@ -218,7 +218,7 @@
         "others": [
           {
             "type": "Service\u00a0Award",
-            "value": 1796
+            "value": 1796553
           },
           {
             "type": "Merit\u00a0of\u00a0Honor",
@@ -227,7 +227,7 @@
         ],
         "resources": []
       },
-      "research_time": 68900
+      "research_time": 68900340
     },
     {
       "bonus": {
@@ -269,12 +269,12 @@
           },
           {
             "type": "Service\u00a0Award",
-            "value": 2669
+            "value": 2669728
           }
         ],
         "resources": []
       },
-      "research_time": 88888
+      "research_time": 88888440
     },
     {
       "bonus": {
@@ -303,12 +303,12 @@
           },
           {
             "type": "Service\u00a0Award",
-            "value": 4412
+            "value": 4412607
           }
         ],
         "resources": []
       },
-      "research_time": 113694
+      "research_time": 113694240
     },
     {
       "bonus": {
@@ -338,12 +338,12 @@
           },
           {
             "type": "Service\u00a0Award",
-            "value": 7673
+            "value": 7673146
           }
         ],
         "resources": []
       },
-      "research_time": 150563
+      "research_time": 150563760
     },
     {
       "bonus": {
@@ -372,12 +372,12 @@
           },
           {
             "type": "Service\u00a0Award",
-            "value": 12766
+            "value": 12766604
           }
         ],
         "resources": []
       },
-      "research_time": 189523
+      "research_time": 189523500
     }
   ],
   "location": {

--- a/research/shield_enhancements.json
+++ b/research/shield_enhancements.json
@@ -44,11 +44,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1110
+            "value": 1110000
           }
         ]
       },
-      "research_time": 2600
+      "research_time": 2600040
     },
     {
       "bonus": {
@@ -83,11 +83,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 10400
+            "value": 10400000
           }
         ]
       },
-      "research_time": 14125
+      "research_time": 14125380
     },
     {
       "bonus": {
@@ -122,11 +122,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 15100
+            "value": 15100000
           }
         ]
       },
-      "research_time": 13456
+      "research_time": 13456140
     },
     {
       "bonus": {
@@ -170,11 +170,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 22450
+            "value": 22450000
           }
         ]
       },
-      "research_time": 21017
+      "research_time": 21017460
     },
     {
       "bonus": {
@@ -209,11 +209,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 32600
+            "value": 32600000
           }
         ]
       },
-      "research_time": 29338
+      "research_time": 29338800
     },
     {
       "bonus": {
@@ -248,11 +248,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 49650
+            "value": 49650000
           }
         ]
       },
-      "research_time": 38934
+      "research_time": 38934120
     },
     {
       "bonus": {
@@ -287,11 +287,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 70800
+            "value": 70800000
           }
         ]
       },
-      "research_time": 51090
+      "research_time": 51090420
     },
     {
       "bonus": {
@@ -326,11 +326,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 98750
+            "value": 98750000
           }
         ]
       },
-      "research_time": 68900
+      "research_time": 68900340
     },
     {
       "bonus": {
@@ -365,11 +365,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 146000
+            "value": 146000000
           }
         ]
       },
-      "research_time": 88888
+      "research_time": 88888440
     },
     {
       "bonus": {
@@ -413,11 +413,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 399000
+            "value": 399000000
           }
         ]
       },
-      "research_time": 150563
+      "research_time": 150563760
     }
   ],
   "location": {

--- a/research/shield_modification.json
+++ b/research/shield_modification.json
@@ -39,11 +39,11 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 3000
+            "value": 3000000
           },
           {
             "type": "dilithium",
-            "value": 1800
+            "value": 1800000
           }
         ]
       },
@@ -81,15 +81,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 4650
+            "value": 4650000
           },
           {
             "type": "dilithium",
-            "value": 2790
+            "value": 2790000
           }
         ]
       },
-      "research_time": 1449
+      "research_time": 1449420
     },
     {
       "bonus": {
@@ -128,15 +128,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 7460
+            "value": 7460000
           },
           {
             "type": "dilithium",
-            "value": 4470
+            "value": 4470000
           }
         ]
       },
-      "research_time": 1937
+      "research_time": 1937880
     },
     {
       "bonus": {
@@ -170,15 +170,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 11100
+            "value": 11100000
           },
           {
             "type": "dilithium",
-            "value": 6670
+            "value": 6670000
           }
         ]
       },
-      "research_time": 2600
+      "research_time": 2600040
     },
     {
       "bonus": {
@@ -217,15 +217,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 16600
+            "value": 16600000
           },
           {
             "type": "dilithium",
-            "value": 9950
+            "value": 9950000
           }
         ]
       },
-      "research_time": 3499
+      "research_time": 3499500
     },
     {
       "bonus": {
@@ -263,15 +263,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 24450
+            "value": 24450000
           },
           {
             "type": "dilithium",
-            "value": 14650
+            "value": 14650000
           }
         ]
       },
-      "research_time": 3483
+      "research_time": 3483960
     },
     {
       "bonus": {
@@ -313,15 +313,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 38650
+            "value": 38650000
           },
           {
             "type": "dilithium",
-            "value": 23200
+            "value": 23200000
           }
         ]
       },
-      "research_time": 5965
+      "research_time": 5965920
     },
     {
       "bonus": {
@@ -352,15 +352,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 65800
+            "value": 65800000
           },
           {
             "type": "dilithium",
-            "value": 39500
+            "value": 39500000
           }
         ]
       },
-      "research_time": 8058
+      "research_time": 8058720
     },
     {
       "bonus": {
@@ -398,15 +398,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 104000
+            "value": 104000000
           },
           {
             "type": "dilithium",
-            "value": 62350
+            "value": 62350000
           }
         ]
       },
-      "research_time": 14125
+      "research_time": 14125380
     },
     {
       "bonus": {

--- a/research/ship_component_efficiency.json
+++ b/research/ship_component_efficiency.json
@@ -35,15 +35,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 45350
+            "value": 45350000
           },
           {
             "type": "dilithium",
-            "value": 11100
+            "value": 11100000
           }
         ]
       },
-      "research_time": 2600
+      "research_time": 2600040
     },
     {
       "bonus": {
@@ -75,15 +75,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 99700
+            "value": 99700000
           },
           {
             "type": "dilithium",
-            "value": 24450
+            "value": 24450000
           }
         ]
       },
-      "research_time": 3483
+      "research_time": 3483960
     },
     {
       "bonus": {
@@ -118,15 +118,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 268500
+            "value": 268500000
           },
           {
             "type": "dilithium",
-            "value": 65800
+            "value": 65800000
           }
         ]
       },
-      "research_time": 8058
+      "research_time": 8058720
     },
     {
       "bonus": {
@@ -158,15 +158,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 615100
+            "value": 615100000
           },
           {
             "type": "dilithium",
-            "value": 150800
+            "value": 150800000
           }
         ]
       },
-      "research_time": 13456
+      "research_time": 13456140
     },
     {
       "bonus": {
@@ -201,15 +201,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1330
+            "value": 1330000000
           },
           {
             "type": "dilithium",
-            "value": 326000
+            "value": 326000000
           }
         ]
       },
-      "research_time": 29338
+      "research_time": 29338800
     },
     {
       "bonus": {
@@ -244,15 +244,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 5957
+            "value": 5957000000
           },
           {
             "type": "dilithium",
-            "value": 1460
+            "value": 1460000000
           }
         ]
       },
-      "research_time": 88888
+      "research_time": 88888440
     },
     {
       "bonus": {
@@ -279,15 +279,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 2889
+            "value": 2889000000
           },
           {
             "type": "dilithium",
-            "value": 708000
+            "value": 708000000
           }
         ]
       },
-      "research_time": 51090
+      "research_time": 51090420
     },
     {
       "bonus": {
@@ -314,15 +314,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 16279
+            "value": 16279000000
           },
           {
             "type": "dilithium",
-            "value": 3990
+            "value": 3990000000
           }
         ]
       },
-      "research_time": 150563
+      "research_time": 150563760
     },
     {
       "bonus": {
@@ -357,11 +357,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 8340
+            "value": 8340000
           },
           {
             "type": "dilithium",
-            "value": 2040
+            "value": 2040000
           }
         ]
       },
@@ -392,15 +392,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 18950
+            "value": 18950000
           },
           {
             "type": "dilithium",
-            "value": 4650
+            "value": 4650000
           }
         ]
       },
-      "research_time": 1449
+      "research_time": 1449420
     }
   ],
   "location": {

--- a/research/shuttlecraft_mk_vi_frame.json
+++ b/research/shuttlecraft_mk_vi_frame.json
@@ -31,7 +31,7 @@
         ],
         "resources": []
       },
-      "research_time": 3152
+      "research_time": 3152640
     }
   ],
   "location": {

--- a/research/siege_warfare.json
+++ b/research/siege_warfare.json
@@ -58,11 +58,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 54100
+            "value": 54100000
           }
         ]
       },
-      "research_time": 8352
+      "research_time": 8352300
     },
     {
       "bonus": {
@@ -103,11 +103,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 92150
+            "value": 92150000
           }
         ]
       },
-      "research_time": 11282
+      "research_time": 11282220
     },
     {
       "bonus": {
@@ -136,11 +136,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 211100
+            "value": 211100000
           }
         ]
       },
-      "research_time": 18838
+      "research_time": 18838560
     },
     {
       "bonus": {
@@ -180,11 +180,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 314600
+            "value": 314600000
           }
         ]
       },
-      "research_time": 29424
+      "research_time": 29424480
     },
     {
       "bonus": {
@@ -225,11 +225,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 695100
+            "value": 695100000
           }
         ]
       },
-      "research_time": 54507
+      "research_time": 54507780
     },
     {
       "bonus": {
@@ -270,11 +270,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 991200
+            "value": 991200000
           }
         ]
       },
-      "research_time": 71526
+      "research_time": 71526540
     },
     {
       "bonus": {
@@ -315,11 +315,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 2044
+            "value": 2044000000
           }
         ]
       },
-      "research_time": 124443
+      "research_time": 124443840
     },
     {
       "bonus": {
@@ -360,11 +360,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 3301
+            "value": 3301000000
           }
         ]
       },
-      "research_time": 159171
+      "research_time": 159171960
     },
     {
       "bonus": {
@@ -405,11 +405,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 9923
+            "value": 9923000000
           }
         ]
       },
-      "research_time": 265332
+      "research_time": 265332840
     },
     {
       "bonus": {
@@ -431,11 +431,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 15104
+            "value": 15104000000
           }
         ]
       },
-      "research_time": 323633
+      "research_time": 323633400
     }
   ],
   "location": {

--- a/research/sneaky_backhander.json
+++ b/research/sneaky_backhander.json
@@ -53,11 +53,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 301500
+            "value": 301500000
           }
         ]
       },
-      "research_time": 26912,
+      "research_time": 26912280,
       "reward": {
         "type": "Mission\u00a0Token\u00a0",
         "value": 1
@@ -110,11 +110,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 652000
+            "value": 652000000
           }
         ]
       },
-      "research_time": 58677,
+      "research_time": 58677600,
       "reward": {
         "type": "Mission\u00a0Token\u00a0",
         "value": 1
@@ -167,11 +167,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1416
+            "value": 1416000000
           }
         ]
       },
-      "research_time": 102180,
+      "research_time": 102180780,
       "reward": {
         "type": "Mission\u00a0Token\u00a0",
         "value": 1
@@ -228,11 +228,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 2920
+            "value": 2920000000
           }
         ]
       },
-      "research_time": 177776,
+      "research_time": 177776880,
       "reward": {
         "type": "Mission\u00a0Token\u00a0",
         "value": 1
@@ -289,11 +289,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 7980
+            "value": 7980000000
           }
         ]
       },
-      "research_time": 301127,
+      "research_time": 301127460,
       "reward": {
         "type": "Mission\u00a0Token\u00a0",
         "value": 1

--- a/research/space_critical_resistance.json
+++ b/research/space_critical_resistance.json
@@ -44,15 +44,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 6630
+            "value": 6630000
           },
           {
             "type": "dilithium",
-            "value": 16600
+            "value": 16600000
           }
         ]
       },
-      "research_time": 4199
+      "research_time": 4199400
     },
     {
       "bonus": {
@@ -78,15 +78,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 9770
+            "value": 9770000
           },
           {
             "type": "dilithium",
-            "value": 24450
+            "value": 24450000
           }
         ]
       },
-      "research_time": 4180
+      "research_time": 4180800
     },
     {
       "bonus": {
@@ -136,15 +136,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 15450
+            "value": 15450000
           },
           {
             "type": "dilithium",
-            "value": 38650
+            "value": 38650000
           }
         ]
       },
-      "research_time": 7159
+      "research_time": 7159140
     },
     {
       "bonus": {
@@ -175,15 +175,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 26350
+            "value": 26350000
           },
           {
             "type": "dilithium",
-            "value": 65800
+            "value": 65800000
           }
         ]
       },
-      "research_time": 9670
+      "research_time": 9670500
     },
     {
       "bonus": {
@@ -216,15 +216,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 41600
+            "value": 41600000
           },
           {
             "type": "dilithium",
-            "value": 104000
+            "value": 104000000
           }
         ]
       },
-      "research_time": 16950
+      "research_time": 16950480
     },
     {
       "bonus": {
@@ -246,15 +246,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 60300
+            "value": 60300000
           },
           {
             "type": "dilithium",
-            "value": 150800
+            "value": 150800000
           }
         ]
       },
-      "research_time": 16147
+      "research_time": 16147380
     },
     {
       "bonus": {
@@ -298,15 +298,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 89900
+            "value": 89900000
           },
           {
             "type": "dilithium",
-            "value": 224700
+            "value": 224700000
           }
         ]
       },
-      "research_time": 25221
+      "research_time": 25221000
     },
     {
       "bonus": {
@@ -333,15 +333,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 130400
+            "value": 130400000
           },
           {
             "type": "dilithium",
-            "value": 326000
+            "value": 326000000
           }
         ]
       },
-      "research_time": 35206
+      "research_time": 35206560
     },
     {
       "bonus": {
@@ -386,15 +386,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 198600
+            "value": 198600000
           },
           {
             "type": "dilithium",
-            "value": 496500
+            "value": 496500000
           }
         ]
       },
-      "research_time": 46720
+      "research_time": 46720980
     },
     {
       "bonus": {
@@ -437,11 +437,11 @@
           },
           {
             "type": "dilithium",
-            "value": 2040
+            "value": 2040000
           }
         ]
       },
-      "research_time": 1140
+      "research_time": 1140660
     }
   ],
   "location": {

--- a/research/station_accuracy.json
+++ b/research/station_accuracy.json
@@ -100,7 +100,7 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 2040
+            "value": 2040000
           }
         ]
       },
@@ -126,7 +126,7 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 3000
+            "value": 3000000
           }
         ]
       },
@@ -152,11 +152,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 7460
+            "value": 7460000
           }
         ]
       },
-      "research_time": 1937
+      "research_time": 1937880
     },
     {
       "bonus": {
@@ -178,11 +178,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 11100
+            "value": 11100000
           }
         ]
       },
-      "research_time": 2600
+      "research_time": 2600040
     },
     {
       "bonus": {
@@ -204,11 +204,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 24450
+            "value": 24450000
           }
         ]
       },
-      "research_time": 3483
+      "research_time": 3483960
     },
     {
       "bonus": {
@@ -249,11 +249,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 38650
+            "value": 38650000
           }
         ]
       },
-      "research_time": 5965
+      "research_time": 5965920
     },
     {
       "bonus": {

--- a/research/station_armor_piercing.json
+++ b/research/station_armor_piercing.json
@@ -100,7 +100,7 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 2040
+            "value": 2040000
           }
         ]
       },
@@ -126,7 +126,7 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 3000
+            "value": 3000000
           }
         ]
       },
@@ -152,11 +152,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 7460
+            "value": 7460000
           }
         ]
       },
-      "research_time": 1937
+      "research_time": 1937880
     },
     {
       "bonus": {
@@ -178,11 +178,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 11100
+            "value": 11100000
           }
         ]
       },
-      "research_time": 2600
+      "research_time": 2600040
     },
     {
       "bonus": {
@@ -204,11 +204,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 24450
+            "value": 24450000
           }
         ]
       },
-      "research_time": 3483
+      "research_time": 3483960
     },
     {
       "bonus": {
@@ -249,11 +249,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 38650
+            "value": 38650000
           }
         ]
       },
-      "research_time": 5965
+      "research_time": 5965920
     },
     {
       "bonus": {

--- a/research/station_destruction.json
+++ b/research/station_destruction.json
@@ -50,11 +50,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 645500
+            "value": 645500000
           }
         ]
       },
-      "research_time": 50614
+      "research_time": 50614380
     },
     {
       "bonus": {
@@ -87,11 +87,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 920400
+            "value": 920400000
           }
         ]
       },
-      "research_time": 66417
+      "research_time": 66417540
     },
     {
       "bonus": {
@@ -135,11 +135,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1283
+            "value": 1283000000
           }
         ]
       },
-      "research_time": 89570
+      "research_time": 89570460
     },
     {
       "bonus": {
@@ -181,11 +181,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1898
+            "value": 1898000000
           }
         ]
       },
-      "research_time": 115554
+      "research_time": 115554960
     },
     {
       "bonus": {
@@ -229,11 +229,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 3065
+            "value": 3065000000
           }
         ]
       },
-      "research_time": 147802
+      "research_time": 147802500
     },
     {
       "bonus": {
@@ -266,11 +266,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 5187
+            "value": 5187000000
           }
         ]
       },
-      "research_time": 195732
+      "research_time": 195732840
     },
     {
       "bonus": {
@@ -314,11 +314,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 9214
+            "value": 9214000000
           }
         ]
       },
-      "research_time": 246380
+      "research_time": 246380520
     },
     {
       "bonus": {
@@ -340,11 +340,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 14025
+            "value": 14025000000
           }
         ]
       },
-      "research_time": 300516
+      "research_time": 300516720
     },
     {
       "bonus": {
@@ -366,11 +366,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 21499
+            "value": 21499000000
           }
         ]
       },
-      "research_time": 386864
+      "research_time": 386864640
     },
     {
       "bonus": {
@@ -392,11 +392,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 19195
+            "value": 19195000000
           }
         ]
       },
-      "research_time": 265945
+      "research_time": 265945140
     }
   ],
   "location": {

--- a/research/station_piercing.json
+++ b/research/station_piercing.json
@@ -35,15 +35,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 3720
+            "value": 3720000
           },
           {
             "type": "dilithium",
-            "value": 4650
+            "value": 4650000
           }
         ]
       },
-      "research_time": 2029
+      "research_time": 2029200
     },
     {
       "bonus": {
@@ -78,15 +78,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 5960
+            "value": 5960000
           },
           {
             "type": "dilithium",
-            "value": 7460
+            "value": 7460000
           }
         ]
       },
-      "research_time": 2713
+      "research_time": 2713080
     },
     {
       "bonus": {
@@ -164,15 +164,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 1070
+            "value": 1070000
           },
           {
             "type": "dilithium",
-            "value": 1340
+            "value": 1340000
           }
         ]
       },
-      "research_time": 1037
+      "research_time": 1037400
     },
     {
       "bonus": {
@@ -207,15 +207,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 1630
+            "value": 1630000
           },
           {
             "type": "dilithium",
-            "value": 2040
+            "value": 2040000
           }
         ]
       },
-      "research_time": 1330
+      "research_time": 1330800
     },
     {
       "bonus": {
@@ -237,15 +237,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 13250
+            "value": 13250000
           },
           {
             "type": "dilithium",
-            "value": 16600
+            "value": 16600000
           }
         ]
       },
-      "research_time": 4899
+      "research_time": 4899360
     },
     {
       "bonus": {
@@ -267,15 +267,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 19550
+            "value": 19550000
           },
           {
             "type": "dilithium",
-            "value": 24450
+            "value": 24450000
           }
         ]
       },
-      "research_time": 4877
+      "research_time": 4877580
     },
     {
       "bonus": {
@@ -297,15 +297,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 52650
+            "value": 52650000
           },
           {
             "type": "dilithium",
-            "value": 65800
+            "value": 65800000
           }
         ]
       },
-      "research_time": 11282
+      "research_time": 11282220
     },
     {
       "bonus": {
@@ -338,15 +338,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 83150
+            "value": 83150000
           },
           {
             "type": "dilithium",
-            "value": 104000
+            "value": 104000000
           }
         ]
       },
-      "research_time": 19775
+      "research_time": 19775580
     },
     {
       "bonus": {

--- a/research/station_pure_resources.json
+++ b/research/station_pure_resources.json
@@ -50,15 +50,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1538
+            "value": 1538000000
           },
           {
             "type": "dilithium",
-            "value": 271400
+            "value": 271400000
           }
         ]
       },
-      "research_time": 13456
+      "research_time": 13456140
     },
     {
       "bonus": {
@@ -98,15 +98,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 2292
+            "value": 2292000000
           },
           {
             "type": "dilithium",
-            "value": 404500
+            "value": 404500000
           }
         ]
       },
-      "research_time": 21017
+      "research_time": 21017460
     },
     {
       "bonus": {
@@ -150,15 +150,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 3325
+            "value": 3325000000
           },
           {
             "type": "dilithium",
-            "value": 586800
+            "value": 586800000
           }
         ]
       },
-      "research_time": 29338
+      "research_time": 29338800
     },
     {
       "bonus": {
@@ -198,15 +198,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 5064
+            "value": 5064000000
           },
           {
             "type": "dilithium",
-            "value": 893700
+            "value": 893700000
           }
         ]
       },
-      "research_time": 38934
+      "research_time": 38934120
     },
     {
       "bonus": {
@@ -262,15 +262,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 7222
+            "value": 7222000000
           },
           {
             "type": "dilithium",
-            "value": 1274
+            "value": 1274000000
           }
         ]
       },
-      "research_time": 51090
+      "research_time": 51090420
     },
     {
       "bonus": {
@@ -305,15 +305,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 10070
+            "value": 10070000000
           },
           {
             "type": "dilithium",
-            "value": 1777
+            "value": 1777000000
           }
         ]
       },
-      "research_time": 68900
+      "research_time": 68900340
     },
     {
       "bonus": {
@@ -357,15 +357,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 14892
+            "value": 14892000000
           },
           {
             "type": "dilithium",
-            "value": 2628
+            "value": 2628000000
           }
         ]
       },
-      "research_time": 88888
+      "research_time": 88888440
     },
     {
       "bonus": {
@@ -400,15 +400,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 24052
+            "value": 24052000000
           },
           {
             "type": "dilithium",
-            "value": 4244
+            "value": 4244000000
           }
         ]
       },
-      "research_time": 113694
+      "research_time": 113694240
     },
     {
       "bonus": {
@@ -452,15 +452,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 40698
+            "value": 40698000000
           },
           {
             "type": "dilithium",
-            "value": 7182
+            "value": 7182000000
           }
         ]
       },
-      "research_time": 150563
+      "research_time": 150563760
     },
     {
       "bonus": {
@@ -516,15 +516,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 72293
+            "value": 72293000000
           },
           {
             "type": "dilithium",
-            "value": 12758
+            "value": 12758000000
           }
         ]
       },
-      "research_time": 189523
+      "research_time": 189523500
     }
   ],
   "location": {

--- a/research/station_sabotage.json
+++ b/research/station_sabotage.json
@@ -54,11 +54,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 920400
+            "value": 920400000
           }
         ]
       },
-      "research_time": 66417
+      "research_time": 66417540
     },
     {
       "bonus": {
@@ -96,11 +96,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1283
+            "value": 1283000000
           }
         ]
       },
-      "research_time": 89570
+      "research_time": 89570460
     },
     {
       "bonus": {
@@ -144,11 +144,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1898
+            "value": 1898000000
           }
         ]
       },
-      "research_time": 115554
+      "research_time": 115554960
     },
     {
       "bonus": {
@@ -186,11 +186,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 3065
+            "value": 3065000000
           }
         ]
       },
-      "research_time": 147802
+      "research_time": 147802500
     },
     {
       "bonus": {
@@ -234,11 +234,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 5187
+            "value": 5187000000
           }
         ]
       },
-      "research_time": 195732
+      "research_time": 195732840
     },
     {
       "bonus": {
@@ -276,11 +276,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 9214
+            "value": 9214000000
           }
         ]
       },
-      "research_time": 246380
+      "research_time": 246380520
     },
     {
       "bonus": {
@@ -302,11 +302,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 14025
+            "value": 14025000000
           }
         ]
       },
-      "research_time": 300516
+      "research_time": 300516720
     },
     {
       "bonus": {
@@ -328,11 +328,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 21499
+            "value": 21499000000
           }
         ]
       },
-      "research_time": 386864
+      "research_time": 386864640
     },
     {
       "bonus": {
@@ -354,11 +354,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 19195
+            "value": 19195000000
           }
         ]
       },
-      "research_time": 265945
+      "research_time": 265945140
     },
     {
       "bonus": {
@@ -380,11 +380,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 28793
+            "value": 28793000000
           }
         ]
       },
-      "research_time": 319134
+      "research_time": 319134180
     }
   ],
   "location": {

--- a/research/station_shield_piercing.json
+++ b/research/station_shield_piercing.json
@@ -100,7 +100,7 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 2040
+            "value": 2040000
           }
         ]
       },
@@ -126,7 +126,7 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 3000
+            "value": 3000000
           }
         ]
       },
@@ -152,11 +152,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 7460
+            "value": 7460000
           }
         ]
       },
-      "research_time": 1937
+      "research_time": 1937880
     },
     {
       "bonus": {
@@ -178,11 +178,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 11100
+            "value": 11100000
           }
         ]
       },
-      "research_time": 2600
+      "research_time": 2600040
     },
     {
       "bonus": {
@@ -204,11 +204,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 24450
+            "value": 24450000
           }
         ]
       },
-      "research_time": 3483
+      "research_time": 3483960
     },
     {
       "bonus": {
@@ -249,11 +249,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 38650
+            "value": 38650000
           }
         ]
       },
-      "research_time": 5965
+      "research_time": 5965920
     },
     {
       "bonus": {

--- a/research/station_targeting.json
+++ b/research/station_targeting.json
@@ -53,15 +53,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 45350
+            "value": 45350000
           },
           {
             "type": "dilithium",
-            "value": 11100
+            "value": 11100000
           }
         ]
       },
-      "research_time": 2600
+      "research_time": 2600040
     },
     {
       "bonus": {
@@ -109,15 +109,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 99700
+            "value": 99700000
           },
           {
             "type": "dilithium",
-            "value": 24450
+            "value": 24450000
           }
         ]
       },
-      "research_time": 3483
+      "research_time": 3483960
     },
     {
       "bonus": {
@@ -169,15 +169,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 268500
+            "value": 268500000
           },
           {
             "type": "dilithium",
-            "value": 65800
+            "value": 65800000
           }
         ]
       },
-      "research_time": 8058
+      "research_time": 8058720
     },
     {
       "bonus": {
@@ -229,15 +229,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 615100
+            "value": 615100000
           },
           {
             "type": "dilithium",
-            "value": 150800
+            "value": 150800000
           }
         ]
       },
-      "research_time": 13456
+      "research_time": 13456140
     },
     {
       "bonus": {
@@ -290,11 +290,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 8340
+            "value": 8340000
           },
           {
             "type": "dilithium",
-            "value": 2040
+            "value": 2040000
           }
         ]
       },

--- a/research/station_weaponry.json
+++ b/research/station_weaponry.json
@@ -82,7 +82,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1500
+            "value": 1500000
           },
           {
             "type": "dilithium",

--- a/research/stella_defenses.json
+++ b/research/stella_defenses.json
@@ -176,7 +176,7 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1670
+            "value": 1670000
           }
         ]
       },
@@ -212,7 +212,7 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1999
+            "value": 1999800
           }
         ]
       },
@@ -243,7 +243,7 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 3670
+            "value": 3670000
           }
         ]
       },
@@ -274,7 +274,7 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 4398
+            "value": 4398300
           }
         ]
       },
@@ -318,11 +318,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 9870
+            "value": 9870000
           }
         ]
       },
-      "research_time": 1208
+      "research_time": 1208820
     },
     {
       "bonus": {
@@ -354,11 +354,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 11846
+            "value": 11846250
           }
         ]
       },
-      "research_time": 1450
+      "research_time": 1450560
     },
     {
       "bonus": {
@@ -385,11 +385,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 22600
+            "value": 22600000
           }
         ]
       },
-      "research_time": 2018
+      "research_time": 2018400
     },
     {
       "bonus": {
@@ -416,11 +416,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 48900
+            "value": 48900000
           }
         ]
       },
-      "research_time": 4400
+      "research_time": 4400820
     },
     {
       "bonus": {
@@ -452,11 +452,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 106200
+            "value": 106200000
           }
         ]
       },
-      "research_time": 7663
+      "research_time": 7663560
     },
     {
       "bonus": {
@@ -491,11 +491,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 219000
+            "value": 219000000
           }
         ]
       },
-      "research_time": 13333
+      "research_time": 13333260
     },
     {
       "bonus": {
@@ -522,11 +522,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 598500
+            "value": 598500000
           }
         ]
       },
-      "research_time": 22584
+      "research_time": 22584540
     }
   ],
   "location": {

--- a/research/stella_hull.json
+++ b/research/stella_hull.json
@@ -366,7 +366,7 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1660
+            "value": 1660000
           }
         ]
       },
@@ -410,7 +410,7 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 3860
+            "value": 3860000
           }
         ]
       },
@@ -441,11 +441,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 10400
+            "value": 10400000
           }
         ]
       },
-      "research_time": 1412
+      "research_time": 1412520
     },
     {
       "bonus": {
@@ -472,11 +472,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 22450
+            "value": 22450000
           }
         ]
       },
-      "research_time": 2101
+      "research_time": 2101740
     },
     {
       "bonus": {
@@ -503,11 +503,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 49650
+            "value": 49650000
           }
         ]
       },
-      "research_time": 3893
+      "research_time": 3893400
     },
     {
       "bonus": {
@@ -543,11 +543,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 98750
+            "value": 98750000
           }
         ]
       },
-      "research_time": 6890
+      "research_time": 6890040
     }
   ],
   "location": {

--- a/research/stella_piercing.json
+++ b/research/stella_piercing.json
@@ -97,7 +97,7 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1670
+            "value": 1670000
           }
         ]
       },
@@ -133,7 +133,7 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1999
+            "value": 1999800
           }
         ]
       },
@@ -164,7 +164,7 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 3670
+            "value": 3670000
           }
         ]
       },
@@ -195,7 +195,7 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 4398
+            "value": 4398300
           }
         ]
       },
@@ -239,11 +239,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 9870
+            "value": 9870000
           }
         ]
       },
-      "research_time": 1208
+      "research_time": 1208820
     },
     {
       "bonus": {
@@ -275,11 +275,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 11846
+            "value": 11846250
           }
         ]
       },
-      "research_time": 1450
+      "research_time": 1450560
     },
     {
       "bonus": {
@@ -306,11 +306,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 22600
+            "value": 22600000
           }
         ]
       },
-      "research_time": 2018
+      "research_time": 2018400
     },
     {
       "bonus": {
@@ -337,11 +337,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 48900
+            "value": 48900000
           }
         ]
       },
-      "research_time": 4400
+      "research_time": 4400820
     },
     {
       "bonus": {
@@ -373,11 +373,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 106200
+            "value": 106200000
           }
         ]
       },
-      "research_time": 7663
+      "research_time": 7663560
     },
     {
       "bonus": {
@@ -412,11 +412,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 219000
+            "value": 219000000
           }
         ]
       },
-      "research_time": 13333
+      "research_time": 13333260
     },
     {
       "bonus": {
@@ -443,11 +443,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 598500
+            "value": 598500000
           }
         ]
       },
-      "research_time": 22584
+      "research_time": 22584540
     },
     {
       "bonus": {

--- a/research/stella_research.json
+++ b/research/stella_research.json
@@ -50,7 +50,7 @@
           },
           {
             "type": "dilithium",
-            "value": 1100
+            "value": 1100000
           }
         ]
       },

--- a/research/stella_targeting.json
+++ b/research/stella_targeting.json
@@ -48,7 +48,7 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1670
+            "value": 1670000
           }
         ]
       },
@@ -79,7 +79,7 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 2490
+            "value": 2490000
           }
         ]
       },
@@ -127,7 +127,7 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 5800
+            "value": 5800000
           }
         ]
       },
@@ -163,11 +163,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 15600
+            "value": 15600000
           }
         ]
       },
-      "research_time": 2118
+      "research_time": 2118840
     },
     {
       "bonus": {
@@ -207,11 +207,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 18711
+            "value": 18711000
           }
         ]
       },
-      "research_time": 2542
+      "research_time": 2542560
     },
     {
       "bonus": {
@@ -247,11 +247,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 33700
+            "value": 33700000
           }
         ]
       },
-      "research_time": 3152
+      "research_time": 3152640
     },
     {
       "bonus": {
@@ -283,11 +283,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 40446
+            "value": 40446000
           }
         ]
       },
-      "research_time": 3783
+      "research_time": 3783120
     },
     {
       "bonus": {
@@ -319,11 +319,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 74500
+            "value": 74500000
           }
         ]
       },
-      "research_time": 5840
+      "research_time": 5840100
     },
     {
       "bonus": {
@@ -355,11 +355,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 148100
+            "value": 148100000
           }
         ]
       },
-      "research_time": 10335
+      "research_time": 10335060
     },
     {
       "bonus": {
@@ -395,11 +395,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 89370
+            "value": 89370000
           }
         ]
       },
-      "research_time": 7008
+      "research_time": 7008120
     }
   ],
   "location": {

--- a/research/stella_warp_drive.json
+++ b/research/stella_warp_drive.json
@@ -32,7 +32,7 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1120
+            "value": 1120000
           }
         ]
       },
@@ -63,7 +63,7 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 2490
+            "value": 2490000
           }
         ]
       },
@@ -102,7 +102,7 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 5800
+            "value": 5800000
           }
         ]
       },
@@ -133,11 +133,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 15600
+            "value": 15600000
           }
         ]
       },
-      "research_time": 2118
+      "research_time": 2118840
     },
     {
       "bonus": {
@@ -177,11 +177,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 33700
+            "value": 33700000
           }
         ]
       },
-      "research_time": 3152
+      "research_time": 3152640
     },
     {
       "bonus": {

--- a/research/stella_weaponry.json
+++ b/research/stella_weaponry.json
@@ -437,7 +437,7 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1110
+            "value": 1110000
           }
         ]
       },
@@ -485,7 +485,7 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 2440
+            "value": 2440000
           }
         ]
       },
@@ -516,7 +516,7 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 6580
+            "value": 6580000
           }
         ]
       },
@@ -552,11 +552,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 15100
+            "value": 15100000
           }
         ]
       },
-      "research_time": 1345
+      "research_time": 1345620
     },
     {
       "bonus": {
@@ -591,11 +591,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 32600
+            "value": 32600000
           }
         ]
       },
-      "research_time": 2933
+      "research_time": 2933880
     }
   ],
   "location": {

--- a/research/strategic_exploits.json
+++ b/research/strategic_exploits.json
@@ -57,11 +57,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 8340
+            "value": 8340000
           },
           {
             "type": "dilithium",
-            "value": 2040
+            "value": 2040000
           }
         ]
       },
@@ -122,15 +122,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 45350
+            "value": 45350000
           },
           {
             "type": "dilithium",
-            "value": 11100
+            "value": 11100000
           }
         ]
       },
-      "research_time": 2600
+      "research_time": 2600040
     },
     {
       "bonus": {
@@ -183,15 +183,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 99700
+            "value": 99700000
           },
           {
             "type": "dilithium",
-            "value": 24450
+            "value": 24450000
           }
         ]
       },
-      "research_time": 3483
+      "research_time": 3483960
     },
     {
       "bonus": {
@@ -248,15 +248,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 268500
+            "value": 268500000
           },
           {
             "type": "dilithium",
-            "value": 65800
+            "value": 65800000
           }
         ]
       },
-      "research_time": 8058
+      "research_time": 8058720
     },
     {
       "bonus": {
@@ -313,15 +313,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 615100
+            "value": 615100000
           },
           {
             "type": "dilithium",
-            "value": 150800
+            "value": 150800000
           }
         ]
       },
-      "research_time": 13456
+      "research_time": 13456140
     }
   ],
   "location": {

--- a/research/strength_of_kahless.json
+++ b/research/strength_of_kahless.json
@@ -39,15 +39,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 6500
+            "value": 6500000
           },
           {
             "type": "dilithium",
-            "value": 5110
+            "value": 5110000
           }
         ]
       },
-      "research_time": 2608
+      "research_time": 2608980
     },
     {
       "bonus": {
@@ -92,15 +92,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 15550
+            "value": 15550000
           },
           {
             "type": "dilithium",
-            "value": 12200
+            "value": 12200000
           }
         ]
       },
-      "research_time": 4680
+      "research_time": 4680060
     },
     {
       "bonus": {
@@ -145,15 +145,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 34200
+            "value": 34200000
           },
           {
             "type": "dilithium",
-            "value": 26900
+            "value": 26900000
           }
         ]
       },
-      "research_time": 6271
+      "research_time": 6271200
     },
     {
       "bonus": {
@@ -198,15 +198,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 92150
+            "value": 92150000
           },
           {
             "type": "dilithium",
-            "value": 72400
+            "value": 72400000
           }
         ]
       },
-      "research_time": 14505
+      "research_time": 14505720
     },
     {
       "bonus": {
@@ -239,15 +239,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 211100
+            "value": 211100000
           },
           {
             "type": "dilithium",
-            "value": 165800
+            "value": 165800000
           }
         ]
       },
-      "research_time": 24221
+      "research_time": 24221040
     },
     {
       "bonus": {
@@ -286,15 +286,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 456400
+            "value": 456400000
           },
           {
             "type": "dilithium",
-            "value": 358600
+            "value": 358600000
           }
         ]
       },
-      "research_time": 52809
+      "research_time": 52809840
     },
     {
       "bonus": {
@@ -339,15 +339,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 991200
+            "value": 991200000
           },
           {
             "type": "dilithium",
-            "value": 778800
+            "value": 778800000
           }
         ]
       },
-      "research_time": 91962
+      "research_time": 91962720
     },
     {
       "bonus": {
@@ -392,15 +392,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 2044
+            "value": 2044000000
           },
           {
             "type": "dilithium",
-            "value": 1606
+            "value": 1606000000
           }
         ]
       },
-      "research_time": 159999
+      "research_time": 159999240
     },
     {
       "bonus": {
@@ -439,15 +439,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 2860
+            "value": 2860000
           },
           {
             "type": "dilithium",
-            "value": 2250
+            "value": 2250000
           }
         ]
       },
-      "research_time": 1711
+      "research_time": 1711020
     },
     {
       "bonus": {
@@ -495,7 +495,7 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 1210
+            "value": 1210000
           },
           {
             "type": "dilithium",
@@ -503,7 +503,7 @@
           }
         ]
       },
-      "research_time": 1169
+      "research_time": 1169340
     }
   ],
   "location": {

--- a/research/survey_defenses.json
+++ b/research/survey_defenses.json
@@ -44,11 +44,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 269600
+            "value": 269600000
           }
         ]
       },
-      "research_time": 25221
+      "research_time": 25221000
     },
     {
       "bonus": {
@@ -92,11 +92,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 391200
+            "value": 391200000
           }
         ]
       },
-      "research_time": 35206
+      "research_time": 35206560
     },
     {
       "bonus": {
@@ -140,11 +140,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 595800
+            "value": 595800000
           }
         ]
       },
-      "research_time": 46720
+      "research_time": 46720980
     },
     {
       "bonus": {
@@ -188,11 +188,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 849600
+            "value": 849600000
           }
         ]
       },
-      "research_time": 61308
+      "research_time": 61308480
     },
     {
       "bonus": {
@@ -236,11 +236,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1185
+            "value": 1185000000
           }
         ]
       },
-      "research_time": 82680
+      "research_time": 82680420
     },
     {
       "bonus": {
@@ -284,11 +284,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1752
+            "value": 1752000000
           }
         ]
       },
-      "research_time": 106666
+      "research_time": 106666140
     },
     {
       "bonus": {
@@ -332,11 +332,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 2830
+            "value": 2830000000
           }
         ]
       },
-      "research_time": 136433
+      "research_time": 136433100
     },
     {
       "bonus": {
@@ -380,11 +380,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 4788
+            "value": 4788000000
           }
         ]
       },
-      "research_time": 180676
+      "research_time": 180676500
     },
     {
       "bonus": {
@@ -428,11 +428,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 8505
+            "value": 8505000000
           }
         ]
       },
-      "research_time": 227428
+      "research_time": 227428200
     },
     {
       "bonus": {
@@ -454,11 +454,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 12947
+            "value": 12947000000
           }
         ]
       },
-      "research_time": 277400
+      "research_time": 277400040
     }
   ],
   "location": {

--- a/research/survey_nacelles.json
+++ b/research/survey_nacelles.json
@@ -139,7 +139,7 @@
         ],
         "resources": []
       },
-      "research_time": 1162
+      "research_time": 1162740
     },
     {
       "bonus": {

--- a/research/survey_repair_costs.json
+++ b/research/survey_repair_costs.json
@@ -38,7 +38,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 2290
+            "value": 2290000
           },
           {
             "type": "dilithium",
@@ -130,7 +130,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1500
+            "value": 1500000
           },
           {
             "type": "dilithium",
@@ -180,7 +180,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 3530
+            "value": 3530000
           },
           {
             "type": "dilithium",
@@ -219,11 +219,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 5470
+            "value": 5470000
           },
           {
             "type": "dilithium",
-            "value": 1340
+            "value": 1340000
           }
         ]
       },
@@ -271,11 +271,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 8340
+            "value": 8340000
           },
           {
             "type": "dilithium",
-            "value": 2040
+            "value": 2040000
           }
         ]
       },
@@ -323,11 +323,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 12250
+            "value": 12250000
           },
           {
             "type": "dilithium",
-            "value": 3000
+            "value": 3000000
           }
         ]
       },
@@ -364,15 +364,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 18950
+            "value": 18950000
           },
           {
             "type": "dilithium",
-            "value": 4650
+            "value": 4650000
           }
         ]
       },
-      "research_time": 1449
+      "research_time": 1449420
     },
     {
       "bonus": {
@@ -403,15 +403,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 30400
+            "value": 30400000
           },
           {
             "type": "dilithium",
-            "value": 7460
+            "value": 7460000
           }
         ]
       },
-      "research_time": 1937
+      "research_time": 1937880
     },
     {
       "bonus": {

--- a/research/survey_repairs.json
+++ b/research/survey_repairs.json
@@ -79,7 +79,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1500
+            "value": 1500000
           },
           {
             "type": "dilithium",
@@ -125,7 +125,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 2290
+            "value": 2290000
           },
           {
             "type": "dilithium",
@@ -171,7 +171,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 3530
+            "value": 3530000
           },
           {
             "type": "dilithium",
@@ -205,11 +205,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 5470
+            "value": 5470000
           },
           {
             "type": "dilithium",
-            "value": 1340
+            "value": 1340000
           }
         ]
       },
@@ -244,11 +244,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 8340
+            "value": 8340000
           },
           {
             "type": "dilithium",
-            "value": 2040
+            "value": 2040000
           }
         ]
       },
@@ -278,11 +278,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 12250
+            "value": 12250000
           },
           {
             "type": "dilithium",
-            "value": 3000
+            "value": 3000000
           }
         ]
       },
@@ -324,15 +324,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 18950
+            "value": 18950000
           },
           {
             "type": "dilithium",
-            "value": 4650
+            "value": 4650000
           }
         ]
       },
-      "research_time": 1449
+      "research_time": 1449420
     },
     {
       "bonus": {
@@ -365,15 +365,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 30400
+            "value": 30400000
           },
           {
             "type": "dilithium",
-            "value": 7460
+            "value": 7460000
           }
         ]
       },
-      "research_time": 1937
+      "research_time": 1937880
     },
     {
       "bonus": {

--- a/research/survey_shield_array_ii.json
+++ b/research/survey_shield_array_ii.json
@@ -58,15 +58,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 224700
+            "value": 224700000
           },
           {
             "type": "dilithium",
-            "value": 134800
+            "value": 134800000
           }
         ]
       },
-      "research_time": 21017
+      "research_time": 21017460
     },
     {
       "bonus": {
@@ -116,15 +116,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 326000
+            "value": 326000000
           },
           {
             "type": "dilithium",
-            "value": 195600
+            "value": 195600000
           }
         ]
       },
-      "research_time": 29338
+      "research_time": 29338800
     },
     {
       "bonus": {
@@ -174,15 +174,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 496500
+            "value": 496500000
           },
           {
             "type": "dilithium",
-            "value": 297900
+            "value": 297900000
           }
         ]
       },
-      "research_time": 38934
+      "research_time": 38934120
     },
     {
       "bonus": {
@@ -232,15 +232,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 708000
+            "value": 708000000
           },
           {
             "type": "dilithium",
-            "value": 424800
+            "value": 424800000
           }
         ]
       },
-      "research_time": 51090
+      "research_time": 51090420
     },
     {
       "bonus": {
@@ -290,15 +290,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 987300
+            "value": 987300000
           },
           {
             "type": "dilithium",
-            "value": 592400
+            "value": 592400000
           }
         ]
       },
-      "research_time": 68900
+      "research_time": 68900340
     },
     {
       "bonus": {
@@ -348,15 +348,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 1460
+            "value": 1460000000
           },
           {
             "type": "dilithium",
-            "value": 876000
+            "value": 876000000
           }
         ]
       },
-      "research_time": 88888
+      "research_time": 88888440
     },
     {
       "bonus": {
@@ -401,15 +401,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 2358
+            "value": 2358000000
           },
           {
             "type": "dilithium",
-            "value": 1415
+            "value": 1415000000
           }
         ]
       },
-      "research_time": 113694
+      "research_time": 113694240
     },
     {
       "bonus": {
@@ -459,15 +459,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 3990
+            "value": 3990000000
           },
           {
             "type": "dilithium",
-            "value": 2394
+            "value": 2394000000
           }
         ]
       },
-      "research_time": 150563
+      "research_time": 150563760
     },
     {
       "bonus": {
@@ -512,15 +512,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 7088
+            "value": 7088000000
           },
           {
             "type": "dilithium",
-            "value": 4253
+            "value": 4253000000
           }
         ]
       },
-      "research_time": 189523
+      "research_time": 189523500
     },
     {
       "bonus": {
@@ -542,15 +542,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 10789
+            "value": 10789000000
           },
           {
             "type": "dilithium",
-            "value": 6473
+            "value": 6473000000
           }
         ]
       },
-      "research_time": 231166
+      "research_time": 231166740
     }
   ],
   "location": {

--- a/research/survey_warp.json
+++ b/research/survey_warp.json
@@ -205,7 +205,7 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1230
+            "value": 1230000
           }
         ]
       },
@@ -236,7 +236,7 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1800
+            "value": 1800000
           }
         ]
       },
@@ -271,7 +271,7 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 2790
+            "value": 2790000
           }
         ]
       },
@@ -315,11 +315,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 4470
+            "value": 4470000
           }
         ]
       },
-      "research_time": 1162
+      "research_time": 1162740
     },
     {
       "bonus": {
@@ -345,11 +345,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 6670
+            "value": 6670000
           }
         ]
       },
-      "research_time": 1560
+      "research_time": 1560000
     },
     {
       "bonus": {

--- a/research/swarm_fortification.json
+++ b/research/swarm_fortification.json
@@ -27,11 +27,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 11100
+            "value": 11100000
           }
         ]
       },
-      "research_time": 2600
+      "research_time": 2600040
     },
     {
       "bonus": {
@@ -62,11 +62,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 16600
+            "value": 16600000
           }
         ]
       },
-      "research_time": 3499
+      "research_time": 3499500
     },
     {
       "bonus": {
@@ -97,11 +97,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 24450
+            "value": 24450000
           }
         ]
       },
-      "research_time": 3483
+      "research_time": 3483960
     },
     {
       "bonus": {
@@ -123,11 +123,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 38650
+            "value": 38650000
           }
         ]
       },
-      "research_time": 5965
+      "research_time": 5965920
     },
     {
       "bonus": {
@@ -153,7 +153,7 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1340
+            "value": 1340000
           }
         ]
       },
@@ -188,11 +188,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 4650
+            "value": 4650000
           }
         ]
       },
-      "research_time": 1449
+      "research_time": 1449420
     },
     {
       "bonus": {
@@ -264,7 +264,7 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 3000
+            "value": 3000000
           }
         ]
       },
@@ -295,7 +295,7 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 2040
+            "value": 2040000
           }
         ]
       },
@@ -321,11 +321,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 7460
+            "value": 7460000
           }
         ]
       },
-      "research_time": 1937
+      "research_time": 1937880
     }
   ],
   "location": {

--- a/research/swarm_jammer.json
+++ b/research/swarm_jammer.json
@@ -31,11 +31,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 11100
+            "value": 11100000
           }
         ]
       },
-      "research_time": 2600
+      "research_time": 2600040
     },
     {
       "bonus": {
@@ -57,11 +57,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 16600
+            "value": 16600000
           }
         ]
       },
-      "research_time": 3499
+      "research_time": 3499500
     },
     {
       "bonus": {
@@ -87,11 +87,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 24450
+            "value": 24450000
           }
         ]
       },
-      "research_time": 3483
+      "research_time": 3483960
     },
     {
       "bonus": {
@@ -148,11 +148,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 4650
+            "value": 4650000
           }
         ]
       },
-      "research_time": 1449
+      "research_time": 1449420
     },
     {
       "bonus": {
@@ -225,7 +225,7 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 2040
+            "value": 2040000
           }
         ]
       },
@@ -251,7 +251,7 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 3000
+            "value": 3000000
           }
         ]
       },
@@ -282,7 +282,7 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1340
+            "value": 1340000
           }
         ]
       },
@@ -312,11 +312,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 7460
+            "value": 7460000
           }
         ]
       },
-      "research_time": 1937
+      "research_time": 1937880
     }
   ],
   "location": {

--- a/research/swarm_targeting.json
+++ b/research/swarm_targeting.json
@@ -26,11 +26,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 11100
+            "value": 11100000
           }
         ]
       },
-      "research_time": 2600
+      "research_time": 2600040
     },
     {
       "bonus": {
@@ -57,11 +57,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 16600
+            "value": 16600000
           }
         ]
       },
-      "research_time": 3499
+      "research_time": 3499500
     },
     {
       "bonus": {
@@ -83,11 +83,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 24450
+            "value": 24450000
           }
         ]
       },
-      "research_time": 3483
+      "research_time": 3483960
     },
     {
       "bonus": {
@@ -109,11 +109,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 38650
+            "value": 38650000
           }
         ]
       },
-      "research_time": 5965
+      "research_time": 5965920
     },
     {
       "bonus": {
@@ -144,7 +144,7 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1340
+            "value": 1340000
           }
         ]
       },
@@ -179,7 +179,7 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 2040
+            "value": 2040000
           }
         ]
       },
@@ -214,7 +214,7 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 3000
+            "value": 3000000
           }
         ]
       },
@@ -240,11 +240,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 4650
+            "value": 4650000
           }
         ]
       },
-      "research_time": 1449
+      "research_time": 1449420
     },
     {
       "bonus": {
@@ -317,11 +317,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 7460
+            "value": 7460000
           }
         ]
       },
-      "research_time": 1937
+      "research_time": 1937880
     }
   ],
   "location": {

--- a/research/swarm_weakpoints.json
+++ b/research/swarm_weakpoints.json
@@ -31,11 +31,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 7460
+            "value": 7460000
           }
         ]
       },
-      "research_time": 1937
+      "research_time": 1937880
     },
     {
       "bonus": {
@@ -61,11 +61,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 16600
+            "value": 16600000
           }
         ]
       },
-      "research_time": 3499
+      "research_time": 3499500
     },
     {
       "bonus": {
@@ -92,11 +92,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 24450
+            "value": 24450000
           }
         ]
       },
-      "research_time": 3483
+      "research_time": 3483960
     },
     {
       "bonus": {
@@ -149,7 +149,7 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1340
+            "value": 1340000
           }
         ]
       },
@@ -179,7 +179,7 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 2040
+            "value": 2040000
           }
         ]
       },
@@ -210,7 +210,7 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 3000
+            "value": 3000000
           }
         ]
       },
@@ -240,11 +240,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 4650
+            "value": 4650000
           }
         ]
       },
-      "research_time": 1449
+      "research_time": 1449420
     },
     {
       "bonus": {
@@ -266,11 +266,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 11100
+            "value": 11100000
           }
         ]
       },
-      "research_time": 2600
+      "research_time": 2600040
     },
     {
       "bonus": {

--- a/research/synchronized_crew.json
+++ b/research/synchronized_crew.json
@@ -34,7 +34,7 @@
         ],
         "resources": []
       },
-      "research_time": 4176
+      "research_time": 4176180
     },
     {
       "bonus": {
@@ -69,7 +69,7 @@
         ],
         "resources": []
       },
-      "research_time": 5641
+      "research_time": 5641140
     },
     {
       "bonus": {
@@ -108,7 +108,7 @@
         ],
         "resources": []
       },
-      "research_time": 9887
+      "research_time": 9887760
     },
     {
       "bonus": {
@@ -143,7 +143,7 @@
         ],
         "resources": []
       },
-      "research_time": 2438
+      "research_time": 2438820
     },
     {
       "bonus": {
@@ -190,7 +190,7 @@
         ],
         "resources": []
       },
-      "research_time": 1820
+      "research_time": 1820040
     }
   ],
   "location": {

--- a/research/tactical_aggression.json
+++ b/research/tactical_aggression.json
@@ -35,7 +35,7 @@
         ],
         "resources": []
       },
-      "research_time": 2099
+      "research_time": 2099700
     },
     {
       "bonus": {
@@ -101,7 +101,7 @@
         ],
         "resources": []
       },
-      "research_time": 1162
+      "research_time": 1162740
     },
     {
       "bonus": {
@@ -136,7 +136,7 @@
         ],
         "resources": []
       },
-      "research_time": 3579
+      "research_time": 3579540
     },
     {
       "bonus": {
@@ -175,7 +175,7 @@
         ],
         "resources": []
       },
-      "research_time": 8475
+      "research_time": 8475240
     }
   ],
   "location": {

--- a/research/territory_challenger.json
+++ b/research/territory_challenger.json
@@ -83,11 +83,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 10400
+            "value": 10400000
           }
         ]
       },
-      "research_time": 14125,
+      "research_time": 14125380,
       "reward": {
         "type": "Challenger\u00a0Token\u00a0II\u00a0",
         "value": 1

--- a/research/territory_conqueror.json
+++ b/research/territory_conqueror.json
@@ -35,11 +35,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1110
+            "value": 1110000
           }
         ]
       },
-      "research_time": 2600,
+      "research_time": 2600040,
       "reward": {
         "type": "Conqueror\u00a0Token\u00a0I\u00a0",
         "value": 1
@@ -78,11 +78,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 708800
+            "value": 708800000
           }
         ]
       },
-      "research_time": 189523,
+      "research_time": 189523500,
       "reward": {
         "type": "Conqueror\u00a0Token\u00a0II\u00a0",
         "value": 1

--- a/research/thorough_scanning.json
+++ b/research/thorough_scanning.json
@@ -35,7 +35,7 @@
           }
         ]
       },
-      "research_time": 1937
+      "research_time": 1937880
     },
     {
       "bonus": {
@@ -66,11 +66,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1660
+            "value": 1660000
           }
         ]
       },
-      "research_time": 3499
+      "research_time": 3499500
     },
     {
       "bonus": {
@@ -101,11 +101,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 3860
+            "value": 3860000
           }
         ]
       },
-      "research_time": 5965
+      "research_time": 5965920
     },
     {
       "bonus": {
@@ -136,11 +136,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 10400
+            "value": 10400000
           }
         ]
       },
-      "research_time": 14125
+      "research_time": 14125380
     },
     {
       "bonus": {
@@ -171,11 +171,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 22450
+            "value": 22450000
           }
         ]
       },
-      "research_time": 21017
+      "research_time": 21017460
     },
     {
       "bonus": {
@@ -206,11 +206,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 49650
+            "value": 49650000
           }
         ]
       },
-      "research_time": 38934
+      "research_time": 38934120
     },
     {
       "bonus": {
@@ -241,11 +241,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 98750
+            "value": 98750000
           }
         ]
       },
-      "research_time": 68900
+      "research_time": 68900340
     },
     {
       "bonus": {
@@ -276,11 +276,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 235800
+            "value": 235800000
           }
         ]
       },
-      "research_time": 113694
+      "research_time": 113694240
     },
     {
       "bonus": {
@@ -311,11 +311,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 708800
+            "value": 708800000
           }
         ]
       },
-      "research_time": 189523
+      "research_time": 189523500
     },
     {
       "bonus": {
@@ -475,7 +475,7 @@
           }
         ]
       },
-      "research_time": 1449
+      "research_time": 1449420
     },
     {
       "bonus": {

--- a/research/tier_up_boost.json
+++ b/research/tier_up_boost.json
@@ -41,7 +41,7 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 2010
+            "value": 2010000
           }
         ]
       },
@@ -90,11 +90,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 3060
+            "value": 3060000
           }
         ]
       },
-      "research_time": 1188
+      "research_time": 1188180
     },
     {
       "bonus": {
@@ -140,11 +140,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 6970
+            "value": 6970000
           }
         ]
       },
-      "research_time": 1811
+      "research_time": 1811820
     },
     {
       "bonus": {
@@ -170,11 +170,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 11200
+            "value": 11200000
           }
         ]
       },
-      "research_time": 2422
+      "research_time": 2422380
     },
     {
       "bonus": {
@@ -215,11 +215,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 24900
+            "value": 24900000
           }
         ]
       },
-      "research_time": 4374
+      "research_time": 4374420
     },
     {
       "bonus": {
@@ -269,11 +269,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 36650
+            "value": 36650000
           }
         ]
       },
-      "research_time": 4354
+      "research_time": 4354980
     },
     {
       "bonus": {

--- a/research/transneural_blocker.json
+++ b/research/transneural_blocker.json
@@ -58,11 +58,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 3065
+            "value": 3065000000
           }
         ]
       },
-      "research_time": 147802
+      "research_time": 147802500
     },
     {
       "bonus": {
@@ -97,11 +97,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 5187
+            "value": 5187000000
           }
         ]
       },
-      "research_time": 195732
+      "research_time": 195732840
     },
     {
       "bonus": {
@@ -142,11 +142,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 9214
+            "value": 9214000000
           }
         ]
       },
-      "research_time": 246380
+      "research_time": 246380520
     },
     {
       "bonus": {
@@ -186,11 +186,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 14025
+            "value": 14025000000
           }
         ]
       },
-      "research_time": 300516
+      "research_time": 300516720
     },
     {
       "bonus": {
@@ -230,11 +230,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 21499
+            "value": 21499000000
           }
         ]
       },
-      "research_time": 386864
+      "research_time": 386864640
     },
     {
       "bonus": {
@@ -274,11 +274,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 19195
+            "value": 19195000000
           }
         ]
       },
-      "research_time": 265945
+      "research_time": 265945140
     },
     {
       "bonus": {
@@ -318,11 +318,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 28793
+            "value": 28793000000
           }
         ]
       },
-      "research_time": 319134
+      "research_time": 319134180
     },
     {
       "bonus": {
@@ -362,11 +362,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 43189
+            "value": 43189000000
           }
         ]
       },
-      "research_time": 419913
+      "research_time": 419913420
     },
     {
       "bonus": {
@@ -388,11 +388,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 64784
+            "value": 64784000000
           }
         ]
       },
-      "research_time": 503896
+      "research_time": 503896080
     },
     {
       "bonus": {
@@ -414,11 +414,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 97176
+            "value": 97176000000
           }
         ]
       },
-      "research_time": 604675
+      "research_time": 604675320
     }
   ],
   "location": {

--- a/research/transport_capacity.json
+++ b/research/transport_capacity.json
@@ -30,7 +30,7 @@
         ],
         "resources": []
       },
-      "research_time": 1739
+      "research_time": 1739340
     },
     {
       "bonus": {
@@ -60,7 +60,7 @@
         ],
         "resources": []
       },
-      "research_time": 2325
+      "research_time": 2325480
     },
     {
       "bonus": {
@@ -94,7 +94,7 @@
         ],
         "resources": []
       },
-      "research_time": 3120
+      "research_time": 3120060
     },
     {
       "bonus": {
@@ -129,7 +129,7 @@
         ],
         "resources": []
       },
-      "research_time": 4199
+      "research_time": 4199400
     },
     {
       "bonus": {
@@ -160,7 +160,7 @@
         ],
         "resources": []
       },
-      "research_time": 4180
+      "research_time": 4180800
     },
     {
       "bonus": {
@@ -195,7 +195,7 @@
         ],
         "resources": []
       },
-      "research_time": 7159
+      "research_time": 7159140
     },
     {
       "bonus": {
@@ -225,7 +225,7 @@
         ],
         "resources": []
       },
-      "research_time": 9670
+      "research_time": 9670500
     },
     {
       "bonus": {
@@ -259,7 +259,7 @@
         ],
         "resources": []
       },
-      "research_time": 16950
+      "research_time": 16950480
     },
     {
       "bonus": {
@@ -294,7 +294,7 @@
         ],
         "resources": []
       },
-      "research_time": 16147
+      "research_time": 16147380
     },
     {
       "bonus": {

--- a/research/tritanium_accelerator.json
+++ b/research/tritanium_accelerator.json
@@ -52,7 +52,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1520
+            "value": 1520000
           },
           {
             "type": "dilithium",
@@ -95,7 +95,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 3650
+            "value": 3650000
           },
           {
             "type": "dilithium",
@@ -125,11 +125,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 8150
+            "value": 8150000
           },
           {
             "type": "dilithium",
-            "value": 1800
+            "value": 1800000
           }
         ]
       },
@@ -168,11 +168,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 12650
+            "value": 12650000
           },
           {
             "type": "dilithium",
-            "value": 2790
+            "value": 2790000
           }
         ]
       },
@@ -215,15 +215,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 30200
+            "value": 30200000
           },
           {
             "type": "dilithium",
-            "value": 6670
+            "value": 6670000
           }
         ]
       },
-      "research_time": 1560
+      "research_time": 1560000
     },
     {
       "bonus": {
@@ -258,15 +258,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 45100
+            "value": 45100000
           },
           {
             "type": "dilithium",
-            "value": 9950
+            "value": 9950000
           }
         ]
       },
-      "research_time": 2099
+      "research_time": 2099700
     },
     {
       "bonus": {
@@ -293,15 +293,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 105100
+            "value": 105100000
           },
           {
             "type": "dilithium",
-            "value": 23200
+            "value": 23200000
           }
         ]
       },
-      "research_time": 3579
+      "research_time": 3579540
     },
     {
       "bonus": {
@@ -336,15 +336,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 179000
+            "value": 179000000
           },
           {
             "type": "dilithium",
-            "value": 39500
+            "value": 39500000
           }
         ]
       },
-      "research_time": 4835
+      "research_time": 4835220
     },
     {
       "bonus": {
@@ -374,15 +374,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 410000
+            "value": 410000000
           },
           {
             "type": "dilithium",
-            "value": 90450
+            "value": 90450000
           }
         ]
       },
-      "research_time": 8073
+      "research_time": 8073660
     },
     {
       "bonus": {
@@ -412,15 +412,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 611200
+            "value": 611200000
           },
           {
             "type": "dilithium",
-            "value": 134800
+            "value": 134800000
           }
         ]
       },
-      "research_time": 12610
+      "research_time": 12610500
     }
   ],
   "location": {

--- a/research/tritanium_fortification.json
+++ b/research/tritanium_fortification.json
@@ -42,15 +42,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 565500
+            "value": 565500000
           },
           {
             "type": "dilithium",
-            "value": 104000
+            "value": 104000000
           }
         ]
       },
-      "research_time": 17656
+      "research_time": 17656740
     },
     {
       "bonus": {
@@ -87,15 +87,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 820100
+            "value": 820100000
           },
           {
             "type": "dilithium",
-            "value": 150800
+            "value": 150800000
           }
         ]
       },
-      "research_time": 16820
+      "research_time": 16820160
     },
     {
       "bonus": {
@@ -143,15 +143,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1222
+            "value": 1222000000
           },
           {
             "type": "dilithium",
-            "value": 224700
+            "value": 224700000
           }
         ]
       },
-      "research_time": 26271
+      "research_time": 26271840
     },
     {
       "bonus": {
@@ -194,15 +194,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1773
+            "value": 1773000000
           },
           {
             "type": "dilithium",
-            "value": 326000
+            "value": 326000000
           }
         ]
       },
-      "research_time": 36673
+      "research_time": 36673500
     },
     {
       "bonus": {
@@ -245,15 +245,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 2701
+            "value": 2701000000
           },
           {
             "type": "dilithium",
-            "value": 496500
+            "value": 496500000
           }
         ]
       },
-      "research_time": 48667
+      "research_time": 48667680
     },
     {
       "bonus": {
@@ -296,15 +296,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 3852
+            "value": 3852000000
           },
           {
             "type": "dilithium",
-            "value": 708000
+            "value": 708000000
           }
         ]
       },
-      "research_time": 63862
+      "research_time": 63862980
     },
     {
       "bonus": {
@@ -352,15 +352,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 5371
+            "value": 5371000000
           },
           {
             "type": "dilithium",
-            "value": 987300
+            "value": 987300000
           }
         ]
       },
-      "research_time": 86125
+      "research_time": 86125440
     },
     {
       "bonus": {
@@ -403,15 +403,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 7942
+            "value": 7942000000
           },
           {
             "type": "dilithium",
-            "value": 1460
+            "value": 1460000000
           }
         ]
       },
-      "research_time": 111110
+      "research_time": 111110580
     },
     {
       "bonus": {
@@ -459,15 +459,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 12828
+            "value": 12828000000
           },
           {
             "type": "dilithium",
-            "value": 2358
+            "value": 2358000000
           }
         ]
       },
-      "research_time": 142117
+      "research_time": 142117800
     },
     {
       "bonus": {
@@ -504,15 +504,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 21706
+            "value": 21706000000
           },
           {
             "type": "dilithium",
-            "value": 3990
+            "value": 3990000000
           }
         ]
       },
-      "research_time": 188204
+      "research_time": 188204640
     }
   ],
   "location": {

--- a/research/tritanium_holding.json
+++ b/research/tritanium_holding.json
@@ -31,7 +31,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 4170
+            "value": 4170000
           },
           {
             "type": "dilithium",
@@ -74,11 +74,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 9480
+            "value": 9480000
           },
           {
             "type": "dilithium",
-            "value": 1860
+            "value": 1860000
           }
         ]
       },
@@ -104,11 +104,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 15200
+            "value": 15200000
           },
           {
             "type": "dilithium",
-            "value": 2980
+            "value": 2980000
           }
         ]
       },
@@ -143,15 +143,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 33850
+            "value": 33850000
           },
           {
             "type": "dilithium",
-            "value": 6630
+            "value": 6630000
           }
         ]
       },
-      "research_time": 1399
+      "research_time": 1399800
     },
     {
       "bonus": {
@@ -182,15 +182,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 49850
+            "value": 49850000
           },
           {
             "type": "dilithium",
-            "value": 9770
+            "value": 9770000
           }
         ]
       },
-      "research_time": 1393
+      "research_time": 1393620
     },
     {
       "bonus": {
@@ -217,15 +217,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 134300
+            "value": 134300000
           },
           {
             "type": "dilithium",
-            "value": 26350
+            "value": 26350000
           }
         ]
       },
-      "research_time": 3223
+      "research_time": 3223500
     },
     {
       "bonus": {
@@ -251,15 +251,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 212100
+            "value": 212100000
           },
           {
             "type": "dilithium",
-            "value": 41600
+            "value": 41600000
           }
         ]
       },
-      "research_time": 5650
+      "research_time": 5650140
     },
     {
       "bonus": {
@@ -286,15 +286,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 458400
+            "value": 458400000
           },
           {
             "type": "dilithium",
-            "value": 89900
+            "value": 89900000
           }
         ]
       },
-      "research_time": 8407
+      "research_time": 8407020
     },
     {
       "bonus": {
@@ -316,15 +316,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 665000
+            "value": 665000000
           },
           {
             "type": "dilithium",
-            "value": 130400
+            "value": 130400000
           }
         ]
       },
-      "research_time": 11735
+      "research_time": 11735520
     },
     {
       "bonus": {
@@ -374,7 +374,7 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 2740
+            "value": 2740000
           },
           {
             "type": "dilithium",

--- a/research/tritanium_hunter.json
+++ b/research/tritanium_hunter.json
@@ -159,7 +159,7 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1070
+            "value": 1070000
           }
         ]
       },
@@ -201,7 +201,7 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1630
+            "value": 1630000
           }
         ]
       },
@@ -250,7 +250,7 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 2400
+            "value": 2400000
           }
         ]
       },

--- a/research/tritanium_miner.json
+++ b/research/tritanium_miner.json
@@ -135,7 +135,7 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1340
+            "value": 1340000
           }
         ]
       },
@@ -170,7 +170,7 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 3000
+            "value": 3000000
           }
         ]
       },
@@ -201,11 +201,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 7460
+            "value": 7460000
           }
         ]
       },
-      "research_time": 1937
+      "research_time": 1937880
     },
     {
       "bonus": {
@@ -232,11 +232,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 16600
+            "value": 16600000
           }
         ]
       },
-      "research_time": 3499
+      "research_time": 3499500
     },
     {
       "bonus": {
@@ -262,11 +262,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 38650
+            "value": 38650000
           }
         ]
       },
-      "research_time": 5965
+      "research_time": 5965920
     },
     {
       "bonus": {
@@ -292,11 +292,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 104000
+            "value": 104000000
           }
         ]
       },
-      "research_time": 14125
+      "research_time": 14125380
     },
     {
       "bonus": {

--- a/research/tritanium_security.json
+++ b/research/tritanium_security.json
@@ -54,15 +54,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 16300
+            "value": 16300000
           },
           {
             "type": "dilithium",
-            "value": 3000
+            "value": 3000000
           }
         ]
       },
-      "research_time": 1223
+      "research_time": 1223160
     },
     {
       "bonus": {
@@ -84,15 +84,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 25250
+            "value": 25250000
           },
           {
             "type": "dilithium",
-            "value": 4650
+            "value": 4650000
           }
         ]
       },
-      "research_time": 1811
+      "research_time": 1811820
     },
     {
       "bonus": {
@@ -114,15 +114,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 60450
+            "value": 60450000
           },
           {
             "type": "dilithium",
-            "value": 11100
+            "value": 11100000
           }
         ]
       },
-      "research_time": 3250
+      "research_time": 3250080
     },
     {
       "bonus": {
@@ -157,15 +157,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 90200
+            "value": 90200000
           },
           {
             "type": "dilithium",
-            "value": 16600
+            "value": 16600000
           }
         ]
       },
-      "research_time": 4374
+      "research_time": 4374420
     },
     {
       "bonus": {
@@ -187,15 +187,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 210200
+            "value": 210200000
           },
           {
             "type": "dilithium",
-            "value": 38650
+            "value": 38650000
           }
         ]
       },
-      "research_time": 7457
+      "research_time": 7457400
     },
     {
       "bonus": {
@@ -217,15 +217,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 358000
+            "value": 358000000
           },
           {
             "type": "dilithium",
-            "value": 65800
+            "value": 65800000
           }
         ]
       },
-      "research_time": 10073
+      "research_time": 10073400
     },
     {
       "bonus": {
@@ -255,15 +255,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 820100
+            "value": 820100000
           },
           {
             "type": "dilithium",
-            "value": 150800
+            "value": 150800000
           }
         ]
       },
-      "research_time": 16820
+      "research_time": 16820160
     },
     {
       "bonus": {
@@ -290,15 +290,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1222
+            "value": 1222000000
           },
           {
             "type": "dilithium",
-            "value": 224700
+            "value": 224700000
           }
         ]
       },
-      "research_time": 26271
+      "research_time": 26271840
     },
     {
       "bonus": {
@@ -320,15 +320,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 2701
+            "value": 2701000000
           },
           {
             "type": "dilithium",
-            "value": 496500
+            "value": 496500000
           }
         ]
       },
-      "research_time": 48667
+      "research_time": 48667680
     },
     {
       "bonus": {
@@ -358,15 +358,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 3852
+            "value": 3852000000
           },
           {
             "type": "dilithium",
-            "value": 708000
+            "value": 708000000
           }
         ]
       },
-      "research_time": 63862
+      "research_time": 63862980
     }
   ],
   "location": {

--- a/research/tritanium_stockpile.json
+++ b/research/tritanium_stockpile.json
@@ -54,11 +54,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 8340
+            "value": 8340000
           },
           {
             "type": "dilithium",
-            "value": 1530
+            "value": 1530000
           }
         ]
       },
@@ -84,11 +84,11 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 12250
+            "value": 12250000
           },
           {
             "type": "dilithium",
-            "value": 2250
+            "value": 2250000
           }
         ]
       },
@@ -122,15 +122,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 30400
+            "value": 30400000
           },
           {
             "type": "dilithium",
-            "value": 5590
+            "value": 5590000
           }
         ]
       },
-      "research_time": 1453
+      "research_time": 1453440
     },
     {
       "bonus": {
@@ -161,15 +161,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 45350
+            "value": 45350000
           },
           {
             "type": "dilithium",
-            "value": 8330
+            "value": 8330000
           }
         ]
       },
-      "research_time": 1950
+      "research_time": 1950060
     },
     {
       "bonus": {
@@ -191,15 +191,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 99700
+            "value": 99700000
           },
           {
             "type": "dilithium",
-            "value": 18350
+            "value": 18350000
           }
         ]
       },
-      "research_time": 2613
+      "research_time": 2613000
     },
     {
       "bonus": {
@@ -229,15 +229,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 157700
+            "value": 157700000
           },
           {
             "type": "dilithium",
-            "value": 29000
+            "value": 29000000
           }
         ]
       },
-      "research_time": 4474
+      "research_time": 4474440
     },
     {
       "bonus": {
@@ -264,15 +264,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 424100
+            "value": 424100000
           },
           {
             "type": "dilithium",
-            "value": 77950
+            "value": 77950000
           }
         ]
       },
-      "research_time": 10594
+      "research_time": 10594080
     },
     {
       "bonus": {
@@ -299,15 +299,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 615100
+            "value": 615100000
           },
           {
             "type": "dilithium",
-            "value": 113100
+            "value": 113100000
           }
         ]
       },
-      "research_time": 10092
+      "research_time": 10092120
     },
     {
       "bonus": {
@@ -337,15 +337,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1330
+            "value": 1330000000
           },
           {
             "type": "dilithium",
-            "value": 244500
+            "value": 244500000
           }
         ]
       },
-      "research_time": 22004
+      "research_time": 22004100
     },
     {
       "bonus": {
@@ -372,15 +372,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 2026
+            "value": 2026000000
           },
           {
             "type": "dilithium",
-            "value": 372400
+            "value": 372400000
           }
         ]
       },
-      "research_time": 29200
+      "research_time": 29200620
     }
   ],
   "location": {

--- a/research/tritanium_upgrades.json
+++ b/research/tritanium_upgrades.json
@@ -42,15 +42,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 1330
+            "value": 1330000000
           },
           {
             "type": "dilithium",
-            "value": 326000
+            "value": 326000000
           }
         ]
       },
-      "research_time": 46942
+      "research_time": 46942080
     },
     {
       "bonus": {
@@ -84,15 +84,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 2026
+            "value": 2026000000
           },
           {
             "type": "dilithium",
-            "value": 496500
+            "value": 496500000
           }
         ]
       },
-      "research_time": 62294
+      "research_time": 62294640
     },
     {
       "bonus": {
@@ -134,15 +134,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 2889
+            "value": 2889000000
           },
           {
             "type": "dilithium",
-            "value": 708000
+            "value": 708000000
           }
         ]
       },
-      "research_time": 81744
+      "research_time": 81744660
     },
     {
       "bonus": {
@@ -182,15 +182,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 4028
+            "value": 4028000000
           },
           {
             "type": "dilithium",
-            "value": 987300
+            "value": 987300000
           }
         ]
       },
-      "research_time": 110240
+      "research_time": 110240520
     },
     {
       "bonus": {
@@ -242,15 +242,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 5957
+            "value": 5957000000
           },
           {
             "type": "dilithium",
-            "value": 1460
+            "value": 1460000000
           }
         ]
       },
-      "research_time": 142221
+      "research_time": 142221540
     },
     {
       "bonus": {
@@ -294,15 +294,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 9621
+            "value": 9621000000
           },
           {
             "type": "dilithium",
-            "value": 2358
+            "value": 2358000000
           }
         ]
       },
-      "research_time": 181910
+      "research_time": 181910760
     },
     {
       "bonus": {
@@ -354,15 +354,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 16279
+            "value": 16279000000
           },
           {
             "type": "dilithium",
-            "value": 3990
+            "value": 3990000000
           }
         ]
       },
-      "research_time": 240901
+      "research_time": 240901980
     },
     {
       "bonus": {
@@ -402,15 +402,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 28917
+            "value": 28917000000
           },
           {
             "type": "dilithium",
-            "value": 7088
+            "value": 7088000000
           }
         ]
       },
-      "research_time": 303237
+      "research_time": 303237540
     },
     {
       "bonus": {
@@ -437,15 +437,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 44018
+            "value": 44018000000
           },
           {
             "type": "dilithium",
-            "value": 10789
+            "value": 10789000000
           }
         ]
       },
-      "research_time": 369866
+      "research_time": 369866760
     },
     {
       "bonus": {
@@ -472,15 +472,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 67473
+            "value": 67473000000
           },
           {
             "type": "dilithium",
-            "value": 16538
+            "value": 16538000000
           }
         ]
       },
-      "research_time": 476141
+      "research_time": 476141100
     }
   ],
   "location": {

--- a/research/unlock_epic_assignments.json
+++ b/research/unlock_epic_assignments.json
@@ -30,7 +30,7 @@
         ],
         "resources": []
       },
-      "research_time": 1412,
+      "research_time": 1412520,
       "reward": {
         "type": "Mission\u00a0Token\u00a0",
         "value": 1

--- a/research/unstoppable_battleships.json
+++ b/research/unstoppable_battleships.json
@@ -35,7 +35,7 @@
         ],
         "resources": []
       },
-      "research_time": 8058
+      "research_time": 8058720
     },
     {
       "bonus": {
@@ -70,7 +70,7 @@
         ],
         "resources": []
       },
-      "research_time": 14125
+      "research_time": 14125380
     },
     {
       "bonus": {
@@ -104,7 +104,7 @@
         ],
         "resources": []
       },
-      "research_time": 13456
+      "research_time": 13456140
     },
     {
       "bonus": {
@@ -139,7 +139,7 @@
         ],
         "resources": []
       },
-      "research_time": 21017
+      "research_time": 21017460
     },
     {
       "bonus": {
@@ -173,7 +173,7 @@
         ],
         "resources": []
       },
-      "research_time": 29338
+      "research_time": 29338800
     },
     {
       "bonus": {
@@ -208,7 +208,7 @@
         ],
         "resources": []
       },
-      "research_time": 38934
+      "research_time": 38934120
     },
     {
       "bonus": {
@@ -238,12 +238,12 @@
           },
           {
             "type": "Service\u00a0Award",
-            "value": 1796
+            "value": 1796553
           }
         ],
         "resources": []
       },
-      "research_time": 68900
+      "research_time": 68900340
     },
     {
       "bonus": {
@@ -273,7 +273,7 @@
         "others": [
           {
             "type": "Service\u00a0Award",
-            "value": 2669
+            "value": 2669728
           },
           {
             "type": "Merit\u00a0of\u00a0Honor",
@@ -282,7 +282,7 @@
         ],
         "resources": []
       },
-      "research_time": 88888
+      "research_time": 88888440
     },
     {
       "bonus": {
@@ -316,12 +316,12 @@
           },
           {
             "type": "Service\u00a0Award",
-            "value": 1259
+            "value": 1259626
           }
         ],
         "resources": []
       },
-      "research_time": 51090
+      "research_time": 51090420
     },
     {
       "bonus": {
@@ -356,7 +356,7 @@
         ],
         "resources": []
       },
-      "research_time": 2600
+      "research_time": 2600040
     }
   ],
   "location": {

--- a/research/unstoppable_explorers.json
+++ b/research/unstoppable_explorers.json
@@ -35,7 +35,7 @@
         ],
         "resources": []
       },
-      "research_time": 8058
+      "research_time": 8058720
     },
     {
       "bonus": {
@@ -70,7 +70,7 @@
         ],
         "resources": []
       },
-      "research_time": 14125
+      "research_time": 14125380
     },
     {
       "bonus": {
@@ -104,7 +104,7 @@
         ],
         "resources": []
       },
-      "research_time": 13456
+      "research_time": 13456140
     },
     {
       "bonus": {
@@ -139,7 +139,7 @@
         ],
         "resources": []
       },
-      "research_time": 21017
+      "research_time": 21017460
     },
     {
       "bonus": {
@@ -173,7 +173,7 @@
         ],
         "resources": []
       },
-      "research_time": 29338
+      "research_time": 29338800
     },
     {
       "bonus": {
@@ -208,7 +208,7 @@
         ],
         "resources": []
       },
-      "research_time": 38934
+      "research_time": 38934120
     },
     {
       "bonus": {
@@ -234,7 +234,7 @@
         "others": [
           {
             "type": "Service\u00a0Award",
-            "value": 1796
+            "value": 1796553
           },
           {
             "type": "Merit\u00a0of\u00a0Honor",
@@ -243,7 +243,7 @@
         ],
         "resources": []
       },
-      "research_time": 68900
+      "research_time": 68900340
     },
     {
       "bonus": {
@@ -273,7 +273,7 @@
         "others": [
           {
             "type": "Service\u00a0Award",
-            "value": 2669
+            "value": 2669728
           },
           {
             "type": "Merit\u00a0of\u00a0Honor",
@@ -282,7 +282,7 @@
         ],
         "resources": []
       },
-      "research_time": 88888
+      "research_time": 88888440
     },
     {
       "bonus": {
@@ -312,7 +312,7 @@
         "others": [
           {
             "type": "Service\u00a0Award",
-            "value": 1259
+            "value": 1259626
           },
           {
             "type": "Merit\u00a0of\u00a0Honor",
@@ -321,7 +321,7 @@
         ],
         "resources": []
       },
-      "research_time": 51090
+      "research_time": 51090420
     },
     {
       "bonus": {
@@ -356,7 +356,7 @@
         ],
         "resources": []
       },
-      "research_time": 2600
+      "research_time": 2600040
     }
   ],
   "location": {

--- a/research/unstoppable_interceptors.json
+++ b/research/unstoppable_interceptors.json
@@ -35,7 +35,7 @@
         ],
         "resources": []
       },
-      "research_time": 8058
+      "research_time": 8058720
     },
     {
       "bonus": {
@@ -70,7 +70,7 @@
         ],
         "resources": []
       },
-      "research_time": 14125
+      "research_time": 14125380
     },
     {
       "bonus": {
@@ -104,7 +104,7 @@
         ],
         "resources": []
       },
-      "research_time": 13456
+      "research_time": 13456140
     },
     {
       "bonus": {
@@ -139,7 +139,7 @@
         ],
         "resources": []
       },
-      "research_time": 21017
+      "research_time": 21017460
     },
     {
       "bonus": {
@@ -173,7 +173,7 @@
         ],
         "resources": []
       },
-      "research_time": 29338
+      "research_time": 29338800
     },
     {
       "bonus": {
@@ -208,7 +208,7 @@
         ],
         "resources": []
       },
-      "research_time": 38934
+      "research_time": 38934120
     },
     {
       "bonus": {
@@ -242,12 +242,12 @@
           },
           {
             "type": "Service\u00a0Award",
-            "value": 1259
+            "value": 1259626
           }
         ],
         "resources": []
       },
-      "research_time": 51090
+      "research_time": 51090420
     },
     {
       "bonus": {
@@ -277,12 +277,12 @@
           },
           {
             "type": "Service\u00a0Award",
-            "value": 1796
+            "value": 1796553
           }
         ],
         "resources": []
       },
-      "research_time": 68900
+      "research_time": 68900340
     },
     {
       "bonus": {
@@ -312,7 +312,7 @@
         "others": [
           {
             "type": "Service\u00a0Award",
-            "value": 2669
+            "value": 2669728
           },
           {
             "type": "Merit\u00a0of\u00a0Honor",
@@ -321,7 +321,7 @@
         ],
         "resources": []
       },
-      "research_time": 88888
+      "research_time": 88888440
     },
     {
       "bonus": {
@@ -360,7 +360,7 @@
         ],
         "resources": []
       },
-      "research_time": 2600
+      "research_time": 2600040
     }
   ],
   "location": {

--- a/research/uss_constellation_skin_for_iss_jellyfish.json
+++ b/research/uss_constellation_skin_for_iss_jellyfish.json
@@ -41,15 +41,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 9621
+            "value": 9621000000
           },
           {
             "type": "dilithium",
-            "value": 2358
+            "value": 2358000000
           }
         ]
       },
-      "research_time": 113694
+      "research_time": 113694240
     },
     {
       "bonus": {
@@ -88,15 +88,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 16279
+            "value": 16279000000
           },
           {
             "type": "dilithium",
-            "value": 3990
+            "value": 3990000000
           }
         ]
       },
-      "research_time": 150563
+      "research_time": 150563760
     },
     {
       "bonus": {
@@ -135,15 +135,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 28917
+            "value": 28917000000
           },
           {
             "type": "dilithium",
-            "value": 7088
+            "value": 7088000000
           }
         ]
       },
-      "research_time": 189523
+      "research_time": 189523500
     },
     {
       "bonus": {
@@ -176,15 +176,15 @@
         "resources": [
           {
             "type": "parsteel",
-            "value": 44018
+            "value": 44018000000
           },
           {
             "type": "dilithium",
-            "value": 10789
+            "value": 10789000000
           }
         ]
       },
-      "research_time": 216000
+      "research_time": 216000000
     }
   ],
   "location": {

--- a/research/uss_discovery_impulse_speed.json
+++ b/research/uss_discovery_impulse_speed.json
@@ -62,7 +62,7 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 2081
+            "value": 2081250
           }
         ]
       },
@@ -100,7 +100,7 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 6723
+            "value": 6723750
           }
         ]
       },

--- a/research/uss_discovery_summoning.json
+++ b/research/uss_discovery_summoning.json
@@ -33,11 +33,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 16300
+            "value": 16300000
           }
         ]
       },
-      "research_time": 2376
+      "research_time": 2376360
     }
   ],
   "location": {

--- a/research/uss_discovery_warp_range.json
+++ b/research/uss_discovery_warp_range.json
@@ -29,11 +29,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 2379
+            "value": 2379000
           }
         ]
       },
-      "research_time": 1274
+      "research_time": 1274880
     },
     {
       "bonus": {
@@ -62,11 +62,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 3172
+            "value": 3172000
           }
         ]
       },
-      "research_time": 1164
+      "research_time": 1164960
     },
     {
       "bonus": {
@@ -95,11 +95,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 5015
+            "value": 5015000
           }
         ]
       },
-      "research_time": 1672
+      "research_time": 1672080
     },
     {
       "bonus": {
@@ -128,11 +128,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 20900
+            "value": 20900000
           }
         ]
       },
-      "research_time": 1940
+      "research_time": 1940160
     },
     {
       "bonus": {
@@ -194,7 +194,7 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1146
+            "value": 1146000
           }
         ]
       },
@@ -227,11 +227,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 45500
+            "value": 45500000
           }
         ]
       },
-      "research_time": 2311
+      "research_time": 2311200
     },
     {
       "bonus": {
@@ -260,11 +260,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 75200
+            "value": 75200000
           }
         ]
       },
-      "research_time": 2598
+      "research_time": 2598480
     },
     {
       "bonus": {
@@ -293,11 +293,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 142000
+            "value": 142000000
           }
         ]
       },
-      "research_time": 2964
+      "research_time": 2964000
     },
     {
       "bonus": {
@@ -326,11 +326,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 327500
+            "value": 327500000
           }
         ]
       },
-      "research_time": 3802
+      "research_time": 3802320
     }
   ],
   "location": {

--- a/research/valor_of_starfleet.json
+++ b/research/valor_of_starfleet.json
@@ -39,15 +39,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 6500
+            "value": 6500000
           },
           {
             "type": "dilithium",
-            "value": 5110
+            "value": 5110000
           }
         ]
       },
-      "research_time": 2608
+      "research_time": 2608980
     },
     {
       "bonus": {
@@ -92,15 +92,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 15550
+            "value": 15550000
           },
           {
             "type": "dilithium",
-            "value": 12200
+            "value": 12200000
           }
         ]
       },
-      "research_time": 4680
+      "research_time": 4680060
     },
     {
       "bonus": {
@@ -145,15 +145,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 34200
+            "value": 34200000
           },
           {
             "type": "dilithium",
-            "value": 26900
+            "value": 26900000
           }
         ]
       },
-      "research_time": 6271
+      "research_time": 6271200
     },
     {
       "bonus": {
@@ -198,15 +198,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 92150
+            "value": 92150000
           },
           {
             "type": "dilithium",
-            "value": 72400
+            "value": 72400000
           }
         ]
       },
-      "research_time": 14505
+      "research_time": 14505720
     },
     {
       "bonus": {
@@ -239,15 +239,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 211100
+            "value": 211100000
           },
           {
             "type": "dilithium",
-            "value": 165800
+            "value": 165800000
           }
         ]
       },
-      "research_time": 24221
+      "research_time": 24221040
     },
     {
       "bonus": {
@@ -286,15 +286,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 456400
+            "value": 456400000
           },
           {
             "type": "dilithium",
-            "value": 358600
+            "value": 358600000
           }
         ]
       },
-      "research_time": 52809
+      "research_time": 52809840
     },
     {
       "bonus": {
@@ -339,15 +339,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 991200
+            "value": 991200000
           },
           {
             "type": "dilithium",
-            "value": 778800
+            "value": 778800000
           }
         ]
       },
-      "research_time": 91962
+      "research_time": 91962720
     },
     {
       "bonus": {
@@ -392,15 +392,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 2044
+            "value": 2044000000
           },
           {
             "type": "dilithium",
-            "value": 1606
+            "value": 1606000000
           }
         ]
       },
-      "research_time": 159999
+      "research_time": 159999240
     },
     {
       "bonus": {
@@ -439,15 +439,15 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 2860
+            "value": 2860000
           },
           {
             "type": "dilithium",
-            "value": 2250
+            "value": 2250000
           }
         ]
       },
-      "research_time": 1711
+      "research_time": 1711020
     },
     {
       "bonus": {
@@ -495,7 +495,7 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 1210
+            "value": 1210000
           },
           {
             "type": "dilithium",
@@ -503,7 +503,7 @@
           }
         ]
       },
-      "research_time": 1169
+      "research_time": 1169340
     }
   ],
   "location": {

--- a/research/warp_technology.json
+++ b/research/warp_technology.json
@@ -195,7 +195,7 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 2040
+            "value": 2040000
           }
         ]
       },
@@ -238,11 +238,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 4650
+            "value": 4650000
           }
         ]
       },
-      "research_time": 1449
+      "research_time": 1449420
     },
     {
       "bonus": {
@@ -298,11 +298,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 11100
+            "value": 11100000
           }
         ]
       },
-      "research_time": 2600
+      "research_time": 2600040
     },
     {
       "bonus": {
@@ -344,11 +344,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 24450
+            "value": 24450000
           }
         ]
       },
-      "research_time": 3483
+      "research_time": 3483960
     },
     {
       "bonus": {

--- a/research/weapon_development.json
+++ b/research/weapon_development.json
@@ -44,11 +44,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1110
+            "value": 1110000
           }
         ]
       },
-      "research_time": 2600
+      "research_time": 2600040
     },
     {
       "bonus": {
@@ -83,11 +83,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 10400
+            "value": 10400000
           }
         ]
       },
-      "research_time": 14125
+      "research_time": 14125380
     },
     {
       "bonus": {
@@ -122,11 +122,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 15100
+            "value": 15100000
           }
         ]
       },
-      "research_time": 13456
+      "research_time": 13456140
     },
     {
       "bonus": {
@@ -170,11 +170,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 22450
+            "value": 22450000
           }
         ]
       },
-      "research_time": 21017
+      "research_time": 21017460
     },
     {
       "bonus": {
@@ -209,11 +209,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 32600
+            "value": 32600000
           }
         ]
       },
-      "research_time": 29338
+      "research_time": 29338800
     },
     {
       "bonus": {
@@ -248,11 +248,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 49650
+            "value": 49650000
           }
         ]
       },
-      "research_time": 38934
+      "research_time": 38934120
     },
     {
       "bonus": {
@@ -287,11 +287,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 70800
+            "value": 70800000
           }
         ]
       },
-      "research_time": 51090
+      "research_time": 51090420
     },
     {
       "bonus": {
@@ -326,11 +326,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 98750
+            "value": 98750000
           }
         ]
       },
-      "research_time": 68900
+      "research_time": 68900340
     },
     {
       "bonus": {
@@ -365,11 +365,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 146000
+            "value": 146000000
           }
         ]
       },
-      "research_time": 88888
+      "research_time": 88888440
     },
     {
       "bonus": {
@@ -413,11 +413,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 399000
+            "value": 399000000
           }
         ]
       },
-      "research_time": 150563
+      "research_time": 150563760
     }
   ],
   "location": {

--- a/research/weapon_refactor.json
+++ b/research/weapon_refactor.json
@@ -42,11 +42,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 2250
+            "value": 2250000
           }
         ]
       },
-      "research_time": 1901
+      "research_time": 1901100
     },
     {
       "bonus": {
@@ -92,11 +92,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 72400
+            "value": 72400000
           }
         ]
       },
-      "research_time": 16117
+      "research_time": 16117440
     },
     {
       "bonus": {
@@ -146,11 +146,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 114300
+            "value": 114300000
           }
         ]
       },
-      "research_time": 28250
+      "research_time": 28250820
     },
     {
       "bonus": {
@@ -195,11 +195,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 165800
+            "value": 165800000
           }
         ]
       },
-      "research_time": 26912
+      "research_time": 26912280
     },
     {
       "bonus": {
@@ -245,11 +245,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 247200
+            "value": 247200000
           }
         ]
       },
-      "research_time": 42034
+      "research_time": 42034980
     },
     {
       "bonus": {
@@ -290,11 +290,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 358600
+            "value": 358600000
           }
         ]
       },
-      "research_time": 58677
+      "research_time": 58677600
     },
     {
       "bonus": {
@@ -339,11 +339,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 546200
+            "value": 546200000
           }
         ]
       },
-      "research_time": 77868
+      "research_time": 77868300
     },
     {
       "bonus": {
@@ -388,11 +388,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 778800
+            "value": 778800000
           }
         ]
       },
-      "research_time": 102180
+      "research_time": 102180780
     },
     {
       "bonus": {
@@ -438,11 +438,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1086
+            "value": 1086000000
           }
         ]
       },
-      "research_time": 137800
+      "research_time": 137800680
     },
     {
       "bonus": {
@@ -483,11 +483,11 @@
         "resources": [
           {
             "type": "dilithium",
-            "value": 1606
+            "value": 1606000000
           }
         ]
       },
-      "research_time": 177776
+      "research_time": 177776880
     }
   ],
   "location": {


### PR DESCRIPTION
updated the parser to correctly handle the numbers. this should fix the numbers for build times and also resources and materials when they are above `1000000`