### PR TITLE
Updated hostiles with changed schema

### DIFF
--- a/examples/hostiles/example.json
+++ b/examples/hostiles/example.json
@@ -1,6 +1,11 @@
 {
   "description": "This hostile patrols...",
   "group": "borg",
+  "head_stats": {
+    "attack": 30000,
+    "defense": 10000,
+    "health": 40000
+  },
   "hostile_name": "Borg Tactical Probe",
   "level": 30,
   "rarity": "common",
@@ -60,7 +65,6 @@
         1
       ],
       "quantity": 2,
-      "weapon_id": "E1",
       "weapon_stats": {
         "accuracy": 71402,
         "armor_pierce": 82997,

--- a/hostiles/assimilated_ferengi_miner_28_survey.json
+++ b/hostiles/assimilated_ferengi_miner_28_survey.json
@@ -1,6 +1,11 @@
 {
   "description": "",
   "group": "borg",
+  "head_stats": {
+    "attack": 718627,
+    "defense": 135240,
+    "health": 2279942
+  },
   "hostile_name": "Assimilated Ferengi Miner",
   "level": 28,
   "rarity": "common",
@@ -165,10 +170,5 @@
       },
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 718627,
-    "defense": 135240,
-    "health": 2279942
-  }
+  ]
 }

--- a/hostiles/assimilated_ferengi_miner_28_survey.json
+++ b/hostiles/assimilated_ferengi_miner_28_survey.json
@@ -1,9 +1,6 @@
 {
   "description": "",
-  "attack": 718627,
-  "defense": 135240,
   "group": "borg",
-  "health": 2279942,
   "hostile_name": "Assimilated Ferengi Miner",
   "level": 28,
   "rarity": "common",
@@ -33,7 +30,6 @@
       "shield_health": 1954000
     }
   },
-  "strength": 3133809,
   "systems": [
     {
       "$ref": "systems/torra_sedra_28"
@@ -64,7 +60,6 @@
         0
       ],
       "quantity": 1,
-      "weapon_id": "K1",
       "weapon_stats": {
         "accuracy": 12125,
         "armor_pierce": 12125,
@@ -96,7 +91,6 @@
         0
       ],
       "quantity": 1,
-      "weapon_id": "K2",
       "weapon_stats": {
         "accuracy": 12125,
         "armor_pierce": 12125,
@@ -128,7 +122,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_stats": {
         "accuracy": 12125,
         "armor_pierce": 12125,
@@ -160,7 +153,6 @@
         0
       ],
       "quantity": 1,
-      "weapon_id": "E2",
       "weapon_stats": {
         "accuracy": 12125,
         "armor_pierce": 12125,
@@ -173,5 +165,10 @@
       },
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 718627,
+    "defense": 135240,
+    "health": 2279942
+  }
 }

--- a/hostiles/assimilated_ferengi_trader_26_survey.json
+++ b/hostiles/assimilated_ferengi_trader_26_survey.json
@@ -1,9 +1,6 @@
 {
   "description": "",
-  "attack": 331895,
-  "defense": 72455,
   "group": "borg",
-  "health": 1935739,
   "hostile_name": "Assimilated Ferengi Trader \u21d4",
   "level": 26,
   "rarity": "common",
@@ -37,7 +34,6 @@
       "shield_health": 1659000
     }
   },
-  "strength": 2340089,
   "systems": [
     {
       "$ref": "systems/benes_beta_26"
@@ -68,7 +64,6 @@
         0
       ],
       "quantity": 1,
-      "weapon_id": "K1",
       "weapon_type": "kinetic"
     },
     {
@@ -90,7 +85,6 @@
         0
       ],
       "quantity": 1,
-      "weapon_id": "K2",
       "weapon_type": "kinetic"
     },
     {
@@ -112,7 +106,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_type": "energy"
     },
     {
@@ -134,8 +127,12 @@
         0
       ],
       "quantity": 1,
-      "weapon_id": "E2",
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 331895,
+    "defense": 72455,
+    "health": 1935739
+  }
 }

--- a/hostiles/assimilated_ferengi_trader_26_survey.json
+++ b/hostiles/assimilated_ferengi_trader_26_survey.json
@@ -1,6 +1,11 @@
 {
   "description": "",
   "group": "borg",
+  "head_stats": {
+    "attack": 331895,
+    "defense": 72455,
+    "health": 1935739
+  },
   "hostile_name": "Assimilated Ferengi Trader \u21d4",
   "level": 26,
   "rarity": "common",
@@ -129,10 +134,5 @@
       "quantity": 1,
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 331895,
-    "defense": 72455,
-    "health": 1935739
-  }
+  ]
 }

--- a/hostiles/assimilated_ferengi_trader_29_survey.json
+++ b/hostiles/assimilated_ferengi_trader_29_survey.json
@@ -1,6 +1,11 @@
 {
   "description": "",
   "group": "borg",
+  "head_stats": {
+    "attack": 994809,
+    "defense": 175420,
+    "health": 2375381
+  },
   "hostile_name": "Assimilated Ferengi Trader \u21d4",
   "level": 29,
   "rarity": "common",
@@ -129,10 +134,5 @@
       "quantity": 1,
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 994809,
-    "defense": 175420,
-    "health": 2375381
-  }
+  ]
 }

--- a/hostiles/assimilated_ferengi_trader_29_survey.json
+++ b/hostiles/assimilated_ferengi_trader_29_survey.json
@@ -1,9 +1,6 @@
 {
   "description": "",
-  "attack": 994809,
-  "defense": 175420,
   "group": "borg",
-  "health": 2375381,
   "hostile_name": "Assimilated Ferengi Trader \u21d4",
   "level": 29,
   "rarity": "common",
@@ -37,7 +34,6 @@
       "shield_health": 2036000
     }
   },
-  "strength": 3545610,
   "systems": [
     {
       "$ref": "systems/roda_gamma_29"
@@ -68,7 +64,6 @@
         0
       ],
       "quantity": 1,
-      "weapon_id": "K1",
       "weapon_type": "kinetic"
     },
     {
@@ -90,7 +85,6 @@
         0
       ],
       "quantity": 1,
-      "weapon_id": "K2",
       "weapon_type": "kinetic"
     },
     {
@@ -112,7 +106,6 @@
         0
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_type": "energy"
     },
     {
@@ -134,8 +127,12 @@
         0
       ],
       "quantity": 1,
-      "weapon_id": "E2",
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 994809,
+    "defense": 175420,
+    "health": 2375381
+  }
 }

--- a/hostiles/assimilated_ferengi_trader_33_survey.json
+++ b/hostiles/assimilated_ferengi_trader_33_survey.json
@@ -1,6 +1,11 @@
 {
   "description": "",
   "group": "borg",
+  "head_stats": {
+    "attack": 3522531,
+    "defense": 541315,
+    "health": 3089287
+  },
   "hostile_name": "Assimilated Ferengi Trader \u21d4",
   "level": 33,
   "rarity": "common",
@@ -117,10 +122,5 @@
       "quantity": 1,
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 3522531,
-    "defense": 541315,
-    "health": 3089287
-  }
+  ]
 }

--- a/hostiles/assimilated_ferengi_trader_33_survey.json
+++ b/hostiles/assimilated_ferengi_trader_33_survey.json
@@ -1,9 +1,6 @@
 {
   "description": "",
-  "attack": 3522531,
-  "defense": 541315,
   "group": "borg",
-  "health": 3089287,
   "hostile_name": "Assimilated Ferengi Trader \u21d4",
   "level": 33,
   "rarity": "common",
@@ -37,7 +34,6 @@
       "shield_health": 2647000
     }
   },
-  "strength": 7153133,
   "systems": [
     {
       "$ref": "systems/corta_gamma_33"
@@ -65,7 +61,6 @@
         0
       ],
       "quantity": 1,
-      "weapon_id": "K1",
       "weapon_type": "kinetic"
     },
     {
@@ -84,7 +79,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_type": "energy"
     },
     {
@@ -103,7 +97,6 @@
         0
       ],
       "quantity": 1,
-      "weapon_id": "K2",
       "weapon_type": "kinetic"
     },
     {
@@ -122,8 +115,12 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E2",
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 3522531,
+    "defense": 541315,
+    "health": 3089287
+  }
 }

--- a/hostiles/benzar_smuggler_27_battleship.json
+++ b/hostiles/benzar_smuggler_27_battleship.json
@@ -1,9 +1,6 @@
 {
   "description": "This Hostile patrols the different systems of the universe, looking for easy prey",
-  "attack": 29664,
-  "defense": 30000,
   "group": "",
-  "health": 14700,
   "hostile_name": "Benzar Smuggler",
   "level": 27,
   "rarity": "common",
@@ -28,7 +25,6 @@
       "shield_health": 12000
     }
   },
-  "strength": 74364,
   "systems": [
     {
       "$ref": "systems/nasturta_26"
@@ -56,7 +52,6 @@
         0
       ],
       "quantity": 1,
-      "weapon_id": "K1",
       "weapon_type": "kinetic"
     },
     {
@@ -75,7 +70,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_type": "energy"
     },
     {
@@ -94,8 +88,12 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E2",
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 29664,
+    "defense": 30000,
+    "health": 14700
+  }
 }

--- a/hostiles/benzar_smuggler_27_battleship.json
+++ b/hostiles/benzar_smuggler_27_battleship.json
@@ -1,6 +1,11 @@
 {
   "description": "This Hostile patrols the different systems of the universe, looking for easy prey",
   "group": "",
+  "head_stats": {
+    "attack": 29664,
+    "defense": 30000,
+    "health": 14700
+  },
   "hostile_name": "Benzar Smuggler",
   "level": 27,
   "rarity": "common",
@@ -90,10 +95,5 @@
       "quantity": 1,
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 29664,
-    "defense": 30000,
-    "health": 14700
-  }
+  ]
 }

--- a/hostiles/bird_of_prey_annihilator_35_battleship.json
+++ b/hostiles/bird_of_prey_annihilator_35_battleship.json
@@ -1,9 +1,6 @@
 {
   "description": "These Klingon Invaders are ruthless and completely devoid of mercy. They have been seen wandering our galaxy, gathering forgotten, ancient technology for unknown purposes.",
-  "attack": 1216725,
-  "defense": 442170,
   "group": "",
-  "health": 2168403,
   "hostile_name": "Bird of Prey Annihilator \u21d5",
   "level": 35,
   "rarity": "common",
@@ -33,7 +30,6 @@
       "shield_health": 1758000
     }
   },
-  "strength": 3827298,
   "systems": [
     {
       "$ref": "systems/kraatu_36"
@@ -70,7 +66,6 @@
         3
       ],
       "quantity": 1,
-      "weapon_id": "K1",
       "weapon_type": "kinetic"
     },
     {
@@ -92,7 +87,6 @@
         3
       ],
       "quantity": 1,
-      "weapon_id": "K2",
       "weapon_type": "kinetic"
     },
     {
@@ -114,7 +108,6 @@
         3
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_type": "energy"
     },
     {
@@ -136,8 +129,12 @@
         3
       ],
       "quantity": 1,
-      "weapon_id": "E2",
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 1216725,
+    "defense": 442170,
+    "health": 2168403
+  }
 }

--- a/hostiles/bird_of_prey_annihilator_35_battleship.json
+++ b/hostiles/bird_of_prey_annihilator_35_battleship.json
@@ -1,6 +1,11 @@
 {
   "description": "These Klingon Invaders are ruthless and completely devoid of mercy. They have been seen wandering our galaxy, gathering forgotten, ancient technology for unknown purposes.",
   "group": "",
+  "head_stats": {
+    "attack": 1216725,
+    "defense": 442170,
+    "health": 2168403
+  },
   "hostile_name": "Bird of Prey Annihilator \u21d5",
   "level": 35,
   "rarity": "common",
@@ -131,10 +136,5 @@
       "quantity": 1,
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 1216725,
-    "defense": 442170,
-    "health": 2168403
-  }
+  ]
 }

--- a/hostiles/bird_of_prey_annihilator_37_battleship.json
+++ b/hostiles/bird_of_prey_annihilator_37_battleship.json
@@ -1,6 +1,11 @@
 {
   "description": "These Klingon Invaders are ruthless and completely devoid of mercy. They have been seen wandering our galaxy, gathering forgotten, ancient technology for unknown purposes.",
   "group": "",
+  "head_stats": {
+    "attack": 2356402,
+    "defense": 838145,
+    "health": 4073700
+  },
   "hostile_name": "Bird of Prey Annihilator \u21d5",
   "level": 37,
   "rarity": "common",
@@ -140,10 +145,5 @@
       "quantity": 1,
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 2356402,
-    "defense": 838145,
-    "health": 4073700
-  }
+  ]
 }

--- a/hostiles/bird_of_prey_annihilator_37_battleship.json
+++ b/hostiles/bird_of_prey_annihilator_37_battleship.json
@@ -1,9 +1,6 @@
 {
   "description": "These Klingon Invaders are ruthless and completely devoid of mercy. They have been seen wandering our galaxy, gathering forgotten, ancient technology for unknown purposes.",
-  "attack": 2356402,
-  "defense": 838145,
   "group": "",
-  "health": 4073700,
   "hostile_name": "Bird of Prey Annihilator \u21d5",
   "level": 37,
   "rarity": "common",
@@ -33,7 +30,6 @@
       "shield_health": 3302000
     }
   },
-  "strength": 7268247,
   "systems": [
     {
       "$ref": "systems/kraatu_36"
@@ -79,7 +75,6 @@
         3
       ],
       "quantity": 1,
-      "weapon_id": "K1",
       "weapon_type": "kinetic"
     },
     {
@@ -101,7 +96,6 @@
         3
       ],
       "quantity": 1,
-      "weapon_id": "K2",
       "weapon_type": "kinetic"
     },
     {
@@ -123,7 +117,6 @@
         3
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_type": "energy"
     },
     {
@@ -145,8 +138,12 @@
         3
       ],
       "quantity": 1,
-      "weapon_id": "E2",
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 2356402,
+    "defense": 838145,
+    "health": 4073700
+  }
 }

--- a/hostiles/bird_of_prey_fighter_31_interceptor.json
+++ b/hostiles/bird_of_prey_fighter_31_interceptor.json
@@ -1,6 +1,11 @@
 {
   "description": "These Klingon Invaders are ruthless and completely devoid of mercy. They have been seen wandering our galaxy, gathering forgotten, ancient technology for unknown purposes.",
   "group": "",
+  "head_stats": {
+    "attack": 509608,
+    "defense": 499030,
+    "health": 141650
+  },
   "hostile_name": "Bird of Prey Fighter \u21ef",
   "level": 31,
   "rarity": "common",
@@ -101,10 +106,5 @@
       "quantity": 1,
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 509608,
-    "defense": 499030,
-    "health": 141650
-  }
+  ]
 }

--- a/hostiles/bird_of_prey_fighter_31_interceptor.json
+++ b/hostiles/bird_of_prey_fighter_31_interceptor.json
@@ -1,9 +1,6 @@
 {
   "description": "These Klingon Invaders are ruthless and completely devoid of mercy. They have been seen wandering our galaxy, gathering forgotten, ancient technology for unknown purposes.",
-  "attack": 509608,
-  "defense": 499030,
   "group": "",
-  "health": 141650,
   "hostile_name": "Bird of Prey Fighter \u21ef",
   "level": 31,
   "rarity": "common",
@@ -33,7 +30,6 @@
       "shield_health": 141000
     }
   },
-  "strength": 1150288,
   "systems": [
     {
       "$ref": "systems/aletara_31"
@@ -67,7 +63,6 @@
         0
       ],
       "quantity": 1,
-      "weapon_id": "K1",
       "weapon_type": "kinetic"
     },
     {
@@ -86,7 +81,6 @@
         0
       ],
       "quantity": 1,
-      "weapon_id": "K2",
       "weapon_type": "kinetic"
     },
     {
@@ -105,8 +99,12 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 509608,
+    "defense": 499030,
+    "health": 141650
+  }
 }

--- a/hostiles/bird_of_prey_scout_31_explorer.json
+++ b/hostiles/bird_of_prey_scout_31_explorer.json
@@ -1,6 +1,11 @@
 {
   "description": "These Klingon Invaders are ruthless and completely devoid of mercy. They have been seen wandering our galaxy, gathering forgotten, ancient technology for unknown purposes.",
   "group": "",
+  "head_stats": {
+    "attack": 483872,
+    "defense": 499030,
+    "health": 160900
+  },
   "hostile_name": "Bird of Prey Scout \u21ef",
   "level": 31,
   "rarity": "common",
@@ -101,10 +106,5 @@
       "quantity": 1,
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 483872,
-    "defense": 499030,
-    "health": 160900
-  }
+  ]
 }

--- a/hostiles/bird_of_prey_scout_31_explorer.json
+++ b/hostiles/bird_of_prey_scout_31_explorer.json
@@ -1,9 +1,6 @@
 {
   "description": "These Klingon Invaders are ruthless and completely devoid of mercy. They have been seen wandering our galaxy, gathering forgotten, ancient technology for unknown purposes.",
-  "attack": 483872,
-  "defense": 499030,
   "group": "",
-  "health": 160900,
   "hostile_name": "Bird of Prey Scout \u21ef",
   "level": 31,
   "rarity": "common",
@@ -33,7 +30,6 @@
       "shield_health": 190000
     }
   },
-  "strength": 1143802,
   "systems": [
     {
       "$ref": "systems/aletara_31"
@@ -67,7 +63,6 @@
         0
       ],
       "quantity": 1,
-      "weapon_id": "K1",
       "weapon_type": "kinetic"
     },
     {
@@ -86,7 +81,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_type": "energy"
     },
     {
@@ -105,8 +99,12 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E2",
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 483872,
+    "defense": 499030,
+    "health": 160900
+  }
 }

--- a/hostiles/bird_of_prey_warmaster_37_interceptor.json
+++ b/hostiles/bird_of_prey_warmaster_37_interceptor.json
@@ -1,9 +1,6 @@
 {
   "description": "These Klingon Invaders are ruthless and completely devoid of mercy. They have been seen wandering our galaxy, gathering forgotten, ancient technology for unknown purposes.",
-  "attack": 2247453,
-  "defense": 1090010,
   "group": "",
-  "health": 3481192,
   "hostile_name": "Bird of Prey Warmaster \u21d5",
   "level": 37,
   "rarity": "common",
@@ -33,7 +30,6 @@
       "shield_health": 3481000
     }
   },
-  "strength": 6818655,
   "systems": [
     {
       "$ref": "systems/kraatu_36"
@@ -79,7 +75,6 @@
         3
       ],
       "quantity": 1,
-      "weapon_id": "K1",
       "weapon_type": "kinetic"
     },
     {
@@ -101,7 +96,6 @@
         3
       ],
       "quantity": 1,
-      "weapon_id": "K2",
       "weapon_type": "kinetic"
     },
     {
@@ -123,7 +117,6 @@
         3
       ],
       "quantity": 1,
-      "weapon_id": "K3",
       "weapon_type": "kinetic"
     },
     {
@@ -145,8 +138,12 @@
         3
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 2247453,
+    "defense": 1090010,
+    "health": 3481192
+  }
 }

--- a/hostiles/bird_of_prey_warmaster_37_interceptor.json
+++ b/hostiles/bird_of_prey_warmaster_37_interceptor.json
@@ -1,6 +1,11 @@
 {
   "description": "These Klingon Invaders are ruthless and completely devoid of mercy. They have been seen wandering our galaxy, gathering forgotten, ancient technology for unknown purposes.",
   "group": "",
+  "head_stats": {
+    "attack": 2247453,
+    "defense": 1090010,
+    "health": 3481192
+  },
   "hostile_name": "Bird of Prey Warmaster \u21d5",
   "level": 37,
   "rarity": "common",
@@ -140,10 +145,5 @@
       "quantity": 1,
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 2247453,
-    "defense": 1090010,
-    "health": 3481192
-  }
+  ]
 }

--- a/hostiles/bird_of_prey_warship_31_battleship.json
+++ b/hostiles/bird_of_prey_warship_31_battleship.json
@@ -1,9 +1,6 @@
 {
   "description": "These Klingon Invaders are ruthless and completely devoid of mercy. They have been seen wandering our galaxy, gathering forgotten, ancient technology for unknown purposes.",
-  "attack": 588108,
-  "defense": 616525,
   "group": "",
-  "health": 192945,
   "hostile_name": "Bird of Prey Warship \u21ef",
   "level": 31,
   "rarity": "common",
@@ -33,7 +30,6 @@
       "shield_health": 136000
     }
   },
-  "strength": 1397578,
   "systems": [
     {
       "$ref": "systems/aletara_31"
@@ -70,7 +66,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "K1",
       "weapon_type": "kinetic"
     },
     {
@@ -92,7 +87,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_type": "energy"
     },
     {
@@ -114,8 +108,12 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E2",
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 588108,
+    "defense": 616525,
+    "health": 192945
+  }
 }

--- a/hostiles/bird_of_prey_warship_31_battleship.json
+++ b/hostiles/bird_of_prey_warship_31_battleship.json
@@ -1,6 +1,11 @@
 {
   "description": "These Klingon Invaders are ruthless and completely devoid of mercy. They have been seen wandering our galaxy, gathering forgotten, ancient technology for unknown purposes.",
   "group": "",
+  "head_stats": {
+    "attack": 588108,
+    "defense": 616525,
+    "health": 192945
+  },
   "hostile_name": "Bird of Prey Warship \u21ef",
   "level": 31,
   "rarity": "common",
@@ -110,10 +115,5 @@
       "quantity": 1,
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 588108,
-    "defense": 616525,
-    "health": 192945
-  }
+  ]
 }

--- a/hostiles/bird_of_prey_wayfinder_35_explorer.json
+++ b/hostiles/bird_of_prey_wayfinder_35_explorer.json
@@ -1,9 +1,6 @@
 {
   "description": "These Klingon Invaders are ruthless and completely devoid of mercy. They have been seen wandering our galaxy, gathering forgotten, ancient technology for unknown purposes.",
-  "attack": 1669801,
-  "defense": 478760,
   "group": "",
-  "health": 1585631,
   "hostile_name": "Bird of Prey Wayfinder \u21d5",
   "level": 35,
   "rarity": "common",
@@ -33,7 +30,6 @@
       "shield_health": 1849000
     }
   },
-  "strength": 3734192,
   "systems": [
     {
       "$ref": "systems/kraatu_36"
@@ -70,7 +66,6 @@
         3
       ],
       "quantity": 1,
-      "weapon_id": "K1",
       "weapon_type": "kinetic"
     },
     {
@@ -92,7 +87,6 @@
         3
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_type": "energy"
     },
     {
@@ -114,7 +108,6 @@
         3
       ],
       "quantity": 1,
-      "weapon_id": "E2",
       "weapon_type": "energy"
     },
     {
@@ -136,8 +129,12 @@
         3
       ],
       "quantity": 1,
-      "weapon_id": "E3",
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 1669801,
+    "defense": 478760,
+    "health": 1585631
+  }
 }

--- a/hostiles/bird_of_prey_wayfinder_35_explorer.json
+++ b/hostiles/bird_of_prey_wayfinder_35_explorer.json
@@ -1,6 +1,11 @@
 {
   "description": "These Klingon Invaders are ruthless and completely devoid of mercy. They have been seen wandering our galaxy, gathering forgotten, ancient technology for unknown purposes.",
   "group": "",
+  "head_stats": {
+    "attack": 1669801,
+    "defense": 478760,
+    "health": 1585631
+  },
   "hostile_name": "Bird of Prey Wayfinder \u21d5",
   "level": 35,
   "rarity": "common",
@@ -131,10 +136,5 @@
       "quantity": 1,
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 1669801,
-    "defense": 478760,
-    "health": 1585631
-  }
+  ]
 }

--- a/hostiles/bird_of_prey_wayfinder_37_explorer.json
+++ b/hostiles/bird_of_prey_wayfinder_37_explorer.json
@@ -1,9 +1,6 @@
 {
   "description": "These Klingon Invaders are ruthless and completely devoid of mercy. They have been seen wandering our galaxy, gathering forgotten, ancient technology for unknown purposes.",
-  "attack": 3165993,
-  "defense": 854025,
   "group": "",
-  "health": 2824320,
   "hostile_name": "Bird of Prey Wayfinder \u21d5",
   "level": 37,
   "rarity": "common",
@@ -33,7 +30,6 @@
       "shield_health": 3295000
     }
   },
-  "strength": 6844338,
   "systems": [
     {
       "$ref": "systems/kraatu_36"
@@ -79,7 +75,6 @@
         3
       ],
       "quantity": 1,
-      "weapon_id": "K1",
       "weapon_type": "kinetic"
     },
     {
@@ -101,7 +96,6 @@
         3
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_type": "energy"
     },
     {
@@ -123,7 +117,6 @@
         3
       ],
       "quantity": 1,
-      "weapon_id": "E2",
       "weapon_type": "energy"
     },
     {
@@ -145,8 +138,12 @@
         3
       ],
       "quantity": 1,
-      "weapon_id": "E3",
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 3165993,
+    "defense": 854025,
+    "health": 2824320
+  }
 }

--- a/hostiles/bird_of_prey_wayfinder_37_explorer.json
+++ b/hostiles/bird_of_prey_wayfinder_37_explorer.json
@@ -1,6 +1,11 @@
 {
   "description": "These Klingon Invaders are ruthless and completely devoid of mercy. They have been seen wandering our galaxy, gathering forgotten, ancient technology for unknown purposes.",
   "group": "",
+  "head_stats": {
+    "attack": 3165993,
+    "defense": 854025,
+    "health": 2824320
+  },
   "hostile_name": "Bird of Prey Wayfinder \u21d5",
   "level": 37,
   "rarity": "common",
@@ -140,10 +145,5 @@
       "quantity": 1,
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 3165993,
-    "defense": 854025,
-    "health": 2824320
-  }
+  ]
 }

--- a/hostiles/bird_of_prey_wayfinder_39_explorer.json
+++ b/hostiles/bird_of_prey_wayfinder_39_explorer.json
@@ -1,6 +1,11 @@
 {
   "description": "These Klingon Invaders are ruthless and completely devoid of mercy. They have been seen wandering our galaxy, gathering forgotten, ancient technology for unknown purposes.",
   "group": "",
+  "head_stats": {
+    "attack": 6357680,
+    "defense": 1545990,
+    "health": 5096240
+  },
   "hostile_name": "Bird of Prey Wayfinder \u21d5",
   "level": 39,
   "rarity": "common",
@@ -131,10 +136,5 @@
       "quantity": 1,
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 6357680,
-    "defense": 1545990,
-    "health": 5096240
-  }
+  ]
 }

--- a/hostiles/bird_of_prey_wayfinder_39_explorer.json
+++ b/hostiles/bird_of_prey_wayfinder_39_explorer.json
@@ -1,9 +1,6 @@
 {
   "description": "These Klingon Invaders are ruthless and completely devoid of mercy. They have been seen wandering our galaxy, gathering forgotten, ancient technology for unknown purposes.",
-  "attack": 6357680,
-  "defense": 1545990,
   "group": "",
-  "health": 5096240,
   "hostile_name": "Bird of Prey Wayfinder \u21d5",
   "level": 39,
   "rarity": "common",
@@ -33,7 +30,6 @@
       "shield_health": 5945000
     }
   },
-  "strength": 12999910,
   "systems": [
     {
       "$ref": "systems/evans_38"
@@ -70,7 +66,6 @@
         3
       ],
       "quantity": 1,
-      "weapon_id": "K1",
       "weapon_type": "kinetic"
     },
     {
@@ -92,7 +87,6 @@
         3
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_type": "energy"
     },
     {
@@ -114,7 +108,6 @@
         3
       ],
       "quantity": 1,
-      "weapon_id": "E2",
       "weapon_type": "energy"
     },
     {
@@ -136,8 +129,12 @@
         3
       ],
       "quantity": 1,
-      "weapon_id": "E3",
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 6357680,
+    "defense": 1545990,
+    "health": 5096240
+  }
 }

--- a/hostiles/borg_tactical_probe_25_battleship.json
+++ b/hostiles/borg_tactical_probe_25_battleship.json
@@ -1,6 +1,11 @@
 {
   "description": "This Hostile patrols the different systems of the universe, looking for easy prey",
   "group": "borg",
+  "head_stats": {
+    "attack": 250567,
+    "defense": 50250,
+    "health": 1105860
+  },
   "hostile_name": "Borg Tactical Probe",
   "level": 25,
   "rarity": "common",
@@ -171,10 +176,5 @@
       },
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 250567,
-    "defense": 50250,
-    "health": 1105860
-  }
+  ]
 }

--- a/hostiles/borg_tactical_probe_25_battleship.json
+++ b/hostiles/borg_tactical_probe_25_battleship.json
@@ -1,9 +1,6 @@
 {
   "description": "This Hostile patrols the different systems of the universe, looking for easy prey",
-  "attack": 250567,
-  "defense": 50250,
   "group": "borg",
-  "health": 1105860,
   "hostile_name": "Borg Tactical Probe",
   "level": 25,
   "rarity": "common",
@@ -33,7 +30,6 @@
       "shield_health": 947900
     }
   },
-  "strength": 1406677,
   "systems": [
     {
       "$ref": "systems/metra_alpha_25"
@@ -70,7 +66,6 @@
         0
       ],
       "quantity": 1,
-      "weapon_id": "K1",
       "weapon_stats": {
         "accuracy": 1250,
         "armor_pierce": 1250,
@@ -102,7 +97,6 @@
         0
       ],
       "quantity": 1,
-      "weapon_id": "K2",
       "weapon_stats": {
         "accuracy": 1250,
         "armor_pierce": 1250,
@@ -134,7 +128,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_stats": {
         "accuracy": 1250,
         "armor_pierce": 1250,
@@ -166,7 +159,6 @@
         0
       ],
       "quantity": 1,
-      "weapon_id": "E2",
       "weapon_stats": {
         "accuracy": 1250,
         "armor_pierce": 1250,
@@ -179,5 +171,10 @@
       },
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 250567,
+    "defense": 50250,
+    "health": 1105860
+  }
 }

--- a/hostiles/borg_tactical_probe_26_battleship.json
+++ b/hostiles/borg_tactical_probe_26_battleship.json
@@ -1,6 +1,11 @@
 {
   "description": "This Hostile patrols the different systems of the universe, looking for easy prey",
   "group": "borg",
+  "head_stats": {
+    "attack": 331895,
+    "defense": 72455,
+    "health": 1935739
+  },
   "hostile_name": "Borg Tactical Probe",
   "level": 26,
   "rarity": "common",
@@ -168,10 +173,5 @@
       },
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 331895,
-    "defense": 72455,
-    "health": 1935739
-  }
+  ]
 }

--- a/hostiles/borg_tactical_probe_26_battleship.json
+++ b/hostiles/borg_tactical_probe_26_battleship.json
@@ -1,9 +1,6 @@
 {
   "description": "This Hostile patrols the different systems of the universe, looking for easy prey",
-  "attack": 331895,
-  "defense": 72455,
   "group": "borg",
-  "health": 1935739,
   "hostile_name": "Borg Tactical Probe",
   "level": 26,
   "rarity": "common",
@@ -33,7 +30,6 @@
       "shield_health": 1659000
     }
   },
-  "strength": 2340089,
   "systems": [
     {
       "$ref": "systems/benes_alpha_26"
@@ -67,7 +63,6 @@
         0
       ],
       "quantity": 1,
-      "weapon_id": "K1",
       "weapon_stats": {
         "accuracy": 4875,
         "armor_pierce": 4875,
@@ -99,7 +94,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_stats": {
         "accuracy": 4875,
         "armor_pierce": 4875,
@@ -131,7 +125,6 @@
         0
       ],
       "quantity": 1,
-      "weapon_id": "K2",
       "weapon_stats": {
         "accuracy": 4875,
         "armor_pierce": 4875,
@@ -163,7 +156,6 @@
         0
       ],
       "quantity": 1,
-      "weapon_id": "E2",
       "weapon_stats": {
         "accuracy": 4875,
         "armor_pierce": 4875,
@@ -176,5 +168,10 @@
       },
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 331895,
+    "defense": 72455,
+    "health": 1935739
+  }
 }

--- a/hostiles/borg_tactical_probe_27_battleship.json
+++ b/hostiles/borg_tactical_probe_27_battleship.json
@@ -1,6 +1,11 @@
 {
   "description": "This Hostile patrols the different systems of the universe, looking for easy prey",
   "group": "borg",
+  "head_stats": {
+    "attack": 496769,
+    "defense": 93290,
+    "health": 2100803
+  },
   "hostile_name": "Borg Tactical Probe",
   "level": 27,
   "rarity": "common",
@@ -168,10 +173,5 @@
       },
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 496769,
-    "defense": 93290,
-    "health": 2100803
-  }
+  ]
 }

--- a/hostiles/borg_tactical_probe_27_battleship.json
+++ b/hostiles/borg_tactical_probe_27_battleship.json
@@ -1,9 +1,6 @@
 {
   "description": "This Hostile patrols the different systems of the universe, looking for easy prey",
-  "attack": 496769,
-  "defense": 93290,
   "group": "borg",
-  "health": 2100803,
   "hostile_name": "Borg Tactical Probe",
   "level": 27,
   "rarity": "common",
@@ -33,7 +30,6 @@
       "shield_health": 1800000
     }
   },
-  "strength": 2690862,
   "systems": [
     {
       "$ref": "systems/benes_delta_27"
@@ -67,7 +63,6 @@
         0
       ],
       "quantity": 1,
-      "weapon_id": "K1",
       "weapon_stats": {
         "accuracy": 8500,
         "armor_pierce": 8500,
@@ -99,7 +94,6 @@
         0
       ],
       "quantity": 1,
-      "weapon_id": "K2",
       "weapon_stats": {
         "accuracy": 8500,
         "armor_pierce": 8500,
@@ -131,7 +125,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_stats": {
         "accuracy": 8500,
         "armor_pierce": 8500,
@@ -163,7 +156,6 @@
         0
       ],
       "quantity": 1,
-      "weapon_id": "E2",
       "weapon_stats": {
         "accuracy": 8500,
         "armor_pierce": 8500,
@@ -176,5 +168,10 @@
       },
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 496769,
+    "defense": 93290,
+    "health": 2100803
+  }
 }

--- a/hostiles/borg_tactical_probe_28_battleship.json
+++ b/hostiles/borg_tactical_probe_28_battleship.json
@@ -1,6 +1,11 @@
 {
   "description": "This Hostile patrols the different systems of the universe, looking for easy prey",
   "group": "borg",
+  "head_stats": {
+    "attack": 718627,
+    "defense": 135240,
+    "health": 2279942
+  },
   "hostile_name": "Borg Tactical Probe",
   "level": 28,
   "rarity": "common",
@@ -168,10 +173,5 @@
       },
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 718627,
-    "defense": 135240,
-    "health": 2279942
-  }
+  ]
 }

--- a/hostiles/borg_tactical_probe_28_battleship.json
+++ b/hostiles/borg_tactical_probe_28_battleship.json
@@ -1,9 +1,6 @@
 {
   "description": "This Hostile patrols the different systems of the universe, looking for easy prey",
-  "attack": 718627,
-  "defense": 135240,
   "group": "borg",
-  "health": 2279942,
   "hostile_name": "Borg Tactical Probe",
   "level": 28,
   "rarity": "common",
@@ -33,7 +30,6 @@
       "shield_health": 1954000
     }
   },
-  "strength": 3133809,
   "systems": [
     {
       "$ref": "systems/roda_alpha_28"
@@ -67,7 +63,6 @@
         0
       ],
       "quantity": 1,
-      "weapon_id": "K1",
       "weapon_stats": {
         "accuracy": 12125,
         "armor_pierce": 12125,
@@ -99,7 +94,6 @@
         0
       ],
       "quantity": 1,
-      "weapon_id": "K2",
       "weapon_stats": {
         "accuracy": 12125,
         "armor_pierce": 12125,
@@ -131,7 +125,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_stats": {
         "accuracy": 12125,
         "armor_pierce": 12125,
@@ -163,7 +156,6 @@
         0
       ],
       "quantity": 1,
-      "weapon_id": "E2",
       "weapon_stats": {
         "accuracy": 12125,
         "armor_pierce": 12125,
@@ -176,5 +168,10 @@
       },
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 718627,
+    "defense": 135240,
+    "health": 2279942
+  }
 }

--- a/hostiles/borg_tactical_probe_29_battleship.json
+++ b/hostiles/borg_tactical_probe_29_battleship.json
@@ -1,9 +1,6 @@
 {
   "description": "This Hostile patrols the different systems of the universe, looking for easy prey",
-  "attack": 994809,
-  "defense": 175420,
   "group": "borg",
-  "health": 2375381,
   "hostile_name": "Borg Tactical Probe",
   "level": 29,
   "rarity": "common",
@@ -33,7 +30,6 @@
       "shield_health": 2036000
     }
   },
-  "strength": 3545610,
   "systems": [
     {
       "$ref": "systems/roda_gamma_29"
@@ -64,7 +60,6 @@
         0
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_stats": {
         "accuracy": 15750,
         "armor_pierce": 15750,
@@ -96,7 +91,6 @@
         0
       ],
       "quantity": 1,
-      "weapon_id": "E2",
       "weapon_stats": {
         "accuracy": 15750,
         "armor_pierce": 15750,
@@ -128,7 +122,6 @@
         0
       ],
       "quantity": 1,
-      "weapon_id": "K1",
       "weapon_stats": {
         "accuracy": 15750,
         "armor_pierce": 15750,
@@ -160,7 +153,6 @@
         0
       ],
       "quantity": 1,
-      "weapon_id": "K2",
       "weapon_stats": {
         "accuracy": 15750,
         "armor_pierce": 15750,
@@ -173,5 +165,10 @@
       },
       "weapon_type": "kinetic"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 994809,
+    "defense": 175420,
+    "health": 2375381
+  }
 }

--- a/hostiles/borg_tactical_probe_29_battleship.json
+++ b/hostiles/borg_tactical_probe_29_battleship.json
@@ -1,6 +1,11 @@
 {
   "description": "This Hostile patrols the different systems of the universe, looking for easy prey",
   "group": "borg",
+  "head_stats": {
+    "attack": 994809,
+    "defense": 175420,
+    "health": 2375381
+  },
   "hostile_name": "Borg Tactical Probe",
   "level": 29,
   "rarity": "common",
@@ -165,10 +170,5 @@
       },
       "weapon_type": "kinetic"
     }
-  ],
-  "head_stats": {
-    "attack": 994809,
-    "defense": 175420,
-    "health": 2375381
-  }
+  ]
 }

--- a/hostiles/borg_tactical_probe_30_battleship.json
+++ b/hostiles/borg_tactical_probe_30_battleship.json
@@ -1,9 +1,6 @@
 {
   "description": "This Hostile patrols the different systems of the universe, looking for easy prey",
-  "attack": 1361922,
-  "defense": 246475,
   "group": "borg",
-  "health": 2416813,
   "hostile_name": "Borg Tactical Probe",
   "level": 30,
   "rarity": "common",
@@ -33,7 +30,6 @@
       "shield_health": 2071000
     }
   },
-  "strength": 4025210,
   "systems": [
     {
       "$ref": "systems/roda_delta_30"
@@ -64,7 +60,6 @@
         0
       ],
       "quantity": 1,
-      "weapon_id": "K1",
       "weapon_stats": {
         "accuracy": 19375,
         "armor_pierce": 19375,
@@ -96,7 +91,6 @@
         0
       ],
       "quantity": 1,
-      "weapon_id": "K2",
       "weapon_stats": {
         "accuracy": 19375,
         "armor_pierce": 19375,
@@ -128,7 +122,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_stats": {
         "accuracy": 19375,
         "armor_pierce": 19375,
@@ -160,7 +153,6 @@
         0
       ],
       "quantity": 1,
-      "weapon_id": "E2",
       "weapon_stats": {
         "accuracy": 19375,
         "armor_pierce": 19375,
@@ -173,5 +165,10 @@
       },
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 1361922,
+    "defense": 246475,
+    "health": 2416813
+  }
 }

--- a/hostiles/borg_tactical_probe_30_battleship.json
+++ b/hostiles/borg_tactical_probe_30_battleship.json
@@ -1,6 +1,11 @@
 {
   "description": "This Hostile patrols the different systems of the universe, looking for easy prey",
   "group": "borg",
+  "head_stats": {
+    "attack": 1361922,
+    "defense": 246475,
+    "health": 2416813
+  },
   "hostile_name": "Borg Tactical Probe",
   "level": 30,
   "rarity": "common",
@@ -165,10 +170,5 @@
       },
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 1361922,
-    "defense": 246475,
-    "health": 2416813
-  }
+  ]
 }

--- a/hostiles/borg_tactical_probe_31_battleship.json
+++ b/hostiles/borg_tactical_probe_31_battleship.json
@@ -1,6 +1,11 @@
 {
   "description": "This Hostile patrols the different systems of the universe, looking for easy prey",
   "group": "borg",
+  "head_stats": {
+    "attack": 1890794,
+    "defense": 320350,
+    "health": 2768615
+  },
   "hostile_name": "Borg Tactical Probe",
   "level": 31,
   "rarity": "common",
@@ -165,10 +170,5 @@
       },
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 1890794,
-    "defense": 320350,
-    "health": 2768615
-  }
+  ]
 }

--- a/hostiles/borg_tactical_probe_31_battleship.json
+++ b/hostiles/borg_tactical_probe_31_battleship.json
@@ -1,9 +1,6 @@
 {
   "description": "This Hostile patrols the different systems of the universe, looking for easy prey",
-  "attack": 1890794,
-  "defense": 320350,
   "group": "borg",
-  "health": 2768615,
   "hostile_name": "Borg Tactical Probe",
   "level": 31,
   "rarity": "common",
@@ -33,7 +30,6 @@
       "shield_health": 2373000
     }
   },
-  "strength": 4979759,
   "systems": [
     {
       "$ref": "systems/corta_alpha_31"
@@ -64,7 +60,6 @@
         0
       ],
       "quantity": 1,
-      "weapon_id": "K1",
       "weapon_stats": {
         "accuracy": 23000,
         "armor_pierce": 23000,
@@ -96,7 +91,6 @@
         0
       ],
       "quantity": 1,
-      "weapon_id": "K2",
       "weapon_stats": {
         "accuracy": 23000,
         "armor_pierce": 23000,
@@ -128,7 +122,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_stats": {
         "accuracy": 23000,
         "armor_pierce": 23000,
@@ -160,7 +153,6 @@
         0
       ],
       "quantity": 1,
-      "weapon_id": "E2",
       "weapon_stats": {
         "accuracy": 23000,
         "armor_pierce": 23000,
@@ -173,5 +165,10 @@
       },
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 1890794,
+    "defense": 320350,
+    "health": 2768615
+  }
 }

--- a/hostiles/borg_tactical_probe_32_battleship.json
+++ b/hostiles/borg_tactical_probe_32_battleship.json
@@ -1,6 +1,11 @@
 {
   "description": "This Hostile patrols the different systems of the universe, looking for easy prey",
   "group": "borg",
+  "head_stats": {
+    "attack": 2599848,
+    "defense": 450130,
+    "health": 3004699
+  },
   "hostile_name": "Borg Tactical Probe",
   "level": 32,
   "rarity": "common",
@@ -165,10 +170,5 @@
       },
       "weapon_type": "kinetic"
     }
-  ],
-  "head_stats": {
-    "attack": 2599848,
-    "defense": 450130,
-    "health": 3004699
-  }
+  ]
 }

--- a/hostiles/borg_tactical_probe_32_battleship.json
+++ b/hostiles/borg_tactical_probe_32_battleship.json
@@ -1,9 +1,6 @@
 {
   "description": "This Hostile patrols the different systems of the universe, looking for easy prey",
-  "attack": 2599848,
-  "defense": 450130,
   "group": "borg",
-  "health": 3004699,
   "hostile_name": "Borg Tactical Probe",
   "level": 32,
   "rarity": "common",
@@ -33,7 +30,6 @@
       "shield_health": 2575000
     }
   },
-  "strength": 6054677,
   "systems": [
     {
       "$ref": "systems/corta_beta_32"
@@ -64,7 +60,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_stats": {
         "accuracy": 26625,
         "armor_pierce": 26625,
@@ -96,7 +91,6 @@
         0
       ],
       "quantity": 1,
-      "weapon_id": "E2",
       "weapon_stats": {
         "accuracy": 26625,
         "armor_pierce": 26625,
@@ -128,7 +122,6 @@
         0
       ],
       "quantity": 1,
-      "weapon_id": "K1",
       "weapon_stats": {
         "accuracy": 26625,
         "armor_pierce": 26625,
@@ -160,7 +153,6 @@
         0
       ],
       "quantity": 1,
-      "weapon_id": "K2",
       "weapon_stats": {
         "accuracy": 26625,
         "armor_pierce": 26625,
@@ -173,5 +165,10 @@
       },
       "weapon_type": "kinetic"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 2599848,
+    "defense": 450130,
+    "health": 3004699
+  }
 }

--- a/hostiles/borg_tactical_probe_33_battleship.json
+++ b/hostiles/borg_tactical_probe_33_battleship.json
@@ -1,9 +1,6 @@
 {
   "description": "This Hostile patrols the different systems of the universe, looking for easy prey",
-  "attack": 3522531,
-  "defense": 541315,
   "group": "borg",
-  "health": 3089287,
   "hostile_name": "Borg Tactical Probe",
   "level": 33,
   "rarity": "common",
@@ -33,7 +30,6 @@
       "shield_health": 2647000
     }
   },
-  "strength": 7153133,
   "systems": [
     {
       "$ref": "systems/corta_gamma_33"
@@ -64,7 +60,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_stats": {
         "accuracy": 30250,
         "armor_pierce": 30250,
@@ -96,7 +91,6 @@
         0
       ],
       "quantity": 1,
-      "weapon_id": "E2",
       "weapon_stats": {
         "accuracy": 30250,
         "armor_pierce": 30250,
@@ -128,7 +122,6 @@
         0
       ],
       "quantity": 1,
-      "weapon_id": "K1",
       "weapon_stats": {
         "accuracy": 30250,
         "armor_pierce": 30250,
@@ -160,7 +153,6 @@
         0
       ],
       "quantity": 1,
-      "weapon_id": "K2",
       "weapon_stats": {
         "accuracy": 30250,
         "armor_pierce": 30250,
@@ -173,5 +165,10 @@
       },
       "weapon_type": "kinetic"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 3522531,
+    "defense": 541315,
+    "health": 3089287
+  }
 }

--- a/hostiles/borg_tactical_probe_33_battleship.json
+++ b/hostiles/borg_tactical_probe_33_battleship.json
@@ -1,6 +1,11 @@
 {
   "description": "This Hostile patrols the different systems of the universe, looking for easy prey",
   "group": "borg",
+  "head_stats": {
+    "attack": 3522531,
+    "defense": 541315,
+    "health": 3089287
+  },
   "hostile_name": "Borg Tactical Probe",
   "level": 33,
   "rarity": "common",
@@ -165,10 +170,5 @@
       },
       "weapon_type": "kinetic"
     }
-  ],
-  "head_stats": {
-    "attack": 3522531,
-    "defense": 541315,
-    "health": 3089287
-  }
+  ]
 }

--- a/hostiles/boslic_slave_trader_15_explorer.json
+++ b/hostiles/boslic_slave_trader_15_explorer.json
@@ -1,9 +1,6 @@
 {
   "description": "This Hostile patrols the different systems of the universe, looking for easy prey",
-  "attack": 2338,
-  "defense": 3000,
   "group": "",
-  "health": 1275,
   "hostile_name": "Boslic Slave Trader",
   "level": 15,
   "rarity": "common",
@@ -28,7 +25,6 @@
       "shield_health": 1310
     }
   },
-  "strength": 6613,
   "systems": [
     {
       "$ref": "systems/deneva_15"
@@ -65,7 +61,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_type": "energy"
     },
     {
@@ -84,8 +79,12 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E2",
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 2338,
+    "defense": 3000,
+    "health": 1275
+  }
 }

--- a/hostiles/boslic_slave_trader_15_explorer.json
+++ b/hostiles/boslic_slave_trader_15_explorer.json
@@ -1,6 +1,11 @@
 {
   "description": "This Hostile patrols the different systems of the universe, looking for easy prey",
   "group": "",
+  "head_stats": {
+    "attack": 2338,
+    "defense": 3000,
+    "health": 1275
+  },
   "hostile_name": "Boslic Slave Trader",
   "level": 15,
   "rarity": "common",
@@ -81,10 +86,5 @@
       "quantity": 1,
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 2338,
-    "defense": 3000,
-    "health": 1275
-  }
+  ]
 }

--- a/hostiles/boslic_slave_trader_17_explorer.json
+++ b/hostiles/boslic_slave_trader_17_explorer.json
@@ -1,6 +1,11 @@
 {
   "description": "This Hostile patrols the different systems of the universe, looking for easy prey",
   "group": "",
+  "head_stats": {
+    "attack": 4491,
+    "defense": 4585,
+    "health": 2220
+  },
   "hostile_name": "Boslic Slave Trader",
   "level": 17,
   "rarity": "common",
@@ -126,10 +131,5 @@
       "quantity": 1,
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 4491,
-    "defense": 4585,
-    "health": 2220
-  }
+  ]
 }

--- a/hostiles/boslic_slave_trader_17_explorer.json
+++ b/hostiles/boslic_slave_trader_17_explorer.json
@@ -1,9 +1,6 @@
 {
   "description": "This Hostile patrols the different systems of the universe, looking for easy prey",
-  "attack": 4491,
-  "defense": 4585,
   "group": "",
-  "health": 2220,
   "hostile_name": "Boslic Slave Trader",
   "level": 17,
   "rarity": "common",
@@ -28,7 +25,6 @@
       "shield_health": 2280
     }
   },
-  "strength": 11296,
   "systems": [
     {
       "$ref": "systems/eizeb_16"
@@ -92,7 +88,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_type": "energy"
     },
     {
@@ -111,7 +106,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E2",
       "weapon_type": "energy"
     },
     {
@@ -130,8 +124,12 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E3",
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 4491,
+    "defense": 4585,
+    "health": 2220
+  }
 }

--- a/hostiles/boslic_slave_trader_18_explorer.json
+++ b/hostiles/boslic_slave_trader_18_explorer.json
@@ -1,9 +1,6 @@
 {
   "description": "This Hostile patrols the different systems of the universe, looking for easy prey",
-  "attack": 5255,
-  "defense": 5165,
   "group": "",
-  "health": 2485,
   "hostile_name": "Boslic Slave Trader",
   "level": 18,
   "rarity": "common",
@@ -28,7 +25,6 @@
       "shield_health": 2550
     }
   },
-  "strength": 12905,
   "systems": [
     {
       "$ref": "systems/freyda_17"
@@ -92,7 +88,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_type": "energy"
     },
     {
@@ -111,7 +106,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E2",
       "weapon_type": "energy"
     },
     {
@@ -130,8 +124,12 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E3",
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 5255,
+    "defense": 5165,
+    "health": 2485
+  }
 }

--- a/hostiles/boslic_slave_trader_18_explorer.json
+++ b/hostiles/boslic_slave_trader_18_explorer.json
@@ -1,6 +1,11 @@
 {
   "description": "This Hostile patrols the different systems of the universe, looking for easy prey",
   "group": "",
+  "head_stats": {
+    "attack": 5255,
+    "defense": 5165,
+    "health": 2485
+  },
   "hostile_name": "Boslic Slave Trader",
   "level": 18,
   "rarity": "common",
@@ -126,10 +131,5 @@
       "quantity": 1,
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 5255,
-    "defense": 5165,
-    "health": 2485
-  }
+  ]
 }

--- a/hostiles/corvallen_rebel_38_battleship.json
+++ b/hostiles/corvallen_rebel_38_battleship.json
@@ -1,9 +1,6 @@
 {
   "description": "This Hostile patrols the different systems of the universe, looking for easy prey",
-  "attack": 608342,
-  "defense": 580865,
   "group": "",
-  "health": 208170,
   "hostile_name": "Corvallen Rebel",
   "level": 38,
   "rarity": "common",
@@ -28,7 +25,6 @@
       "shield_health": 178400
     }
   },
-  "strength": 1397377,
   "systems": [
     {
       "$ref": "systems/lanaj_37"
@@ -89,7 +85,6 @@
         1
       ],
       "quantity": 2,
-      "weapon_id": "E1",
       "weapon_stats": {
         "accuracy": 19362,
         "armor_pierce": 19362,
@@ -121,7 +116,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "K1",
       "weapon_stats": {
         "accuracy": 19362,
         "armor_pierce": 19362,
@@ -153,8 +147,12 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E2",
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 608342,
+    "defense": 580865,
+    "health": 208170
+  }
 }

--- a/hostiles/corvallen_rebel_38_battleship.json
+++ b/hostiles/corvallen_rebel_38_battleship.json
@@ -1,6 +1,11 @@
 {
   "description": "This Hostile patrols the different systems of the universe, looking for easy prey",
   "group": "",
+  "head_stats": {
+    "attack": 608342,
+    "defense": 580865,
+    "health": 208170
+  },
   "hostile_name": "Corvallen Rebel",
   "level": 38,
   "rarity": "common",
@@ -149,10 +154,5 @@
       "quantity": 1,
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 608342,
-    "defense": 580865,
-    "health": 208170
-  }
+  ]
 }

--- a/hostiles/doomsday_worm_27_battleship.json
+++ b/hostiles/doomsday_worm_27_battleship.json
@@ -1,6 +1,11 @@
 {
   "description": "Doctor McCoy's studies suggest that these parasitic beings are discarded from the carapace of the Doomsday creature. Feeding on the planetary rubble left in the creature's wake of destruction, the Doomsday Worms roam the galaxy in search of their next meal.",
   "group": "",
+  "head_stats": {
+    "attack": 50440,
+    "defense": 52500,
+    "health": 28875
+  },
   "hostile_name": "Doomsday Worm",
   "level": 27,
   "rarity": "common",
@@ -105,10 +110,5 @@
       "quantity": 1,
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 50440,
-    "defense": 52500,
-    "health": 28875
-  }
+  ]
 }

--- a/hostiles/doomsday_worm_27_battleship.json
+++ b/hostiles/doomsday_worm_27_battleship.json
@@ -1,9 +1,6 @@
 {
   "description": "Doctor McCoy's studies suggest that these parasitic beings are discarded from the carapace of the Doomsday creature. Feeding on the planetary rubble left in the creature's wake of destruction, the Doomsday Worms roam the galaxy in search of their next meal.",
-  "attack": 50440,
-  "defense": 52500,
   "group": "",
-  "health": 28875,
   "hostile_name": "Doomsday Worm",
   "level": 27,
   "rarity": "common",
@@ -28,7 +25,6 @@
       "shield_health": 24000
     }
   },
-  "strength": 131815,
   "systems": [
     {
       "$ref": "systems/elya_27"
@@ -65,7 +61,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "K1",
       "weapon_type": "kinetic"
     },
     {
@@ -87,7 +82,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_type": "energy"
     },
     {
@@ -109,8 +103,12 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E2",
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 50440,
+    "defense": 52500,
+    "health": 28875
+  }
 }

--- a/hostiles/doomsday_worm_27_explorer.json
+++ b/hostiles/doomsday_worm_27_explorer.json
@@ -1,9 +1,6 @@
 {
   "description": "Doctor McCoy's studies suggest that these parasitic beings are discarded from the carapace of the Doomsday creature. Feeding on the planetary rubble left in the creature's wake of destruction, the Doomsday Worms roam the galaxy in search of their next meal.",
-  "attack": 50440,
-  "defense": 52500,
   "group": "",
-  "health": 30525,
   "hostile_name": "Doomsday Worm",
   "level": 27,
   "rarity": "common",
@@ -28,7 +25,6 @@
       "shield_health": 31000
     }
   },
-  "strength": 133465,
   "systems": [
     {
       "$ref": "systems/elya_27"
@@ -65,7 +61,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "K1",
       "weapon_type": "kinetic"
     },
     {
@@ -87,7 +82,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_type": "energy"
     },
     {
@@ -109,8 +103,12 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E2",
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 50440,
+    "defense": 52500,
+    "health": 30525
+  }
 }

--- a/hostiles/doomsday_worm_27_explorer.json
+++ b/hostiles/doomsday_worm_27_explorer.json
@@ -1,6 +1,11 @@
 {
   "description": "Doctor McCoy's studies suggest that these parasitic beings are discarded from the carapace of the Doomsday creature. Feeding on the planetary rubble left in the creature's wake of destruction, the Doomsday Worms roam the galaxy in search of their next meal.",
   "group": "",
+  "head_stats": {
+    "attack": 50440,
+    "defense": 52500,
+    "health": 30525
+  },
   "hostile_name": "Doomsday Worm",
   "level": 27,
   "rarity": "common",
@@ -105,10 +110,5 @@
       "quantity": 1,
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 50440,
-    "defense": 52500,
-    "health": 30525
-  }
+  ]
 }

--- a/hostiles/doomsday_worm_27_interceptor.json
+++ b/hostiles/doomsday_worm_27_interceptor.json
@@ -1,6 +1,11 @@
 {
   "description": "Doctor McCoy's studies suggest that these parasitic beings are discarded from the carapace of the Doomsday creature. Feeding on the planetary rubble left in the creature's wake of destruction, the Doomsday Worms roam the galaxy in search of their next meal.",
   "group": "",
+  "head_stats": {
+    "attack": 52280,
+    "defense": 52500,
+    "health": 26400
+  },
   "hostile_name": "Doomsday Worm",
   "level": 27,
   "rarity": "common",
@@ -105,10 +110,5 @@
       "quantity": 1,
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 52280,
-    "defense": 52500,
-    "health": 26400
-  }
+  ]
 }

--- a/hostiles/doomsday_worm_27_interceptor.json
+++ b/hostiles/doomsday_worm_27_interceptor.json
@@ -1,9 +1,6 @@
 {
   "description": "Doctor McCoy's studies suggest that these parasitic beings are discarded from the carapace of the Doomsday creature. Feeding on the planetary rubble left in the creature's wake of destruction, the Doomsday Worms roam the galaxy in search of their next meal.",
-  "attack": 52280,
-  "defense": 52500,
   "group": "",
-  "health": 26400,
   "hostile_name": "Doomsday Worm",
   "level": 27,
   "rarity": "common",
@@ -28,7 +25,6 @@
       "shield_health": 26000
     }
   },
-  "strength": 131180,
   "systems": [
     {
       "$ref": "systems/elya_27"
@@ -65,7 +61,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "K1",
       "weapon_type": "kinetic"
     },
     {
@@ -87,7 +82,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "K2",
       "weapon_type": "kinetic"
     },
     {
@@ -109,8 +103,12 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 52280,
+    "defense": 52500,
+    "health": 26400
+  }
 }

--- a/hostiles/doomsday_worm_32_battleship.json
+++ b/hostiles/doomsday_worm_32_battleship.json
@@ -1,9 +1,6 @@
 {
   "description": "Doctor McCoy's studies suggest that these parasitic beings are discarded from the carapace of the Doomsday creature. Feeding on the planetary rubble left in the creature's wake of destruction, the Doomsday Worms roam the galaxy in search of their next meal.",
-  "attack": 185807,
-  "defense": 176250,
   "group": "",
-  "health": 60375,
   "hostile_name": "Doomsday Worm",
   "level": 32,
   "rarity": "common",
@@ -28,7 +25,6 @@
       "shield_health": 51000
     }
   },
-  "strength": 422432,
   "systems": [
     {
       "$ref": "systems/etalon_32"
@@ -59,7 +55,6 @@
         0
       ],
       "quantity": 1,
-      "weapon_id": "K1",
       "weapon_type": "kinetic"
     },
     {
@@ -78,7 +73,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_type": "energy"
     },
     {
@@ -97,8 +91,12 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E2",
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 185807,
+    "defense": 176250,
+    "health": 60375
+  }
 }

--- a/hostiles/doomsday_worm_32_battleship.json
+++ b/hostiles/doomsday_worm_32_battleship.json
@@ -1,6 +1,11 @@
 {
   "description": "Doctor McCoy's studies suggest that these parasitic beings are discarded from the carapace of the Doomsday creature. Feeding on the planetary rubble left in the creature's wake of destruction, the Doomsday Worms roam the galaxy in search of their next meal.",
   "group": "",
+  "head_stats": {
+    "attack": 185807,
+    "defense": 176250,
+    "health": 60375
+  },
   "hostile_name": "Doomsday Worm",
   "level": 32,
   "rarity": "common",
@@ -93,10 +98,5 @@
       "quantity": 1,
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 185807,
-    "defense": 176250,
-    "health": 60375
-  }
+  ]
 }

--- a/hostiles/doomsday_worm_32_explorer.json
+++ b/hostiles/doomsday_worm_32_explorer.json
@@ -1,6 +1,11 @@
 {
   "description": "Doctor McCoy's studies suggest that these parasitic beings are discarded from the carapace of the Doomsday creature. Feeding on the planetary rubble left in the creature's wake of destruction, the Doomsday Worms roam the galaxy in search of their next meal.",
   "group": "",
+  "head_stats": {
+    "attack": 178601,
+    "defense": 176250,
+    "health": 63825
+  },
   "hostile_name": "Doomsday Worm",
   "level": 32,
   "rarity": "common",
@@ -93,10 +98,5 @@
       "quantity": 1,
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 178601,
-    "defense": 176250,
-    "health": 63825
-  }
+  ]
 }

--- a/hostiles/doomsday_worm_32_explorer.json
+++ b/hostiles/doomsday_worm_32_explorer.json
@@ -1,9 +1,6 @@
 {
   "description": "Doctor McCoy's studies suggest that these parasitic beings are discarded from the carapace of the Doomsday creature. Feeding on the planetary rubble left in the creature's wake of destruction, the Doomsday Worms roam the galaxy in search of their next meal.",
-  "attack": 178601,
-  "defense": 176250,
   "group": "",
-  "health": 63825,
   "hostile_name": "Doomsday Worm",
   "level": 32,
   "rarity": "common",
@@ -28,7 +25,6 @@
       "shield_health": 65000
     }
   },
-  "strength": 418676,
   "systems": [
     {
       "$ref": "systems/etalon_32"
@@ -59,7 +55,6 @@
         0
       ],
       "quantity": 1,
-      "weapon_id": "K1",
       "weapon_type": "kinetic"
     },
     {
@@ -78,7 +73,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_type": "energy"
     },
     {
@@ -97,8 +91,12 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E2",
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 178601,
+    "defense": 176250,
+    "health": 63825
+  }
 }

--- a/hostiles/doomsday_worm_32_interceptor.json
+++ b/hostiles/doomsday_worm_32_interceptor.json
@@ -1,9 +1,6 @@
 {
   "description": "Doctor McCoy's studies suggest that these parasitic beings are discarded from the carapace of the Doomsday creature. Feeding on the planetary rubble left in the creature's wake of destruction, the Doomsday Worms roam the galaxy in search of their next meal.",
-  "attack": 193014,
-  "defense": 176250,
   "group": "",
-  "health": 55200,
   "hostile_name": "Doomsday Worm",
   "level": 32,
   "rarity": "common",
@@ -28,7 +25,6 @@
       "shield_health": 55000
     }
   },
-  "strength": 424464,
   "systems": [
     {
       "$ref": "systems/etalon_32"
@@ -59,7 +55,6 @@
         0
       ],
       "quantity": 1,
-      "weapon_id": "K1",
       "weapon_type": "kinetic"
     },
     {
@@ -78,7 +73,6 @@
         0
       ],
       "quantity": 1,
-      "weapon_id": "K2",
       "weapon_type": "kinetic"
     },
     {
@@ -97,8 +91,12 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 193014,
+    "defense": 176250,
+    "health": 55200
+  }
 }

--- a/hostiles/doomsday_worm_32_interceptor.json
+++ b/hostiles/doomsday_worm_32_interceptor.json
@@ -1,6 +1,11 @@
 {
   "description": "Doctor McCoy's studies suggest that these parasitic beings are discarded from the carapace of the Doomsday creature. Feeding on the planetary rubble left in the creature's wake of destruction, the Doomsday Worms roam the galaxy in search of their next meal.",
   "group": "",
+  "head_stats": {
+    "attack": 193014,
+    "defense": 176250,
+    "health": 55200
+  },
   "hostile_name": "Doomsday Worm",
   "level": 32,
   "rarity": "common",
@@ -93,10 +98,5 @@
       "quantity": 1,
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 193014,
-    "defense": 176250,
-    "health": 55200
-  }
+  ]
 }

--- a/hostiles/doomsday_worm_35_battleship.json
+++ b/hostiles/doomsday_worm_35_battleship.json
@@ -1,9 +1,6 @@
 {
   "description": "Doctor McCoy's studies suggest that these parasitic beings are discarded from the carapace of the Doomsday creature. Feeding on the planetary rubble left in the creature's wake of destruction, the Doomsday Worms roam the galaxy in search of their next meal.",
-  "attack": 331485,
-  "defense": 313165,
   "group": "",
-  "health": 109650,
   "hostile_name": "Doomsday Worm",
   "level": 35,
   "rarity": "common",
@@ -28,7 +25,6 @@
       "shield_health": 93000
     }
   },
-  "strength": 754300,
   "systems": [
     {
       "$ref": "systems/kullendi_34"
@@ -62,7 +58,6 @@
         0
       ],
       "quantity": 1,
-      "weapon_id": "K1",
       "weapon_type": "kinetic"
     },
     {
@@ -81,7 +76,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_type": "energy"
     },
     {
@@ -100,8 +94,12 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E2",
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 331485,
+    "defense": 313165,
+    "health": 109650
+  }
 }

--- a/hostiles/doomsday_worm_35_battleship.json
+++ b/hostiles/doomsday_worm_35_battleship.json
@@ -1,6 +1,11 @@
 {
   "description": "Doctor McCoy's studies suggest that these parasitic beings are discarded from the carapace of the Doomsday creature. Feeding on the planetary rubble left in the creature's wake of destruction, the Doomsday Worms roam the galaxy in search of their next meal.",
   "group": "",
+  "head_stats": {
+    "attack": 331485,
+    "defense": 313165,
+    "health": 109650
+  },
   "hostile_name": "Doomsday Worm",
   "level": 35,
   "rarity": "common",
@@ -96,10 +101,5 @@
       "quantity": 1,
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 331485,
-    "defense": 313165,
-    "health": 109650
-  }
+  ]
 }

--- a/hostiles/doomsday_worm_35_explorer.json
+++ b/hostiles/doomsday_worm_35_explorer.json
@@ -1,9 +1,6 @@
 {
   "description": "Doctor McCoy's studies suggest that these parasitic beings are discarded from the carapace of the Doomsday creature. Feeding on the planetary rubble left in the creature's wake of destruction, the Doomsday Worms roam the galaxy in search of their next meal.",
-  "attack": 318596,
-  "defense": 313165,
   "group": "",
-  "health": 115915,
   "hostile_name": "Doomsday Worm",
   "level": 35,
   "rarity": "common",
@@ -28,7 +25,6 @@
       "shield_health": 119000
     }
   },
-  "strength": 747676,
   "systems": [
     {
       "$ref": "systems/kullendi_34"
@@ -62,7 +58,6 @@
         0
       ],
       "quantity": 1,
-      "weapon_id": "K1",
       "weapon_type": "kinetic"
     },
     {
@@ -81,7 +76,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_type": "energy"
     },
     {
@@ -100,8 +94,12 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E2",
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 318596,
+    "defense": 313165,
+    "health": 115915
+  }
 }

--- a/hostiles/doomsday_worm_35_explorer.json
+++ b/hostiles/doomsday_worm_35_explorer.json
@@ -1,6 +1,11 @@
 {
   "description": "Doctor McCoy's studies suggest that these parasitic beings are discarded from the carapace of the Doomsday creature. Feeding on the planetary rubble left in the creature's wake of destruction, the Doomsday Worms roam the galaxy in search of their next meal.",
   "group": "",
+  "head_stats": {
+    "attack": 318596,
+    "defense": 313165,
+    "health": 115915
+  },
   "hostile_name": "Doomsday Worm",
   "level": 35,
   "rarity": "common",
@@ -96,10 +101,5 @@
       "quantity": 1,
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 318596,
-    "defense": 313165,
-    "health": 115915
-  }
+  ]
 }

--- a/hostiles/doomsday_worm_35_interceptor.json
+++ b/hostiles/doomsday_worm_35_interceptor.json
@@ -1,9 +1,6 @@
 {
   "description": "Doctor McCoy's studies suggest that these parasitic beings are discarded from the carapace of the Doomsday creature. Feeding on the planetary rubble left in the creature's wake of destruction, the Doomsday Worms roam the galaxy in search of their next meal.",
-  "attack": 344373,
-  "defense": 313165,
   "group": "",
-  "health": 100250,
   "hostile_name": "Doomsday Worm",
   "level": 35,
   "rarity": "common",
@@ -28,7 +25,6 @@
       "shield_health": 100000
     }
   },
-  "strength": 757788,
   "systems": [
     {
       "$ref": "systems/kullendi_34"
@@ -62,7 +58,6 @@
         0
       ],
       "quantity": 1,
-      "weapon_id": "K1",
       "weapon_type": "kinetic"
     },
     {
@@ -81,7 +76,6 @@
         0
       ],
       "quantity": 1,
-      "weapon_id": "K2",
       "weapon_type": "kinetic"
     },
     {
@@ -100,8 +94,12 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 344373,
+    "defense": 313165,
+    "health": 100250
+  }
 }

--- a/hostiles/doomsday_worm_35_interceptor.json
+++ b/hostiles/doomsday_worm_35_interceptor.json
@@ -1,6 +1,11 @@
 {
   "description": "Doctor McCoy's studies suggest that these parasitic beings are discarded from the carapace of the Doomsday creature. Feeding on the planetary rubble left in the creature's wake of destruction, the Doomsday Worms roam the galaxy in search of their next meal.",
   "group": "",
+  "head_stats": {
+    "attack": 344373,
+    "defense": 313165,
+    "health": 100250
+  },
   "hostile_name": "Doomsday Worm",
   "level": 35,
   "rarity": "common",
@@ -96,10 +101,5 @@
       "quantity": 1,
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 344373,
-    "defense": 313165,
-    "health": 100250
-  }
+  ]
 }

--- a/hostiles/doomsday_worm_37_battleship.json
+++ b/hostiles/doomsday_worm_37_battleship.json
@@ -1,9 +1,6 @@
 {
   "description": "Doctor McCoy's studies suggest that these parasitic beings are discarded from the carapace of the Doomsday creature. Feeding on the planetary rubble left in the creature's wake of destruction, the Doomsday Worms roam the galaxy in search of their next meal.",
-  "attack": 495017,
-  "defense": 471235,
   "group": "",
-  "health": 167780,
   "hostile_name": "Doomsday Worm",
   "level": 37,
   "rarity": "common",
@@ -28,7 +25,6 @@
       "shield_health": 143000
     }
   },
-  "strength": 1134032,
   "systems": [
     {
       "$ref": "systems/nya_tuum_36"
@@ -59,7 +55,6 @@
         0
       ],
       "quantity": 1,
-      "weapon_id": "K1",
       "weapon_type": "kinetic"
     },
     {
@@ -78,7 +73,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_type": "energy"
     },
     {
@@ -97,8 +91,12 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E2",
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 495017,
+    "defense": 471235,
+    "health": 167780
+  }
 }

--- a/hostiles/doomsday_worm_37_battleship.json
+++ b/hostiles/doomsday_worm_37_battleship.json
@@ -1,6 +1,11 @@
 {
   "description": "Doctor McCoy's studies suggest that these parasitic beings are discarded from the carapace of the Doomsday creature. Feeding on the planetary rubble left in the creature's wake of destruction, the Doomsday Worms roam the galaxy in search of their next meal.",
   "group": "",
+  "head_stats": {
+    "attack": 495017,
+    "defense": 471235,
+    "health": 167780
+  },
   "hostile_name": "Doomsday Worm",
   "level": 37,
   "rarity": "common",
@@ -93,10 +98,5 @@
       "quantity": 1,
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 495017,
-    "defense": 471235,
-    "health": 167780
-  }
+  ]
 }

--- a/hostiles/doomsday_worm_37_explorer.json
+++ b/hostiles/doomsday_worm_37_explorer.json
@@ -1,6 +1,11 @@
 {
   "description": "Doctor McCoy's studies suggest that these parasitic beings are discarded from the carapace of the Doomsday creature. Feeding on the planetary rubble left in the creature's wake of destruction, the Doomsday Worms roam the galaxy in search of their next meal.",
   "group": "",
+  "head_stats": {
+    "attack": 475859,
+    "defense": 471235,
+    "health": 177365
+  },
   "hostile_name": "Doomsday Worm",
   "level": 37,
   "rarity": "common",
@@ -93,10 +98,5 @@
       "quantity": 1,
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 475859,
-    "defense": 471235,
-    "health": 177365
-  }
+  ]
 }

--- a/hostiles/doomsday_worm_37_explorer.json
+++ b/hostiles/doomsday_worm_37_explorer.json
@@ -1,9 +1,6 @@
 {
   "description": "Doctor McCoy's studies suggest that these parasitic beings are discarded from the carapace of the Doomsday creature. Feeding on the planetary rubble left in the creature's wake of destruction, the Doomsday Worms roam the galaxy in search of their next meal.",
-  "attack": 475859,
-  "defense": 471235,
   "group": "",
-  "health": 177365,
   "hostile_name": "Doomsday Worm",
   "level": 37,
   "rarity": "common",
@@ -28,7 +25,6 @@
       "shield_health": 182000
     }
   },
-  "strength": 1124459,
   "systems": [
     {
       "$ref": "systems/nya_tuum_36"
@@ -59,7 +55,6 @@
         0
       ],
       "quantity": 1,
-      "weapon_id": "K1",
       "weapon_type": "kinetic"
     },
     {
@@ -78,7 +73,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_type": "energy"
     },
     {
@@ -97,8 +91,12 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E2",
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 475859,
+    "defense": 471235,
+    "health": 177365
+  }
 }

--- a/hostiles/doomsday_worm_37_interceptor.json
+++ b/hostiles/doomsday_worm_37_interceptor.json
@@ -1,9 +1,6 @@
 {
   "description": "Doctor McCoy's studies suggest that these parasitic beings are discarded from the carapace of the Doomsday creature. Feeding on the planetary rubble left in the creature's wake of destruction, the Doomsday Worms roam the galaxy in search of their next meal.",
-  "attack": 514175,
-  "defense": 471235,
   "group": "",
-  "health": 153400,
   "hostile_name": "Doomsday Worm",
   "level": 37,
   "rarity": "common",
@@ -28,7 +25,6 @@
       "shield_health": 153000
     }
   },
-  "strength": 1138810,
   "systems": [
     {
       "$ref": "systems/nya_tuum_36"
@@ -59,7 +55,6 @@
         0
       ],
       "quantity": 1,
-      "weapon_id": "K1",
       "weapon_type": "kinetic"
     },
     {
@@ -78,7 +73,6 @@
         0
       ],
       "quantity": 1,
-      "weapon_id": "K2",
       "weapon_type": "kinetic"
     },
     {
@@ -97,8 +91,12 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 514175,
+    "defense": 471235,
+    "health": 153400
+  }
 }

--- a/hostiles/doomsday_worm_37_interceptor.json
+++ b/hostiles/doomsday_worm_37_interceptor.json
@@ -1,6 +1,11 @@
 {
   "description": "Doctor McCoy's studies suggest that these parasitic beings are discarded from the carapace of the Doomsday creature. Feeding on the planetary rubble left in the creature's wake of destruction, the Doomsday Worms roam the galaxy in search of their next meal.",
   "group": "",
+  "head_stats": {
+    "attack": 514175,
+    "defense": 471235,
+    "health": 153400
+  },
   "hostile_name": "Doomsday Worm",
   "level": 37,
   "rarity": "common",
@@ -93,10 +98,5 @@
       "quantity": 1,
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 514175,
-    "defense": 471235,
-    "health": 153400
-  }
+  ]
 }

--- a/hostiles/doomsday_worm_38_battleship.json
+++ b/hostiles/doomsday_worm_38_battleship.json
@@ -1,9 +1,6 @@
 {
   "description": "Doctor McCoy's studies suggest that these parasitic beings are discarded from the carapace of the Doomsday creature. Feeding on the planetary rubble left in the creature's wake of destruction, the Doomsday Worms roam the galaxy in search of their next meal.",
-  "attack": 1067799,
-  "defense": 423115,
   "group": "",
-  "health": 2051192,
   "hostile_name": "Doomsday Worm",
   "level": 38,
   "rarity": "common",
@@ -28,7 +25,6 @@
       "shield_health": 1758000
     }
   },
-  "strength": 3542106,
   "systems": [
     {
       "$ref": "systems/mal_tahn_38"
@@ -56,7 +52,6 @@
         0
       ],
       "quantity": 1,
-      "weapon_id": "K1",
       "weapon_type": "kinetic"
     },
     {
@@ -75,7 +70,6 @@
         3
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_type": "energy"
     },
     {
@@ -94,8 +88,12 @@
         3
       ],
       "quantity": 1,
-      "weapon_id": "E2",
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 1067799,
+    "defense": 423115,
+    "health": 2051192
+  }
 }

--- a/hostiles/doomsday_worm_38_battleship.json
+++ b/hostiles/doomsday_worm_38_battleship.json
@@ -1,6 +1,11 @@
 {
   "description": "Doctor McCoy's studies suggest that these parasitic beings are discarded from the carapace of the Doomsday creature. Feeding on the planetary rubble left in the creature's wake of destruction, the Doomsday Worms roam the galaxy in search of their next meal.",
   "group": "",
+  "head_stats": {
+    "attack": 1067799,
+    "defense": 423115,
+    "health": 2051192
+  },
   "hostile_name": "Doomsday Worm",
   "level": 38,
   "rarity": "common",
@@ -90,10 +95,5 @@
       "quantity": 1,
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 1067799,
-    "defense": 423115,
-    "health": 2051192
-  }
+  ]
 }

--- a/hostiles/doomsday_worm_38_explorer.json
+++ b/hostiles/doomsday_worm_38_explorer.json
@@ -1,9 +1,6 @@
 {
   "description": "Doctor McCoy's studies suggest that these parasitic beings are discarded from the carapace of the Doomsday creature. Feeding on the planetary rubble left in the creature's wake of destruction, the Doomsday Worms roam the galaxy in search of their next meal.",
-  "attack": 1157573,
-  "defense": 564065,
   "group": "",
-  "health": 1876931,
   "hostile_name": "Doomsday Worm",
   "level": 38,
   "rarity": "common",
@@ -28,7 +25,6 @@
       "shield_health": 2102000
     }
   },
-  "strength": 3598569,
   "systems": [
     {
       "$ref": "systems/mal_tahn_38"
@@ -56,7 +52,6 @@
         0
       ],
       "quantity": 1,
-      "weapon_id": "K1",
       "weapon_type": "kinetic"
     },
     {
@@ -75,7 +70,6 @@
         3
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_type": "energy"
     },
     {
@@ -94,8 +88,12 @@
         3
       ],
       "quantity": 1,
-      "weapon_id": "E2",
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 1157573,
+    "defense": 564065,
+    "health": 1876931
+  }
 }

--- a/hostiles/doomsday_worm_38_explorer.json
+++ b/hostiles/doomsday_worm_38_explorer.json
@@ -1,6 +1,11 @@
 {
   "description": "Doctor McCoy's studies suggest that these parasitic beings are discarded from the carapace of the Doomsday creature. Feeding on the planetary rubble left in the creature's wake of destruction, the Doomsday Worms roam the galaxy in search of their next meal.",
   "group": "",
+  "head_stats": {
+    "attack": 1157573,
+    "defense": 564065,
+    "health": 1876931
+  },
   "hostile_name": "Doomsday Worm",
   "level": 38,
   "rarity": "common",
@@ -90,10 +95,5 @@
       "quantity": 1,
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 1157573,
-    "defense": 564065,
-    "health": 1876931
-  }
+  ]
 }

--- a/hostiles/doomsday_worm_38_interceptor.json
+++ b/hostiles/doomsday_worm_38_interceptor.json
@@ -1,9 +1,6 @@
 {
   "description": "Doctor McCoy's studies suggest that these parasitic beings are discarded from the carapace of the Doomsday creature. Feeding on the planetary rubble left in the creature's wake of destruction, the Doomsday Worms roam the galaxy in search of their next meal.",
-  "attack": 1001818,
-  "defense": 558065,
   "group": "",
-  "health": 1753286,
   "hostile_name": "Doomsday Worm",
   "level": 38,
   "rarity": "common",
@@ -28,7 +25,6 @@
       "shield_health": 1753000
     }
   },
-  "strength": 3313169,
   "systems": [
     {
       "$ref": "systems/mal_tahn_38"
@@ -56,7 +52,6 @@
         0
       ],
       "quantity": 1,
-      "weapon_id": "K1",
       "weapon_type": "kinetic"
     },
     {
@@ -75,7 +70,6 @@
         0
       ],
       "quantity": 1,
-      "weapon_id": "K2",
       "weapon_type": "kinetic"
     },
     {
@@ -94,8 +88,12 @@
         5
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 1001818,
+    "defense": 558065,
+    "health": 1753286
+  }
 }

--- a/hostiles/doomsday_worm_38_interceptor.json
+++ b/hostiles/doomsday_worm_38_interceptor.json
@@ -1,6 +1,11 @@
 {
   "description": "Doctor McCoy's studies suggest that these parasitic beings are discarded from the carapace of the Doomsday creature. Feeding on the planetary rubble left in the creature's wake of destruction, the Doomsday Worms roam the galaxy in search of their next meal.",
   "group": "",
+  "head_stats": {
+    "attack": 1001818,
+    "defense": 558065,
+    "health": 1753286
+  },
   "hostile_name": "Doomsday Worm",
   "level": 38,
   "rarity": "common",
@@ -90,10 +95,5 @@
       "quantity": 1,
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 1001818,
-    "defense": 558065,
-    "health": 1753286
-  }
+  ]
 }

--- a/hostiles/doomsday_worm_39_battleship.json
+++ b/hostiles/doomsday_worm_39_battleship.json
@@ -1,6 +1,11 @@
 {
   "description": "Doctor McCoy's studies suggest that these parasitic beings are discarded from the carapace of the Doomsday creature. Feeding on the planetary rubble left in the creature's wake of destruction, the Doomsday Worms roam the galaxy in search of their next meal.",
   "group": "",
+  "head_stats": {
+    "attack": 1315385,
+    "defense": 521230,
+    "health": 2526810
+  },
   "hostile_name": "Doomsday Worm",
   "level": 39,
   "rarity": "common",
@@ -93,10 +98,5 @@
       "quantity": 1,
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 1315385,
-    "defense": 521230,
-    "health": 2526810
-  }
+  ]
 }

--- a/hostiles/doomsday_worm_39_battleship.json
+++ b/hostiles/doomsday_worm_39_battleship.json
@@ -1,9 +1,6 @@
 {
   "description": "Doctor McCoy's studies suggest that these parasitic beings are discarded from the carapace of the Doomsday creature. Feeding on the planetary rubble left in the creature's wake of destruction, the Doomsday Worms roam the galaxy in search of their next meal.",
-  "attack": 1315385,
-  "defense": 521230,
   "group": "",
-  "health": 2526810,
   "hostile_name": "Doomsday Worm",
   "level": 39,
   "rarity": "common",
@@ -28,7 +25,6 @@
       "shield_health": 2165000
     }
   },
-  "strength": 4363425,
   "systems": [
     {
       "$ref": "systems/mal_tahn_38"
@@ -59,7 +55,6 @@
         0
       ],
       "quantity": 1,
-      "weapon_id": "K1",
       "weapon_type": "kinetic"
     },
     {
@@ -78,7 +73,6 @@
         3
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_type": "energy"
     },
     {
@@ -97,8 +91,12 @@
         3
       ],
       "quantity": 1,
-      "weapon_id": "E2",
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 1315385,
+    "defense": 521230,
+    "health": 2526810
+  }
 }

--- a/hostiles/doomsday_worm_39_explorer.json
+++ b/hostiles/doomsday_worm_39_explorer.json
@@ -1,9 +1,6 @@
 {
   "description": "Doctor McCoy's studies suggest that these parasitic beings are discarded from the carapace of the Doomsday creature. Feeding on the planetary rubble left in the creature's wake of destruction, the Doomsday Worms roam the galaxy in search of their next meal.",
-  "attack": 1412386,
-  "defense": 683390,
   "group": "",
-  "health": 2244112,
   "hostile_name": "Doomsday Worm",
   "level": 39,
   "rarity": "common",
@@ -28,7 +25,6 @@
       "shield_health": 2513000
     }
   },
-  "strength": 4339888,
   "systems": [
     {
       "$ref": "systems/mal_tahn_38"
@@ -59,7 +55,6 @@
         0
       ],
       "quantity": 1,
-      "weapon_id": "K1",
       "weapon_type": "kinetic"
     },
     {
@@ -78,7 +73,6 @@
         3
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_type": "energy"
     },
     {
@@ -97,8 +91,12 @@
         3
       ],
       "quantity": 1,
-      "weapon_id": "E2",
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 1412386,
+    "defense": 683390,
+    "health": 2244112
+  }
 }

--- a/hostiles/doomsday_worm_39_explorer.json
+++ b/hostiles/doomsday_worm_39_explorer.json
@@ -1,6 +1,11 @@
 {
   "description": "Doctor McCoy's studies suggest that these parasitic beings are discarded from the carapace of the Doomsday creature. Feeding on the planetary rubble left in the creature's wake of destruction, the Doomsday Worms roam the galaxy in search of their next meal.",
   "group": "",
+  "head_stats": {
+    "attack": 1412386,
+    "defense": 683390,
+    "health": 2244112
+  },
   "hostile_name": "Doomsday Worm",
   "level": 39,
   "rarity": "common",
@@ -93,10 +98,5 @@
       "quantity": 1,
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 1412386,
-    "defense": 683390,
-    "health": 2244112
-  }
+  ]
 }

--- a/hostiles/doomsday_worm_39_interceptor.json
+++ b/hostiles/doomsday_worm_39_interceptor.json
@@ -1,6 +1,11 @@
 {
   "description": "Doctor McCoy's studies suggest that these parasitic beings are discarded from the carapace of the Doomsday creature. Feeding on the planetary rubble left in the creature's wake of destruction, the Doomsday Worms roam the galaxy in search of their next meal.",
   "group": "",
+  "head_stats": {
+    "attack": 1234739,
+    "defense": 687805,
+    "health": 2160925
+  },
   "hostile_name": "Doomsday Worm",
   "level": 39,
   "rarity": "common",
@@ -93,10 +98,5 @@
       "quantity": 1,
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 1234739,
-    "defense": 687805,
-    "health": 2160925
-  }
+  ]
 }

--- a/hostiles/doomsday_worm_39_interceptor.json
+++ b/hostiles/doomsday_worm_39_interceptor.json
@@ -1,9 +1,6 @@
 {
   "description": "Doctor McCoy's studies suggest that these parasitic beings are discarded from the carapace of the Doomsday creature. Feeding on the planetary rubble left in the creature's wake of destruction, the Doomsday Worms roam the galaxy in search of their next meal.",
-  "attack": 1234739,
-  "defense": 687805,
   "group": "",
-  "health": 2160925,
   "hostile_name": "Doomsday Worm",
   "level": 39,
   "rarity": "common",
@@ -28,7 +25,6 @@
       "shield_health": 2160000
     }
   },
-  "strength": 4083469,
   "systems": [
     {
       "$ref": "systems/mal_tahn_38"
@@ -59,7 +55,6 @@
         0
       ],
       "quantity": 1,
-      "weapon_id": "K1",
       "weapon_type": "kinetic"
     },
     {
@@ -78,7 +73,6 @@
         0
       ],
       "quantity": 1,
-      "weapon_id": "K2",
       "weapon_type": "kinetic"
     },
     {
@@ -97,8 +91,12 @@
         5
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 1234739,
+    "defense": 687805,
+    "health": 2160925
+  }
 }

--- a/hostiles/doomsday_worm_40_battleship.json
+++ b/hostiles/doomsday_worm_40_battleship.json
@@ -1,6 +1,11 @@
 {
   "description": "Doctor McCoy's studies suggest that these parasitic beings are discarded from the carapace of the Doomsday creature. Feeding on the planetary rubble left in the creature's wake of destruction, the Doomsday Worms roam the galaxy in search of their next meal.",
   "group": "",
+  "head_stats": {
+    "attack": 1794203,
+    "defense": 710965,
+    "health": 3446602
+  },
   "hostile_name": "Doomsday Worm",
   "level": 40,
   "rarity": "common",
@@ -90,10 +95,5 @@
       "quantity": 1,
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 1794203,
-    "defense": 710965,
-    "health": 3446602
-  }
+  ]
 }

--- a/hostiles/doomsday_worm_40_battleship.json
+++ b/hostiles/doomsday_worm_40_battleship.json
@@ -1,9 +1,6 @@
 {
   "description": "Doctor McCoy's studies suggest that these parasitic beings are discarded from the carapace of the Doomsday creature. Feeding on the planetary rubble left in the creature's wake of destruction, the Doomsday Worms roam the galaxy in search of their next meal.",
-  "attack": 1794203,
-  "defense": 710965,
   "group": "",
-  "health": 3446602,
   "hostile_name": "Doomsday Worm",
   "level": 40,
   "rarity": "common",
@@ -28,7 +25,6 @@
       "shield_health": 2954000
     }
   },
-  "strength": 5951770,
   "systems": [
     {
       "$ref": "systems/doka_40"
@@ -56,7 +52,6 @@
         0
       ],
       "quantity": 1,
-      "weapon_id": "K1",
       "weapon_type": "kinetic"
     },
     {
@@ -75,7 +70,6 @@
         3
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_type": "energy"
     },
     {
@@ -94,8 +88,12 @@
         3
       ],
       "quantity": 1,
-      "weapon_id": "E2",
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 1794203,
+    "defense": 710965,
+    "health": 3446602
+  }
 }

--- a/hostiles/doomsday_worm_40_explorer.json
+++ b/hostiles/doomsday_worm_40_explorer.json
@@ -1,6 +1,11 @@
 {
   "description": "Doctor McCoy's studies suggest that these parasitic beings are discarded from the carapace of the Doomsday creature. Feeding on the planetary rubble left in the creature's wake of destruction, the Doomsday Worms roam the galaxy in search of their next meal.",
   "group": "",
+  "head_stats": {
+    "attack": 1908436,
+    "defense": 893960,
+    "health": 2970933
+  },
   "hostile_name": "Doomsday Worm",
   "level": 40,
   "rarity": "common",
@@ -90,10 +95,5 @@
       "quantity": 1,
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 1908436,
-    "defense": 893960,
-    "health": 2970933
-  }
+  ]
 }

--- a/hostiles/doomsday_worm_40_explorer.json
+++ b/hostiles/doomsday_worm_40_explorer.json
@@ -1,9 +1,6 @@
 {
   "description": "Doctor McCoy's studies suggest that these parasitic beings are discarded from the carapace of the Doomsday creature. Feeding on the planetary rubble left in the creature's wake of destruction, the Doomsday Worms roam the galaxy in search of their next meal.",
-  "attack": 1908436,
-  "defense": 893960,
   "group": "",
-  "health": 2970933,
   "hostile_name": "Doomsday Worm",
   "level": 40,
   "rarity": "common",
@@ -28,7 +25,6 @@
       "shield_health": 3327000
     }
   },
-  "strength": 5773329,
   "systems": [
     {
       "$ref": "systems/doka_40"
@@ -56,7 +52,6 @@
         0
       ],
       "quantity": 1,
-      "weapon_id": "K1",
       "weapon_type": "kinetic"
     },
     {
@@ -75,7 +70,6 @@
         3
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_type": "energy"
     },
     {
@@ -94,8 +88,12 @@
         3
       ],
       "quantity": 1,
-      "weapon_id": "E2",
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 1908436,
+    "defense": 893960,
+    "health": 2970933
+  }
 }

--- a/hostiles/doomsday_worm_40_interceptor.json
+++ b/hostiles/doomsday_worm_40_interceptor.json
@@ -1,6 +1,11 @@
 {
   "description": "Doctor McCoy's studies suggest that these parasitic beings are discarded from the carapace of the Doomsday creature. Feeding on the planetary rubble left in the creature's wake of destruction, the Doomsday Worms roam the galaxy in search of their next meal.",
   "group": "",
+  "head_stats": {
+    "attack": 1685057,
+    "defense": 938660,
+    "health": 2949027
+  },
   "hostile_name": "Doomsday Worm",
   "level": 40,
   "rarity": "common",
@@ -90,10 +95,5 @@
       "quantity": 1,
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 1685057,
-    "defense": 938660,
-    "health": 2949027
-  }
+  ]
 }

--- a/hostiles/doomsday_worm_40_interceptor.json
+++ b/hostiles/doomsday_worm_40_interceptor.json
@@ -1,9 +1,6 @@
 {
   "description": "Doctor McCoy's studies suggest that these parasitic beings are discarded from the carapace of the Doomsday creature. Feeding on the planetary rubble left in the creature's wake of destruction, the Doomsday Worms roam the galaxy in search of their next meal.",
-  "attack": 1685057,
-  "defense": 938660,
   "group": "",
-  "health": 2949027,
   "hostile_name": "Doomsday Worm",
   "level": 40,
   "rarity": "common",
@@ -28,7 +25,6 @@
       "shield_health": 2949000
     }
   },
-  "strength": 5572744,
   "systems": [
     {
       "$ref": "systems/doka_40"
@@ -56,7 +52,6 @@
         0
       ],
       "quantity": 1,
-      "weapon_id": "K1",
       "weapon_type": "kinetic"
     },
     {
@@ -75,7 +70,6 @@
         0
       ],
       "quantity": 1,
-      "weapon_id": "K2",
       "weapon_type": "kinetic"
     },
     {
@@ -94,8 +88,12 @@
         5
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 1685057,
+    "defense": 938660,
+    "health": 2949027
+  }
 }

--- a/hostiles/doomsday_worm_41_battleship.json
+++ b/hostiles/doomsday_worm_41_battleship.json
@@ -1,9 +1,6 @@
 {
   "description": "Doctor McCoy's studies suggest that these parasitic beings are discarded from the carapace of the Doomsday creature. Feeding on the planetary rubble left in the creature's wake of destruction, the Doomsday Worms roam the galaxy in search of their next meal.",
-  "attack": 2067414,
-  "defense": 801975,
   "group": "",
-  "health": 3853500,
   "hostile_name": "Doomsday Worm",
   "level": 41,
   "rarity": "common",
@@ -28,7 +25,6 @@
       "shield_health": 3302000
     }
   },
-  "strength": 6722889,
   "systems": [
     {
       "$ref": "systems/doka_40"
@@ -59,7 +55,6 @@
         0
       ],
       "quantity": 1,
-      "weapon_id": "K1",
       "weapon_type": "kinetic"
     },
     {
@@ -78,7 +73,6 @@
         3
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_type": "energy"
     },
     {
@@ -97,8 +91,12 @@
         3
       ],
       "quantity": 1,
-      "weapon_id": "E2",
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 2067414,
+    "defense": 801975,
+    "health": 3853500
+  }
 }

--- a/hostiles/doomsday_worm_41_battleship.json
+++ b/hostiles/doomsday_worm_41_battleship.json
@@ -1,6 +1,11 @@
 {
   "description": "Doctor McCoy's studies suggest that these parasitic beings are discarded from the carapace of the Doomsday creature. Feeding on the planetary rubble left in the creature's wake of destruction, the Doomsday Worms roam the galaxy in search of their next meal.",
   "group": "",
+  "head_stats": {
+    "attack": 2067414,
+    "defense": 801975,
+    "health": 3853500
+  },
   "hostile_name": "Doomsday Worm",
   "level": 41,
   "rarity": "common",
@@ -93,10 +98,5 @@
       "quantity": 1,
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 2067414,
-    "defense": 801975,
-    "health": 3853500
-  }
+  ]
 }

--- a/hostiles/doomsday_worm_41_explorer.json
+++ b/hostiles/doomsday_worm_41_explorer.json
@@ -1,9 +1,6 @@
 {
   "description": "Doctor McCoy's studies suggest that these parasitic beings are discarded from the carapace of the Doomsday creature. Feeding on the planetary rubble left in the creature's wake of destruction, the Doomsday Worms roam the galaxy in search of their next meal.",
-  "attack": 2192231,
-  "defense": 1006655,
   "group": "",
-  "health": 3343182,
   "hostile_name": "Doomsday Worm",
   "level": 41,
   "rarity": "common",
@@ -28,7 +25,6 @@
       "shield_health": 3744000
     }
   },
-  "strength": 6542068,
   "systems": [
     {
       "$ref": "systems/doka_40"
@@ -59,7 +55,6 @@
         0
       ],
       "quantity": 1,
-      "weapon_id": "K1",
       "weapon_type": "kinetic"
     },
     {
@@ -78,7 +73,6 @@
         3
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_type": "energy"
     },
     {
@@ -97,8 +91,12 @@
         3
       ],
       "quantity": 1,
-      "weapon_id": "E2",
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 2192231,
+    "defense": 1006655,
+    "health": 3343182
+  }
 }

--- a/hostiles/doomsday_worm_41_explorer.json
+++ b/hostiles/doomsday_worm_41_explorer.json
@@ -1,6 +1,11 @@
 {
   "description": "Doctor McCoy's studies suggest that these parasitic beings are discarded from the carapace of the Doomsday creature. Feeding on the planetary rubble left in the creature's wake of destruction, the Doomsday Worms roam the galaxy in search of their next meal.",
   "group": "",
+  "head_stats": {
+    "attack": 2192231,
+    "defense": 1006655,
+    "health": 3343182
+  },
   "hostile_name": "Doomsday Worm",
   "level": 41,
   "rarity": "common",
@@ -93,10 +98,5 @@
       "quantity": 1,
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 2192231,
-    "defense": 1006655,
-    "health": 3343182
-  }
+  ]
 }

--- a/hostiles/doomsday_worm_41_interceptor.json
+++ b/hostiles/doomsday_worm_41_interceptor.json
@@ -1,6 +1,11 @@
 {
   "description": "Doctor McCoy's studies suggest that these parasitic beings are discarded from the carapace of the Doomsday creature. Feeding on the planetary rubble left in the creature's wake of destruction, the Doomsday Worms roam the galaxy in search of their next meal.",
   "group": "",
+  "head_stats": {
+    "attack": 1939392,
+    "defense": 1044925,
+    "health": 3315421
+  },
   "hostile_name": "Doomsday Worm",
   "level": 41,
   "rarity": "common",
@@ -93,10 +98,5 @@
       "quantity": 1,
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 1939392,
-    "defense": 1044925,
-    "health": 3315421
-  }
+  ]
 }

--- a/hostiles/doomsday_worm_41_interceptor.json
+++ b/hostiles/doomsday_worm_41_interceptor.json
@@ -1,9 +1,6 @@
 {
   "description": "Doctor McCoy's studies suggest that these parasitic beings are discarded from the carapace of the Doomsday creature. Feeding on the planetary rubble left in the creature's wake of destruction, the Doomsday Worms roam the galaxy in search of their next meal.",
-  "attack": 1939392,
-  "defense": 1044925,
   "group": "",
-  "health": 3315421,
   "hostile_name": "Doomsday Worm",
   "level": 41,
   "rarity": "common",
@@ -28,7 +25,6 @@
       "shield_health": 3315000
     }
   },
-  "strength": 6299738,
   "systems": [
     {
       "$ref": "systems/doka_40"
@@ -59,7 +55,6 @@
         0
       ],
       "quantity": 1,
-      "weapon_id": "K1",
       "weapon_type": "kinetic"
     },
     {
@@ -78,7 +73,6 @@
         0
       ],
       "quantity": 1,
-      "weapon_id": "K2",
       "weapon_type": "kinetic"
     },
     {
@@ -97,8 +91,12 @@
         5
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 1939392,
+    "defense": 1044925,
+    "health": 3315421
+  }
 }

--- a/hostiles/doomsday_worm_45_battleship.json
+++ b/hostiles/doomsday_worm_45_battleship.json
@@ -1,9 +1,6 @@
 {
   "description": "Doctor McCoy's studies suggest that these parasitic beings are discarded from the carapace of the Doomsday creature. Feeding on the planetary rubble left in the creature's wake of destruction, the Doomsday Worms roam the galaxy in search of their next meal.",
-  "attack": 3649113,
-  "defense": 1298770,
   "group": "",
-  "health": 6021606,
   "hostile_name": "Doomsday Worm",
   "level": 45,
   "rarity": "common",
@@ -28,7 +25,6 @@
       "shield_health": 5161000
     }
   },
-  "strength": 10969489,
   "systems": [
     {
       "$ref": "systems/hollin_44"
@@ -59,7 +55,6 @@
         0
       ],
       "quantity": 1,
-      "weapon_id": "K1",
       "weapon_type": "kinetic"
     },
     {
@@ -78,7 +73,6 @@
         3
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_type": "energy"
     },
     {
@@ -97,8 +91,12 @@
         3
       ],
       "quantity": 1,
-      "weapon_id": "E2",
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 3649113,
+    "defense": 1298770,
+    "health": 6021606
+  }
 }

--- a/hostiles/doomsday_worm_45_battleship.json
+++ b/hostiles/doomsday_worm_45_battleship.json
@@ -1,6 +1,11 @@
 {
   "description": "Doctor McCoy's studies suggest that these parasitic beings are discarded from the carapace of the Doomsday creature. Feeding on the planetary rubble left in the creature's wake of destruction, the Doomsday Worms roam the galaxy in search of their next meal.",
   "group": "",
+  "head_stats": {
+    "attack": 3649113,
+    "defense": 1298770,
+    "health": 6021606
+  },
   "hostile_name": "Doomsday Worm",
   "level": 45,
   "rarity": "common",
@@ -93,10 +98,5 @@
       "quantity": 1,
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 3649113,
-    "defense": 1298770,
-    "health": 6021606
-  }
+  ]
 }

--- a/hostiles/doomsday_worm_45_explorer.json
+++ b/hostiles/doomsday_worm_45_explorer.json
@@ -1,6 +1,11 @@
 {
   "description": "Doctor McCoy's studies suggest that these parasitic beings are discarded from the carapace of the Doomsday creature. Feeding on the planetary rubble left in the creature's wake of destruction, the Doomsday Worms roam the galaxy in search of their next meal.",
   "group": "",
+  "head_stats": {
+    "attack": 3822598,
+    "defense": 1619140,
+    "health": 5360790
+  },
   "hostile_name": "Doomsday Worm",
   "level": 45,
   "rarity": "common",
@@ -93,10 +98,5 @@
       "quantity": 1,
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 3822598,
-    "defense": 1619140,
-    "health": 5360790
-  }
+  ]
 }

--- a/hostiles/doomsday_worm_45_explorer.json
+++ b/hostiles/doomsday_worm_45_explorer.json
@@ -1,9 +1,6 @@
 {
   "description": "Doctor McCoy's studies suggest that these parasitic beings are discarded from the carapace of the Doomsday creature. Feeding on the planetary rubble left in the creature's wake of destruction, the Doomsday Worms roam the galaxy in search of their next meal.",
-  "attack": 3822598,
-  "defense": 1619140,
   "group": "",
-  "health": 5360790,
   "hostile_name": "Doomsday Worm",
   "level": 45,
   "rarity": "common",
@@ -28,7 +25,6 @@
       "shield_health": 6004000
     }
   },
-  "strength": 10802528,
   "systems": [
     {
       "$ref": "systems/hollin_44"
@@ -59,7 +55,6 @@
         0
       ],
       "quantity": 1,
-      "weapon_id": "K1",
       "weapon_type": "kinetic"
     },
     {
@@ -78,7 +73,6 @@
         3
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_type": "energy"
     },
     {
@@ -97,8 +91,12 @@
         3
       ],
       "quantity": 1,
-      "weapon_id": "E2",
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 3822598,
+    "defense": 1619140,
+    "health": 5360790
+  }
 }

--- a/hostiles/doomsday_worm_45_interceptor.json
+++ b/hostiles/doomsday_worm_45_interceptor.json
@@ -1,6 +1,11 @@
 {
   "description": "Doctor McCoy's studies suggest that these parasitic beings are discarded from the carapace of the Doomsday creature. Feeding on the planetary rubble left in the creature's wake of destruction, the Doomsday Worms roam the galaxy in search of their next meal.",
   "group": "",
+  "head_stats": {
+    "attack": 3410387,
+    "defense": 1607540,
+    "health": 5296372
+  },
   "hostile_name": "Doomsday Worm",
   "level": 45,
   "rarity": "common",
@@ -93,10 +98,5 @@
       "quantity": 1,
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 3410387,
-    "defense": 1607540,
-    "health": 5296372
-  }
+  ]
 }

--- a/hostiles/doomsday_worm_45_interceptor.json
+++ b/hostiles/doomsday_worm_45_interceptor.json
@@ -1,9 +1,6 @@
 {
   "description": "Doctor McCoy's studies suggest that these parasitic beings are discarded from the carapace of the Doomsday creature. Feeding on the planetary rubble left in the creature's wake of destruction, the Doomsday Worms roam the galaxy in search of their next meal.",
-  "attack": 3410387,
-  "defense": 1607540,
   "group": "",
-  "health": 5296372,
   "hostile_name": "Doomsday Worm",
   "level": 45,
   "rarity": "common",
@@ -28,7 +25,6 @@
       "shield_health": 5296000
     }
   },
-  "strength": 10314299,
   "systems": [
     {
       "$ref": "systems/hollin_44"
@@ -59,7 +55,6 @@
         0
       ],
       "quantity": 1,
-      "weapon_id": "K1",
       "weapon_type": "kinetic"
     },
     {
@@ -78,7 +73,6 @@
         0
       ],
       "quantity": 1,
-      "weapon_id": "K2",
       "weapon_type": "kinetic"
     },
     {
@@ -97,8 +91,12 @@
         5
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 3410387,
+    "defense": 1607540,
+    "health": 5296372
+  }
 }

--- a/hostiles/doomsday_worm_46_battleship.json
+++ b/hostiles/doomsday_worm_46_battleship.json
@@ -1,6 +1,11 @@
 {
   "description": "Doctor McCoy's studies suggest that these parasitic beings are discarded from the carapace of the Doomsday creature. Feeding on the planetary rubble left in the creature's wake of destruction, the Doomsday Worms roam the galaxy in search of their next meal.",
   "group": "",
+  "head_stats": {
+    "attack": 4207332,
+    "defense": 1465225,
+    "health": 6732503
+  },
   "hostile_name": "Doomsday Worm",
   "level": 46,
   "rarity": "common",
@@ -90,10 +95,5 @@
       "quantity": 1,
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 4207332,
-    "defense": 1465225,
-    "health": 6732503
-  }
+  ]
 }

--- a/hostiles/doomsday_worm_46_battleship.json
+++ b/hostiles/doomsday_worm_46_battleship.json
@@ -1,9 +1,6 @@
 {
   "description": "Doctor McCoy's studies suggest that these parasitic beings are discarded from the carapace of the Doomsday creature. Feeding on the planetary rubble left in the creature's wake of destruction, the Doomsday Worms roam the galaxy in search of their next meal.",
-  "attack": 4207332,
-  "defense": 1465225,
   "group": "",
-  "health": 6732503,
   "hostile_name": "Doomsday Worm",
   "level": 46,
   "rarity": "common",
@@ -28,7 +25,6 @@
       "shield_health": 5770000
     }
   },
-  "strength": 12405060,
   "systems": [
     {
       "$ref": "systems/kendi_46"
@@ -56,7 +52,6 @@
         0
       ],
       "quantity": 1,
-      "weapon_id": "K1",
       "weapon_type": "kinetic"
     },
     {
@@ -75,7 +70,6 @@
         3
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_type": "energy"
     },
     {
@@ -94,8 +88,12 @@
         3
       ],
       "quantity": 1,
-      "weapon_id": "E2",
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 4207332,
+    "defense": 1465225,
+    "health": 6732503
+  }
 }

--- a/hostiles/doomsday_worm_46_explorer.json
+++ b/hostiles/doomsday_worm_46_explorer.json
@@ -1,6 +1,11 @@
 {
   "description": "Doctor McCoy's studies suggest that these parasitic beings are discarded from the carapace of the Doomsday creature. Feeding on the planetary rubble left in the creature's wake of destruction, the Doomsday Worms roam the galaxy in search of their next meal.",
   "group": "",
+  "head_stats": {
+    "attack": 4394213,
+    "defense": 1823575,
+    "health": 6032481
+  },
   "hostile_name": "Doomsday Worm",
   "level": 46,
   "rarity": "common",
@@ -90,10 +95,5 @@
       "quantity": 1,
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 4394213,
-    "defense": 1823575,
-    "health": 6032481
-  }
+  ]
 }

--- a/hostiles/doomsday_worm_46_explorer.json
+++ b/hostiles/doomsday_worm_46_explorer.json
@@ -1,9 +1,6 @@
 {
   "description": "Doctor McCoy's studies suggest that these parasitic beings are discarded from the carapace of the Doomsday creature. Feeding on the planetary rubble left in the creature's wake of destruction, the Doomsday Worms roam the galaxy in search of their next meal.",
-  "attack": 4394213,
-  "defense": 1823575,
   "group": "",
-  "health": 6032481,
   "hostile_name": "Doomsday Worm",
   "level": 46,
   "rarity": "common",
@@ -28,7 +25,6 @@
       "shield_health": 6756000
     }
   },
-  "strength": 12250269,
   "systems": [
     {
       "$ref": "systems/kendi_46"
@@ -56,7 +52,6 @@
         0
       ],
       "quantity": 1,
-      "weapon_id": "K1",
       "weapon_type": "kinetic"
     },
     {
@@ -75,7 +70,6 @@
         3
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_type": "energy"
     },
     {
@@ -94,8 +88,12 @@
         3
       ],
       "quantity": 1,
-      "weapon_id": "E2",
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 4394213,
+    "defense": 1823575,
+    "health": 6032481
+  }
 }

--- a/hostiles/doomsday_worm_46_interceptor.json
+++ b/hostiles/doomsday_worm_46_interceptor.json
@@ -1,6 +1,11 @@
 {
   "description": "Doctor McCoy's studies suggest that these parasitic beings are discarded from the carapace of the Doomsday creature. Feeding on the planetary rubble left in the creature's wake of destruction, the Doomsday Worms roam the galaxy in search of their next meal.",
   "group": "",
+  "head_stats": {
+    "attack": 3929263,
+    "defense": 1791065,
+    "health": 5954405
+  },
   "hostile_name": "Doomsday Worm",
   "level": 46,
   "rarity": "common",
@@ -90,10 +95,5 @@
       "quantity": 1,
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 3929263,
-    "defense": 1791065,
-    "health": 5954405
-  }
+  ]
 }

--- a/hostiles/doomsday_worm_46_interceptor.json
+++ b/hostiles/doomsday_worm_46_interceptor.json
@@ -1,9 +1,6 @@
 {
   "description": "Doctor McCoy's studies suggest that these parasitic beings are discarded from the carapace of the Doomsday creature. Feeding on the planetary rubble left in the creature's wake of destruction, the Doomsday Worms roam the galaxy in search of their next meal.",
-  "attack": 3929263,
-  "defense": 1791065,
   "group": "",
-  "health": 5954405,
   "hostile_name": "Doomsday Worm",
   "level": 46,
   "rarity": "common",
@@ -28,7 +25,6 @@
       "shield_health": 5954000
     }
   },
-  "strength": 11674733,
   "systems": [
     {
       "$ref": "systems/kendi_46"
@@ -56,7 +52,6 @@
         0
       ],
       "quantity": 1,
-      "weapon_id": "K1",
       "weapon_type": "kinetic"
     },
     {
@@ -75,7 +70,6 @@
         0
       ],
       "quantity": 1,
-      "weapon_id": "K2",
       "weapon_type": "kinetic"
     },
     {
@@ -94,8 +88,12 @@
         5
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 3929263,
+    "defense": 1791065,
+    "health": 5954405
+  }
 }

--- a/hostiles/exchange_transport_27_survey.json
+++ b/hostiles/exchange_transport_27_survey.json
@@ -1,9 +1,6 @@
 {
   "description": "The many corporations, leisure centers and casinos that function in the Exchange value two things above all else: security and discretion.\nTo keep their many clients and investors happy and worry-free, these conglomerates hire elite mercenaries to ensure that precious cargo is transported safely across Exchange space.\nOf course, such bounty would prove attractive to the many rogues, scoundrels and brigands across the galaxy. In order to better protect their cargo, these transports have been fitted with heavy hull plating, well capable of taking hits from even the most powerful of bandits.",
-  "attack": 47630,
-  "defense": 135000,
   "group": "eclipse",
-  "health": 970940,
   "hostile_name": "Exchange Transport",
   "level": 27,
   "rarity": "common",
@@ -33,7 +30,6 @@
       "shield_health": 944800
     }
   },
-  "strength": 1153570,
   "systems": [
     {
       "$ref": "systems/leone_27"
@@ -79,7 +75,6 @@
         2
       ],
       "quantity": 1,
-      "weapon_id": "K1",
       "weapon_stats": {
         "accuracy": 12721,
         "armor_pierce": 12721,
@@ -111,7 +106,6 @@
         2
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_stats": {
         "accuracy": 12721,
         "armor_pierce": 12721,
@@ -124,5 +118,10 @@
       },
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 47630,
+    "defense": 135000,
+    "health": 970940
+  }
 }

--- a/hostiles/exchange_transport_27_survey.json
+++ b/hostiles/exchange_transport_27_survey.json
@@ -1,6 +1,11 @@
 {
   "description": "The many corporations, leisure centers and casinos that function in the Exchange value two things above all else: security and discretion.\nTo keep their many clients and investors happy and worry-free, these conglomerates hire elite mercenaries to ensure that precious cargo is transported safely across Exchange space.\nOf course, such bounty would prove attractive to the many rogues, scoundrels and brigands across the galaxy. In order to better protect their cargo, these transports have been fitted with heavy hull plating, well capable of taking hits from even the most powerful of bandits.",
   "group": "eclipse",
+  "head_stats": {
+    "attack": 47630,
+    "defense": 135000,
+    "health": 970940
+  },
   "hostile_name": "Exchange Transport",
   "level": 27,
   "rarity": "common",
@@ -118,10 +123,5 @@
       },
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 47630,
-    "defense": 135000,
-    "health": 970940
-  }
+  ]
 }

--- a/hostiles/exchange_transport_28_survey.json
+++ b/hostiles/exchange_transport_28_survey.json
@@ -1,9 +1,6 @@
 {
   "description": "The many corporations, leisure centers and casinos that function in the Exchange value two things above all else: security and discretion.\nTo keep their many clients and investors happy and worry-free, these conglomerates hire elite mercenaries to ensure that precious cargo is transported safely across Exchange space.\nOf course, such bounty would prove attractive to the many rogues, scoundrels and brigands across the galaxy. In order to better protect their cargo, these transports have been fitted with heavy hull plating, well capable of taking hits from even the most powerful of bandits.",
-  "attack": 62127,
-  "defense": 204375,
   "group": "eclipse",
-  "health": 1178999,
   "hostile_name": "Exchange Transport",
   "level": 28,
   "rarity": "common",
@@ -33,7 +30,6 @@
       "shield_health": 1147000
     }
   },
-  "strength": 1445501,
   "systems": [
     {
       "$ref": "systems/leone_27"
@@ -94,7 +90,6 @@
         2
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_stats": {
         "accuracy": 16876,
         "armor_pierce": 16876,
@@ -126,7 +121,6 @@
         2
       ],
       "quantity": 1,
-      "weapon_id": "K1",
       "weapon_stats": {
         "accuracy": 16876,
         "armor_pierce": 16876,
@@ -139,5 +133,10 @@
       },
       "weapon_type": "kinetic"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 62127,
+    "defense": 204375,
+    "health": 1178999
+  }
 }

--- a/hostiles/exchange_transport_28_survey.json
+++ b/hostiles/exchange_transport_28_survey.json
@@ -1,6 +1,11 @@
 {
   "description": "The many corporations, leisure centers and casinos that function in the Exchange value two things above all else: security and discretion.\nTo keep their many clients and investors happy and worry-free, these conglomerates hire elite mercenaries to ensure that precious cargo is transported safely across Exchange space.\nOf course, such bounty would prove attractive to the many rogues, scoundrels and brigands across the galaxy. In order to better protect their cargo, these transports have been fitted with heavy hull plating, well capable of taking hits from even the most powerful of bandits.",
   "group": "eclipse",
+  "head_stats": {
+    "attack": 62127,
+    "defense": 204375,
+    "health": 1178999
+  },
   "hostile_name": "Exchange Transport",
   "level": 28,
   "rarity": "common",
@@ -133,10 +138,5 @@
       },
       "weapon_type": "kinetic"
     }
-  ],
-  "head_stats": {
-    "attack": 62127,
-    "defense": 204375,
-    "health": 1178999
-  }
+  ]
 }

--- a/hostiles/exchange_transport_29_survey.json
+++ b/hostiles/exchange_transport_29_survey.json
@@ -1,6 +1,11 @@
 {
   "description": "The many corporations, leisure centers and casinos that function in the Exchange value two things above all else: security and discretion.\nTo keep their many clients and investors happy and worry-free, these conglomerates hire elite mercenaries to ensure that precious cargo is transported safely across Exchange space.\nOf course, such bounty would prove attractive to the many rogues, scoundrels and brigands across the galaxy. In order to better protect their cargo, these transports have been fitted with heavy hull plating, well capable of taking hits from even the most powerful of bandits.",
   "group": "eclipse",
+  "head_stats": {
+    "attack": 76620,
+    "defense": 273750,
+    "health": 1387057
+  },
   "hostile_name": "Exchange Transport",
   "level": 29,
   "rarity": "common",
@@ -142,10 +147,5 @@
       },
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 76620,
-    "defense": 273750,
-    "health": 1387057
-  }
+  ]
 }

--- a/hostiles/exchange_transport_29_survey.json
+++ b/hostiles/exchange_transport_29_survey.json
@@ -1,9 +1,6 @@
 {
   "description": "The many corporations, leisure centers and casinos that function in the Exchange value two things above all else: security and discretion.\nTo keep their many clients and investors happy and worry-free, these conglomerates hire elite mercenaries to ensure that precious cargo is transported safely across Exchange space.\nOf course, such bounty would prove attractive to the many rogues, scoundrels and brigands across the galaxy. In order to better protect their cargo, these transports have been fitted with heavy hull plating, well capable of taking hits from even the most powerful of bandits.",
-  "attack": 76620,
-  "defense": 273750,
   "group": "eclipse",
-  "health": 1387057,
   "hostile_name": "Exchange Transport",
   "level": 29,
   "rarity": "common",
@@ -33,7 +30,6 @@
       "shield_health": 1349000
     }
   },
-  "strength": 1737427,
   "systems": [
     {
       "$ref": "systems/d0d_g_28"
@@ -103,7 +99,6 @@
         2
       ],
       "quantity": 1,
-      "weapon_id": "K1",
       "weapon_stats": {
         "accuracy": 21030,
         "armor_pierce": 21030,
@@ -135,7 +130,6 @@
         2
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_stats": {
         "accuracy": 21030,
         "armor_pierce": 21030,
@@ -148,5 +142,10 @@
       },
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 76620,
+    "defense": 273750,
+    "health": 1387057
+  }
 }

--- a/hostiles/exchange_transport_30_survey.json
+++ b/hostiles/exchange_transport_30_survey.json
@@ -1,9 +1,6 @@
 {
   "description": "The many corporations, leisure centers and casinos that function in the Exchange value two things above all else: security and discretion.\nTo keep their many clients and investors happy and worry-free, these conglomerates hire elite mercenaries to ensure that precious cargo is transported safely across Exchange space.\nOf course, such bounty would prove attractive to the many rogues, scoundrels and brigands across the galaxy. In order to better protect their cargo, these transports have been fitted with heavy hull plating, well capable of taking hits from even the most powerful of bandits.",
-  "attack": 139125,
-  "defense": 418125,
   "group": "eclipse",
-  "health": 1684284,
   "hostile_name": "Exchange Transport",
   "level": 30,
   "rarity": "common",
@@ -33,7 +30,6 @@
       "shield_health": 1638000
     }
   },
-  "strength": 2241534,
   "systems": [
     {
       "$ref": "systems/doniphon_29"
@@ -91,7 +87,6 @@
         2
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_stats": {
         "accuracy": 40540,
         "armor_pierce": 40540,
@@ -123,7 +118,6 @@
         2
       ],
       "quantity": 1,
-      "weapon_id": "K1",
       "weapon_stats": {
         "accuracy": 40540,
         "armor_pierce": 40540,
@@ -136,5 +130,10 @@
       },
       "weapon_type": "kinetic"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 139125,
+    "defense": 418125,
+    "health": 1684284
+  }
 }

--- a/hostiles/exchange_transport_30_survey.json
+++ b/hostiles/exchange_transport_30_survey.json
@@ -1,6 +1,11 @@
 {
   "description": "The many corporations, leisure centers and casinos that function in the Exchange value two things above all else: security and discretion.\nTo keep their many clients and investors happy and worry-free, these conglomerates hire elite mercenaries to ensure that precious cargo is transported safely across Exchange space.\nOf course, such bounty would prove attractive to the many rogues, scoundrels and brigands across the galaxy. In order to better protect their cargo, these transports have been fitted with heavy hull plating, well capable of taking hits from even the most powerful of bandits.",
   "group": "eclipse",
+  "head_stats": {
+    "attack": 139125,
+    "defense": 418125,
+    "health": 1684284
+  },
   "hostile_name": "Exchange Transport",
   "level": 30,
   "rarity": "common",
@@ -130,10 +135,5 @@
       },
       "weapon_type": "kinetic"
     }
-  ],
-  "head_stats": {
-    "attack": 139125,
-    "defense": 418125,
-    "health": 1684284
-  }
+  ]
 }

--- a/hostiles/exchange_transport_31_survey.json
+++ b/hostiles/exchange_transport_31_survey.json
@@ -1,9 +1,6 @@
 {
   "description": "The many corporations, leisure centers and casinos that function in the Exchange value two things above all else: security and discretion.\nTo keep their many clients and investors happy and worry-free, these conglomerates hire elite mercenaries to ensure that precious cargo is transported safely across Exchange space.\nOf course, such bounty would prove attractive to the many rogues, scoundrels and brigands across the galaxy. In order to better protect their cargo, these transports have been fitted with heavy hull plating, well capable of taking hits from even the most powerful of bandits.",
-  "attack": 201629,
-  "defense": 562500,
   "group": "eclipse",
-  "health": 1981511,
   "hostile_name": "Exchange Transport",
   "level": 31,
   "rarity": "common",
@@ -33,7 +30,6 @@
       "shield_health": 1928000
     }
   },
-  "strength": 2745640,
   "systems": [
     {
       "$ref": "systems/andkara_30"
@@ -82,7 +78,6 @@
         2
       ],
       "quantity": 1,
-      "weapon_id": "K1",
       "weapon_stats": {
         "accuracy": 60050,
         "armor_pierce": 60050,
@@ -114,7 +109,6 @@
         2
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_stats": {
         "accuracy": 60050,
         "armor_pierce": 60050,
@@ -127,5 +121,10 @@
       },
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 201629,
+    "defense": 562500,
+    "health": 1981511
+  }
 }

--- a/hostiles/exchange_transport_31_survey.json
+++ b/hostiles/exchange_transport_31_survey.json
@@ -1,6 +1,11 @@
 {
   "description": "The many corporations, leisure centers and casinos that function in the Exchange value two things above all else: security and discretion.\nTo keep their many clients and investors happy and worry-free, these conglomerates hire elite mercenaries to ensure that precious cargo is transported safely across Exchange space.\nOf course, such bounty would prove attractive to the many rogues, scoundrels and brigands across the galaxy. In order to better protect their cargo, these transports have been fitted with heavy hull plating, well capable of taking hits from even the most powerful of bandits.",
   "group": "eclipse",
+  "head_stats": {
+    "attack": 201629,
+    "defense": 562500,
+    "health": 1981511
+  },
   "hostile_name": "Exchange Transport",
   "level": 31,
   "rarity": "common",
@@ -121,10 +126,5 @@
       },
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 201629,
-    "defense": 562500,
-    "health": 1981511
-  }
+  ]
 }

--- a/hostiles/exchange_transport_32_survey.json
+++ b/hostiles/exchange_transport_32_survey.json
@@ -1,9 +1,6 @@
 {
   "description": "The many corporations, leisure centers and casinos that function in the Exchange value two things above all else: security and discretion.\nTo keep their many clients and investors happy and worry-free, these conglomerates hire elite mercenaries to ensure that precious cargo is transported safely across Exchange space.\nOf course, such bounty would prove attractive to the many rogues, scoundrels and brigands across the galaxy. In order to better protect their cargo, these transports have been fitted with heavy hull plating, well capable of taking hits from even the most powerful of bandits.",
-  "attack": 319467,
-  "defense": 656250,
   "group": "eclipse",
-  "health": 2353676,
   "hostile_name": "Exchange Transport",
   "level": 32,
   "rarity": "common",
@@ -33,7 +30,6 @@
       "shield_health": 2154000
     }
   },
-  "strength": 3329393,
   "systems": [
     {
       "$ref": "systems/exchange_gamma_32"
@@ -67,7 +63,6 @@
         2
       ],
       "quantity": 1,
-      "weapon_id": "K1",
       "weapon_stats": {
         "accuracy": 97225,
         "armor_pierce": 97225,
@@ -99,7 +94,6 @@
         2
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_stats": {
         "accuracy": 97225,
         "armor_pierce": 97225,
@@ -112,5 +106,10 @@
       },
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 319467,
+    "defense": 656250,
+    "health": 2353676
+  }
 }

--- a/hostiles/exchange_transport_32_survey.json
+++ b/hostiles/exchange_transport_32_survey.json
@@ -1,6 +1,11 @@
 {
   "description": "The many corporations, leisure centers and casinos that function in the Exchange value two things above all else: security and discretion.\nTo keep their many clients and investors happy and worry-free, these conglomerates hire elite mercenaries to ensure that precious cargo is transported safely across Exchange space.\nOf course, such bounty would prove attractive to the many rogues, scoundrels and brigands across the galaxy. In order to better protect their cargo, these transports have been fitted with heavy hull plating, well capable of taking hits from even the most powerful of bandits.",
   "group": "eclipse",
+  "head_stats": {
+    "attack": 319467,
+    "defense": 656250,
+    "health": 2353676
+  },
   "hostile_name": "Exchange Transport",
   "level": 32,
   "rarity": "common",
@@ -106,10 +111,5 @@
       },
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 319467,
-    "defense": 656250,
-    "health": 2353676
-  }
+  ]
 }

--- a/hostiles/exchange_transport_33_survey.json
+++ b/hostiles/exchange_transport_33_survey.json
@@ -1,9 +1,6 @@
 {
   "description": "The many corporations, leisure centers and casinos that function in the Exchange value two things above all else: security and discretion.\nTo keep their many clients and investors happy and worry-free, these conglomerates hire elite mercenaries to ensure that precious cargo is transported safely across Exchange space.\nOf course, such bounty would prove attractive to the many rogues, scoundrels and brigands across the galaxy. In order to better protect their cargo, these transports have been fitted with heavy hull plating, well capable of taking hits from even the most powerful of bandits.",
-  "attack": 437304,
-  "defense": 750000,
   "group": "eclipse",
-  "health": 2725841,
   "hostile_name": "Exchange Transport",
   "level": 33,
   "rarity": "common",
@@ -33,7 +30,6 @@
       "shield_health": 2380000
     }
   },
-  "strength": 3913145,
   "systems": [
     {
       "$ref": "systems/exchange_gamma_32"
@@ -73,7 +69,6 @@
         2
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_stats": {
         "accuracy": 134400,
         "armor_pierce": 134400,
@@ -105,7 +100,6 @@
         2
       ],
       "quantity": 1,
-      "weapon_id": "K1",
       "weapon_stats": {
         "accuracy": 134400,
         "armor_pierce": 134400,
@@ -118,5 +112,10 @@
       },
       "weapon_type": "kinetic"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 437304,
+    "defense": 750000,
+    "health": 2725841
+  }
 }

--- a/hostiles/exchange_transport_33_survey.json
+++ b/hostiles/exchange_transport_33_survey.json
@@ -1,6 +1,11 @@
 {
   "description": "The many corporations, leisure centers and casinos that function in the Exchange value two things above all else: security and discretion.\nTo keep their many clients and investors happy and worry-free, these conglomerates hire elite mercenaries to ensure that precious cargo is transported safely across Exchange space.\nOf course, such bounty would prove attractive to the many rogues, scoundrels and brigands across the galaxy. In order to better protect their cargo, these transports have been fitted with heavy hull plating, well capable of taking hits from even the most powerful of bandits.",
   "group": "eclipse",
+  "head_stats": {
+    "attack": 437304,
+    "defense": 750000,
+    "health": 2725841
+  },
   "hostile_name": "Exchange Transport",
   "level": 33,
   "rarity": "common",
@@ -112,10 +117,5 @@
       },
       "weapon_type": "kinetic"
     }
-  ],
-  "head_stats": {
-    "attack": 437304,
-    "defense": 750000,
-    "health": 2725841
-  }
+  ]
 }

--- a/hostiles/exchange_transport_34_survey.json
+++ b/hostiles/exchange_transport_34_survey.json
@@ -1,9 +1,6 @@
 {
   "description": "The many corporations, leisure centers and casinos that function in the Exchange value two things above all else: security and discretion.\nTo keep their many clients and investors happy and worry-free, these conglomerates hire elite mercenaries to ensure that precious cargo is transported safely across Exchange space.\nOf course, such bounty would prove attractive to the many rogues, scoundrels and brigands across the galaxy. In order to better protect their cargo, these transports have been fitted with heavy hull plating, well capable of taking hits from even the most powerful of bandits.",
-  "attack": 530695,
-  "defense": 1125000,
   "group": "eclipse",
-  "health": 3560561,
   "hostile_name": "Exchange Transport",
   "level": 34,
   "rarity": "common",
@@ -33,7 +30,6 @@
       "shield_health": 2843000
     }
   },
-  "strength": 5216256,
   "systems": [
     {
       "$ref": "systems/exchange_delta_34"
@@ -67,7 +63,6 @@
         2
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_stats": {
         "accuracy": 163200,
         "armor_pierce": 163200,
@@ -99,7 +94,6 @@
         2
       ],
       "quantity": 1,
-      "weapon_id": "K1",
       "weapon_stats": {
         "accuracy": 163200,
         "armor_pierce": 163200,
@@ -112,5 +106,10 @@
       },
       "weapon_type": "kinetic"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 530695,
+    "defense": 1125000,
+    "health": 3560561
+  }
 }

--- a/hostiles/exchange_transport_34_survey.json
+++ b/hostiles/exchange_transport_34_survey.json
@@ -1,6 +1,11 @@
 {
   "description": "The many corporations, leisure centers and casinos that function in the Exchange value two things above all else: security and discretion.\nTo keep their many clients and investors happy and worry-free, these conglomerates hire elite mercenaries to ensure that precious cargo is transported safely across Exchange space.\nOf course, such bounty would prove attractive to the many rogues, scoundrels and brigands across the galaxy. In order to better protect their cargo, these transports have been fitted with heavy hull plating, well capable of taking hits from even the most powerful of bandits.",
   "group": "eclipse",
+  "head_stats": {
+    "attack": 530695,
+    "defense": 1125000,
+    "health": 3560561
+  },
   "hostile_name": "Exchange Transport",
   "level": 34,
   "rarity": "common",
@@ -106,10 +111,5 @@
       },
       "weapon_type": "kinetic"
     }
-  ],
-  "head_stats": {
-    "attack": 530695,
-    "defense": 1125000,
-    "health": 3560561
-  }
+  ]
 }

--- a/hostiles/exchange_transport_35_survey.json
+++ b/hostiles/exchange_transport_35_survey.json
@@ -1,9 +1,6 @@
 {
   "description": "The many corporations, leisure centers and casinos that function in the Exchange value two things above all else: security and discretion.\nTo keep their many clients and investors happy and worry-free, these conglomerates hire elite mercenaries to ensure that precious cargo is transported safely across Exchange space.\nOf course, such bounty would prove attractive to the many rogues, scoundrels and brigands across the galaxy. In order to better protect their cargo, these transports have been fitted with heavy hull plating, well capable of taking hits from even the most powerful of bandits.",
-  "attack": 624082,
-  "defense": 1500000,
   "group": "eclipse",
-  "health": 4395281,
   "hostile_name": "Exchange Transport",
   "level": 35,
   "rarity": "common",
@@ -33,7 +30,6 @@
       "shield_health": 3306000
     }
   },
-  "strength": 6519363,
   "systems": [
     {
       "$ref": "systems/exchange_delta_34"
@@ -70,7 +66,6 @@
         2
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_stats": {
         "accuracy": 192000,
         "armor_pierce": 192000,
@@ -102,7 +97,6 @@
         2
       ],
       "quantity": 1,
-      "weapon_id": "K1",
       "weapon_stats": {
         "accuracy": 192000,
         "armor_pierce": 192000,
@@ -115,5 +109,10 @@
       },
       "weapon_type": "kinetic"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 624082,
+    "defense": 1500000,
+    "health": 4395281
+  }
 }

--- a/hostiles/exchange_transport_35_survey.json
+++ b/hostiles/exchange_transport_35_survey.json
@@ -1,6 +1,11 @@
 {
   "description": "The many corporations, leisure centers and casinos that function in the Exchange value two things above all else: security and discretion.\nTo keep their many clients and investors happy and worry-free, these conglomerates hire elite mercenaries to ensure that precious cargo is transported safely across Exchange space.\nOf course, such bounty would prove attractive to the many rogues, scoundrels and brigands across the galaxy. In order to better protect their cargo, these transports have been fitted with heavy hull plating, well capable of taking hits from even the most powerful of bandits.",
   "group": "eclipse",
+  "head_stats": {
+    "attack": 624082,
+    "defense": 1500000,
+    "health": 4395281
+  },
   "hostile_name": "Exchange Transport",
   "level": 35,
   "rarity": "common",
@@ -109,10 +114,5 @@
       },
       "weapon_type": "kinetic"
     }
-  ],
-  "head_stats": {
-    "attack": 624082,
-    "defense": 1500000,
-    "health": 4395281
-  }
+  ]
 }

--- a/hostiles/exchange_transport_36_survey.json
+++ b/hostiles/exchange_transport_36_survey.json
@@ -1,9 +1,6 @@
 {
   "description": "The many corporations, leisure centers and casinos that function in the Exchange value two things above all else: security and discretion.\nTo keep their many clients and investors happy and worry-free, these conglomerates hire elite mercenaries to ensure that precious cargo is transported safely across Exchange space.\nOf course, such bounty would prove attractive to the many rogues, scoundrels and brigands across the galaxy. In order to better protect their cargo, these transports have been fitted with heavy hull plating, well capable of taking hits from even the most powerful of bandits.",
-  "attack": 747837,
-  "defense": 1800000,
   "group": "eclipse",
-  "health": 5337127,
   "hostile_name": "Exchange Transport",
   "level": 36,
   "rarity": "common",
@@ -33,7 +30,6 @@
       "shield_health": 4014000
     }
   },
-  "strength": 7884964,
   "systems": [
     {
       "$ref": "systems/karppinen_36"
@@ -64,7 +60,6 @@
         2
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_stats": {
         "accuracy": 226000,
         "armor_pierce": 226000,
@@ -96,7 +91,6 @@
         2
       ],
       "quantity": 1,
-      "weapon_id": "K1",
       "weapon_stats": {
         "accuracy": 226000,
         "armor_pierce": 226000,
@@ -109,5 +103,10 @@
       },
       "weapon_type": "kinetic"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 747837,
+    "defense": 1800000,
+    "health": 5337127
+  }
 }

--- a/hostiles/exchange_transport_36_survey.json
+++ b/hostiles/exchange_transport_36_survey.json
@@ -1,6 +1,11 @@
 {
   "description": "The many corporations, leisure centers and casinos that function in the Exchange value two things above all else: security and discretion.\nTo keep their many clients and investors happy and worry-free, these conglomerates hire elite mercenaries to ensure that precious cargo is transported safely across Exchange space.\nOf course, such bounty would prove attractive to the many rogues, scoundrels and brigands across the galaxy. In order to better protect their cargo, these transports have been fitted with heavy hull plating, well capable of taking hits from even the most powerful of bandits.",
   "group": "eclipse",
+  "head_stats": {
+    "attack": 747837,
+    "defense": 1800000,
+    "health": 5337127
+  },
   "hostile_name": "Exchange Transport",
   "level": 36,
   "rarity": "common",
@@ -103,10 +108,5 @@
       },
       "weapon_type": "kinetic"
     }
-  ],
-  "head_stats": {
-    "attack": 747837,
-    "defense": 1800000,
-    "health": 5337127
-  }
+  ]
 }

--- a/hostiles/exchange_transport_37_survey.json
+++ b/hostiles/exchange_transport_37_survey.json
@@ -1,9 +1,6 @@
 {
   "description": "The many corporations, leisure centers and casinos that function in the Exchange value two things above all else: security and discretion.\nTo keep their many clients and investors happy and worry-free, these conglomerates hire elite mercenaries to ensure that precious cargo is transported safely across Exchange space.\nOf course, such bounty would prove attractive to the many rogues, scoundrels and brigands across the galaxy. In order to better protect their cargo, these transports have been fitted with heavy hull plating, well capable of taking hits from even the most powerful of bandits.",
-  "attack": 871588,
-  "defense": 2100000,
   "group": "eclipse",
-  "health": 6278973,
   "hostile_name": "Exchange Transport",
   "level": 37,
   "rarity": "common",
@@ -33,7 +30,6 @@
       "shield_health": 4722000
     }
   },
-  "strength": 9250561,
   "systems": [
     {
       "$ref": "systems/karppinen_36"
@@ -67,7 +63,6 @@
         2
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_stats": {
         "accuracy": 260000,
         "armor_pierce": 260000,
@@ -99,7 +94,6 @@
         2
       ],
       "quantity": 1,
-      "weapon_id": "K1",
       "weapon_stats": {
         "accuracy": 260000,
         "armor_pierce": 260000,
@@ -112,5 +106,10 @@
       },
       "weapon_type": "kinetic"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 871588,
+    "defense": 2100000,
+    "health": 6278973
+  }
 }

--- a/hostiles/exchange_transport_37_survey.json
+++ b/hostiles/exchange_transport_37_survey.json
@@ -1,6 +1,11 @@
 {
   "description": "The many corporations, leisure centers and casinos that function in the Exchange value two things above all else: security and discretion.\nTo keep their many clients and investors happy and worry-free, these conglomerates hire elite mercenaries to ensure that precious cargo is transported safely across Exchange space.\nOf course, such bounty would prove attractive to the many rogues, scoundrels and brigands across the galaxy. In order to better protect their cargo, these transports have been fitted with heavy hull plating, well capable of taking hits from even the most powerful of bandits.",
   "group": "eclipse",
+  "head_stats": {
+    "attack": 871588,
+    "defense": 2100000,
+    "health": 6278973
+  },
   "hostile_name": "Exchange Transport",
   "level": 37,
   "rarity": "common",
@@ -106,10 +111,5 @@
       },
       "weapon_type": "kinetic"
     }
-  ],
-  "head_stats": {
-    "attack": 871588,
-    "defense": 2100000,
-    "health": 6278973
-  }
+  ]
 }

--- a/hostiles/exchange_transport_38_survey.json
+++ b/hostiles/exchange_transport_38_survey.json
@@ -1,6 +1,11 @@
 {
   "description": "The many corporations, leisure centers and casinos that function in the Exchange value two things above all else: security and discretion.\nTo keep their many clients and investors happy and worry-free, these conglomerates hire elite mercenaries to ensure that precious cargo is transported safely across Exchange space.\nOf course, such bounty would prove attractive to the many rogues, scoundrels and brigands across the galaxy. In order to better protect their cargo, these transports have been fitted with heavy hull plating, well capable of taking hits from even the most powerful of bandits.",
   "group": "eclipse",
+  "head_stats": {
+    "attack": 1037458,
+    "defense": 2300010,
+    "health": 7175969
+  },
   "hostile_name": "Exchange Transport",
   "level": 38,
   "rarity": "common",
@@ -103,10 +108,5 @@
       },
       "weapon_type": "kinetic"
     }
-  ],
-  "head_stats": {
-    "attack": 1037458,
-    "defense": 2300010,
-    "health": 7175969
-  }
+  ]
 }

--- a/hostiles/exchange_transport_38_survey.json
+++ b/hostiles/exchange_transport_38_survey.json
@@ -1,9 +1,6 @@
 {
   "description": "The many corporations, leisure centers and casinos that function in the Exchange value two things above all else: security and discretion.\nTo keep their many clients and investors happy and worry-free, these conglomerates hire elite mercenaries to ensure that precious cargo is transported safely across Exchange space.\nOf course, such bounty would prove attractive to the many rogues, scoundrels and brigands across the galaxy. In order to better protect their cargo, these transports have been fitted with heavy hull plating, well capable of taking hits from even the most powerful of bandits.",
-  "attack": 1037458,
-  "defense": 2300010,
   "group": "eclipse",
-  "health": 7175969,
   "hostile_name": "Exchange Transport",
   "level": 38,
   "rarity": "common",
@@ -33,7 +30,6 @@
       "shield_health": 5397000
     }
   },
-  "strength": 10513437,
   "systems": [
     {
       "$ref": "systems/mige_38"
@@ -64,7 +60,6 @@
         2
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_stats": {
         "accuracy": 300667,
         "armor_pierce": 300667,
@@ -96,7 +91,6 @@
         2
       ],
       "quantity": 1,
-      "weapon_id": "K1",
       "weapon_stats": {
         "accuracy": 300667,
         "armor_pierce": 300667,
@@ -109,5 +103,10 @@
       },
       "weapon_type": "kinetic"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 1037458,
+    "defense": 2300010,
+    "health": 7175969
+  }
 }

--- a/hostiles/exchange_transport_39_survey.json
+++ b/hostiles/exchange_transport_39_survey.json
@@ -1,6 +1,11 @@
 {
   "description": "The many corporations, leisure centers and casinos that function in the Exchange value two things above all else: security and discretion.\nTo keep their many clients and investors happy and worry-free, these conglomerates hire elite mercenaries to ensure that precious cargo is transported safely across Exchange space.\nOf course, such bounty would prove attractive to the many rogues, scoundrels and brigands across the galaxy. In order to better protect their cargo, these transports have been fitted with heavy hull plating, well capable of taking hits from even the most powerful of bandits.",
   "group": "eclipse",
+  "head_stats": {
+    "attack": 1203328,
+    "defense": 2500020,
+    "health": 8072966
+  },
   "hostile_name": "Exchange Transport",
   "level": 39,
   "rarity": "common",
@@ -109,10 +114,5 @@
       },
       "weapon_type": "kinetic"
     }
-  ],
-  "head_stats": {
-    "attack": 1203328,
-    "defense": 2500020,
-    "health": 8072966
-  }
+  ]
 }

--- a/hostiles/exchange_transport_39_survey.json
+++ b/hostiles/exchange_transport_39_survey.json
@@ -1,9 +1,6 @@
 {
   "description": "The many corporations, leisure centers and casinos that function in the Exchange value two things above all else: security and discretion.\nTo keep their many clients and investors happy and worry-free, these conglomerates hire elite mercenaries to ensure that precious cargo is transported safely across Exchange space.\nOf course, such bounty would prove attractive to the many rogues, scoundrels and brigands across the galaxy. In order to better protect their cargo, these transports have been fitted with heavy hull plating, well capable of taking hits from even the most powerful of bandits.",
-  "attack": 1203328,
-  "defense": 2500020,
   "group": "eclipse",
-  "health": 8072966,
   "hostile_name": "Exchange Transport",
   "level": 39,
   "rarity": "common",
@@ -33,7 +30,6 @@
       "shield_health": 6072000
     }
   },
-  "strength": 11776314,
   "systems": [
     {
       "$ref": "systems/mige_38"
@@ -70,7 +66,6 @@
         2
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_stats": {
         "accuracy": 341334,
         "armor_pierce": 341334,
@@ -102,7 +97,6 @@
         2
       ],
       "quantity": 1,
-      "weapon_id": "K1",
       "weapon_stats": {
         "accuracy": 341334,
         "armor_pierce": 341334,
@@ -115,5 +109,10 @@
       },
       "weapon_type": "kinetic"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 1203328,
+    "defense": 2500020,
+    "health": 8072966
+  }
 }

--- a/hostiles/exchange_transport_40_survey.json
+++ b/hostiles/exchange_transport_40_survey.json
@@ -1,9 +1,6 @@
 {
   "description": "The many corporations, leisure centers and casinos that function in the Exchange value two things above all else: security and discretion.\nTo keep their many clients and investors happy and worry-free, these conglomerates hire elite mercenaries to ensure that precious cargo is transported safely across Exchange space.\nOf course, such bounty would prove attractive to the many rogues, scoundrels and brigands across the galaxy. In order to better protect their cargo, these transports have been fitted with heavy hull plating, well capable of taking hits from even the most powerful of bandits.",
-  "attack": 1369188,
-  "defense": 2700000,
   "group": "eclipse",
-  "health": 8969962,
   "hostile_name": "Exchange Transport",
   "level": 40,
   "rarity": "common",
@@ -33,7 +30,6 @@
       "shield_health": 6747000
     }
   },
-  "strength": 13039150,
   "systems": [
     {
       "$ref": "systems/lindstrom_40"
@@ -67,7 +63,6 @@
         2
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_stats": {
         "accuracy": 382000,
         "armor_pierce": 382000,
@@ -99,7 +94,6 @@
         2
       ],
       "quantity": 1,
-      "weapon_id": "K1",
       "weapon_stats": {
         "accuracy": 382000,
         "armor_pierce": 382000,
@@ -112,5 +106,10 @@
       },
       "weapon_type": "kinetic"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 1369188,
+    "defense": 2700000,
+    "health": 8969962
+  }
 }

--- a/hostiles/exchange_transport_40_survey.json
+++ b/hostiles/exchange_transport_40_survey.json
@@ -1,6 +1,11 @@
 {
   "description": "The many corporations, leisure centers and casinos that function in the Exchange value two things above all else: security and discretion.\nTo keep their many clients and investors happy and worry-free, these conglomerates hire elite mercenaries to ensure that precious cargo is transported safely across Exchange space.\nOf course, such bounty would prove attractive to the many rogues, scoundrels and brigands across the galaxy. In order to better protect their cargo, these transports have been fitted with heavy hull plating, well capable of taking hits from even the most powerful of bandits.",
   "group": "eclipse",
+  "head_stats": {
+    "attack": 1369188,
+    "defense": 2700000,
+    "health": 8969962
+  },
   "hostile_name": "Exchange Transport",
   "level": 40,
   "rarity": "common",
@@ -106,10 +111,5 @@
       },
       "weapon_type": "kinetic"
     }
-  ],
-  "head_stats": {
-    "attack": 1369188,
-    "defense": 2700000,
-    "health": 8969962
-  }
+  ]
 }

--- a/hostiles/fearless_bandits_42_battleship.json
+++ b/hostiles/fearless_bandits_42_battleship.json
@@ -1,9 +1,6 @@
 {
   "description": "This Hostile patrols the different systems of the universe, looking for easy prey",
-  "attack": 1794203,
-  "defense": 710965,
   "group": "",
-  "health": 3446602,
   "hostile_name": "Fearless Bandits",
   "level": 42,
   "rarity": "common",
@@ -33,7 +30,6 @@
       "shield_health": 2954000
     }
   },
-  "strength": 5951770,
   "systems": [
     {
       "$ref": "systems/singularity_apex_41"
@@ -76,7 +72,6 @@
         3
       ],
       "quantity": 1,
-      "weapon_id": "K1",
       "weapon_type": "kinetic"
     },
     {
@@ -98,7 +93,6 @@
         3
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_type": "energy"
     },
     {
@@ -120,8 +114,12 @@
         3
       ],
       "quantity": 1,
-      "weapon_id": "E2",
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 1794203,
+    "defense": 710965,
+    "health": 3446602
+  }
 }

--- a/hostiles/fearless_bandits_42_battleship.json
+++ b/hostiles/fearless_bandits_42_battleship.json
@@ -1,6 +1,11 @@
 {
   "description": "This Hostile patrols the different systems of the universe, looking for easy prey",
   "group": "",
+  "head_stats": {
+    "attack": 1794203,
+    "defense": 710965,
+    "health": 3446602
+  },
   "hostile_name": "Fearless Bandits",
   "level": 42,
   "rarity": "common",
@@ -116,10 +121,5 @@
       "quantity": 1,
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 1794203,
-    "defense": 710965,
-    "health": 3446602
-  }
+  ]
 }

--- a/hostiles/federation_patrol_31_explorer.json
+++ b/hostiles/federation_patrol_31_explorer.json
@@ -1,9 +1,6 @@
 {
   "description": "This ship is part of the Federation. Attacking it will result in a loss of reputation towards the Federation and a gain of reputation towards the Romulan and Klingon factions.",
-  "attack": 99132,
-  "defense": 107940,
   "group": "federation",
-  "health": 43890,
   "hostile_name": "Federation Patrol",
   "level": 31,
   "rarity": "common",
@@ -41,7 +38,6 @@
       "shield_health": 51000
     }
   },
-  "strength": 250962,
   "systems": [
     {
       "$ref": "systems/ascher_30"
@@ -78,7 +74,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_type": "energy"
     },
     {
@@ -100,7 +95,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E2",
       "weapon_type": "energy"
     },
     {
@@ -122,8 +116,12 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E3",
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 99132,
+    "defense": 107940,
+    "health": 43890
+  }
 }

--- a/hostiles/federation_patrol_31_explorer.json
+++ b/hostiles/federation_patrol_31_explorer.json
@@ -1,6 +1,11 @@
 {
   "description": "This ship is part of the Federation. Attacking it will result in a loss of reputation towards the Federation and a gain of reputation towards the Romulan and Klingon factions.",
   "group": "federation",
+  "head_stats": {
+    "attack": 99132,
+    "defense": 107940,
+    "health": 43890
+  },
   "hostile_name": "Federation Patrol",
   "level": 31,
   "rarity": "common",
@@ -118,10 +123,5 @@
       "quantity": 1,
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 99132,
-    "defense": 107940,
-    "health": 43890
-  }
+  ]
 }

--- a/hostiles/federation_patrol_31_interceptor.json
+++ b/hostiles/federation_patrol_31_interceptor.json
@@ -1,9 +1,6 @@
 {
   "description": "This ship is part of the Federation. Attacking it will result in a loss of reputation towards the Federation and a gain of reputation towards the Romulan and Klingon factions.",
-  "attack": 93753,
-  "defense": 93500,
   "group": "federation",
-  "health": 37800,
   "hostile_name": "Federation Patrol",
   "level": 31,
   "rarity": "common",
@@ -41,7 +38,6 @@
       "shield_health": 43000
     }
   },
-  "strength": 225053,
   "systems": [
     {
       "$ref": "systems/doloran_30"
@@ -78,7 +74,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "K1",
       "weapon_type": "kinetic"
     },
     {
@@ -100,7 +95,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "K2",
       "weapon_type": "kinetic"
     },
     {
@@ -122,8 +116,12 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 93753,
+    "defense": 93500,
+    "health": 37800
+  }
 }

--- a/hostiles/federation_patrol_31_interceptor.json
+++ b/hostiles/federation_patrol_31_interceptor.json
@@ -1,6 +1,11 @@
 {
   "description": "This ship is part of the Federation. Attacking it will result in a loss of reputation towards the Federation and a gain of reputation towards the Romulan and Klingon factions.",
   "group": "federation",
+  "head_stats": {
+    "attack": 93753,
+    "defense": 93500,
+    "health": 37800
+  },
   "hostile_name": "Federation Patrol",
   "level": 31,
   "rarity": "common",
@@ -118,10 +123,5 @@
       "quantity": 1,
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 93753,
-    "defense": 93500,
-    "health": 37800
-  }
+  ]
 }

--- a/hostiles/federation_patrol_41_explorer.json
+++ b/hostiles/federation_patrol_41_explorer.json
@@ -1,6 +1,11 @@
 {
   "description": "This ship is part of the Federation. Attacking it will result in a loss of reputation towards the Federation and a gain of reputation towards the Romulan and Klingon factions.",
   "group": "federation",
+  "head_stats": {
+    "attack": 1733842,
+    "defense": 703705,
+    "health": 2369783
+  },
   "hostile_name": "Federation Patrol",
   "level": 41,
   "rarity": "common",
@@ -135,10 +140,5 @@
       "quantity": 1,
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 1733842,
-    "defense": 703705,
-    "health": 2369783
-  }
+  ]
 }

--- a/hostiles/federation_patrol_41_explorer.json
+++ b/hostiles/federation_patrol_41_explorer.json
@@ -1,9 +1,6 @@
 {
   "description": "This ship is part of the Federation. Attacking it will result in a loss of reputation towards the Federation and a gain of reputation towards the Romulan and Klingon factions.",
-  "attack": 1733842,
-  "defense": 703705,
   "group": "federation",
-  "health": 2369783,
   "hostile_name": "Federation Patrol",
   "level": 41,
   "rarity": "common",
@@ -45,7 +42,6 @@
       "shield_health": 2764000
     }
   },
-  "strength": 4807330,
   "systems": [
     {
       "$ref": "systems/groombridge_34_40"
@@ -85,7 +81,6 @@
         3
       ],
       "quantity": 3,
-      "weapon_id": "E1",
       "weapon_stats": {
         "accuracy": 150329,
         "armor_pierce": 72455,
@@ -117,7 +112,6 @@
         3
       ],
       "quantity": 1,
-      "weapon_id": "E2",
       "weapon_type": "energy"
     },
     {
@@ -139,8 +133,12 @@
         3
       ],
       "quantity": 1,
-      "weapon_id": "E3",
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 1733842,
+    "defense": 703705,
+    "health": 2369783
+  }
 }

--- a/hostiles/federation_scout_32_interceptor.json
+++ b/hostiles/federation_scout_32_interceptor.json
@@ -1,6 +1,11 @@
 {
   "description": "This ship is part of the Federation. Attacking it will result in a loss of reputation towards the Federation and a gain of reputation towards the Romulan and Klingon factions.",
   "group": "federation",
+  "head_stats": {
+    "attack": 93753,
+    "defense": 93500,
+    "health": 37800
+  },
   "hostile_name": "Federation Scout \u2605",
   "level": 32,
   "rarity": "common",
@@ -132,10 +137,5 @@
       "quantity": 1,
       "weapon_type": "kinetic"
     }
-  ],
-  "head_stats": {
-    "attack": 93753,
-    "defense": 93500,
-    "health": 37800
-  }
+  ]
 }

--- a/hostiles/federation_scout_32_interceptor.json
+++ b/hostiles/federation_scout_32_interceptor.json
@@ -1,9 +1,6 @@
 {
   "description": "This ship is part of the Federation. Attacking it will result in a loss of reputation towards the Federation and a gain of reputation towards the Romulan and Klingon factions.",
-  "attack": 93753,
-  "defense": 93500,
   "group": "federation",
-  "health": 37800,
   "hostile_name": "Federation Scout \u2605",
   "level": 32,
   "rarity": "common",
@@ -41,7 +38,6 @@
       "shield_health": 43000
     }
   },
-  "strength": 225053,
   "systems": [
     {
       "$ref": "systems/thama_32"
@@ -72,7 +68,6 @@
         1
       ],
       "quantity": 2,
-      "weapon_id": "K1",
       "weapon_stats": {
         "accuracy": 3850,
         "armor_pierce": 17325,
@@ -104,7 +99,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_stats": {
         "accuracy": 3850,
         "armor_pierce": 17325,
@@ -136,8 +130,12 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "K2",
       "weapon_type": "kinetic"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 93753,
+    "defense": 93500,
+    "health": 37800
+  }
 }

--- a/hostiles/federation_scout_34_interceptor.json
+++ b/hostiles/federation_scout_34_interceptor.json
@@ -1,9 +1,6 @@
 {
   "description": "This ship is part of the Federation. Attacking it will result in a loss of reputation towards the Federation and a gain of reputation towards the Romulan and Klingon factions.",
-  "attack": 169556,
-  "defense": 170340,
   "group": "federation",
-  "health": 52380,
   "hostile_name": "Federation Scout \u2605",
   "level": 34,
   "rarity": "common",
@@ -41,7 +38,6 @@
       "shield_health": 60000
     }
   },
-  "strength": 392276,
   "systems": [
     {
       "$ref": "systems/andoria_34"
@@ -75,7 +71,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "K1",
       "weapon_type": "kinetic"
     },
     {
@@ -97,7 +92,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "K2",
       "weapon_type": "kinetic"
     },
     {
@@ -119,8 +113,12 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 169556,
+    "defense": 170340,
+    "health": 52380
+  }
 }

--- a/hostiles/federation_scout_34_interceptor.json
+++ b/hostiles/federation_scout_34_interceptor.json
@@ -1,6 +1,11 @@
 {
   "description": "This ship is part of the Federation. Attacking it will result in a loss of reputation towards the Federation and a gain of reputation towards the Romulan and Klingon factions.",
   "group": "federation",
+  "head_stats": {
+    "attack": 169556,
+    "defense": 170340,
+    "health": 52380
+  },
   "hostile_name": "Federation Scout \u2605",
   "level": 34,
   "rarity": "common",
@@ -115,10 +120,5 @@
       "quantity": 1,
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 169556,
-    "defense": 170340,
-    "health": 52380
-  }
+  ]
 }

--- a/hostiles/federation_scout_35_interceptor.json
+++ b/hostiles/federation_scout_35_interceptor.json
@@ -1,6 +1,11 @@
 {
   "description": "This ship is part of the Federation. Attacking it will result in a loss of reputation towards the Federation and a gain of reputation towards the Romulan and Klingon factions.",
   "group": "federation",
+  "head_stats": {
+    "attack": 212476,
+    "defense": 199750,
+    "health": 62100
+  },
   "hostile_name": "Federation Scout \u2605",
   "level": 35,
   "rarity": "common",
@@ -112,10 +117,5 @@
       "quantity": 1,
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 212476,
-    "defense": 199750,
-    "health": 62100
-  }
+  ]
 }

--- a/hostiles/federation_scout_35_interceptor.json
+++ b/hostiles/federation_scout_35_interceptor.json
@@ -1,9 +1,6 @@
 {
   "description": "This ship is part of the Federation. Attacking it will result in a loss of reputation towards the Federation and a gain of reputation towards the Romulan and Klingon factions.",
-  "attack": 212476,
-  "defense": 199750,
   "group": "federation",
-  "health": 62100,
   "hostile_name": "Federation Scout \u2605",
   "level": 35,
   "rarity": "common",
@@ -41,7 +38,6 @@
       "shield_health": 71000
     }
   },
-  "strength": 474326,
   "systems": [
     {
       "$ref": "systems/siiolux_35"
@@ -72,7 +68,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "K1",
       "weapon_type": "kinetic"
     },
     {
@@ -94,7 +89,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "K2",
       "weapon_type": "kinetic"
     },
     {
@@ -116,8 +110,12 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 212476,
+    "defense": 199750,
+    "health": 62100
+  }
 }

--- a/hostiles/federation_scout_36_interceptor.json
+++ b/hostiles/federation_scout_36_interceptor.json
@@ -1,9 +1,6 @@
 {
   "description": "This ship is part of the Federation. Attacking it will result in a loss of reputation towards the Federation and a gain of reputation towards the Romulan and Klingon factions.",
-  "attack": 265541,
-  "defense": 255000,
   "group": "federation",
-  "health": 81000,
   "hostile_name": "Federation Scout \u2605",
   "level": 36,
   "rarity": "common",
@@ -41,7 +38,6 @@
       "shield_health": 93000
     }
   },
-  "strength": 601541,
   "systems": [
     {
       "$ref": "systems/archer_36"
@@ -75,7 +71,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "K1",
       "weapon_type": "kinetic"
     },
     {
@@ -97,7 +92,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "K2",
       "weapon_type": "kinetic"
     },
     {
@@ -119,8 +113,12 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 265541,
+    "defense": 255000,
+    "health": 81000
+  }
 }

--- a/hostiles/federation_scout_36_interceptor.json
+++ b/hostiles/federation_scout_36_interceptor.json
@@ -1,6 +1,11 @@
 {
   "description": "This ship is part of the Federation. Attacking it will result in a loss of reputation towards the Federation and a gain of reputation towards the Romulan and Klingon factions.",
   "group": "federation",
+  "head_stats": {
+    "attack": 265541,
+    "defense": 255000,
+    "health": 81000
+  },
   "hostile_name": "Federation Scout \u2605",
   "level": 36,
   "rarity": "common",
@@ -115,10 +120,5 @@
       "quantity": 1,
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 265541,
-    "defense": 255000,
-    "health": 81000
-  }
+  ]
 }

--- a/hostiles/federation_scout_39_interceptor.json
+++ b/hostiles/federation_scout_39_interceptor.json
@@ -1,9 +1,6 @@
 {
   "description": "This ship is part of the Federation. Attacking it will result in a loss of reputation towards the Federation and a gain of reputation towards the Romulan and Klingon factions.",
-  "attack": 459856,
-  "defense": 432280,
   "group": "federation",
-  "health": 138575,
   "hostile_name": "Federation Scout \u2605",
   "level": 39,
   "rarity": "common",
@@ -41,7 +38,6 @@
       "shield_health": 160100
     }
   },
-  "strength": 1030711,
   "systems": [
     {
       "$ref": "systems/wolf_39"
@@ -72,7 +68,6 @@
         1
       ],
       "quantity": 2,
-      "weapon_id": "K1",
       "weapon_stats": {
         "accuracy": 17800,
         "armor_pierce": 80098,
@@ -104,7 +99,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_stats": {
         "accuracy": 17800,
         "armor_pierce": 80098,
@@ -136,8 +130,12 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "K2",
       "weapon_type": "kinetic"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 459856,
+    "defense": 432280,
+    "health": 138575
+  }
 }

--- a/hostiles/federation_scout_39_interceptor.json
+++ b/hostiles/federation_scout_39_interceptor.json
@@ -1,6 +1,11 @@
 {
   "description": "This ship is part of the Federation. Attacking it will result in a loss of reputation towards the Federation and a gain of reputation towards the Romulan and Klingon factions.",
   "group": "federation",
+  "head_stats": {
+    "attack": 459856,
+    "defense": 432280,
+    "health": 138575
+  },
   "hostile_name": "Federation Scout \u2605",
   "level": 39,
   "rarity": "common",
@@ -132,10 +137,5 @@
       "quantity": 1,
       "weapon_type": "kinetic"
     }
-  ],
-  "head_stats": {
-    "attack": 459856,
-    "defense": 432280,
-    "health": 138575
-  }
+  ]
 }

--- a/hostiles/federation_trader_20_survey.json
+++ b/hostiles/federation_trader_20_survey.json
@@ -1,6 +1,11 @@
 {
   "description": "The Horizon freighter was part of the ECS's privately owned fleet and used for the transport of all types of goods, ranging from hazardous material to passengers on long-haul journeys. Originally built in the early 22nd century, they started service as pre-warp vessels but have since been maintained and upgraded for low-warp travel.",
   "group": "federation",
+  "head_stats": {
+    "attack": 3816,
+    "defense": 9750,
+    "health": 5760
+  },
   "hostile_name": "Federation Trader",
   "level": 20,
   "rarity": "common",
@@ -89,10 +94,5 @@
       },
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 3816,
-    "defense": 9750,
-    "health": 5760
-  }
+  ]
 }

--- a/hostiles/federation_trader_20_survey.json
+++ b/hostiles/federation_trader_20_survey.json
@@ -1,9 +1,6 @@
 {
   "description": "The Horizon freighter was part of the ECS's privately owned fleet and used for the transport of all types of goods, ranging from hazardous material to passengers on long-haul journeys. Originally built in the early 22nd century, they started service as pre-warp vessels but have since been maintained and upgraded for low-warp travel.",
-  "attack": 3816,
-  "defense": 9750,
   "group": "federation",
-  "health": 5760,
   "hostile_name": "Federation Trader",
   "level": 20,
   "rarity": "common",
@@ -41,7 +38,6 @@
       "shield_health": 5760
     }
   },
-  "strength": 19326,
   "systems": [
     {
       "$ref": "systems/voss_20"
@@ -81,7 +77,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_stats": {
         "accuracy": 520,
         "armor_pierce": 520,
@@ -94,5 +89,10 @@
       },
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 3816,
+    "defense": 9750,
+    "health": 5760
+  }
 }

--- a/hostiles/federation_trader_21_survey.json
+++ b/hostiles/federation_trader_21_survey.json
@@ -1,9 +1,6 @@
 {
   "description": "The Horizon freighter was part of the ECS's privately owned fleet and used for the transport of all types of goods, ranging from hazardous material to passengers on long-haul journeys. Originally built in the early 22nd century, they started service as pre-warp vessels but have since been maintained and upgraded for low-warp travel.",
-  "attack": 4914,
-  "defense": 13125,
   "group": "federation",
-  "health": 7200,
   "hostile_name": "Federation Trader",
   "level": 21,
   "rarity": "common",
@@ -41,7 +38,6 @@
       "shield_health": 7200
     }
   },
-  "strength": 25239,
   "systems": [
     {
       "$ref": "systems/voss_20"
@@ -87,8 +83,12 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 4914,
+    "defense": 13125,
+    "health": 7200
+  }
 }

--- a/hostiles/federation_trader_21_survey.json
+++ b/hostiles/federation_trader_21_survey.json
@@ -1,6 +1,11 @@
 {
   "description": "The Horizon freighter was part of the ECS's privately owned fleet and used for the transport of all types of goods, ranging from hazardous material to passengers on long-haul journeys. Originally built in the early 22nd century, they started service as pre-warp vessels but have since been maintained and upgraded for low-warp travel.",
   "group": "federation",
+  "head_stats": {
+    "attack": 4914,
+    "defense": 13125,
+    "health": 7200
+  },
   "hostile_name": "Federation Trader",
   "level": 21,
   "rarity": "common",
@@ -85,10 +90,5 @@
       "quantity": 1,
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 4914,
-    "defense": 13125,
-    "health": 7200
-  }
+  ]
 }

--- a/hostiles/federation_trader_27_survey.json
+++ b/hostiles/federation_trader_27_survey.json
@@ -1,6 +1,11 @@
 {
   "description": "The Horizon freighter was part of the ECS's privately owned fleet and used for the transport of all types of goods, ranging from hazardous material to passengers on long-haul journeys. Originally built in the early 22nd century, they started service as pre-warp vessels but have since been maintained and upgraded for low-warp travel.",
   "group": "federation",
+  "head_stats": {
+    "attack": 16962,
+    "defense": 41250,
+    "health": 28800
+  },
   "hostile_name": "Federation Trader",
   "level": 27,
   "rarity": "common",
@@ -76,10 +81,5 @@
       "quantity": 1,
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 16962,
-    "defense": 41250,
-    "health": 28800
-  }
+  ]
 }

--- a/hostiles/federation_trader_27_survey.json
+++ b/hostiles/federation_trader_27_survey.json
@@ -1,9 +1,6 @@
 {
   "description": "The Horizon freighter was part of the ECS's privately owned fleet and used for the transport of all types of goods, ranging from hazardous material to passengers on long-haul journeys. Originally built in the early 22nd century, they started service as pre-warp vessels but have since been maintained and upgraded for low-warp travel.",
-  "attack": 16962,
-  "defense": 41250,
   "group": "federation",
-  "health": 28800,
   "hostile_name": "Federation Trader",
   "level": 27,
   "rarity": "common",
@@ -41,7 +38,6 @@
       "shield_health": 28000
     }
   },
-  "strength": 87012,
   "systems": [
     {
       "$ref": "systems/durchman_26"
@@ -78,8 +74,12 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 16962,
+    "defense": 41250,
+    "health": 28800
+  }
 }

--- a/hostiles/federation_trader_31_survey.json
+++ b/hostiles/federation_trader_31_survey.json
@@ -1,9 +1,6 @@
 {
   "description": "The H-Class freighter is a long-distance heavy hauler capable of transporting vast quantities of materials and goods.",
-  "attack": 55164,
-  "defense": 123750,
   "group": "federation",
-  "health": 61920,
   "hostile_name": "Federation Trader",
   "level": 31,
   "rarity": "common",
@@ -41,7 +38,6 @@
       "shield_health": 61000
     }
   },
-  "strength": 240834,
   "systems": [
     {
       "$ref": "systems/noakyn_30"
@@ -75,8 +71,12 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 55164,
+    "defense": 123750,
+    "health": 61920
+  }
 }

--- a/hostiles/federation_trader_31_survey.json
+++ b/hostiles/federation_trader_31_survey.json
@@ -1,6 +1,11 @@
 {
   "description": "The H-Class freighter is a long-distance heavy hauler capable of transporting vast quantities of materials and goods.",
   "group": "federation",
+  "head_stats": {
+    "attack": 55164,
+    "defense": 123750,
+    "health": 61920
+  },
   "hostile_name": "Federation Trader",
   "level": 31,
   "rarity": "common",
@@ -73,10 +78,5 @@
       "quantity": 1,
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 55164,
-    "defense": 123750,
-    "health": 61920
-  }
+  ]
 }

--- a/hostiles/heavy_federation_transport_49_survey.json
+++ b/hostiles/heavy_federation_transport_49_survey.json
@@ -1,9 +1,6 @@
 {
   "description": "The H-Class freighter is a long-distance heavy hauler capable of transporting vast quantities of materials and goods.",
-  "attack": 1783778,
-  "defense": 5116850,
   "group": "federation",
-  "health": 17352294,
   "hostile_name": "Heavy Federation Transport",
   "level": 49,
   "rarity": "common",
@@ -45,7 +42,6 @@
       "shield_health": 17000000
     }
   },
-  "strength": 24252922,
   "systems": [
     {
       "$ref": "systems/sol_60"
@@ -76,8 +72,12 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "K1",
       "weapon_type": "kinetic"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 1783778,
+    "defense": 5116850,
+    "health": 17352294
+  }
 }

--- a/hostiles/heavy_federation_transport_49_survey.json
+++ b/hostiles/heavy_federation_transport_49_survey.json
@@ -1,6 +1,11 @@
 {
   "description": "The H-Class freighter is a long-distance heavy hauler capable of transporting vast quantities of materials and goods.",
   "group": "federation",
+  "head_stats": {
+    "attack": 1783778,
+    "defense": 5116850,
+    "health": 17352294
+  },
   "hostile_name": "Heavy Federation Transport",
   "level": 49,
   "rarity": "common",
@@ -74,10 +79,5 @@
       "quantity": 1,
       "weapon_type": "kinetic"
     }
-  ],
-  "head_stats": {
-    "attack": 1783778,
-    "defense": 5116850,
-    "health": 17352294
-  }
+  ]
 }

--- a/hostiles/heavy_klingon_transport_49_survey.json
+++ b/hostiles/heavy_klingon_transport_49_survey.json
@@ -1,6 +1,11 @@
 {
   "description": "The H-Class freighter is a long-distance heavy hauler capable of transporting vast quantities of materials and goods.",
   "group": "klingon",
+  "head_stats": {
+    "attack": 1823947,
+    "defense": 5116850,
+    "health": 17364737
+  },
   "hostile_name": "Heavy Klingon Transport",
   "level": 49,
   "rarity": "common",
@@ -71,10 +76,5 @@
       "quantity": 1,
       "weapon_type": "kinetic"
     }
-  ],
-  "head_stats": {
-    "attack": 1823947,
-    "defense": 5116850,
-    "health": 17364737
-  }
+  ]
 }

--- a/hostiles/heavy_klingon_transport_49_survey.json
+++ b/hostiles/heavy_klingon_transport_49_survey.json
@@ -1,9 +1,6 @@
 {
   "description": "The H-Class freighter is a long-distance heavy hauler capable of transporting vast quantities of materials and goods.",
-  "attack": 1823947,
-  "defense": 5116850,
   "group": "klingon",
-  "health": 17364737,
   "hostile_name": "Heavy Klingon Transport",
   "level": 49,
   "rarity": "common",
@@ -45,7 +42,6 @@
       "shield_health": 17000000
     }
   },
-  "strength": 24305534,
   "systems": [
     {
       "$ref": "systems/kronos_60"
@@ -73,8 +69,12 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "K1",
       "weapon_type": "kinetic"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 1823947,
+    "defense": 5116850,
+    "health": 17364737
+  }
 }

--- a/hostiles/heavy_romulan_transport_49_survey.json
+++ b/hostiles/heavy_romulan_transport_49_survey.json
@@ -1,9 +1,6 @@
 {
   "description": "The H-Class freighter is a long-distance heavy hauler capable of transporting vast quantities of materials and goods.",
-  "attack": 1823947,
-  "defense": 5116850,
   "group": "romulan",
-  "health": 17377181,
   "hostile_name": "Heavy Romulan Transport",
   "level": 49,
   "rarity": "common",
@@ -45,7 +42,6 @@
       "shield_health": 16288000
     }
   },
-  "strength": 24317978,
   "systems": [
     {
       "$ref": "systems/romulus_60"
@@ -76,7 +72,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "K1",
       "weapon_stats": {
         "accuracy": 159957,
         "armor_pierce": 159957,
@@ -89,5 +84,10 @@
       },
       "weapon_type": "kinetic"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 1823947,
+    "defense": 5116850,
+    "health": 17377181
+  }
 }

--- a/hostiles/heavy_romulan_transport_49_survey.json
+++ b/hostiles/heavy_romulan_transport_49_survey.json
@@ -1,6 +1,11 @@
 {
   "description": "The H-Class freighter is a long-distance heavy hauler capable of transporting vast quantities of materials and goods.",
   "group": "romulan",
+  "head_stats": {
+    "attack": 1823947,
+    "defense": 5116850,
+    "health": 17377181
+  },
   "hostile_name": "Heavy Romulan Transport",
   "level": 49,
   "rarity": "common",
@@ -84,10 +89,5 @@
       },
       "weapon_type": "kinetic"
     }
-  ],
-  "head_stats": {
-    "attack": 1823947,
-    "defense": 5116850,
-    "health": 17377181
-  }
+  ]
 }

--- a/hostiles/klingon_fighter_20_interceptor.json
+++ b/hostiles/klingon_fighter_20_interceptor.json
@@ -1,6 +1,11 @@
 {
   "description": "This ship is Klingon. Attacking it will result in a loss of reputation towards the Klingons and a gain of reputation towards the Federation and Romulan factions.",
   "group": "klingon",
+  "head_stats": {
+    "attack": 18830,
+    "defense": 21095,
+    "health": 6620
+  },
   "hostile_name": "Klingon Fighter",
   "level": 20,
   "rarity": "common",
@@ -103,10 +108,5 @@
       "quantity": 1,
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 18830,
-    "defense": 21095,
-    "health": 6620
-  }
+  ]
 }

--- a/hostiles/klingon_fighter_20_interceptor.json
+++ b/hostiles/klingon_fighter_20_interceptor.json
@@ -1,9 +1,6 @@
 {
   "description": "This ship is Klingon. Attacking it will result in a loss of reputation towards the Klingons and a gain of reputation towards the Federation and Romulan factions.",
-  "attack": 18830,
-  "defense": 21095,
   "group": "klingon",
-  "health": 6620,
   "hostile_name": "Klingon Fighter",
   "level": 20,
   "rarity": "common",
@@ -41,7 +38,6 @@
       "shield_health": 6620
     }
   },
-  "strength": 46545,
   "systems": [
     {
       "$ref": "systems/francihk_20"
@@ -69,7 +65,6 @@
         0
       ],
       "quantity": 1,
-      "weapon_id": "K1",
       "weapon_type": "kinetic"
     },
     {
@@ -88,7 +83,6 @@
         0
       ],
       "quantity": 1,
-      "weapon_id": "K2",
       "weapon_type": "kinetic"
     },
     {
@@ -107,8 +101,12 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 18830,
+    "defense": 21095,
+    "health": 6620
+  }
 }

--- a/hostiles/klingon_fighter_21_interceptor.json
+++ b/hostiles/klingon_fighter_21_interceptor.json
@@ -1,9 +1,6 @@
 {
   "description": "This ship is Klingon. Attacking it will result in a loss of reputation towards the Klingons and a gain of reputation towards the Federation and Romulan factions.",
-  "attack": 20334,
-  "defense": 22570,
   "group": "klingon",
-  "health": 7180,
   "hostile_name": "Klingon Fighter",
   "level": 21,
   "rarity": "common",
@@ -41,7 +38,6 @@
       "shield_health": 7180
     }
   },
-  "strength": 50084,
   "systems": [
     {
       "$ref": "systems/francihk_20"
@@ -81,7 +77,6 @@
         1
       ],
       "quantity": 2,
-      "weapon_id": "K1",
       "weapon_stats": {
         "accuracy": 690,
         "armor_pierce": 4830,
@@ -113,7 +108,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_stats": {
         "accuracy": 690,
         "armor_pierce": 4830,
@@ -145,8 +139,12 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "K2",
       "weapon_type": "kinetic"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 20334,
+    "defense": 22570,
+    "health": 7180
+  }
 }

--- a/hostiles/klingon_fighter_21_interceptor.json
+++ b/hostiles/klingon_fighter_21_interceptor.json
@@ -1,6 +1,11 @@
 {
   "description": "This ship is Klingon. Attacking it will result in a loss of reputation towards the Klingons and a gain of reputation towards the Federation and Romulan factions.",
   "group": "klingon",
+  "head_stats": {
+    "attack": 20334,
+    "defense": 22570,
+    "health": 7180
+  },
   "hostile_name": "Klingon Fighter",
   "level": 21,
   "rarity": "common",
@@ -141,10 +146,5 @@
       "quantity": 1,
       "weapon_type": "kinetic"
     }
-  ],
-  "head_stats": {
-    "attack": 20334,
-    "defense": 22570,
-    "health": 7180
-  }
+  ]
 }

--- a/hostiles/klingon_fighter_27_interceptor.json
+++ b/hostiles/klingon_fighter_27_interceptor.json
@@ -1,6 +1,11 @@
 {
   "description": "This ship is Klingon. Attacking it will result in a loss of reputation towards the Klingons and a gain of reputation towards the Federation and Romulan factions.",
   "group": "klingon",
+  "head_stats": {
+    "attack": 78743,
+    "defense": 82425,
+    "health": 32020
+  },
   "hostile_name": "Klingon Fighter",
   "level": 27,
   "rarity": "common",
@@ -115,10 +120,5 @@
       "quantity": 1,
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 78743,
-    "defense": 82425,
-    "health": 32020
-  }
+  ]
 }

--- a/hostiles/klingon_fighter_27_interceptor.json
+++ b/hostiles/klingon_fighter_27_interceptor.json
@@ -1,9 +1,6 @@
 {
   "description": "This ship is Klingon. Attacking it will result in a loss of reputation towards the Klingons and a gain of reputation towards the Federation and Romulan factions.",
-  "attack": 78743,
-  "defense": 82425,
   "group": "klingon",
-  "health": 32020,
   "hostile_name": "Klingon Fighter",
   "level": 27,
   "rarity": "common",
@@ -41,7 +38,6 @@
       "shield_health": 32000
     }
   },
-  "strength": 193188,
   "systems": [
     {
       "$ref": "systems/ciara_26"
@@ -75,7 +71,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "K1",
       "weapon_type": "kinetic"
     },
     {
@@ -97,7 +92,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "K2",
       "weapon_type": "kinetic"
     },
     {
@@ -119,8 +113,12 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 78743,
+    "defense": 82425,
+    "health": 32020
+  }
 }

--- a/hostiles/klingon_fighter_30_interceptor.json
+++ b/hostiles/klingon_fighter_30_interceptor.json
@@ -1,6 +1,11 @@
 {
   "description": "This ship is Klingon. Attacking it will result in a loss of reputation towards the Klingons and a gain of reputation towards the Federation and Romulan factions.",
   "group": "klingon",
+  "head_stats": {
+    "attack": 188504,
+    "defense": 196645,
+    "health": 53540
+  },
   "hostile_name": "Klingon Fighter",
   "level": 30,
   "rarity": "common",
@@ -109,10 +114,5 @@
       "quantity": 1,
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 188504,
-    "defense": 196645,
-    "health": 53540
-  }
+  ]
 }

--- a/hostiles/klingon_fighter_30_interceptor.json
+++ b/hostiles/klingon_fighter_30_interceptor.json
@@ -1,9 +1,6 @@
 {
   "description": "This ship is Klingon. Attacking it will result in a loss of reputation towards the Klingons and a gain of reputation towards the Federation and Romulan factions.",
-  "attack": 188504,
-  "defense": 196645,
   "group": "klingon",
-  "health": 53540,
   "hostile_name": "Klingon Fighter",
   "level": 30,
   "rarity": "common",
@@ -41,7 +38,6 @@
       "shield_health": 53000
     }
   },
-  "strength": 438689,
   "systems": [
     {
       "$ref": "systems/ebisu_31"
@@ -75,7 +71,6 @@
         0
       ],
       "quantity": 1,
-      "weapon_id": "K1",
       "weapon_type": "kinetic"
     },
     {
@@ -94,7 +89,6 @@
         0
       ],
       "quantity": 1,
-      "weapon_id": "K2",
       "weapon_type": "kinetic"
     },
     {
@@ -113,8 +107,12 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 188504,
+    "defense": 196645,
+    "health": 53540
+  }
 }

--- a/hostiles/klingon_fighter_32_interceptor.json
+++ b/hostiles/klingon_fighter_32_interceptor.json
@@ -1,9 +1,6 @@
 {
   "description": "This ship is Klingon. Attacking it will result in a loss of reputation towards the Klingons and a gain of reputation towards the Federation and Romulan factions.",
-  "attack": 294567,
-  "defense": 294375,
   "group": "klingon",
-  "health": 82800,
   "hostile_name": "Klingon Fighter",
   "level": 32,
   "rarity": "common",
@@ -41,7 +38,6 @@
       "shield_health": 82000
     }
   },
-  "strength": 671742,
   "systems": [
     {
       "$ref": "systems/ebisu_31"
@@ -87,7 +83,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "K1",
       "weapon_type": "kinetic"
     },
     {
@@ -109,7 +104,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "K2",
       "weapon_type": "kinetic"
     },
     {
@@ -131,8 +125,12 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 294567,
+    "defense": 294375,
+    "health": 82800
+  }
 }

--- a/hostiles/klingon_fighter_32_interceptor.json
+++ b/hostiles/klingon_fighter_32_interceptor.json
@@ -1,6 +1,11 @@
 {
   "description": "This ship is Klingon. Attacking it will result in a loss of reputation towards the Klingons and a gain of reputation towards the Federation and Romulan factions.",
   "group": "klingon",
+  "head_stats": {
+    "attack": 294567,
+    "defense": 294375,
+    "health": 82800
+  },
   "hostile_name": "Klingon Fighter",
   "level": 32,
   "rarity": "common",
@@ -127,10 +132,5 @@
       "quantity": 1,
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 294567,
-    "defense": 294375,
-    "health": 82800
-  }
+  ]
 }

--- a/hostiles/klingon_patrol_25_explorer.json
+++ b/hostiles/klingon_patrol_25_explorer.json
@@ -1,9 +1,6 @@
 {
   "description": "This ship is Klingon. Attacking it will result in a loss of reputation towards the Klingons and a gain of reputation towards the Federation and Romulan factions.",
-  "attack": 18707,
-  "defense": 22655,
   "group": "klingon",
-  "health": 10215,
   "hostile_name": "Klingon Patrol",
   "level": 25,
   "rarity": "common",
@@ -41,7 +38,6 @@
       "shield_health": 10490
     }
   },
-  "strength": 51577,
   "systems": [
     {
       "$ref": "systems/loiat_24"
@@ -93,7 +89,6 @@
         1
       ],
       "quantity": 3,
-      "weapon_id": "E1",
       "weapon_stats": {
         "accuracy": 4500,
         "armor_pierce": 875,
@@ -125,7 +120,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E2",
       "weapon_type": "energy"
     },
     {
@@ -147,8 +141,12 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E3",
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 18707,
+    "defense": 22655,
+    "health": 10215
+  }
 }

--- a/hostiles/klingon_patrol_25_explorer.json
+++ b/hostiles/klingon_patrol_25_explorer.json
@@ -1,6 +1,11 @@
 {
   "description": "This ship is Klingon. Attacking it will result in a loss of reputation towards the Klingons and a gain of reputation towards the Federation and Romulan factions.",
   "group": "klingon",
+  "head_stats": {
+    "attack": 18707,
+    "defense": 22655,
+    "health": 10215
+  },
   "hostile_name": "Klingon Patrol",
   "level": 25,
   "rarity": "common",
@@ -143,10 +148,5 @@
       "quantity": 1,
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 18707,
-    "defense": 22655,
-    "health": 10215
-  }
+  ]
 }

--- a/hostiles/klingon_patrol_25_interceptor.json
+++ b/hostiles/klingon_patrol_25_interceptor.json
@@ -1,9 +1,6 @@
 {
   "description": "This ship is Klingon. Attacking it will result in a loss of reputation towards the Klingons and a gain of reputation towards the Federation and Romulan factions.",
-  "attack": 22036,
-  "defense": 24530,
   "group": "klingon",
-  "health": 8830,
   "hostile_name": "Klingon Patrol",
   "level": 25,
   "rarity": "common",
@@ -41,7 +38,6 @@
       "shield_health": 8830
     }
   },
-  "strength": 55396,
   "systems": [
     {
       "$ref": "systems/loiat_24"
@@ -81,7 +77,6 @@
         1
       ],
       "quantity": 2,
-      "weapon_id": "K1",
       "weapon_stats": {
         "accuracy": 750,
         "armor_pierce": 5250,
@@ -113,7 +108,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_stats": {
         "accuracy": 750,
         "armor_pierce": 5250,
@@ -145,8 +139,12 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "K2",
       "weapon_type": "kinetic"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 22036,
+    "defense": 24530,
+    "health": 8830
+  }
 }

--- a/hostiles/klingon_patrol_25_interceptor.json
+++ b/hostiles/klingon_patrol_25_interceptor.json
@@ -1,6 +1,11 @@
 {
   "description": "This ship is Klingon. Attacking it will result in a loss of reputation towards the Klingons and a gain of reputation towards the Federation and Romulan factions.",
   "group": "klingon",
+  "head_stats": {
+    "attack": 22036,
+    "defense": 24530,
+    "health": 8830
+  },
   "hostile_name": "Klingon Patrol",
   "level": 25,
   "rarity": "common",
@@ -141,10 +146,5 @@
       "quantity": 1,
       "weapon_type": "kinetic"
     }
-  ],
-  "head_stats": {
-    "attack": 22036,
-    "defense": 24530,
-    "health": 8830
-  }
+  ]
 }

--- a/hostiles/klingon_patrol_29_battleship.json
+++ b/hostiles/klingon_patrol_29_battleship.json
@@ -1,9 +1,6 @@
 {
   "description": "This ship is Klingon. Attacking it will result in a loss of reputation towards the Klingons and a gain of reputation towards the Federation and Romulan factions.",
-  "attack": 55931,
-  "defense": 59500,
   "group": "klingon",
-  "health": 33205,
   "hostile_name": "Klingon Patrol",
   "level": 29,
   "rarity": "common",
@@ -41,7 +38,6 @@
       "shield_health": 28000
     }
   },
-  "strength": 148636,
   "systems": [
     {
       "$ref": "systems/morska_29"
@@ -81,7 +77,6 @@
         0
       ],
       "quantity": 1,
-      "weapon_id": "K1",
       "weapon_type": "kinetic"
     },
     {
@@ -100,7 +95,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_type": "energy"
     },
     {
@@ -119,8 +113,12 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E2",
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 55931,
+    "defense": 59500,
+    "health": 33205
+  }
 }

--- a/hostiles/klingon_patrol_29_battleship.json
+++ b/hostiles/klingon_patrol_29_battleship.json
@@ -1,6 +1,11 @@
 {
   "description": "This ship is Klingon. Attacking it will result in a loss of reputation towards the Klingons and a gain of reputation towards the Federation and Romulan factions.",
   "group": "klingon",
+  "head_stats": {
+    "attack": 55931,
+    "defense": 59500,
+    "health": 33205
+  },
   "hostile_name": "Klingon Patrol",
   "level": 29,
   "rarity": "common",
@@ -115,10 +120,5 @@
       "quantity": 1,
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 55931,
-    "defense": 59500,
-    "health": 33205
-  }
+  ]
 }

--- a/hostiles/klingon_patrol_29_explorer.json
+++ b/hostiles/klingon_patrol_29_explorer.json
@@ -1,9 +1,6 @@
 {
   "description": "This ship is Klingon. Attacking it will result in a loss of reputation towards the Klingons and a gain of reputation towards the Federation and Romulan factions.",
-  "attack": 54312,
-  "defense": 63440,
   "group": "klingon",
-  "health": 35105,
   "hostile_name": "Klingon Patrol",
   "level": 29,
   "rarity": "common",
@@ -41,7 +38,6 @@
       "shield_health": 36000
     }
   },
-  "strength": 152857,
   "systems": [
     {
       "$ref": "systems/morska_29"
@@ -81,7 +77,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_type": "energy"
     },
     {
@@ -100,7 +95,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E2",
       "weapon_type": "energy"
     },
     {
@@ -119,8 +113,12 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E3",
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 54312,
+    "defense": 63440,
+    "health": 35105
+  }
 }

--- a/hostiles/klingon_patrol_29_explorer.json
+++ b/hostiles/klingon_patrol_29_explorer.json
@@ -1,6 +1,11 @@
 {
   "description": "This ship is Klingon. Attacking it will result in a loss of reputation towards the Klingons and a gain of reputation towards the Federation and Romulan factions.",
   "group": "klingon",
+  "head_stats": {
+    "attack": 54312,
+    "defense": 63440,
+    "health": 35105
+  },
   "hostile_name": "Klingon Patrol",
   "level": 29,
   "rarity": "common",
@@ -115,10 +120,5 @@
       "quantity": 1,
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 54312,
-    "defense": 63440,
-    "health": 35105
-  }
+  ]
 }

--- a/hostiles/klingon_patrol_29_interceptor.json
+++ b/hostiles/klingon_patrol_29_interceptor.json
@@ -1,6 +1,11 @@
 {
   "description": "This ship is Klingon. Attacking it will result in a loss of reputation towards the Klingons and a gain of reputation towards the Federation and Romulan factions.",
   "group": "klingon",
+  "head_stats": {
+    "attack": 64113,
+    "defense": 68690,
+    "health": 30360
+  },
   "hostile_name": "Klingon Patrol",
   "level": 29,
   "rarity": "common",
@@ -115,10 +120,5 @@
       "quantity": 1,
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 64113,
-    "defense": 68690,
-    "health": 30360
-  }
+  ]
 }

--- a/hostiles/klingon_patrol_29_interceptor.json
+++ b/hostiles/klingon_patrol_29_interceptor.json
@@ -1,9 +1,6 @@
 {
   "description": "This ship is Klingon. Attacking it will result in a loss of reputation towards the Klingons and a gain of reputation towards the Federation and Romulan factions.",
-  "attack": 64113,
-  "defense": 68690,
   "group": "klingon",
-  "health": 30360,
   "hostile_name": "Klingon Patrol",
   "level": 29,
   "rarity": "common",
@@ -41,7 +38,6 @@
       "shield_health": 30000
     }
   },
-  "strength": 163163,
   "systems": [
     {
       "$ref": "systems/morska_29"
@@ -81,7 +77,6 @@
         0
       ],
       "quantity": 1,
-      "weapon_id": "K1",
       "weapon_type": "kinetic"
     },
     {
@@ -100,7 +95,6 @@
         0
       ],
       "quantity": 1,
-      "weapon_id": "K2",
       "weapon_type": "kinetic"
     },
     {
@@ -119,8 +113,12 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 64113,
+    "defense": 68690,
+    "health": 30360
+  }
 }

--- a/hostiles/klingon_patrol_30_explorer.json
+++ b/hostiles/klingon_patrol_30_explorer.json
@@ -1,6 +1,11 @@
 {
   "description": "This ship is Klingon. Attacking it will result in a loss of reputation towards the Klingons and a gain of reputation towards the Federation and Romulan factions.",
   "group": "klingon",
+  "head_stats": {
+    "attack": 66623,
+    "defense": 76125,
+    "health": 37020
+  },
   "hostile_name": "Klingon Patrol",
   "level": 30,
   "rarity": "common",
@@ -109,10 +114,5 @@
       "quantity": 1,
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 66623,
-    "defense": 76125,
-    "health": 37020
-  }
+  ]
 }

--- a/hostiles/klingon_patrol_30_explorer.json
+++ b/hostiles/klingon_patrol_30_explorer.json
@@ -1,9 +1,6 @@
 {
   "description": "This ship is Klingon. Attacking it will result in a loss of reputation towards the Klingons and a gain of reputation towards the Federation and Romulan factions.",
-  "attack": 66623,
-  "defense": 76125,
   "group": "klingon",
-  "health": 37020,
   "hostile_name": "Klingon Patrol",
   "level": 30,
   "rarity": "common",
@@ -41,7 +38,6 @@
       "shield_health": 38000
     }
   },
-  "strength": 179768,
   "systems": [
     {
       "$ref": "systems/morska_29"
@@ -75,7 +71,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_type": "energy"
     },
     {
@@ -94,7 +89,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E2",
       "weapon_type": "energy"
     },
     {
@@ -113,8 +107,12 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E3",
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 66623,
+    "defense": 76125,
+    "health": 37020
+  }
 }

--- a/hostiles/klingon_patrol_30_interceptor.json
+++ b/hostiles/klingon_patrol_30_interceptor.json
@@ -1,9 +1,6 @@
 {
   "description": "This ship is Klingon. Attacking it will result in a loss of reputation towards the Klingons and a gain of reputation towards the Federation and Romulan factions.",
-  "attack": 78743,
-  "defense": 82425,
   "group": "klingon",
-  "health": 32020,
   "hostile_name": "Klingon Patrol",
   "level": 30,
   "rarity": "common",
@@ -41,7 +38,6 @@
       "shield_health": 32000
     }
   },
-  "strength": 193188,
   "systems": [
     {
       "$ref": "systems/morska_29"
@@ -78,7 +74,6 @@
         0
       ],
       "quantity": 1,
-      "weapon_id": "K1",
       "weapon_type": "kinetic"
     },
     {
@@ -97,7 +92,6 @@
         0
       ],
       "quantity": 1,
-      "weapon_id": "K2",
       "weapon_type": "kinetic"
     },
     {
@@ -116,8 +110,12 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 78743,
+    "defense": 82425,
+    "health": 32020
+  }
 }

--- a/hostiles/klingon_patrol_30_interceptor.json
+++ b/hostiles/klingon_patrol_30_interceptor.json
@@ -1,6 +1,11 @@
 {
   "description": "This ship is Klingon. Attacking it will result in a loss of reputation towards the Klingons and a gain of reputation towards the Federation and Romulan factions.",
   "group": "klingon",
+  "head_stats": {
+    "attack": 78743,
+    "defense": 82425,
+    "health": 32020
+  },
   "hostile_name": "Klingon Patrol",
   "level": 30,
   "rarity": "common",
@@ -112,10 +117,5 @@
       "quantity": 1,
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 78743,
-    "defense": 82425,
-    "health": 32020
-  }
+  ]
 }

--- a/hostiles/klingon_patrol_31_battleship.json
+++ b/hostiles/klingon_patrol_31_battleship.json
@@ -1,6 +1,11 @@
 {
   "description": "This ship is Klingon. Attacking it will result in a loss of reputation towards the Klingons and a gain of reputation towards the Federation and Romulan factions.",
   "group": "klingon",
+  "head_stats": {
+    "attack": 90993,
+    "defense": 93500,
+    "health": 42265
+  },
   "hostile_name": "Klingon Patrol",
   "level": 31,
   "rarity": "common",
@@ -133,10 +138,5 @@
       "quantity": 1,
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 90993,
-    "defense": 93500,
-    "health": 42265
-  }
+  ]
 }

--- a/hostiles/klingon_patrol_31_battleship.json
+++ b/hostiles/klingon_patrol_31_battleship.json
@@ -1,9 +1,6 @@
 {
   "description": "This ship is Klingon. Attacking it will result in a loss of reputation towards the Klingons and a gain of reputation towards the Federation and Romulan factions.",
-  "attack": 90993,
-  "defense": 93500,
   "group": "klingon",
-  "health": 42265,
   "hostile_name": "Klingon Patrol",
   "level": 31,
   "rarity": "common",
@@ -41,7 +38,6 @@
       "shield_health": 36000
     }
   },
-  "strength": 226758,
   "systems": [
     {
       "$ref": "systems/elequa_30"
@@ -93,7 +89,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "K1",
       "weapon_type": "kinetic"
     },
     {
@@ -115,7 +110,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_type": "energy"
     },
     {
@@ -137,8 +131,12 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E2",
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 90993,
+    "defense": 93500,
+    "health": 42265
+  }
 }

--- a/hostiles/klingon_patrol_31_explorer.json
+++ b/hostiles/klingon_patrol_31_explorer.json
@@ -1,6 +1,11 @@
 {
   "description": "This ship is Klingon. Attacking it will result in a loss of reputation towards the Klingons and a gain of reputation towards the Federation and Romulan factions.",
   "group": "klingon",
+  "head_stats": {
+    "attack": 88107,
+    "defense": 99690,
+    "health": 44680
+  },
   "hostile_name": "Klingon Patrol",
   "level": 31,
   "rarity": "common",
@@ -106,10 +111,5 @@
       "quantity": 1,
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 88107,
-    "defense": 99690,
-    "health": 44680
-  }
+  ]
 }

--- a/hostiles/klingon_patrol_31_explorer.json
+++ b/hostiles/klingon_patrol_31_explorer.json
@@ -1,9 +1,6 @@
 {
   "description": "This ship is Klingon. Attacking it will result in a loss of reputation towards the Klingons and a gain of reputation towards the Federation and Romulan factions.",
-  "attack": 88107,
-  "defense": 99690,
   "group": "klingon",
-  "health": 44680,
   "hostile_name": "Klingon Patrol",
   "level": 31,
   "rarity": "common",
@@ -41,7 +38,6 @@
       "shield_health": 45000
     }
   },
-  "strength": 232477,
   "systems": [
     {
       "$ref": "systems/elequa_30"
@@ -72,7 +68,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_type": "energy"
     },
     {
@@ -91,7 +86,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E2",
       "weapon_type": "energy"
     },
     {
@@ -110,8 +104,12 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E3",
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 88107,
+    "defense": 99690,
+    "health": 44680
+  }
 }

--- a/hostiles/klingon_patrol_31_interceptor.json
+++ b/hostiles/klingon_patrol_31_interceptor.json
@@ -1,9 +1,6 @@
 {
   "description": "This ship is Klingon. Attacking it will result in a loss of reputation towards the Klingons and a gain of reputation towards the Federation and Romulan factions.",
-  "attack": 104192,
-  "defense": 107940,
   "group": "klingon",
-  "health": 38640,
   "hostile_name": "Klingon Patrol",
   "level": 31,
   "rarity": "common",
@@ -41,7 +38,6 @@
       "shield_health": 38000
     }
   },
-  "strength": 250772,
   "systems": [
     {
       "$ref": "systems/elequa_30"
@@ -93,7 +89,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "K1",
       "weapon_type": "kinetic"
     },
     {
@@ -115,7 +110,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "K2",
       "weapon_type": "kinetic"
     },
     {
@@ -137,8 +131,12 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 104192,
+    "defense": 107940,
+    "health": 38640
+  }
 }

--- a/hostiles/klingon_patrol_31_interceptor.json
+++ b/hostiles/klingon_patrol_31_interceptor.json
@@ -1,6 +1,11 @@
 {
   "description": "This ship is Klingon. Attacking it will result in a loss of reputation towards the Klingons and a gain of reputation towards the Federation and Romulan factions.",
   "group": "klingon",
+  "head_stats": {
+    "attack": 104192,
+    "defense": 107940,
+    "health": 38640
+  },
   "hostile_name": "Klingon Patrol",
   "level": 31,
   "rarity": "common",
@@ -133,10 +138,5 @@
       "quantity": 1,
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 104192,
-    "defense": 107940,
-    "health": 38640
-  }
+  ]
 }

--- a/hostiles/klingon_patrol_35_battleship.json
+++ b/hostiles/klingon_patrol_35_battleship.json
@@ -1,6 +1,11 @@
 {
   "description": "This ship is Klingon. Attacking it will result in a loss of reputation towards the Klingons and a gain of reputation towards the Federation and Romulan factions.",
   "group": "klingon",
+  "head_stats": {
+    "attack": 257537,
+    "defense": 255000,
+    "health": 90565
+  },
   "hostile_name": "Klingon Patrol",
   "level": 35,
   "rarity": "common",
@@ -115,10 +120,5 @@
       "quantity": 1,
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 257537,
-    "defense": 255000,
-    "health": 90565
-  }
+  ]
 }

--- a/hostiles/klingon_patrol_35_battleship.json
+++ b/hostiles/klingon_patrol_35_battleship.json
@@ -1,9 +1,6 @@
 {
   "description": "This ship is Klingon. Attacking it will result in a loss of reputation towards the Klingons and a gain of reputation towards the Federation and Romulan factions.",
-  "attack": 257537,
-  "defense": 255000,
   "group": "klingon",
-  "health": 90565,
   "hostile_name": "Klingon Patrol",
   "level": 35,
   "rarity": "common",
@@ -41,7 +38,6 @@
       "shield_health": 77000
     }
   },
-  "strength": 603102,
   "systems": [
     {
       "$ref": "systems/beta_penthe_34"
@@ -81,7 +77,6 @@
         0
       ],
       "quantity": 1,
-      "weapon_id": "K1",
       "weapon_type": "kinetic"
     },
     {
@@ -100,7 +95,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_type": "energy"
     },
     {
@@ -119,8 +113,12 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E2",
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 257537,
+    "defense": 255000,
+    "health": 90565
+  }
 }

--- a/hostiles/klingon_patrol_35_explorer.json
+++ b/hostiles/klingon_patrol_35_explorer.json
@@ -1,6 +1,11 @@
 {
   "description": "This ship is Klingon. Attacking it will result in a loss of reputation towards the Klingons and a gain of reputation towards the Federation and Romulan factions.",
   "group": "klingon",
+  "head_stats": {
+    "attack": 248633,
+    "defense": 271875,
+    "health": 95740
+  },
   "hostile_name": "Klingon Patrol",
   "level": 35,
   "rarity": "common",
@@ -115,10 +120,5 @@
       "quantity": 1,
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 248633,
-    "defense": 271875,
-    "health": 95740
-  }
+  ]
 }

--- a/hostiles/klingon_patrol_35_explorer.json
+++ b/hostiles/klingon_patrol_35_explorer.json
@@ -1,9 +1,6 @@
 {
   "description": "This ship is Klingon. Attacking it will result in a loss of reputation towards the Klingons and a gain of reputation towards the Federation and Romulan factions.",
-  "attack": 248633,
-  "defense": 271875,
   "group": "klingon",
-  "health": 95740,
   "hostile_name": "Klingon Patrol",
   "level": 35,
   "rarity": "common",
@@ -41,7 +38,6 @@
       "shield_health": 98000
     }
   },
-  "strength": 616248,
   "systems": [
     {
       "$ref": "systems/beta_penthe_34"
@@ -81,7 +77,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_type": "energy"
     },
     {
@@ -100,7 +95,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E2",
       "weapon_type": "energy"
     },
     {
@@ -119,8 +113,12 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E3",
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 248633,
+    "defense": 271875,
+    "health": 95740
+  }
 }

--- a/hostiles/klingon_patrol_35_interceptor.json
+++ b/hostiles/klingon_patrol_35_interceptor.json
@@ -1,6 +1,11 @@
 {
   "description": "This ship is Klingon. Attacking it will result in a loss of reputation towards the Klingons and a gain of reputation towards the Federation and Romulan factions.",
   "group": "klingon",
+  "head_stats": {
+    "attack": 294567,
+    "defense": 294375,
+    "health": 82800
+  },
   "hostile_name": "Klingon Patrol",
   "level": 35,
   "rarity": "common",
@@ -115,10 +120,5 @@
       "quantity": 1,
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 294567,
-    "defense": 294375,
-    "health": 82800
-  }
+  ]
 }

--- a/hostiles/klingon_patrol_35_interceptor.json
+++ b/hostiles/klingon_patrol_35_interceptor.json
@@ -1,9 +1,6 @@
 {
   "description": "This ship is Klingon. Attacking it will result in a loss of reputation towards the Klingons and a gain of reputation towards the Federation and Romulan factions.",
-  "attack": 294567,
-  "defense": 294375,
   "group": "klingon",
-  "health": 82800,
   "hostile_name": "Klingon Patrol",
   "level": 35,
   "rarity": "common",
@@ -41,7 +38,6 @@
       "shield_health": 82000
     }
   },
-  "strength": 671742,
   "systems": [
     {
       "$ref": "systems/beta_penthe_34"
@@ -81,7 +77,6 @@
         0
       ],
       "quantity": 1,
-      "weapon_id": "K1",
       "weapon_type": "kinetic"
     },
     {
@@ -100,7 +95,6 @@
         0
       ],
       "quantity": 1,
-      "weapon_id": "K2",
       "weapon_type": "kinetic"
     },
     {
@@ -119,8 +113,12 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 294567,
+    "defense": 294375,
+    "health": 82800
+  }
 }

--- a/hostiles/klingon_patrol_36_battleship.json
+++ b/hostiles/klingon_patrol_36_battleship.json
@@ -1,6 +1,11 @@
 {
   "description": "This ship is Klingon. Attacking it will result in a loss of reputation towards the Klingons and a gain of reputation towards the Federation and Romulan factions.",
   "group": "klingon",
+  "head_stats": {
+    "attack": 321692,
+    "defense": 309820,
+    "health": 109380
+  },
   "hostile_name": "Klingon Patrol",
   "level": 36,
   "rarity": "common",
@@ -141,10 +146,5 @@
       "quantity": 1,
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 321692,
-    "defense": 309820,
-    "health": 109380
-  }
+  ]
 }

--- a/hostiles/klingon_patrol_36_battleship.json
+++ b/hostiles/klingon_patrol_36_battleship.json
@@ -1,9 +1,6 @@
 {
   "description": "This ship is Klingon. Attacking it will result in a loss of reputation towards the Klingons and a gain of reputation towards the Federation and Romulan factions.",
-  "attack": 321692,
-  "defense": 309820,
   "group": "klingon",
-  "health": 109380,
   "hostile_name": "Klingon Patrol",
   "level": 36,
   "rarity": "common",
@@ -41,7 +38,6 @@
       "shield_health": 93750
     }
   },
-  "strength": 740892,
   "systems": [
     {
       "$ref": "systems/lixar_35"
@@ -81,7 +77,6 @@
         1
       ],
       "quantity": 2,
-      "weapon_id": "E1",
       "weapon_stats": {
         "accuracy": 10935,
         "armor_pierce": 12757,
@@ -113,7 +108,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "K1",
       "weapon_stats": {
         "accuracy": 10935,
         "armor_pierce": 12757,
@@ -145,8 +139,12 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E2",
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 321692,
+    "defense": 309820,
+    "health": 109380
+  }
 }

--- a/hostiles/klingon_patrol_36_explorer.json
+++ b/hostiles/klingon_patrol_36_explorer.json
@@ -1,9 +1,6 @@
 {
   "description": "This ship is Klingon. Attacking it will result in a loss of reputation towards the Klingons and a gain of reputation towards the Federation and Romulan factions.",
-  "attack": 309904,
-  "defense": 330320,
   "group": "klingon",
-  "health": 115635,
   "hostile_name": "Klingon Patrol",
   "level": 36,
   "rarity": "common",
@@ -41,7 +38,6 @@
       "shield_health": 118000
     }
   },
-  "strength": 755859,
   "systems": [
     {
       "$ref": "systems/lixar_35"
@@ -78,7 +74,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_type": "energy"
     },
     {
@@ -97,7 +92,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E2",
       "weapon_type": "energy"
     },
     {
@@ -116,8 +110,12 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E3",
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 309904,
+    "defense": 330320,
+    "health": 115635
+  }
 }

--- a/hostiles/klingon_patrol_36_explorer.json
+++ b/hostiles/klingon_patrol_36_explorer.json
@@ -1,6 +1,11 @@
 {
   "description": "This ship is Klingon. Attacking it will result in a loss of reputation towards the Klingons and a gain of reputation towards the Federation and Romulan factions.",
   "group": "klingon",
+  "head_stats": {
+    "attack": 309904,
+    "defense": 330320,
+    "health": 115635
+  },
   "hostile_name": "Klingon Patrol",
   "level": 36,
   "rarity": "common",
@@ -112,10 +117,5 @@
       "quantity": 1,
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 309904,
-    "defense": 330320,
-    "health": 115635
-  }
+  ]
 }

--- a/hostiles/klingon_patrol_36_interceptor.json
+++ b/hostiles/klingon_patrol_36_interceptor.json
@@ -1,9 +1,6 @@
 {
   "description": "This ship is Klingon. Attacking it will result in a loss of reputation towards the Klingons and a gain of reputation towards the Federation and Romulan factions.",
-  "attack": 367652,
-  "defense": 357660,
   "group": "klingon",
-  "health": 100000,
   "hostile_name": "Klingon Patrol",
   "level": 36,
   "rarity": "common",
@@ -41,7 +38,6 @@
       "shield_health": 100000
     }
   },
-  "strength": 825312,
   "systems": [
     {
       "$ref": "systems/lixar_35"
@@ -78,7 +74,6 @@
         0
       ],
       "quantity": 1,
-      "weapon_id": "K1",
       "weapon_type": "kinetic"
     },
     {
@@ -97,7 +92,6 @@
         0
       ],
       "quantity": 1,
-      "weapon_id": "K2",
       "weapon_type": "kinetic"
     },
     {
@@ -116,8 +110,12 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 367652,
+    "defense": 357660,
+    "health": 100000
+  }
 }

--- a/hostiles/klingon_patrol_36_interceptor.json
+++ b/hostiles/klingon_patrol_36_interceptor.json
@@ -1,6 +1,11 @@
 {
   "description": "This ship is Klingon. Attacking it will result in a loss of reputation towards the Klingons and a gain of reputation towards the Federation and Romulan factions.",
   "group": "klingon",
+  "head_stats": {
+    "attack": 367652,
+    "defense": 357660,
+    "health": 100000
+  },
   "hostile_name": "Klingon Patrol",
   "level": 36,
   "rarity": "common",
@@ -112,10 +117,5 @@
       "quantity": 1,
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 367652,
-    "defense": 357660,
-    "health": 100000
-  }
+  ]
 }

--- a/hostiles/klingon_patrol_37_battleship.json
+++ b/hostiles/klingon_patrol_37_battleship.json
@@ -1,9 +1,6 @@
 {
   "description": "This ship is Klingon. Attacking it will result in a loss of reputation towards the Klingons and a gain of reputation towards the Federation and Romulan factions.",
-  "attack": 367488,
-  "defense": 354920,
   "group": "klingon",
-  "health": 126095,
   "hostile_name": "Klingon Patrol",
   "level": 37,
   "rarity": "common",
@@ -41,7 +38,6 @@
       "shield_health": 108100
     }
   },
-  "strength": 848503,
   "systems": [
     {
       "$ref": "systems/jiwu_puh_36"
@@ -90,7 +86,6 @@
         1
       ],
       "quantity": 2,
-      "weapon_id": "E1",
       "weapon_stats": {
         "accuracy": 12527,
         "armor_pierce": 14614,
@@ -122,7 +117,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "K1",
       "weapon_stats": {
         "accuracy": 12527,
         "armor_pierce": 14614,
@@ -154,8 +148,12 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E2",
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 367488,
+    "defense": 354920,
+    "health": 126095
+  }
 }

--- a/hostiles/klingon_patrol_37_battleship.json
+++ b/hostiles/klingon_patrol_37_battleship.json
@@ -1,6 +1,11 @@
 {
   "description": "This ship is Klingon. Attacking it will result in a loss of reputation towards the Klingons and a gain of reputation towards the Federation and Romulan factions.",
   "group": "klingon",
+  "head_stats": {
+    "attack": 367488,
+    "defense": 354920,
+    "health": 126095
+  },
   "hostile_name": "Klingon Patrol",
   "level": 37,
   "rarity": "common",
@@ -150,10 +155,5 @@
       "quantity": 1,
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 367488,
-    "defense": 354920,
-    "health": 126095
-  }
+  ]
 }

--- a/hostiles/klingon_patrol_38_battleship.json
+++ b/hostiles/klingon_patrol_38_battleship.json
@@ -1,9 +1,6 @@
 {
   "description": "This ship is Klingon. Attacking it will result in a loss of reputation towards the Klingons and a gain of reputation towards the Federation and Romulan factions.",
-  "attack": 445817,
-  "defense": 432280,
   "group": "klingon",
-  "health": 154935,
   "hostile_name": "Klingon Patrol",
   "level": 38,
   "rarity": "common",
@@ -41,7 +38,6 @@
       "shield_health": 132000
     }
   },
-  "strength": 1033032,
   "systems": [
     {
       "$ref": "systems/qu_vat_38"
@@ -75,7 +71,6 @@
         0
       ],
       "quantity": 1,
-      "weapon_id": "K1",
       "weapon_type": "kinetic"
     },
     {
@@ -94,7 +89,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_type": "energy"
     },
     {
@@ -113,8 +107,12 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E2",
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 445817,
+    "defense": 432280,
+    "health": 154935
+  }
 }

--- a/hostiles/klingon_patrol_38_battleship.json
+++ b/hostiles/klingon_patrol_38_battleship.json
@@ -1,6 +1,11 @@
 {
   "description": "This ship is Klingon. Attacking it will result in a loss of reputation towards the Klingons and a gain of reputation towards the Federation and Romulan factions.",
   "group": "klingon",
+  "head_stats": {
+    "attack": 445817,
+    "defense": 432280,
+    "health": 154935
+  },
   "hostile_name": "Klingon Patrol",
   "level": 38,
   "rarity": "common",
@@ -109,10 +114,5 @@
       "quantity": 1,
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 445817,
-    "defense": 432280,
-    "health": 154935
-  }
+  ]
 }

--- a/hostiles/klingon_patrol_40_battleship.json
+++ b/hostiles/klingon_patrol_40_battleship.json
@@ -1,6 +1,11 @@
 {
   "description": "This ship is Klingon. Attacking it will result in a loss of reputation towards the Klingons and a gain of reputation towards the Federation and Romulan factions.",
   "group": "klingon",
+  "head_stats": {
+    "attack": 674430,
+    "defense": 658320,
+    "health": 239400
+  },
   "hostile_name": "Klingon Patrol",
   "level": 40,
   "rarity": "common",
@@ -163,10 +168,5 @@
       "quantity": 1,
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 674430,
-    "defense": 658320,
-    "health": 239400
-  }
+  ]
 }

--- a/hostiles/klingon_patrol_40_battleship.json
+++ b/hostiles/klingon_patrol_40_battleship.json
@@ -1,9 +1,6 @@
 {
   "description": "This ship is Klingon. Attacking it will result in a loss of reputation towards the Klingons and a gain of reputation towards the Federation and Romulan factions.",
-  "attack": 674430,
-  "defense": 658320,
   "group": "klingon",
-  "health": 239400,
   "hostile_name": "Klingon Patrol",
   "level": 40,
   "rarity": "common",
@@ -41,7 +38,6 @@
       "shield_health": 205000
     }
   },
-  "strength": 1572150,
   "systems": [
     {
       "$ref": "systems/archanis_39"
@@ -123,7 +119,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "K1",
       "weapon_type": "kinetic"
     },
     {
@@ -145,7 +140,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_type": "energy"
     },
     {
@@ -167,8 +161,12 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E2",
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 674430,
+    "defense": 658320,
+    "health": 239400
+  }
 }

--- a/hostiles/klingon_patrol_40_explorer.json
+++ b/hostiles/klingon_patrol_40_explorer.json
@@ -1,9 +1,6 @@
 {
   "description": "This ship is Klingon. Attacking it will result in a loss of reputation towards the Klingons and a gain of reputation towards the Federation and Romulan factions.",
-  "attack": 1203945,
-  "defense": 559945,
   "group": "klingon",
-  "health": 1840706,
   "hostile_name": "Klingon Patrol",
   "level": 40,
   "rarity": "common",
@@ -45,7 +42,6 @@
       "shield_health": 2207000
     }
   },
-  "strength": 3604596,
   "systems": [
     {
       "$ref": "systems/garyb_40"
@@ -79,7 +75,6 @@
         3
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_type": "energy"
     },
     {
@@ -101,7 +96,6 @@
         3
       ],
       "quantity": 1,
-      "weapon_id": "E2",
       "weapon_type": "energy"
     },
     {
@@ -123,8 +117,12 @@
         3
       ],
       "quantity": 1,
-      "weapon_id": "E3",
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 1203945,
+    "defense": 559945,
+    "health": 1840706
+  }
 }

--- a/hostiles/klingon_patrol_40_explorer.json
+++ b/hostiles/klingon_patrol_40_explorer.json
@@ -1,6 +1,11 @@
 {
   "description": "This ship is Klingon. Attacking it will result in a loss of reputation towards the Klingons and a gain of reputation towards the Federation and Romulan factions.",
   "group": "klingon",
+  "head_stats": {
+    "attack": 1203945,
+    "defense": 559945,
+    "health": 1840706
+  },
   "hostile_name": "Klingon Patrol",
   "level": 40,
   "rarity": "common",
@@ -119,10 +124,5 @@
       "quantity": 1,
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 1203945,
-    "defense": 559945,
-    "health": 1840706
-  }
+  ]
 }

--- a/hostiles/klingon_patrol_40_interceptor.json
+++ b/hostiles/klingon_patrol_40_interceptor.json
@@ -1,9 +1,6 @@
 {
   "description": "This ship is Klingon. Attacking it will result in a loss of reputation towards the Klingons and a gain of reputation towards the Federation and Romulan factions.",
-  "attack": 771081,
-  "defense": 759970,
   "group": "klingon",
-  "health": 218880,
   "hostile_name": "Klingon Patrol",
   "level": 40,
   "rarity": "common",
@@ -41,7 +38,6 @@
       "shield_health": 218000
     }
   },
-  "strength": 1749931,
   "systems": [
     {
       "$ref": "systems/archanis_39"
@@ -123,7 +119,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "K1",
       "weapon_type": "kinetic"
     },
     {
@@ -145,7 +140,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "K2",
       "weapon_type": "kinetic"
     },
     {
@@ -167,8 +161,12 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 771081,
+    "defense": 759970,
+    "health": 218880
+  }
 }

--- a/hostiles/klingon_patrol_40_interceptor.json
+++ b/hostiles/klingon_patrol_40_interceptor.json
@@ -1,6 +1,11 @@
 {
   "description": "This ship is Klingon. Attacking it will result in a loss of reputation towards the Klingons and a gain of reputation towards the Federation and Romulan factions.",
   "group": "klingon",
+  "head_stats": {
+    "attack": 771081,
+    "defense": 759970,
+    "health": 218880
+  },
   "hostile_name": "Klingon Patrol",
   "level": 40,
   "rarity": "common",
@@ -163,10 +168,5 @@
       "quantity": 1,
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 771081,
-    "defense": 759970,
-    "health": 218880
-  }
+  ]
 }

--- a/hostiles/klingon_patrol_42_battleship.json
+++ b/hostiles/klingon_patrol_42_battleship.json
@@ -1,6 +1,11 @@
 {
   "description": "This ship is Klingon. Attacking it will result in a loss of reputation towards the Klingons and a gain of reputation towards the Federation and Romulan factions.",
   "group": "klingon",
+  "head_stats": {
+    "attack": 1868579,
+    "defense": 712735,
+    "health": 3618932
+  },
   "hostile_name": "Klingon Patrol",
   "level": 42,
   "rarity": "common",
@@ -140,10 +145,5 @@
       "quantity": 1,
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 1868579,
-    "defense": 712735,
-    "health": 3618932
-  }
+  ]
 }

--- a/hostiles/klingon_patrol_42_battleship.json
+++ b/hostiles/klingon_patrol_42_battleship.json
@@ -1,9 +1,6 @@
 {
   "description": "This ship is Klingon. Attacking it will result in a loss of reputation towards the Klingons and a gain of reputation towards the Federation and Romulan factions.",
-  "attack": 1868579,
-  "defense": 712735,
   "group": "klingon",
-  "health": 3618932,
   "hostile_name": "Klingon Patrol",
   "level": 42,
   "rarity": "common",
@@ -45,7 +42,6 @@
       "shield_health": 3101000
     }
   },
-  "strength": 6200246,
   "systems": [
     {
       "$ref": "systems/dok_vos_41"
@@ -100,7 +96,6 @@
         3
       ],
       "quantity": 1,
-      "weapon_id": "K1",
       "weapon_type": "kinetic"
     },
     {
@@ -122,7 +117,6 @@
         3
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_type": "energy"
     },
     {
@@ -144,8 +138,12 @@
         3
       ],
       "quantity": 1,
-      "weapon_id": "E2",
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 1868579,
+    "defense": 712735,
+    "health": 3618932
+  }
 }

--- a/hostiles/klingon_patrol_42_explorer.json
+++ b/hostiles/klingon_patrol_42_explorer.json
@@ -1,9 +1,6 @@
 {
   "description": "This ship is Klingon. Attacking it will result in a loss of reputation towards the Klingons and a gain of reputation towards the Federation and Romulan factions.",
-  "attack": 1985663,
-  "defense": 897130,
   "group": "klingon",
-  "health": 3119479,
   "hostile_name": "Klingon Patrol",
   "level": 42,
   "rarity": "common",
@@ -45,7 +42,6 @@
       "shield_health": 3493000
     }
   },
-  "strength": 6002272,
   "systems": [
     {
       "$ref": "systems/dok_vos_41"
@@ -100,7 +96,6 @@
         3
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_type": "energy"
     },
     {
@@ -122,7 +117,6 @@
         3
       ],
       "quantity": 1,
-      "weapon_id": "E2",
       "weapon_type": "energy"
     },
     {
@@ -144,8 +138,12 @@
         3
       ],
       "quantity": 1,
-      "weapon_id": "E3",
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 1985663,
+    "defense": 897130,
+    "health": 3119479
+  }
 }

--- a/hostiles/klingon_patrol_42_explorer.json
+++ b/hostiles/klingon_patrol_42_explorer.json
@@ -1,6 +1,11 @@
 {
   "description": "This ship is Klingon. Attacking it will result in a loss of reputation towards the Klingons and a gain of reputation towards the Federation and Romulan factions.",
   "group": "klingon",
+  "head_stats": {
+    "attack": 1985663,
+    "defense": 897130,
+    "health": 3119479
+  },
   "hostile_name": "Klingon Patrol",
   "level": 42,
   "rarity": "common",
@@ -140,10 +145,5 @@
       "quantity": 1,
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 1985663,
-    "defense": 897130,
-    "health": 3119479
-  }
+  ]
 }

--- a/hostiles/klingon_patrol_42_interceptor.json
+++ b/hostiles/klingon_patrol_42_interceptor.json
@@ -1,6 +1,11 @@
 {
   "description": "This ship is Klingon. Attacking it will result in a loss of reputation towards the Klingons and a gain of reputation towards the Federation and Romulan factions.",
   "group": "klingon",
+  "head_stats": {
+    "attack": 1212396,
+    "defense": 978940,
+    "health": 3096478
+  },
   "hostile_name": "Klingon Patrol",
   "level": 42,
   "rarity": "common",
@@ -140,10 +145,5 @@
       "quantity": 1,
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 1212396,
-    "defense": 978940,
-    "health": 3096478
-  }
+  ]
 }

--- a/hostiles/klingon_patrol_42_interceptor.json
+++ b/hostiles/klingon_patrol_42_interceptor.json
@@ -1,9 +1,6 @@
 {
   "description": "This ship is Klingon. Attacking it will result in a loss of reputation towards the Klingons and a gain of reputation towards the Federation and Romulan factions.",
-  "attack": 1212396,
-  "defense": 978940,
   "group": "klingon",
-  "health": 3096478,
   "hostile_name": "Klingon Patrol",
   "level": 42,
   "rarity": "common",
@@ -45,7 +42,6 @@
       "shield_health": 3096000
     }
   },
-  "strength": 5287814,
   "systems": [
     {
       "$ref": "systems/dok_vos_41"
@@ -100,7 +96,6 @@
         3
       ],
       "quantity": 1,
-      "weapon_id": "K1",
       "weapon_type": "kinetic"
     },
     {
@@ -122,7 +117,6 @@
         3
       ],
       "quantity": 1,
-      "weapon_id": "K2",
       "weapon_type": "kinetic"
     },
     {
@@ -144,8 +138,12 @@
         3
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 1212396,
+    "defense": 978940,
+    "health": 3096478
+  }
 }

--- a/hostiles/klingon_patrol_43_explorer.json
+++ b/hostiles/klingon_patrol_43_explorer.json
@@ -1,9 +1,6 @@
 {
   "description": "This ship is Klingon. Attacking it will result in a loss of reputation towards the Klingons and a gain of reputation towards the Federation and Romulan factions.",
-  "attack": 2281380,
-  "defense": 1010170,
   "group": "klingon",
-  "health": 3510341,
   "hostile_name": "Klingon Patrol",
   "level": 43,
   "rarity": "common",
@@ -45,7 +42,6 @@
       "shield_health": 3931000
     }
   },
-  "strength": 6801891,
   "systems": [
     {
       "$ref": "systems/klopp_42"
@@ -79,7 +75,6 @@
         3
       ],
       "quantity": 3,
-      "weapon_id": "E1",
       "weapon_stats": {
         "accuracy": 181231,
         "armor_pierce": 96187,
@@ -111,7 +106,6 @@
         3
       ],
       "quantity": 1,
-      "weapon_id": "E2",
       "weapon_type": "energy"
     },
     {
@@ -133,8 +127,12 @@
         3
       ],
       "quantity": 1,
-      "weapon_id": "E3",
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 2281380,
+    "defense": 1010170,
+    "health": 3510341
+  }
 }

--- a/hostiles/klingon_patrol_43_explorer.json
+++ b/hostiles/klingon_patrol_43_explorer.json
@@ -1,6 +1,11 @@
 {
   "description": "This ship is Klingon. Attacking it will result in a loss of reputation towards the Klingons and a gain of reputation towards the Federation and Romulan factions.",
   "group": "klingon",
+  "head_stats": {
+    "attack": 2281380,
+    "defense": 1010170,
+    "health": 3510341
+  },
   "hostile_name": "Klingon Patrol",
   "level": 43,
   "rarity": "common",
@@ -129,10 +134,5 @@
       "quantity": 1,
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 2281380,
-    "defense": 1010170,
-    "health": 3510341
-  }
+  ]
 }

--- a/hostiles/klingon_patrol_48_battleship.json
+++ b/hostiles/klingon_patrol_48_battleship.json
@@ -1,6 +1,11 @@
 {
   "description": "This ship is Klingon. Attacking it will result in a loss of reputation towards the Klingons and a gain of reputation towards the Federation and Romulan factions.",
   "group": "klingon",
+  "head_stats": {
+    "attack": 4385884,
+    "defense": 1468535,
+    "health": 7069128
+  },
   "hostile_name": "Klingon Patrol",
   "level": 48,
   "rarity": "common",
@@ -139,10 +144,5 @@
       "quantity": 1,
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 4385884,
-    "defense": 1468535,
-    "health": 7069128
-  }
+  ]
 }

--- a/hostiles/klingon_patrol_48_battleship.json
+++ b/hostiles/klingon_patrol_48_battleship.json
@@ -1,9 +1,6 @@
 {
   "description": "This ship is Klingon. Attacking it will result in a loss of reputation towards the Klingons and a gain of reputation towards the Federation and Romulan factions.",
-  "attack": 4385884,
-  "defense": 1468535,
   "group": "klingon",
-  "health": 7069128,
   "hostile_name": "Klingon Patrol",
   "level": 48,
   "rarity": "common",
@@ -45,7 +42,6 @@
       "shield_health": 6059000
     }
   },
-  "strength": 12923547,
   "systems": [
     {
       "$ref": "systems/annalu_47"
@@ -79,7 +75,6 @@
         3
       ],
       "quantity": 2,
-      "weapon_id": "E1",
       "weapon_stats": {
         "accuracy": 157619,
         "armor_pierce": 165500,
@@ -111,7 +106,6 @@
         3
       ],
       "quantity": 1,
-      "weapon_id": "K1",
       "weapon_stats": {
         "accuracy": 157619,
         "armor_pierce": 165500,
@@ -143,8 +137,12 @@
         3
       ],
       "quantity": 1,
-      "weapon_id": "E2",
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 4385884,
+    "defense": 1468535,
+    "health": 7069128
+  }
 }

--- a/hostiles/klingon_patrol_49_interceptor.json
+++ b/hostiles/klingon_patrol_49_interceptor.json
@@ -1,9 +1,6 @@
 {
   "description": "This ship is Klingon. Attacking it will result in a loss of reputation towards the Klingons and a gain of reputation towards the Federation and Romulan factions.",
-  "attack": 3184112,
-  "defense": 2084500,
   "group": "klingon",
-  "health": 7028904,
   "hostile_name": "Klingon Patrol",
   "level": 49,
   "rarity": "common",
@@ -45,7 +42,6 @@
       "shield_health": 7028000
     }
   },
-  "strength": 12297516,
   "systems": [
     {
       "$ref": "systems/nalla_49"
@@ -79,7 +75,6 @@
         3
       ],
       "quantity": 2,
-      "weapon_id": "K1",
       "weapon_stats": {
         "accuracy": 134655,
         "armor_pierce": 365640,
@@ -111,7 +106,6 @@
         3
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_stats": {
         "accuracy": 134655,
         "armor_pierce": 365640,
@@ -143,8 +137,12 @@
         3
       ],
       "quantity": 1,
-      "weapon_id": "K2",
       "weapon_type": "kinetic"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 3184112,
+    "defense": 2084500,
+    "health": 7028904
+  }
 }

--- a/hostiles/klingon_patrol_49_interceptor.json
+++ b/hostiles/klingon_patrol_49_interceptor.json
@@ -1,6 +1,11 @@
 {
   "description": "This ship is Klingon. Attacking it will result in a loss of reputation towards the Klingons and a gain of reputation towards the Federation and Romulan factions.",
   "group": "klingon",
+  "head_stats": {
+    "attack": 3184112,
+    "defense": 2084500,
+    "health": 7028904
+  },
   "hostile_name": "Klingon Patrol",
   "level": 49,
   "rarity": "common",
@@ -139,10 +144,5 @@
       "quantity": 1,
       "weapon_type": "kinetic"
     }
-  ],
-  "head_stats": {
-    "attack": 3184112,
-    "defense": 2084500,
-    "health": 7028904
-  }
+  ]
 }

--- a/hostiles/klingon_scout_32_interceptor.json
+++ b/hostiles/klingon_scout_32_interceptor.json
@@ -1,9 +1,6 @@
 {
   "description": "This ship is Klingon. Attacking it will result in a loss of reputation towards the Klingons and a gain of reputation towards the Federation and Romulan factions.",
-  "attack": 104192,
-  "defense": 107940,
   "group": "klingon",
-  "health": 38640,
   "hostile_name": "Klingon Scout \u2605",
   "level": 32,
   "rarity": "common",
@@ -41,7 +38,6 @@
       "shield_health": 38000
     }
   },
-  "strength": 250772,
   "systems": [
     {
       "$ref": "systems/ok_vak_32"
@@ -72,7 +68,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "K1",
       "weapon_type": "kinetic"
     },
     {
@@ -94,7 +89,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "K2",
       "weapon_type": "kinetic"
     },
     {
@@ -116,8 +110,12 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 104192,
+    "defense": 107940,
+    "health": 38640
+  }
 }

--- a/hostiles/klingon_scout_32_interceptor.json
+++ b/hostiles/klingon_scout_32_interceptor.json
@@ -1,6 +1,11 @@
 {
   "description": "This ship is Klingon. Attacking it will result in a loss of reputation towards the Klingons and a gain of reputation towards the Federation and Romulan factions.",
   "group": "klingon",
+  "head_stats": {
+    "attack": 104192,
+    "defense": 107940,
+    "health": 38640
+  },
   "hostile_name": "Klingon Scout \u2605",
   "level": 32,
   "rarity": "common",
@@ -112,10 +117,5 @@
       "quantity": 1,
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 104192,
-    "defense": 107940,
-    "health": 38640
-  }
+  ]
 }

--- a/hostiles/klingon_scout_33_interceptor.json
+++ b/hostiles/klingon_scout_33_interceptor.json
@@ -1,6 +1,11 @@
 {
   "description": "This ship is Klingon. Attacking it will result in a loss of reputation towards the Klingons and a gain of reputation towards the Federation and Romulan factions.",
   "group": "klingon",
+  "head_stats": {
+    "attack": 164723,
+    "defense": 161905,
+    "health": 47470
+  },
   "hostile_name": "Klingon Scout \u2605",
   "level": 33,
   "rarity": "common",
@@ -112,10 +117,5 @@
       "quantity": 1,
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 164723,
-    "defense": 161905,
-    "health": 47470
-  }
+  ]
 }

--- a/hostiles/klingon_scout_33_interceptor.json
+++ b/hostiles/klingon_scout_33_interceptor.json
@@ -1,9 +1,6 @@
 {
   "description": "This ship is Klingon. Attacking it will result in a loss of reputation towards the Klingons and a gain of reputation towards the Federation and Romulan factions.",
-  "attack": 164723,
-  "defense": 161905,
   "group": "klingon",
-  "health": 47470,
   "hostile_name": "Klingon Scout \u2605",
   "level": 33,
   "rarity": "common",
@@ -41,7 +38,6 @@
       "shield_health": 47000
     }
   },
-  "strength": 374098,
   "systems": [
     {
       "$ref": "systems/eeli_33"
@@ -72,7 +68,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "K1",
       "weapon_type": "kinetic"
     },
     {
@@ -94,7 +89,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "K2",
       "weapon_type": "kinetic"
     },
     {
@@ -116,8 +110,12 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 164723,
+    "defense": 161905,
+    "health": 47470
+  }
 }

--- a/hostiles/klingon_scout_35_interceptor.json
+++ b/hostiles/klingon_scout_35_interceptor.json
@@ -1,6 +1,11 @@
 {
   "description": "This ship is Klingon. Attacking it will result in a loss of reputation towards the Klingons and a gain of reputation towards the Federation and Romulan factions.",
   "group": "klingon",
+  "head_stats": {
+    "attack": 235465,
+    "defense": 230595,
+    "health": 63480
+  },
   "hostile_name": "Klingon Scout \u2605",
   "level": 35,
   "rarity": "common",
@@ -112,10 +117,5 @@
       "quantity": 1,
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 235465,
-    "defense": 230595,
-    "health": 63480
-  }
+  ]
 }

--- a/hostiles/klingon_scout_35_interceptor.json
+++ b/hostiles/klingon_scout_35_interceptor.json
@@ -1,9 +1,6 @@
 {
   "description": "This ship is Klingon. Attacking it will result in a loss of reputation towards the Klingons and a gain of reputation towards the Federation and Romulan factions.",
-  "attack": 235465,
-  "defense": 230595,
   "group": "klingon",
-  "health": 63480,
   "hostile_name": "Klingon Scout \u2605",
   "level": 35,
   "rarity": "common",
@@ -41,7 +38,6 @@
       "shield_health": 63000
     }
   },
-  "strength": 529540,
   "systems": [
     {
       "$ref": "systems/lixar_35"
@@ -72,7 +68,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "K1",
       "weapon_type": "kinetic"
     },
     {
@@ -94,7 +89,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "K2",
       "weapon_type": "kinetic"
     },
     {
@@ -116,8 +110,12 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 235465,
+    "defense": 230595,
+    "health": 63480
+  }
 }

--- a/hostiles/klingon_trader_26_survey.json
+++ b/hostiles/klingon_trader_26_survey.json
@@ -1,6 +1,11 @@
 {
   "description": "The Horizon freighter was part of the ECS's privately owned fleet and used for the transport of all types of goods, ranging from hazardous material to passengers on long-haul journeys. Originally built in the early 22nd century, they started service as pre-warp vessels but have since been maintained and upgraded for low-warp travel.",
   "group": "klingon",
+  "head_stats": {
+    "attack": 12336,
+    "defense": 30000,
+    "health": 20160
+  },
   "hostile_name": "Klingon Trader",
   "level": 26,
   "rarity": "common",
@@ -85,10 +90,5 @@
       "quantity": 1,
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 12336,
-    "defense": 30000,
-    "health": 20160
-  }
+  ]
 }

--- a/hostiles/klingon_trader_26_survey.json
+++ b/hostiles/klingon_trader_26_survey.json
@@ -1,9 +1,6 @@
 {
   "description": "The Horizon freighter was part of the ECS's privately owned fleet and used for the transport of all types of goods, ranging from hazardous material to passengers on long-haul journeys. Originally built in the early 22nd century, they started service as pre-warp vessels but have since been maintained and upgraded for low-warp travel.",
-  "attack": 12336,
-  "defense": 30000,
   "group": "klingon",
-  "health": 20160,
   "hostile_name": "Klingon Trader",
   "level": 26,
   "rarity": "common",
@@ -41,7 +38,6 @@
       "shield_health": 20000
     }
   },
-  "strength": 62496,
   "systems": [
     {
       "$ref": "systems/laija_25"
@@ -87,8 +83,12 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 12336,
+    "defense": 30000,
+    "health": 20160
+  }
 }

--- a/hostiles/klingon_trader_29_survey.json
+++ b/hostiles/klingon_trader_29_survey.json
@@ -1,9 +1,6 @@
 {
   "description": "The Horizon freighter was part of the ECS's privately owned fleet and used for the transport of all types of goods, ranging from hazardous material to passengers on long-haul journeys. Originally built in the early 22nd century, they started service as pre-warp vessels but have since been maintained and upgraded for low-warp travel.",
-  "attack": 25740,
-  "defense": 63000,
   "group": "klingon",
-  "health": 41760,
   "hostile_name": "Klingon Trader",
   "level": 29,
   "rarity": "common",
@@ -41,7 +38,6 @@
       "shield_health": 41000
     }
   },
-  "strength": 130500,
   "systems": [
     {
       "$ref": "systems/h_atoria_30"
@@ -72,8 +68,12 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 25740,
+    "defense": 63000,
+    "health": 41760
+  }
 }

--- a/hostiles/klingon_trader_29_survey.json
+++ b/hostiles/klingon_trader_29_survey.json
@@ -1,6 +1,11 @@
 {
   "description": "The Horizon freighter was part of the ECS's privately owned fleet and used for the transport of all types of goods, ranging from hazardous material to passengers on long-haul journeys. Originally built in the early 22nd century, they started service as pre-warp vessels but have since been maintained and upgraded for low-warp travel.",
   "group": "klingon",
+  "head_stats": {
+    "attack": 25740,
+    "defense": 63000,
+    "health": 41760
+  },
   "hostile_name": "Klingon Trader",
   "level": 29,
   "rarity": "common",
@@ -70,10 +75,5 @@
       "quantity": 1,
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 25740,
-    "defense": 63000,
-    "health": 41760
-  }
+  ]
 }

--- a/hostiles/klingon_trader_30_survey.json
+++ b/hostiles/klingon_trader_30_survey.json
@@ -1,9 +1,6 @@
 {
   "description": "The H-Class freighter is a long-distance heavy hauler capable of transporting vast quantities of materials and goods.",
-  "attack": 34200,
-  "defense": 82500,
   "group": "klingon",
-  "health": 50400,
   "hostile_name": "Klingon Trader",
   "level": 30,
   "rarity": "common",
@@ -41,7 +38,6 @@
       "shield_health": 50000
     }
   },
-  "strength": 167100,
   "systems": [
     {
       "$ref": "systems/h_atoria_30"
@@ -69,8 +65,12 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 34200,
+    "defense": 82500,
+    "health": 50400
+  }
 }

--- a/hostiles/klingon_trader_30_survey.json
+++ b/hostiles/klingon_trader_30_survey.json
@@ -1,6 +1,11 @@
 {
   "description": "The H-Class freighter is a long-distance heavy hauler capable of transporting vast quantities of materials and goods.",
   "group": "klingon",
+  "head_stats": {
+    "attack": 34200,
+    "defense": 82500,
+    "health": 50400
+  },
   "hostile_name": "Klingon Trader",
   "level": 30,
   "rarity": "common",
@@ -67,10 +72,5 @@
       "quantity": 1,
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 34200,
-    "defense": 82500,
-    "health": 50400
-  }
+  ]
 }

--- a/hostiles/klingon_trader_31_survey.json
+++ b/hostiles/klingon_trader_31_survey.json
@@ -1,6 +1,11 @@
 {
   "description": "The H-Class freighter is a long-distance heavy hauler capable of transporting vast quantities of materials and goods.",
   "group": "klingon",
+  "head_stats": {
+    "attack": 55164,
+    "defense": 123750,
+    "health": 61920
+  },
   "hostile_name": "Klingon Trader",
   "level": 31,
   "rarity": "common",
@@ -67,10 +72,5 @@
       "quantity": 1,
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 55164,
-    "defense": 123750,
-    "health": 61920
-  }
+  ]
 }

--- a/hostiles/klingon_trader_31_survey.json
+++ b/hostiles/klingon_trader_31_survey.json
@@ -1,9 +1,6 @@
 {
   "description": "The H-Class freighter is a long-distance heavy hauler capable of transporting vast quantities of materials and goods.",
-  "attack": 55164,
-  "defense": 123750,
   "group": "klingon",
-  "health": 61920,
   "hostile_name": "Klingon Trader",
   "level": 31,
   "rarity": "common",
@@ -41,7 +38,6 @@
       "shield_health": 61000
     }
   },
-  "strength": 240834,
   "systems": [
     {
       "$ref": "systems/h_atoria_30"
@@ -69,8 +65,12 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 55164,
+    "defense": 123750,
+    "health": 61920
+  }
 }

--- a/hostiles/klingon_trader_32_survey.json
+++ b/hostiles/klingon_trader_32_survey.json
@@ -1,6 +1,11 @@
 {
   "description": "The H-Class freighter is a long-distance heavy hauler capable of transporting vast quantities of materials and goods.",
   "group": "klingon",
+  "head_stats": {
+    "attack": 61704,
+    "defense": 150300,
+    "health": 69840
+  },
   "hostile_name": "Klingon Trader",
   "level": 32,
   "rarity": "common",
@@ -67,10 +72,5 @@
       "quantity": 1,
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 61704,
-    "defense": 150300,
-    "health": 69840
-  }
+  ]
 }

--- a/hostiles/klingon_trader_32_survey.json
+++ b/hostiles/klingon_trader_32_survey.json
@@ -1,9 +1,6 @@
 {
   "description": "The H-Class freighter is a long-distance heavy hauler capable of transporting vast quantities of materials and goods.",
-  "attack": 61704,
-  "defense": 150300,
   "group": "klingon",
-  "health": 69840,
   "hostile_name": "Klingon Trader",
   "level": 32,
   "rarity": "common",
@@ -41,7 +38,6 @@
       "shield_health": 69000
     }
   },
-  "strength": 281844,
   "systems": [
     {
       "$ref": "systems/carraya_33"
@@ -69,8 +65,12 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 61704,
+    "defense": 150300,
+    "health": 69840
+  }
 }

--- a/hostiles/klingon_trader_33_survey.json
+++ b/hostiles/klingon_trader_33_survey.json
@@ -1,6 +1,11 @@
 {
   "description": "The H-Class freighter is a long-distance heavy hauler capable of transporting vast quantities of materials and goods.",
   "group": "klingon",
+  "head_stats": {
+    "attack": 78960,
+    "defense": 176250,
+    "health": 82800
+  },
   "hostile_name": "Klingon Trader",
   "level": 33,
   "rarity": "common",
@@ -67,10 +72,5 @@
       "quantity": 1,
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 78960,
-    "defense": 176250,
-    "health": 82800
-  }
+  ]
 }

--- a/hostiles/klingon_trader_33_survey.json
+++ b/hostiles/klingon_trader_33_survey.json
@@ -1,9 +1,6 @@
 {
   "description": "The H-Class freighter is a long-distance heavy hauler capable of transporting vast quantities of materials and goods.",
-  "attack": 78960,
-  "defense": 176250,
   "group": "klingon",
-  "health": 82800,
   "hostile_name": "Klingon Trader",
   "level": 33,
   "rarity": "common",
@@ -41,7 +38,6 @@
       "shield_health": 82000
     }
   },
-  "strength": 338010,
   "systems": [
     {
       "$ref": "systems/carraya_33"
@@ -69,8 +65,12 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 78960,
+    "defense": 176250,
+    "health": 82800
+  }
 }

--- a/hostiles/klingon_trader_37_survey.json
+++ b/hostiles/klingon_trader_37_survey.json
@@ -1,9 +1,6 @@
 {
   "description": "The H-Class freighter is a long-distance heavy hauler capable of transporting vast quantities of materials and goods.",
-  "attack": 170895,
-  "defense": 381420,
   "group": "klingon",
-  "health": 184770,
   "hostile_name": "Klingon Trader",
   "level": 37,
   "rarity": "common",
@@ -41,7 +38,6 @@
       "shield_health": 184000
     }
   },
-  "strength": 737085,
   "systems": [
     {
       "$ref": "systems/jiwu_puh_36"
@@ -69,8 +65,12 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 170895,
+    "defense": 381420,
+    "health": 184770
+  }
 }

--- a/hostiles/klingon_trader_37_survey.json
+++ b/hostiles/klingon_trader_37_survey.json
@@ -1,6 +1,11 @@
 {
   "description": "The H-Class freighter is a long-distance heavy hauler capable of transporting vast quantities of materials and goods.",
   "group": "klingon",
+  "head_stats": {
+    "attack": 170895,
+    "defense": 381420,
+    "health": 184770
+  },
   "hostile_name": "Klingon Trader",
   "level": 37,
   "rarity": "common",
@@ -67,10 +72,5 @@
       "quantity": 1,
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 170895,
-    "defense": 381420,
-    "health": 184770
-  }
+  ]
 }

--- a/hostiles/klingon_transport_37_survey.json
+++ b/hostiles/klingon_transport_37_survey.json
@@ -1,6 +1,11 @@
 {
   "description": "The H-Class freighter is a long-distance heavy hauler capable of transporting vast quantities of materials and goods.",
   "group": "klingon",
+  "head_stats": {
+    "attack": 257967,
+    "defense": 580875,
+    "health": 285500
+  },
   "hostile_name": "Klingon Transport",
   "level": 37,
   "rarity": "common",
@@ -86,10 +91,5 @@
       },
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 257967,
-    "defense": 580875,
-    "health": 285500
-  }
+  ]
 }

--- a/hostiles/klingon_transport_37_survey.json
+++ b/hostiles/klingon_transport_37_survey.json
@@ -1,9 +1,6 @@
 {
   "description": "The H-Class freighter is a long-distance heavy hauler capable of transporting vast quantities of materials and goods.",
-  "attack": 257967,
-  "defense": 580875,
   "group": "klingon",
-  "health": 285500,
   "hostile_name": "Klingon Transport",
   "level": 37,
   "rarity": "common",
@@ -41,7 +38,6 @@
       "shield_health": 285500
     }
   },
-  "strength": 1124342,
   "systems": [
     {
       "$ref": "systems/quv_qeb_36"
@@ -78,7 +74,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_stats": {
         "accuracy": 30980,
         "armor_pierce": 30980,
@@ -91,5 +86,10 @@
       },
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 257967,
+    "defense": 580875,
+    "health": 285500
+  }
 }

--- a/hostiles/klingon_transport_41_survey.json
+++ b/hostiles/klingon_transport_41_survey.json
@@ -1,6 +1,11 @@
 {
   "description": "The H-Class freighter is a long-distance heavy hauler capable of transporting vast quantities of materials and goods.",
   "group": "klingon",
+  "head_stats": {
+    "attack": 1158050,
+    "defense": 1347415,
+    "health": 2272836
+  },
   "hostile_name": "Klingon Transport",
   "level": 41,
   "rarity": "common",
@@ -74,10 +79,5 @@
       "quantity": 1,
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 1158050,
-    "defense": 1347415,
-    "health": 2272836
-  }
+  ]
 }

--- a/hostiles/klingon_transport_41_survey.json
+++ b/hostiles/klingon_transport_41_survey.json
@@ -1,9 +1,6 @@
 {
   "description": "The H-Class freighter is a long-distance heavy hauler capable of transporting vast quantities of materials and goods.",
-  "attack": 1158050,
-  "defense": 1347415,
   "group": "klingon",
-  "health": 2272836,
   "hostile_name": "Klingon Transport",
   "level": 41,
   "rarity": "common",
@@ -45,7 +42,6 @@
       "shield_health": 2158000
     }
   },
-  "strength": 4778301,
   "systems": [
     {
       "$ref": "systems/ursva_40"
@@ -76,8 +72,12 @@
         3
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 1158050,
+    "defense": 1347415,
+    "health": 2272836
+  }
 }

--- a/hostiles/klingon_transport_49_survey.json
+++ b/hostiles/klingon_transport_49_survey.json
@@ -1,9 +1,6 @@
 {
   "description": "The H-Class freighter is a long-distance heavy hauler capable of transporting vast quantities of materials and goods.",
-  "attack": 1823947,
-  "defense": 5116850,
   "group": "klingon",
-  "health": 17364737,
   "hostile_name": "Klingon Transport",
   "level": 49,
   "rarity": "common",
@@ -45,7 +42,6 @@
       "shield_health": 17103000
     }
   },
-  "strength": 24305534,
   "systems": [
     {
       "$ref": "systems/kronos_60"
@@ -76,7 +72,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_stats": {
         "accuracy": 159957,
         "armor_pierce": 167955,
@@ -89,5 +84,10 @@
       },
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 1823947,
+    "defense": 5116850,
+    "health": 17364737
+  }
 }

--- a/hostiles/klingon_transport_49_survey.json
+++ b/hostiles/klingon_transport_49_survey.json
@@ -1,6 +1,11 @@
 {
   "description": "The H-Class freighter is a long-distance heavy hauler capable of transporting vast quantities of materials and goods.",
   "group": "klingon",
+  "head_stats": {
+    "attack": 1823947,
+    "defense": 5116850,
+    "health": 17364737
+  },
   "hostile_name": "Klingon Transport",
   "level": 49,
   "rarity": "common",
@@ -84,10 +89,5 @@
       },
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 1823947,
-    "defense": 5116850,
-    "health": 17364737
-  }
+  ]
 }

--- a/hostiles/kriosian_rebel_28_battleship.json
+++ b/hostiles/kriosian_rebel_28_battleship.json
@@ -1,6 +1,11 @@
 {
   "description": "This Hostile patrols the different systems of the universe, looking for easy prey",
   "group": "",
+  "head_stats": {
+    "attack": 40788,
+    "defense": 41250,
+    "health": 21000
+  },
   "hostile_name": "Kriosian Rebel",
   "level": 28,
   "rarity": "common",
@@ -99,10 +104,5 @@
       "quantity": 1,
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 40788,
-    "defense": 41250,
-    "health": 21000
-  }
+  ]
 }

--- a/hostiles/kriosian_rebel_28_battleship.json
+++ b/hostiles/kriosian_rebel_28_battleship.json
@@ -1,9 +1,6 @@
 {
   "description": "This Hostile patrols the different systems of the universe, looking for easy prey",
-  "attack": 40788,
-  "defense": 41250,
   "group": "",
-  "health": 21000,
   "hostile_name": "Kriosian Rebel",
   "level": 28,
   "rarity": "common",
@@ -28,7 +25,6 @@
       "shield_health": 18000
     }
   },
-  "strength": 103038,
   "systems": [
     {
       "$ref": "systems/lainey_27"
@@ -65,7 +61,6 @@
         0
       ],
       "quantity": 1,
-      "weapon_id": "K1",
       "weapon_type": "kinetic"
     },
     {
@@ -84,7 +79,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_type": "energy"
     },
     {
@@ -103,8 +97,12 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E2",
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 40788,
+    "defense": 41250,
+    "health": 21000
+  }
 }

--- a/hostiles/nausicaan_marauder_42_explorer.json
+++ b/hostiles/nausicaan_marauder_42_explorer.json
@@ -1,9 +1,6 @@
 {
   "description": "This Hostile patrols the different systems of the universe, looking for easy prey",
-  "attack": 1908436,
-  "defense": 893960,
   "group": "",
-  "health": 2970933,
   "hostile_name": "Nausicaan Marauder",
   "level": 42,
   "rarity": "common",
@@ -33,7 +30,6 @@
       "shield_health": 3327000
     }
   },
-  "strength": 5773329,
   "systems": [
     {
       "$ref": "systems/vita_nova_43"
@@ -64,7 +60,6 @@
         3
       ],
       "quantity": 3,
-      "weapon_id": "E1",
       "weapon_stats": {
         "accuracy": 161080,
         "armor_pierce": 81470,
@@ -96,7 +91,6 @@
         3
       ],
       "quantity": 1,
-      "weapon_id": "E2",
       "weapon_type": "energy"
     },
     {
@@ -118,8 +112,12 @@
         3
       ],
       "quantity": 1,
-      "weapon_id": "E3",
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 1908436,
+    "defense": 893960,
+    "health": 2970933
+  }
 }

--- a/hostiles/nausicaan_marauder_42_explorer.json
+++ b/hostiles/nausicaan_marauder_42_explorer.json
@@ -1,6 +1,11 @@
 {
   "description": "This Hostile patrols the different systems of the universe, looking for easy prey",
   "group": "",
+  "head_stats": {
+    "attack": 1908436,
+    "defense": 893960,
+    "health": 2970933
+  },
   "hostile_name": "Nausicaan Marauder",
   "level": 42,
   "rarity": "common",
@@ -114,10 +119,5 @@
       "quantity": 1,
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 1908436,
-    "defense": 893960,
-    "health": 2970933
-  }
+  ]
 }

--- a/hostiles/orion_slaver_7_explorer.json
+++ b/hostiles/orion_slaver_7_explorer.json
@@ -1,6 +1,11 @@
 {
   "description": "This Hostile patrols the different systems of the universe, looking for easy prey",
   "group": "",
+  "head_stats": {
+    "attack": 244,
+    "defense": 300,
+    "health": 165
+  },
   "hostile_name": "Orion Slaver",
   "level": 7,
   "rarity": "common",
@@ -171,10 +176,5 @@
       "quantity": 1,
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 244,
-    "defense": 300,
-    "health": 165
-  }
+  ]
 }

--- a/hostiles/orion_slaver_7_explorer.json
+++ b/hostiles/orion_slaver_7_explorer.json
@@ -1,9 +1,6 @@
 {
   "description": "This Hostile patrols the different systems of the universe, looking for easy prey",
-  "attack": 244,
-  "defense": 300,
   "group": "",
-  "health": 165,
   "hostile_name": "Orion Slaver",
   "level": 7,
   "rarity": "common",
@@ -28,7 +25,6 @@
       "shield_health": 170
     }
   },
-  "strength": 709,
   "systems": [
     {
       "$ref": "systems/alonso_6"
@@ -152,7 +148,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_type": "energy"
     },
     {
@@ -174,8 +169,12 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E2",
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 244,
+    "defense": 300,
+    "health": 165
+  }
 }

--- a/hostiles/osaarian_pariah_25_explorer.json
+++ b/hostiles/osaarian_pariah_25_explorer.json
@@ -1,6 +1,11 @@
 {
   "description": "This Hostile patrols the different systems of the universe, looking for easy prey",
   "group": "",
+  "head_stats": {
+    "attack": 16699,
+    "defense": 18750,
+    "health": 8880
+  },
   "hostile_name": "Osaarian Pariah",
   "level": 25,
   "rarity": "common",
@@ -99,10 +104,5 @@
       "quantity": 1,
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 16699,
-    "defense": 18750,
-    "health": 8880
-  }
+  ]
 }

--- a/hostiles/osaarian_pariah_25_explorer.json
+++ b/hostiles/osaarian_pariah_25_explorer.json
@@ -1,9 +1,6 @@
 {
   "description": "This Hostile patrols the different systems of the universe, looking for easy prey",
-  "attack": 16699,
-  "defense": 18750,
   "group": "",
-  "health": 8880,
   "hostile_name": "Osaarian Pariah",
   "level": 25,
   "rarity": "common",
@@ -28,7 +25,6 @@
       "shield_health": 9120
     }
   },
-  "strength": 44329,
   "systems": [
     {
       "$ref": "systems/narendra_25"
@@ -59,7 +55,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_type": "energy"
     },
     {
@@ -81,7 +76,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E2",
       "weapon_type": "energy"
     },
     {
@@ -103,8 +97,12 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E3",
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 16699,
+    "defense": 18750,
+    "health": 8880
+  }
 }

--- a/hostiles/pakled_thief_14_battleship.json
+++ b/hostiles/pakled_thief_14_battleship.json
@@ -1,6 +1,11 @@
 {
   "description": "This Hostile patrols the different systems of the universe, looking for easy prey",
   "group": "",
+  "head_stats": {
+    "attack": 1788,
+    "defense": 2480,
+    "health": 840
+  },
   "hostile_name": "Pakled Thief",
   "level": 14,
   "rarity": "common",
@@ -78,10 +83,5 @@
       "quantity": 1,
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 1788,
-    "defense": 2480,
-    "health": 840
-  }
+  ]
 }

--- a/hostiles/pakled_thief_14_battleship.json
+++ b/hostiles/pakled_thief_14_battleship.json
@@ -1,9 +1,6 @@
 {
   "description": "This Hostile patrols the different systems of the universe, looking for easy prey",
-  "attack": 1788,
-  "defense": 2480,
   "group": "",
-  "health": 840,
   "hostile_name": "Pakled Thief",
   "level": 14,
   "rarity": "common",
@@ -28,7 +25,6 @@
       "shield_health": 720
     }
   },
-  "strength": 5108,
   "systems": [
     {
       "$ref": "systems/elona_13"
@@ -62,7 +58,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_type": "energy"
     },
     {
@@ -81,8 +76,12 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E2",
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 1788,
+    "defense": 2480,
+    "health": 840
+  }
 }

--- a/hostiles/pakled_thief_15_battleship.json
+++ b/hostiles/pakled_thief_15_battleship.json
@@ -1,6 +1,11 @@
 {
   "description": "This Hostile patrols the different systems of the universe, looking for easy prey",
   "group": "",
+  "head_stats": {
+    "attack": 2338,
+    "defense": 3000,
+    "health": 1210
+  },
   "hostile_name": "Pakled Thief",
   "level": 15,
   "rarity": "common",
@@ -84,10 +89,5 @@
       "quantity": 1,
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 2338,
-    "defense": 3000,
-    "health": 1210
-  }
+  ]
 }

--- a/hostiles/pakled_thief_15_battleship.json
+++ b/hostiles/pakled_thief_15_battleship.json
@@ -1,9 +1,6 @@
 {
   "description": "This Hostile patrols the different systems of the universe, looking for easy prey",
-  "attack": 2338,
-  "defense": 3000,
   "group": "",
-  "health": 1210,
   "hostile_name": "Pakled Thief",
   "level": 15,
   "rarity": "common",
@@ -28,7 +25,6 @@
       "shield_health": 1040
     }
   },
-  "strength": 6548,
   "systems": [
     {
       "$ref": "systems/dhi_ban_14"
@@ -68,7 +64,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_type": "energy"
     },
     {
@@ -87,8 +82,12 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E2",
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 2338,
+    "defense": 3000,
+    "health": 1210
+  }
 }

--- a/hostiles/pakled_thief_16_battleship.json
+++ b/hostiles/pakled_thief_16_battleship.json
@@ -1,9 +1,6 @@
 {
   "description": "This Hostile patrols the different systems of the universe, looking for easy prey",
-  "attack": 3887,
-  "defense": 3835,
   "group": "",
-  "health": 1735,
   "hostile_name": "Pakled Thief",
   "level": 16,
   "rarity": "common",
@@ -28,7 +25,6 @@
       "shield_health": 1490
     }
   },
-  "strength": 9457,
   "systems": [
     {
       "$ref": "systems/vindemiatrix_15"
@@ -77,7 +73,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "K1",
       "weapon_type": "kinetic"
     },
     {
@@ -99,7 +94,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_type": "energy"
     },
     {
@@ -121,8 +115,12 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E2",
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 3887,
+    "defense": 3835,
+    "health": 1735
+  }
 }

--- a/hostiles/pakled_thief_16_battleship.json
+++ b/hostiles/pakled_thief_16_battleship.json
@@ -1,6 +1,11 @@
 {
   "description": "This Hostile patrols the different systems of the universe, looking for easy prey",
   "group": "",
+  "head_stats": {
+    "attack": 3887,
+    "defense": 3835,
+    "health": 1735
+  },
   "hostile_name": "Pakled Thief",
   "level": 16,
   "rarity": "common",
@@ -117,10 +122,5 @@
       "quantity": 1,
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 3887,
-    "defense": 3835,
-    "health": 1735
-  }
+  ]
 }

--- a/hostiles/pakled_thief_17_battleship.json
+++ b/hostiles/pakled_thief_17_battleship.json
@@ -1,6 +1,11 @@
 {
   "description": "This Hostile patrols the different systems of the universe, looking for easy prey",
   "group": "",
+  "head_stats": {
+    "attack": 4669,
+    "defense": 4585,
+    "health": 2100
+  },
   "hostile_name": "Pakled Thief",
   "level": 17,
   "rarity": "common",
@@ -108,10 +113,5 @@
       "quantity": 1,
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 4669,
-    "defense": 4585,
-    "health": 2100
-  }
+  ]
 }

--- a/hostiles/pakled_thief_17_battleship.json
+++ b/hostiles/pakled_thief_17_battleship.json
@@ -1,9 +1,6 @@
 {
   "description": "This Hostile patrols the different systems of the universe, looking for easy prey",
-  "attack": 4669,
-  "defense": 4585,
   "group": "",
-  "health": 2100,
   "hostile_name": "Pakled Thief",
   "level": 17,
   "rarity": "common",
@@ -28,7 +25,6 @@
       "shield_health": 1800
     }
   },
-  "strength": 11354,
   "systems": [
     {
       "$ref": "systems/coridan_16"
@@ -74,7 +70,6 @@
         0
       ],
       "quantity": 1,
-      "weapon_id": "K1",
       "weapon_type": "kinetic"
     },
     {
@@ -93,7 +88,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_type": "energy"
     },
     {
@@ -112,8 +106,12 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E2",
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 4669,
+    "defense": 4585,
+    "health": 2100
+  }
 }

--- a/hostiles/pakled_thief_20_battleship.json
+++ b/hostiles/pakled_thief_20_battleship.json
@@ -1,6 +1,11 @@
 {
   "description": "This Hostile patrols the different systems of the universe, looking for easy prey",
   "group": "",
+  "head_stats": {
+    "attack": 7619,
+    "defense": 7120,
+    "health": 3360
+  },
   "hostile_name": "Pakled Thief",
   "level": 20,
   "rarity": "common",
@@ -99,10 +104,5 @@
       "quantity": 1,
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 7619,
-    "defense": 7120,
-    "health": 3360
-  }
+  ]
 }

--- a/hostiles/pakled_thief_20_battleship.json
+++ b/hostiles/pakled_thief_20_battleship.json
@@ -1,9 +1,6 @@
 {
   "description": "This Hostile patrols the different systems of the universe, looking for easy prey",
-  "attack": 7619,
-  "defense": 7120,
   "group": "",
-  "health": 3360,
   "hostile_name": "Pakled Thief",
   "level": 20,
   "rarity": "common",
@@ -28,7 +25,6 @@
       "shield_health": 2880
     }
   },
-  "strength": 18099,
   "systems": [
     {
       "$ref": "systems/eisenhorn_19"
@@ -65,7 +61,6 @@
         0
       ],
       "quantity": 1,
-      "weapon_id": "K1",
       "weapon_type": "kinetic"
     },
     {
@@ -84,7 +79,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_type": "energy"
     },
     {
@@ -103,8 +97,12 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E2",
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 7619,
+    "defense": 7120,
+    "health": 3360
+  }
 }

--- a/hostiles/pakled_thief_21_battleship.json
+++ b/hostiles/pakled_thief_21_battleship.json
@@ -1,6 +1,11 @@
 {
   "description": "This Hostile patrols the different systems of the universe, looking for easy prey",
   "group": "",
+  "head_stats": {
+    "attack": 9297,
+    "defense": 9750,
+    "health": 4200
+  },
   "hostile_name": "Pakled Thief",
   "level": 21,
   "rarity": "common",
@@ -102,10 +107,5 @@
       "quantity": 1,
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 9297,
-    "defense": 9750,
-    "health": 4200
-  }
+  ]
 }

--- a/hostiles/pakled_thief_21_battleship.json
+++ b/hostiles/pakled_thief_21_battleship.json
@@ -1,9 +1,6 @@
 {
   "description": "This Hostile patrols the different systems of the universe, looking for easy prey",
-  "attack": 9297,
-  "defense": 9750,
   "group": "",
-  "health": 4200,
   "hostile_name": "Pakled Thief",
   "level": 21,
   "rarity": "common",
@@ -28,7 +25,6 @@
       "shield_health": 3600
     }
   },
-  "strength": 23247,
   "systems": [
     {
       "$ref": "systems/kepler_018_20"
@@ -62,7 +58,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "K1",
       "weapon_type": "kinetic"
     },
     {
@@ -84,7 +79,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_type": "energy"
     },
     {
@@ -106,8 +100,12 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E2",
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 9297,
+    "defense": 9750,
+    "health": 4200
+  }
 }

--- a/hostiles/pakled_thief_22_battleship.json
+++ b/hostiles/pakled_thief_22_battleship.json
@@ -1,9 +1,6 @@
 {
   "description": "This Hostile patrols the different systems of the universe, looking for easy prey",
-  "attack": 12120,
-  "defense": 13130,
   "group": "",
-  "health": 5250,
   "hostile_name": "Pakled Thief",
   "level": 22,
   "rarity": "common",
@@ -28,7 +25,6 @@
       "shield_health": 4500
     }
   },
-  "strength": 30500,
   "systems": [
     {
       "$ref": "systems/fastolf_21"
@@ -59,7 +55,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "K1",
       "weapon_type": "kinetic"
     },
     {
@@ -81,7 +76,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_type": "energy"
     },
     {
@@ -103,8 +97,12 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E2",
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 12120,
+    "defense": 13130,
+    "health": 5250
+  }
 }

--- a/hostiles/pakled_thief_22_battleship.json
+++ b/hostiles/pakled_thief_22_battleship.json
@@ -1,6 +1,11 @@
 {
   "description": "This Hostile patrols the different systems of the universe, looking for easy prey",
   "group": "",
+  "head_stats": {
+    "attack": 12120,
+    "defense": 13130,
+    "health": 5250
+  },
   "hostile_name": "Pakled Thief",
   "level": 22,
   "rarity": "common",
@@ -99,10 +104,5 @@
       "quantity": 1,
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 12120,
-    "defense": 13130,
-    "health": 5250
-  }
+  ]
 }

--- a/hostiles/rigellian_hunter_18_interceptor.json
+++ b/hostiles/rigellian_hunter_18_interceptor.json
@@ -1,9 +1,6 @@
 {
   "description": "This Hostile patrols the different systems of the universe, looking for easy prey",
-  "attack": 5681,
-  "defense": 5165,
   "group": "",
-  "health": 2150,
   "hostile_name": "Rigellian Hunter",
   "level": 18,
   "rarity": "common",
@@ -28,7 +25,6 @@
       "shield_health": 2150
     }
   },
-  "strength": 12996,
   "systems": [
     {
       "$ref": "systems/labac_17"
@@ -62,7 +58,6 @@
         1
       ],
       "quantity": 2,
-      "weapon_id": "K1",
       "weapon_stats": {
         "accuracy": 172,
         "armor_pierce": 1033,
@@ -94,7 +89,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_stats": {
         "accuracy": 172,
         "armor_pierce": 1033,
@@ -126,8 +120,12 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "K2",
       "weapon_type": "kinetic"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 5681,
+    "defense": 5165,
+    "health": 2150
+  }
 }

--- a/hostiles/rigellian_hunter_18_interceptor.json
+++ b/hostiles/rigellian_hunter_18_interceptor.json
@@ -1,6 +1,11 @@
 {
   "description": "This Hostile patrols the different systems of the universe, looking for easy prey",
   "group": "",
+  "head_stats": {
+    "attack": 5681,
+    "defense": 5165,
+    "health": 2150
+  },
   "hostile_name": "Rigellian Hunter",
   "level": 18,
   "rarity": "common",
@@ -122,10 +127,5 @@
       "quantity": 1,
       "weapon_type": "kinetic"
     }
-  ],
-  "head_stats": {
-    "attack": 5681,
-    "defense": 5165,
-    "health": 2150
-  }
+  ]
 }

--- a/hostiles/romulan_patrol_20_battleship.json
+++ b/hostiles/romulan_patrol_20_battleship.json
@@ -1,9 +1,6 @@
 {
   "description": "This ship is Romulan. Attacking it will result in a loss of reputation towards the Romulans and a gain of reputation towards the Federation and Klingon factions.",
-  "attack": 9040,
-  "defense": 9320,
   "group": "romulan",
-  "health": 3865,
   "hostile_name": "Romulan Patrol",
   "level": 20,
   "rarity": "common",
@@ -41,7 +38,6 @@
       "shield_health": 2740
     }
   },
-  "strength": 22225,
   "systems": [
     {
       "$ref": "systems/davidul_20"
@@ -78,7 +74,6 @@
         0
       ],
       "quantity": 1,
-      "weapon_id": "K1",
       "weapon_type": "kinetic"
     },
     {
@@ -97,7 +92,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_type": "energy"
     },
     {
@@ -116,8 +110,12 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E2",
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 9040,
+    "defense": 9320,
+    "health": 3865
+  }
 }

--- a/hostiles/romulan_patrol_20_battleship.json
+++ b/hostiles/romulan_patrol_20_battleship.json
@@ -1,6 +1,11 @@
 {
   "description": "This ship is Romulan. Attacking it will result in a loss of reputation towards the Romulans and a gain of reputation towards the Federation and Klingon factions.",
   "group": "romulan",
+  "head_stats": {
+    "attack": 9040,
+    "defense": 9320,
+    "health": 3865
+  },
   "hostile_name": "Romulan Patrol",
   "level": 20,
   "rarity": "common",
@@ -112,10 +117,5 @@
       "quantity": 1,
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 9040,
-    "defense": 9320,
-    "health": 3865
-  }
+  ]
 }

--- a/hostiles/romulan_patrol_20_explorer.json
+++ b/hostiles/romulan_patrol_20_explorer.json
@@ -1,9 +1,6 @@
 {
   "description": "This ship is Romulan. Attacking it will result in a loss of reputation towards the Romulans and a gain of reputation towards the Federation and Klingon factions.",
-  "attack": 9435,
-  "defense": 12430,
   "group": "romulan",
-  "health": 8655,
   "hostile_name": "Romulan Patrol",
   "level": 20,
   "rarity": "common",
@@ -41,7 +38,6 @@
       "shield_health": 7540
     }
   },
-  "strength": 30520,
   "systems": [
     {
       "$ref": "systems/davidul_20"
@@ -78,7 +74,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_type": "energy"
     },
     {
@@ -97,7 +92,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E2",
       "weapon_type": "energy"
     },
     {
@@ -116,8 +110,12 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E3",
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 9435,
+    "defense": 12430,
+    "health": 8655
+  }
 }

--- a/hostiles/romulan_patrol_20_explorer.json
+++ b/hostiles/romulan_patrol_20_explorer.json
@@ -1,6 +1,11 @@
 {
   "description": "This ship is Romulan. Attacking it will result in a loss of reputation towards the Romulans and a gain of reputation towards the Federation and Klingon factions.",
   "group": "romulan",
+  "head_stats": {
+    "attack": 9435,
+    "defense": 12430,
+    "health": 8655
+  },
   "hostile_name": "Romulan Patrol",
   "level": 20,
   "rarity": "common",
@@ -112,10 +117,5 @@
       "quantity": 1,
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 9435,
-    "defense": 12430,
-    "health": 8655
-  }
+  ]
 }

--- a/hostiles/romulan_patrol_20_interceptor.json
+++ b/hostiles/romulan_patrol_20_interceptor.json
@@ -1,9 +1,6 @@
 {
   "description": "This ship is Romulan. Attacking it will result in a loss of reputation towards the Romulans and a gain of reputation towards the Federation and Klingon factions.",
-  "attack": 9011,
-  "defense": 8605,
   "group": "romulan",
-  "health": 3455,
   "hostile_name": "Romulan Patrol",
   "level": 20,
   "rarity": "common",
@@ -41,7 +38,6 @@
       "shield_health": 2920
     }
   },
-  "strength": 21071,
   "systems": [
     {
       "$ref": "systems/davidul_20"
@@ -78,7 +74,6 @@
         0
       ],
       "quantity": 1,
-      "weapon_id": "K1",
       "weapon_type": "kinetic"
     },
     {
@@ -97,7 +92,6 @@
         0
       ],
       "quantity": 1,
-      "weapon_id": "K2",
       "weapon_type": "kinetic"
     },
     {
@@ -116,8 +110,12 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 9011,
+    "defense": 8605,
+    "health": 3455
+  }
 }

--- a/hostiles/romulan_patrol_20_interceptor.json
+++ b/hostiles/romulan_patrol_20_interceptor.json
@@ -1,6 +1,11 @@
 {
   "description": "This ship is Romulan. Attacking it will result in a loss of reputation towards the Romulans and a gain of reputation towards the Federation and Klingon factions.",
   "group": "romulan",
+  "head_stats": {
+    "attack": 9011,
+    "defense": 8605,
+    "health": 3455
+  },
   "hostile_name": "Romulan Patrol",
   "level": 20,
   "rarity": "common",
@@ -112,10 +117,5 @@
       "quantity": 1,
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 9011,
-    "defense": 8605,
-    "health": 3455
-  }
+  ]
 }

--- a/hostiles/romulan_patrol_28_battleship.json
+++ b/hostiles/romulan_patrol_28_battleship.json
@@ -1,6 +1,11 @@
 {
   "description": "This ship is Romulan. Attacking it will result in a loss of reputation towards the Romulans and a gain of reputation towards the Federation and Klingon factions.",
   "group": "romulan",
+  "head_stats": {
+    "attack": 48683,
+    "defense": 53970,
+    "health": 24150
+  },
   "hostile_name": "Romulan Patrol",
   "level": 28,
   "rarity": "common",
@@ -121,10 +126,5 @@
       "quantity": 1,
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 48683,
-    "defense": 53970,
-    "health": 24150
-  }
+  ]
 }

--- a/hostiles/romulan_patrol_28_battleship.json
+++ b/hostiles/romulan_patrol_28_battleship.json
@@ -1,9 +1,6 @@
 {
   "description": "This ship is Romulan. Attacking it will result in a loss of reputation towards the Romulans and a gain of reputation towards the Federation and Klingon factions.",
-  "attack": 48683,
-  "defense": 53970,
   "group": "romulan",
-  "health": 24150,
   "hostile_name": "Romulan Patrol",
   "level": 28,
   "rarity": "common",
@@ -41,7 +38,6 @@
       "shield_health": 17000
     }
   },
-  "strength": 126803,
   "systems": [
     {
       "$ref": "systems/biruin_27"
@@ -81,7 +77,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "K1",
       "weapon_type": "kinetic"
     },
     {
@@ -103,7 +98,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_type": "energy"
     },
     {
@@ -125,8 +119,12 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E2",
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 48683,
+    "defense": 53970,
+    "health": 24150
+  }
 }

--- a/hostiles/romulan_patrol_28_explorer.json
+++ b/hostiles/romulan_patrol_28_explorer.json
@@ -1,9 +1,6 @@
 {
   "description": "This ship is Romulan. Attacking it will result in a loss of reputation towards the Romulans and a gain of reputation towards the Federation and Klingon factions.",
-  "attack": 43404,
-  "defense": 46750,
   "group": "romulan",
-  "health": 24870,
   "hostile_name": "Romulan Patrol",
   "level": 28,
   "rarity": "common",
@@ -41,7 +38,6 @@
       "shield_health": 21000
     }
   },
-  "strength": 115024,
   "systems": [
     {
       "$ref": "systems/biruin_27"
@@ -81,7 +77,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_type": "energy"
     },
     {
@@ -103,7 +98,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E2",
       "weapon_type": "energy"
     },
     {
@@ -125,8 +119,12 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E3",
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 43404,
+    "defense": 46750,
+    "health": 24870
+  }
 }

--- a/hostiles/romulan_patrol_28_explorer.json
+++ b/hostiles/romulan_patrol_28_explorer.json
@@ -1,6 +1,11 @@
 {
   "description": "This ship is Romulan. Attacking it will result in a loss of reputation towards the Romulans and a gain of reputation towards the Federation and Klingon factions.",
   "group": "romulan",
+  "head_stats": {
+    "attack": 43404,
+    "defense": 46750,
+    "health": 24870
+  },
   "hostile_name": "Romulan Patrol",
   "level": 28,
   "rarity": "common",
@@ -121,10 +126,5 @@
       "quantity": 1,
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 43404,
-    "defense": 46750,
-    "health": 24870
-  }
+  ]
 }

--- a/hostiles/romulan_patrol_28_interceptor.json
+++ b/hostiles/romulan_patrol_28_interceptor.json
@@ -1,6 +1,11 @@
 {
   "description": "This ship is Romulan. Attacking it will result in a loss of reputation towards the Romulans and a gain of reputation towards the Federation and Klingon factions.",
   "group": "romulan",
+  "head_stats": {
+    "attack": 48290,
+    "defense": 49845,
+    "health": 21600
+  },
   "hostile_name": "Romulan Patrol",
   "level": 28,
   "rarity": "common",
@@ -121,10 +126,5 @@
       "quantity": 1,
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 48290,
-    "defense": 49845,
-    "health": 21600
-  }
+  ]
 }

--- a/hostiles/romulan_patrol_28_interceptor.json
+++ b/hostiles/romulan_patrol_28_interceptor.json
@@ -1,9 +1,6 @@
 {
   "description": "This ship is Romulan. Attacking it will result in a loss of reputation towards the Romulans and a gain of reputation towards the Federation and Klingon factions.",
-  "attack": 48290,
-  "defense": 49845,
   "group": "romulan",
-  "health": 21600,
   "hostile_name": "Romulan Patrol",
   "level": 28,
   "rarity": "common",
@@ -41,7 +38,6 @@
       "shield_health": 18000
     }
   },
-  "strength": 119735,
   "systems": [
     {
       "$ref": "systems/biruin_27"
@@ -81,7 +77,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "K1",
       "weapon_type": "kinetic"
     },
     {
@@ -103,7 +98,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "K2",
       "weapon_type": "kinetic"
     },
     {
@@ -125,8 +119,12 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 48290,
+    "defense": 49845,
+    "health": 21600
+  }
 }

--- a/hostiles/romulan_patrol_30_explorer.json
+++ b/hostiles/romulan_patrol_30_explorer.json
@@ -1,6 +1,11 @@
 {
   "description": "This ship is Romulan. Attacking it will result in a loss of reputation towards the Romulans and a gain of reputation towards the Federation and Klingon factions.",
   "group": "romulan",
+  "head_stats": {
+    "attack": 65985,
+    "defense": 71400,
+    "health": 36065
+  },
   "hostile_name": "Romulan Patrol",
   "level": 30,
   "rarity": "common",
@@ -118,10 +123,5 @@
       "quantity": 1,
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 65985,
-    "defense": 71400,
-    "health": 36065
-  }
+  ]
 }

--- a/hostiles/romulan_patrol_30_explorer.json
+++ b/hostiles/romulan_patrol_30_explorer.json
@@ -1,9 +1,6 @@
 {
   "description": "This ship is Romulan. Attacking it will result in a loss of reputation towards the Romulans and a gain of reputation towards the Federation and Klingon factions.",
-  "attack": 65985,
-  "defense": 71400,
   "group": "romulan",
-  "health": 36065,
   "hostile_name": "Romulan Patrol",
   "level": 30,
   "rarity": "common",
@@ -41,7 +38,6 @@
       "shield_health": 31000
     }
   },
-  "strength": 173450,
   "systems": [
     {
       "$ref": "systems/rator_29"
@@ -78,7 +74,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_type": "energy"
     },
     {
@@ -100,7 +95,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E2",
       "weapon_type": "energy"
     },
     {
@@ -122,8 +116,12 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E3",
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 65985,
+    "defense": 71400,
+    "health": 36065
+  }
 }

--- a/hostiles/romulan_patrol_31_battleship.json
+++ b/hostiles/romulan_patrol_31_battleship.json
@@ -1,6 +1,11 @@
 {
   "description": "This ship is Romulan. Attacking it will result in a loss of reputation towards the Romulans and a gain of reputation towards the Federation and Klingon factions.",
   "group": "romulan",
+  "head_stats": {
+    "attack": 97905,
+    "defense": 107940,
+    "health": 42265
+  },
   "hostile_name": "Romulan Patrol",
   "level": 31,
   "rarity": "common",
@@ -130,10 +135,5 @@
       "quantity": 1,
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 97905,
-    "defense": 107940,
-    "health": 42265
-  }
+  ]
 }

--- a/hostiles/romulan_patrol_31_battleship.json
+++ b/hostiles/romulan_patrol_31_battleship.json
@@ -1,9 +1,6 @@
 {
   "description": "This ship is Romulan. Attacking it will result in a loss of reputation towards the Romulans and a gain of reputation towards the Federation and Klingon factions.",
-  "attack": 97905,
-  "defense": 107940,
   "group": "romulan",
-  "health": 42265,
   "hostile_name": "Romulan Patrol",
   "level": 31,
   "rarity": "common",
@@ -41,7 +38,6 @@
       "shield_health": 29000
     }
   },
-  "strength": 248110,
   "systems": [
     {
       "$ref": "systems/galorndon_core_30"
@@ -96,7 +92,6 @@
         0
       ],
       "quantity": 1,
-      "weapon_id": "K1",
       "weapon_type": "kinetic"
     },
     {
@@ -115,7 +110,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_type": "energy"
     },
     {
@@ -134,8 +128,12 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E2",
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 97905,
+    "defense": 107940,
+    "health": 42265
+  }
 }

--- a/hostiles/romulan_patrol_31_explorer.json
+++ b/hostiles/romulan_patrol_31_explorer.json
@@ -1,9 +1,6 @@
 {
   "description": "This ship is Romulan. Attacking it will result in a loss of reputation towards the Romulans and a gain of reputation towards the Federation and Klingon factions.",
-  "attack": 87312,
-  "defense": 93500,
   "group": "romulan",
-  "health": 43525,
   "hostile_name": "Romulan Patrol",
   "level": 31,
   "rarity": "common",
@@ -41,7 +38,6 @@
       "shield_health": 37000
     }
   },
-  "strength": 224337,
   "systems": [
     {
       "$ref": "systems/galorndon_core_30"
@@ -96,7 +92,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_type": "energy"
     },
     {
@@ -115,7 +110,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E2",
       "weapon_type": "energy"
     },
     {
@@ -134,8 +128,12 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E3",
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 87312,
+    "defense": 93500,
+    "health": 43525
+  }
 }

--- a/hostiles/romulan_patrol_31_explorer.json
+++ b/hostiles/romulan_patrol_31_explorer.json
@@ -1,6 +1,11 @@
 {
   "description": "This ship is Romulan. Attacking it will result in a loss of reputation towards the Romulans and a gain of reputation towards the Federation and Klingon factions.",
   "group": "romulan",
+  "head_stats": {
+    "attack": 87312,
+    "defense": 93500,
+    "health": 43525
+  },
   "hostile_name": "Romulan Patrol",
   "level": 31,
   "rarity": "common",
@@ -130,10 +135,5 @@
       "quantity": 1,
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 87312,
-    "defense": 93500,
-    "health": 43525
-  }
+  ]
 }

--- a/hostiles/romulan_patrol_31_interceptor.json
+++ b/hostiles/romulan_patrol_31_interceptor.json
@@ -1,6 +1,11 @@
 {
   "description": "This ship is Romulan. Attacking it will result in a loss of reputation towards the Romulans and a gain of reputation towards the Federation and Klingon factions.",
   "group": "romulan",
+  "head_stats": {
+    "attack": 97153,
+    "defense": 99690,
+    "health": 37800
+  },
   "hostile_name": "Romulan Patrol",
   "level": 31,
   "rarity": "common",
@@ -130,10 +135,5 @@
       "quantity": 1,
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 97153,
-    "defense": 99690,
-    "health": 37800
-  }
+  ]
 }

--- a/hostiles/romulan_patrol_31_interceptor.json
+++ b/hostiles/romulan_patrol_31_interceptor.json
@@ -1,9 +1,6 @@
 {
   "description": "This ship is Romulan. Attacking it will result in a loss of reputation towards the Romulans and a gain of reputation towards the Federation and Klingon factions.",
-  "attack": 97153,
-  "defense": 99690,
   "group": "romulan",
-  "health": 37800,
   "hostile_name": "Romulan Patrol",
   "level": 31,
   "rarity": "common",
@@ -41,7 +38,6 @@
       "shield_health": 31000
     }
   },
-  "strength": 234643,
   "systems": [
     {
       "$ref": "systems/galorndon_core_30"
@@ -96,7 +92,6 @@
         0
       ],
       "quantity": 1,
-      "weapon_id": "K1",
       "weapon_type": "kinetic"
     },
     {
@@ -115,7 +110,6 @@
         0
       ],
       "quantity": 1,
-      "weapon_id": "K2",
       "weapon_type": "kinetic"
     },
     {
@@ -134,8 +128,12 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 97153,
+    "defense": 99690,
+    "health": 37800
+  }
 }

--- a/hostiles/romulan_patrol_35_explorer.json
+++ b/hostiles/romulan_patrol_35_explorer.json
@@ -1,9 +1,6 @@
 {
   "description": "This ship is Romulan. Attacking it will result in a loss of reputation towards the Romulans and a gain of reputation towards the Federation and Klingon factions.",
-  "attack": 246866,
-  "defense": 255000,
   "group": "romulan",
-  "health": 93265,
   "hostile_name": "Romulan Patrol",
   "level": 35,
   "rarity": "common",
@@ -41,7 +38,6 @@
       "shield_health": 81000
     }
   },
-  "strength": 595131,
   "systems": [
     {
       "$ref": "systems/alpha_onias_36"
@@ -72,7 +68,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_type": "energy"
     },
     {
@@ -94,7 +89,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E2",
       "weapon_type": "energy"
     },
     {
@@ -116,8 +110,12 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E3",
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 246866,
+    "defense": 255000,
+    "health": 93265
+  }
 }

--- a/hostiles/romulan_patrol_35_explorer.json
+++ b/hostiles/romulan_patrol_35_explorer.json
@@ -1,6 +1,11 @@
 {
   "description": "This ship is Romulan. Attacking it will result in a loss of reputation towards the Romulans and a gain of reputation towards the Federation and Klingon factions.",
   "group": "romulan",
+  "head_stats": {
+    "attack": 246866,
+    "defense": 255000,
+    "health": 93265
+  },
   "hostile_name": "Romulan Patrol",
   "level": 35,
   "rarity": "common",
@@ -112,10 +117,5 @@
       "quantity": 1,
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 246866,
-    "defense": 255000,
-    "health": 93265
-  }
+  ]
 }

--- a/hostiles/romulan_patrol_36_explorer.json
+++ b/hostiles/romulan_patrol_36_explorer.json
@@ -1,9 +1,6 @@
 {
   "description": "This ship is Romulan. Attacking it will result in a loss of reputation towards the Romulans and a gain of reputation towards the Federation and Klingon factions.",
-  "attack": 308130,
-  "defense": 309820,
   "group": "romulan",
-  "health": 112640,
   "hostile_name": "Romulan Patrol",
   "level": 36,
   "rarity": "common",
@@ -41,7 +38,6 @@
       "shield_health": 98000
     }
   },
-  "strength": 730590,
   "systems": [
     {
       "$ref": "systems/alpha_onias_36"
@@ -72,7 +68,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_type": "energy"
     },
     {
@@ -94,7 +89,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E2",
       "weapon_type": "energy"
     },
     {
@@ -116,8 +110,12 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E3",
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 308130,
+    "defense": 309820,
+    "health": 112640
+  }
 }

--- a/hostiles/romulan_patrol_36_explorer.json
+++ b/hostiles/romulan_patrol_36_explorer.json
@@ -1,6 +1,11 @@
 {
   "description": "This ship is Romulan. Attacking it will result in a loss of reputation towards the Romulans and a gain of reputation towards the Federation and Klingon factions.",
   "group": "romulan",
+  "head_stats": {
+    "attack": 308130,
+    "defense": 309820,
+    "health": 112640
+  },
   "hostile_name": "Romulan Patrol",
   "level": 36,
   "rarity": "common",
@@ -112,10 +117,5 @@
       "quantity": 1,
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 308130,
-    "defense": 309820,
-    "health": 112640
-  }
+  ]
 }

--- a/hostiles/romulan_patrol_39_battleship.json
+++ b/hostiles/romulan_patrol_39_battleship.json
@@ -1,6 +1,11 @@
 {
   "description": "This ship is Romulan. Attacking it will result in a loss of reputation towards the Romulans and a gain of reputation towards the Federation and Klingon factions.",
   "group": "romulan",
+  "head_stats": {
+    "attack": 588108,
+    "defense": 616525,
+    "health": 192945
+  },
   "hostile_name": "Romulan Patrol",
   "level": 39,
   "rarity": "common",
@@ -178,10 +183,5 @@
       "quantity": 1,
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 588108,
-    "defense": 616525,
-    "health": 192945
-  }
+  ]
 }

--- a/hostiles/romulan_patrol_39_battleship.json
+++ b/hostiles/romulan_patrol_39_battleship.json
@@ -1,9 +1,6 @@
 {
   "description": "This ship is Romulan. Attacking it will result in a loss of reputation towards the Romulans and a gain of reputation towards the Federation and Klingon factions.",
-  "attack": 588108,
-  "defense": 616525,
   "group": "romulan",
-  "health": 192945,
   "hostile_name": "Romulan Patrol",
   "level": 39,
   "rarity": "common",
@@ -41,7 +38,6 @@
       "shield_health": 136000
     }
   },
-  "strength": 1397578,
   "systems": [
     {
       "$ref": "systems/altanea_38"
@@ -144,7 +140,6 @@
         0
       ],
       "quantity": 1,
-      "weapon_id": "K1",
       "weapon_type": "kinetic"
     },
     {
@@ -163,7 +158,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_type": "energy"
     },
     {
@@ -182,8 +176,12 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E2",
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 588108,
+    "defense": 616525,
+    "health": 192945
+  }
 }

--- a/hostiles/romulan_patrol_39_explorer.json
+++ b/hostiles/romulan_patrol_39_explorer.json
@@ -1,9 +1,6 @@
 {
   "description": "This ship is Romulan. Attacking it will result in a loss of reputation towards the Romulans and a gain of reputation towards the Federation and Klingon factions.",
-  "attack": 525803,
-  "defense": 534065,
   "group": "romulan",
-  "health": 198700,
   "hostile_name": "Romulan Patrol",
   "level": 39,
   "rarity": "common",
@@ -41,7 +38,6 @@
       "shield_health": 173000
     }
   },
-  "strength": 1258568,
   "systems": [
     {
       "$ref": "systems/altanea_38"
@@ -144,7 +140,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_type": "energy"
     },
     {
@@ -163,7 +158,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E2",
       "weapon_type": "energy"
     },
     {
@@ -182,8 +176,12 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E3",
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 525803,
+    "defense": 534065,
+    "health": 198700
+  }
 }

--- a/hostiles/romulan_patrol_39_explorer.json
+++ b/hostiles/romulan_patrol_39_explorer.json
@@ -1,6 +1,11 @@
 {
   "description": "This ship is Romulan. Attacking it will result in a loss of reputation towards the Romulans and a gain of reputation towards the Federation and Klingon factions.",
   "group": "romulan",
+  "head_stats": {
+    "attack": 525803,
+    "defense": 534065,
+    "health": 198700
+  },
   "hostile_name": "Romulan Patrol",
   "level": 39,
   "rarity": "common",
@@ -178,10 +183,5 @@
       "quantity": 1,
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 525803,
-    "defense": 534065,
-    "health": 198700
-  }
+  ]
 }

--- a/hostiles/romulan_patrol_39_interceptor.json
+++ b/hostiles/romulan_patrol_39_interceptor.json
@@ -1,9 +1,6 @@
 {
   "description": "This ship is Romulan. Attacking it will result in a loss of reputation towards the Romulans and a gain of reputation towards the Federation and Klingon factions.",
-  "attack": 585621,
-  "defense": 569405,
   "group": "romulan",
-  "health": 172575,
   "hostile_name": "Romulan Patrol",
   "level": 39,
   "rarity": "common",
@@ -41,7 +38,6 @@
       "shield_health": 145000
     }
   },
-  "strength": 1327601,
   "systems": [
     {
       "$ref": "systems/altanea_38"
@@ -144,7 +140,6 @@
         0
       ],
       "quantity": 1,
-      "weapon_id": "K1",
       "weapon_type": "kinetic"
     },
     {
@@ -163,7 +158,6 @@
         0
       ],
       "quantity": 1,
-      "weapon_id": "K2",
       "weapon_type": "kinetic"
     },
     {
@@ -182,8 +176,12 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 585621,
+    "defense": 569405,
+    "health": 172575
+  }
 }

--- a/hostiles/romulan_patrol_39_interceptor.json
+++ b/hostiles/romulan_patrol_39_interceptor.json
@@ -1,6 +1,11 @@
 {
   "description": "This ship is Romulan. Attacking it will result in a loss of reputation towards the Romulans and a gain of reputation towards the Federation and Klingon factions.",
   "group": "romulan",
+  "head_stats": {
+    "attack": 585621,
+    "defense": 569405,
+    "health": 172575
+  },
   "hostile_name": "Romulan Patrol",
   "level": 39,
   "rarity": "common",
@@ -178,10 +183,5 @@
       "quantity": 1,
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 585621,
-    "defense": 569405,
-    "health": 172575
-  }
+  ]
 }

--- a/hostiles/romulan_patrol_40_battleship.json
+++ b/hostiles/romulan_patrol_40_battleship.json
@@ -1,6 +1,11 @@
 {
   "description": "This ship is Romulan. Attacking it will result in a loss of reputation towards the Romulans and a gain of reputation towards the Federation and Klingon factions.",
   "group": "romulan",
+  "head_stats": {
+    "attack": 722907,
+    "defense": 759970,
+    "health": 239400
+  },
   "hostile_name": "Romulan Patrol",
   "level": 40,
   "rarity": "common",
@@ -175,10 +180,5 @@
       "quantity": 1,
       "weapon_type": "kinetic"
     }
-  ],
-  "head_stats": {
-    "attack": 722907,
-    "defense": 759970,
-    "health": 239400
-  }
+  ]
 }

--- a/hostiles/romulan_patrol_40_battleship.json
+++ b/hostiles/romulan_patrol_40_battleship.json
@@ -1,9 +1,6 @@
 {
   "description": "This ship is Romulan. Attacking it will result in a loss of reputation towards the Romulans and a gain of reputation towards the Federation and Klingon factions.",
-  "attack": 722907,
-  "defense": 759970,
   "group": "romulan",
-  "health": 239400,
   "hostile_name": "Romulan Patrol",
   "level": 40,
   "rarity": "common",
@@ -41,7 +38,6 @@
       "shield_health": 169000
     }
   },
-  "strength": 1722277,
   "systems": [
     {
       "$ref": "systems/alatum_39"
@@ -135,7 +131,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_type": "energy"
     },
     {
@@ -157,7 +152,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E2",
       "weapon_type": "energy"
     },
     {
@@ -179,8 +173,12 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "K1",
       "weapon_type": "kinetic"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 722907,
+    "defense": 759970,
+    "health": 239400
+  }
 }

--- a/hostiles/romulan_patrol_40_explorer.json
+++ b/hostiles/romulan_patrol_40_explorer.json
@@ -1,9 +1,6 @@
 {
   "description": "This ship is Romulan. Attacking it will result in a loss of reputation towards the Romulans and a gain of reputation towards the Federation and Klingon factions.",
-  "attack": 1203945,
-  "defense": 566125,
   "group": "romulan",
-  "health": 1959516,
   "hostile_name": "Romulan Patrol",
   "level": 40,
   "rarity": "common",
@@ -45,7 +42,6 @@
       "shield_health": 2102000
     }
   },
-  "strength": 3729586,
   "systems": [
     {
       "$ref": "systems/alatum_39"
@@ -139,7 +135,6 @@
         3
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_type": "energy"
     },
     {
@@ -161,7 +156,6 @@
         3
       ],
       "quantity": 1,
-      "weapon_id": "E2",
       "weapon_type": "energy"
     },
     {
@@ -183,8 +177,12 @@
         3
       ],
       "quantity": 1,
-      "weapon_id": "E3",
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 1203945,
+    "defense": 566125,
+    "health": 1959516
+  }
 }

--- a/hostiles/romulan_patrol_40_explorer.json
+++ b/hostiles/romulan_patrol_40_explorer.json
@@ -1,6 +1,11 @@
 {
   "description": "This ship is Romulan. Attacking it will result in a loss of reputation towards the Romulans and a gain of reputation towards the Federation and Klingon factions.",
   "group": "romulan",
+  "head_stats": {
+    "attack": 1203945,
+    "defense": 566125,
+    "health": 1959516
+  },
   "hostile_name": "Romulan Patrol",
   "level": 40,
   "rarity": "common",
@@ -179,10 +184,5 @@
       "quantity": 1,
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 1203945,
-    "defense": 566125,
-    "health": 1959516
-  }
+  ]
 }

--- a/hostiles/romulan_patrol_40_interceptor.json
+++ b/hostiles/romulan_patrol_40_interceptor.json
@@ -1,9 +1,6 @@
 {
   "description": "This ship is Romulan. Attacking it will result in a loss of reputation towards the Romulans and a gain of reputation towards the Federation and Klingon factions.",
-  "attack": 714944,
-  "defense": 560045,
   "group": "romulan",
-  "health": 1840951,
   "hostile_name": "Romulan Patrol",
   "level": 40,
   "rarity": "common",
@@ -45,7 +42,6 @@
       "shield_health": 1753000
     }
   },
-  "strength": 3115940,
   "systems": [
     {
       "$ref": "systems/alatum_39"
@@ -139,7 +135,6 @@
         3
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_type": "energy"
     },
     {
@@ -161,7 +156,6 @@
         3
       ],
       "quantity": 1,
-      "weapon_id": "K1",
       "weapon_type": "kinetic"
     },
     {
@@ -183,8 +177,12 @@
         3
       ],
       "quantity": 1,
-      "weapon_id": "K2",
       "weapon_type": "kinetic"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 714944,
+    "defense": 560045,
+    "health": 1840951
+  }
 }

--- a/hostiles/romulan_patrol_40_interceptor.json
+++ b/hostiles/romulan_patrol_40_interceptor.json
@@ -1,6 +1,11 @@
 {
   "description": "This ship is Romulan. Attacking it will result in a loss of reputation towards the Romulans and a gain of reputation towards the Federation and Klingon factions.",
   "group": "romulan",
+  "head_stats": {
+    "attack": 714944,
+    "defense": 560045,
+    "health": 1840951
+  },
   "hostile_name": "Romulan Patrol",
   "level": 40,
   "rarity": "common",
@@ -179,10 +184,5 @@
       "quantity": 1,
       "weapon_type": "kinetic"
     }
-  ],
-  "head_stats": {
-    "attack": 714944,
-    "defense": 560045,
-    "health": 1840951
-  }
+  ]
 }

--- a/hostiles/romulan_patrol_41_battleship.json
+++ b/hostiles/romulan_patrol_41_battleship.json
@@ -1,9 +1,6 @@
 {
   "description": "This ship is Romulan. Attacking it will result in a loss of reputation towards the Romulans and a gain of reputation towards the Federation and Klingon factions.",
-  "attack": 1372745,
-  "defense": 544700,
   "group": "romulan",
-  "health": 2671199,
   "hostile_name": "Romulan Patrol",
   "level": 41,
   "rarity": "common",
@@ -45,7 +42,6 @@
       "shield_health": 2165000
     }
   },
-  "strength": 4588644,
   "systems": [
     {
       "$ref": "systems/yvnys_40"
@@ -82,7 +78,6 @@
         3
       ],
       "quantity": 2,
-      "weapon_id": "E1",
       "weapon_stats": {
         "accuracy": 56035,
         "armor_pierce": 56035,
@@ -114,7 +109,6 @@
         3
       ],
       "quantity": 1,
-      "weapon_id": "K1",
       "weapon_stats": {
         "accuracy": 56035,
         "armor_pierce": 56035,
@@ -146,8 +140,12 @@
         3
       ],
       "quantity": 1,
-      "weapon_id": "E2",
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 1372745,
+    "defense": 544700,
+    "health": 2671199
+  }
 }

--- a/hostiles/romulan_patrol_41_battleship.json
+++ b/hostiles/romulan_patrol_41_battleship.json
@@ -1,6 +1,11 @@
 {
   "description": "This ship is Romulan. Attacking it will result in a loss of reputation towards the Romulans and a gain of reputation towards the Federation and Klingon factions.",
   "group": "romulan",
+  "head_stats": {
+    "attack": 1372745,
+    "defense": 544700,
+    "health": 2671199
+  },
   "hostile_name": "Romulan Patrol",
   "level": 41,
   "rarity": "common",
@@ -142,10 +147,5 @@
       "quantity": 1,
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 1372745,
-    "defense": 544700,
-    "health": 2671199
-  }
+  ]
 }

--- a/hostiles/romulan_patrol_46_battleship.json
+++ b/hostiles/romulan_patrol_46_battleship.json
@@ -1,9 +1,6 @@
 {
   "description": "This ship is Romulan. Attacking it will result in a loss of reputation towards the Romulans and a gain of reputation towards the Federation and Klingon factions.",
-  "attack": 3305018,
-  "defense": 1203455,
   "group": "romulan",
-  "health": 5693532,
   "hostile_name": "Romulan Patrol",
   "level": 46,
   "rarity": "common",
@@ -45,7 +42,6 @@
       "shield_health": 4616000
     }
   },
-  "strength": 10202005,
   "systems": [
     {
       "$ref": "systems/nuva_45"
@@ -82,7 +78,6 @@
         3
       ],
       "quantity": 1,
-      "weapon_id": "K1",
       "weapon_type": "kinetic"
     },
     {
@@ -104,7 +99,6 @@
         3
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_type": "energy"
     },
     {
@@ -126,8 +120,12 @@
         3
       ],
       "quantity": 1,
-      "weapon_id": "E2",
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 3305018,
+    "defense": 1203455,
+    "health": 5693532
+  }
 }

--- a/hostiles/romulan_patrol_46_battleship.json
+++ b/hostiles/romulan_patrol_46_battleship.json
@@ -1,6 +1,11 @@
 {
   "description": "This ship is Romulan. Attacking it will result in a loss of reputation towards the Romulans and a gain of reputation towards the Federation and Klingon factions.",
   "group": "romulan",
+  "head_stats": {
+    "attack": 3305018,
+    "defense": 1203455,
+    "health": 5693532
+  },
   "hostile_name": "Romulan Patrol",
   "level": 46,
   "rarity": "common",
@@ -122,10 +127,5 @@
       "quantity": 1,
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 3305018,
-    "defense": 1203455,
-    "health": 5693532
-  }
+  ]
 }

--- a/hostiles/romulan_scout_38_interceptor.json
+++ b/hostiles/romulan_scout_38_interceptor.json
@@ -1,9 +1,6 @@
 {
   "description": "This ship is Romulan. Attacking it will result in a loss of reputation towards the Romulans and a gain of reputation towards the Federation and Klingon factions.",
-  "attack": 392120,
-  "defense": 378405,
   "group": "romulan",
-  "health": 112785,
   "hostile_name": "Romulan Scout \u2605",
   "level": 38,
   "rarity": "common",
@@ -41,7 +38,6 @@
       "shield_health": 95000
     }
   },
-  "strength": 883310,
   "systems": [
     {
       "$ref": "systems/altanea_38"
@@ -75,7 +71,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "K1",
       "weapon_type": "kinetic"
     },
     {
@@ -97,7 +92,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "K2",
       "weapon_type": "kinetic"
     },
     {
@@ -119,8 +113,12 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 392120,
+    "defense": 378405,
+    "health": 112785
+  }
 }

--- a/hostiles/romulan_scout_38_interceptor.json
+++ b/hostiles/romulan_scout_38_interceptor.json
@@ -1,6 +1,11 @@
 {
   "description": "This ship is Romulan. Attacking it will result in a loss of reputation towards the Romulans and a gain of reputation towards the Federation and Klingon factions.",
   "group": "romulan",
+  "head_stats": {
+    "attack": 392120,
+    "defense": 378405,
+    "health": 112785
+  },
   "hostile_name": "Romulan Scout \u2605",
   "level": 38,
   "rarity": "common",
@@ -115,10 +120,5 @@
       "quantity": 1,
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 392120,
-    "defense": 378405,
-    "health": 112785
-  }
+  ]
 }

--- a/hostiles/romulan_scout_42_interceptor.json
+++ b/hostiles/romulan_scout_42_interceptor.json
@@ -1,9 +1,6 @@
 {
   "description": "This ship is Romulan. Attacking it will result in a loss of reputation towards the Romulans and a gain of reputation towards the Federation and Klingon factions.",
-  "attack": 881172,
-  "defense": 198635,
   "group": "romulan",
-  "health": 2268972,
   "hostile_name": "Romulan Scout \u2605",
   "level": 42,
   "rarity": "common",
@@ -45,7 +42,6 @@
       "shield_health": 2160000
     }
   },
-  "strength": 3348779,
   "systems": [
     {
       "$ref": "systems/corvidae_42"
@@ -76,7 +72,6 @@
         3
       ],
       "quantity": 1,
-      "weapon_id": "K1",
       "weapon_type": "kinetic"
     },
     {
@@ -98,7 +93,6 @@
         3
       ],
       "quantity": 1,
-      "weapon_id": "K2",
       "weapon_type": "kinetic"
     },
     {
@@ -120,8 +114,12 @@
         3
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 881172,
+    "defense": 198635,
+    "health": 2268972
+  }
 }

--- a/hostiles/romulan_scout_42_interceptor.json
+++ b/hostiles/romulan_scout_42_interceptor.json
@@ -1,6 +1,11 @@
 {
   "description": "This ship is Romulan. Attacking it will result in a loss of reputation towards the Romulans and a gain of reputation towards the Federation and Klingon factions.",
   "group": "romulan",
+  "head_stats": {
+    "attack": 881172,
+    "defense": 198635,
+    "health": 2268972
+  },
   "hostile_name": "Romulan Scout \u2605",
   "level": 42,
   "rarity": "common",
@@ -116,10 +121,5 @@
       "quantity": 1,
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 881172,
-    "defense": 198635,
-    "health": 2268972
-  }
+  ]
 }

--- a/hostiles/romulan_trader_20_survey.json
+++ b/hostiles/romulan_trader_20_survey.json
@@ -1,6 +1,11 @@
 {
   "description": "The Horizon freighter was part of the ECS's privately owned fleet and used for the transport of all types of goods, ranging from hazardous material to passengers on long-haul journeys. Originally built in the early 22nd century, they started service as pre-warp vessels but have since been maintained and upgraded for low-warp travel.",
   "group": "romulan",
+  "head_stats": {
+    "attack": 3816,
+    "defense": 9750,
+    "health": 5760
+  },
   "hostile_name": "Romulan Trader",
   "level": 20,
   "rarity": "common",
@@ -79,10 +84,5 @@
       "quantity": 1,
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 3816,
-    "defense": 9750,
-    "health": 5760
-  }
+  ]
 }

--- a/hostiles/romulan_trader_20_survey.json
+++ b/hostiles/romulan_trader_20_survey.json
@@ -1,9 +1,6 @@
 {
   "description": "The Horizon freighter was part of the ECS's privately owned fleet and used for the transport of all types of goods, ranging from hazardous material to passengers on long-haul journeys. Originally built in the early 22nd century, they started service as pre-warp vessels but have since been maintained and upgraded for low-warp travel.",
-  "attack": 3816,
-  "defense": 9750,
   "group": "romulan",
-  "health": 5760,
   "hostile_name": "Romulan Trader",
   "level": 20,
   "rarity": "common",
@@ -41,7 +38,6 @@
       "shield_health": 5760
     }
   },
-  "strength": 19326,
   "systems": [
     {
       "$ref": "systems/davidul_20"
@@ -81,8 +77,12 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 3816,
+    "defense": 9750,
+    "health": 5760
+  }
 }

--- a/hostiles/romulan_trader_21_survey.json
+++ b/hostiles/romulan_trader_21_survey.json
@@ -1,6 +1,11 @@
 {
   "description": "The Horizon freighter was part of the ECS's privately owned fleet and used for the transport of all types of goods, ranging from hazardous material to passengers on long-haul journeys. Originally built in the early 22nd century, they started service as pre-warp vessels but have since been maintained and upgraded for low-warp travel.",
   "group": "romulan",
+  "head_stats": {
+    "attack": 4914,
+    "defense": 13125,
+    "health": 7200
+  },
   "hostile_name": "Romulan Trader",
   "level": 21,
   "rarity": "common",
@@ -85,10 +90,5 @@
       "quantity": 1,
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 4914,
-    "defense": 13125,
-    "health": 7200
-  }
+  ]
 }

--- a/hostiles/romulan_trader_21_survey.json
+++ b/hostiles/romulan_trader_21_survey.json
@@ -1,9 +1,6 @@
 {
   "description": "The Horizon freighter was part of the ECS's privately owned fleet and used for the transport of all types of goods, ranging from hazardous material to passengers on long-haul journeys. Originally built in the early 22nd century, they started service as pre-warp vessels but have since been maintained and upgraded for low-warp travel.",
-  "attack": 4914,
-  "defense": 13125,
   "group": "romulan",
-  "health": 7200,
   "hostile_name": "Romulan Trader",
   "level": 21,
   "rarity": "common",
@@ -41,7 +38,6 @@
       "shield_health": 7200
     }
   },
-  "strength": 25239,
   "systems": [
     {
       "$ref": "systems/davidul_20"
@@ -87,8 +83,12 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 4914,
+    "defense": 13125,
+    "health": 7200
+  }
 }

--- a/hostiles/romulan_trader_22_survey.json
+++ b/hostiles/romulan_trader_22_survey.json
@@ -1,6 +1,11 @@
 {
   "description": "The Horizon freighter was part of the ECS's privately owned fleet and used for the transport of all types of goods, ranging from hazardous material to passengers on long-haul journeys. Originally built in the early 22nd century, they started service as pre-warp vessels but have since been maintained and upgraded for low-warp travel.",
   "group": "romulan",
+  "head_stats": {
+    "attack": 5982,
+    "defense": 16125,
+    "health": 8640
+  },
   "hostile_name": "Romulan Trader",
   "level": 22,
   "rarity": "common",
@@ -101,10 +106,5 @@
       },
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 5982,
-    "defense": 16125,
-    "health": 8640
-  }
+  ]
 }

--- a/hostiles/romulan_trader_22_survey.json
+++ b/hostiles/romulan_trader_22_survey.json
@@ -1,9 +1,6 @@
 {
   "description": "The Horizon freighter was part of the ECS's privately owned fleet and used for the transport of all types of goods, ranging from hazardous material to passengers on long-haul journeys. Originally built in the early 22nd century, they started service as pre-warp vessels but have since been maintained and upgraded for low-warp travel.",
-  "attack": 5982,
-  "defense": 16125,
   "group": "romulan",
-  "health": 8640,
   "hostile_name": "Romulan Trader",
   "level": 22,
   "rarity": "common",
@@ -41,7 +38,6 @@
       "shield_health": 8640
     }
   },
-  "strength": 30747,
   "systems": [
     {
       "$ref": "systems/llorrac_21"
@@ -93,7 +89,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_stats": {
         "accuracy": 860,
         "armor_pierce": 860,
@@ -106,5 +101,10 @@
       },
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 5982,
+    "defense": 16125,
+    "health": 8640
+  }
 }

--- a/hostiles/romulan_trader_27_survey.json
+++ b/hostiles/romulan_trader_27_survey.json
@@ -1,6 +1,11 @@
 {
   "description": "The Horizon freighter was part of the ECS's privately owned fleet and used for the transport of all types of goods, ranging from hazardous material to passengers on long-haul journeys. Originally built in the early 22nd century, they started service as pre-warp vessels but have since been maintained and upgraded for low-warp travel.",
   "group": "romulan",
+  "head_stats": {
+    "attack": 16962,
+    "defense": 41250,
+    "health": 28800
+  },
   "hostile_name": "Romulan Trader",
   "level": 27,
   "rarity": "common",
@@ -76,10 +81,5 @@
       "quantity": 1,
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 16962,
-    "defense": 41250,
-    "health": 28800
-  }
+  ]
 }

--- a/hostiles/romulan_trader_27_survey.json
+++ b/hostiles/romulan_trader_27_survey.json
@@ -1,9 +1,6 @@
 {
   "description": "The Horizon freighter was part of the ECS's privately owned fleet and used for the transport of all types of goods, ranging from hazardous material to passengers on long-haul journeys. Originally built in the early 22nd century, they started service as pre-warp vessels but have since been maintained and upgraded for low-warp travel.",
-  "attack": 16962,
-  "defense": 41250,
   "group": "romulan",
-  "health": 28800,
   "hostile_name": "Romulan Trader",
   "level": 27,
   "rarity": "common",
@@ -41,7 +38,6 @@
       "shield_health": 28000
     }
   },
-  "strength": 87012,
   "systems": [
     {
       "$ref": "systems/rooth_26"
@@ -78,8 +74,12 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 16962,
+    "defense": 41250,
+    "health": 28800
+  }
 }

--- a/hostiles/romulan_trader_28_survey.json
+++ b/hostiles/romulan_trader_28_survey.json
@@ -1,9 +1,6 @@
 {
   "description": "The Horizon freighter was part of the ECS's privately owned fleet and used for the transport of all types of goods, ranging from hazardous material to passengers on long-haul journeys. Originally built in the early 22nd century, they started service as pre-warp vessels but have since been maintained and upgraded for low-warp travel.",
-  "attack": 20760,
-  "defense": 52500,
   "group": "romulan",
-  "health": 39600,
   "hostile_name": "Romulan Trader",
   "level": 28,
   "rarity": "common",
@@ -41,7 +38,6 @@
       "shield_health": 39000
     }
   },
-  "strength": 112860,
   "systems": [
     {
       "$ref": "systems/vendus_a_27"
@@ -72,8 +68,12 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 20760,
+    "defense": 52500,
+    "health": 39600
+  }
 }

--- a/hostiles/romulan_trader_28_survey.json
+++ b/hostiles/romulan_trader_28_survey.json
@@ -1,6 +1,11 @@
 {
   "description": "The Horizon freighter was part of the ECS's privately owned fleet and used for the transport of all types of goods, ranging from hazardous material to passengers on long-haul journeys. Originally built in the early 22nd century, they started service as pre-warp vessels but have since been maintained and upgraded for low-warp travel.",
   "group": "romulan",
+  "head_stats": {
+    "attack": 20760,
+    "defense": 52500,
+    "health": 39600
+  },
   "hostile_name": "Romulan Trader",
   "level": 28,
   "rarity": "common",
@@ -70,10 +75,5 @@
       "quantity": 1,
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 20760,
-    "defense": 52500,
-    "health": 39600
-  }
+  ]
 }

--- a/hostiles/romulan_trader_32_survey.json
+++ b/hostiles/romulan_trader_32_survey.json
@@ -1,9 +1,6 @@
 {
   "description": "The H-Class freighter is a long-distance heavy hauler capable of transporting vast quantities of materials and goods.",
-  "attack": 61704,
-  "defense": 150300,
   "group": "romulan",
-  "health": 69840,
   "hostile_name": "Romulan Trader",
   "level": 32,
   "rarity": "common",
@@ -41,7 +38,6 @@
       "shield_health": 69840
     }
   },
-  "strength": 281844,
   "systems": [
     {
       "$ref": "systems/izanagi_32"
@@ -75,7 +71,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_stats": {
         "accuracy": 8016,
         "armor_pierce": 8016,
@@ -88,5 +83,10 @@
       },
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 61704,
+    "defense": 150300,
+    "health": 69840
+  }
 }

--- a/hostiles/romulan_trader_32_survey.json
+++ b/hostiles/romulan_trader_32_survey.json
@@ -1,6 +1,11 @@
 {
   "description": "The H-Class freighter is a long-distance heavy hauler capable of transporting vast quantities of materials and goods.",
   "group": "romulan",
+  "head_stats": {
+    "attack": 61704,
+    "defense": 150300,
+    "health": 69840
+  },
   "hostile_name": "Romulan Trader",
   "level": 32,
   "rarity": "common",
@@ -83,10 +88,5 @@
       },
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 61704,
-    "defense": 150300,
-    "health": 69840
-  }
+  ]
 }

--- a/hostiles/romulan_trader_33_survey.json
+++ b/hostiles/romulan_trader_33_survey.json
@@ -1,9 +1,6 @@
 {
   "description": "The H-Class freighter is a long-distance heavy hauler capable of transporting vast quantities of materials and goods.",
-  "attack": 78960,
-  "defense": 176250,
   "group": "romulan",
-  "health": 82800,
   "hostile_name": "Romulan Trader",
   "level": 33,
   "rarity": "common",
@@ -41,7 +38,6 @@
       "shield_health": 82000
     }
   },
-  "strength": 338010,
   "systems": [
     {
       "$ref": "systems/izanagi_32"
@@ -75,8 +71,12 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 78960,
+    "defense": 176250,
+    "health": 82800
+  }
 }

--- a/hostiles/romulan_trader_33_survey.json
+++ b/hostiles/romulan_trader_33_survey.json
@@ -1,6 +1,11 @@
 {
   "description": "The H-Class freighter is a long-distance heavy hauler capable of transporting vast quantities of materials and goods.",
   "group": "romulan",
+  "head_stats": {
+    "attack": 78960,
+    "defense": 176250,
+    "health": 82800
+  },
   "hostile_name": "Romulan Trader",
   "level": 33,
   "rarity": "common",
@@ -73,10 +78,5 @@
       "quantity": 1,
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 78960,
-    "defense": 176250,
-    "health": 82800
-  }
+  ]
 }

--- a/hostiles/romulan_trader_34_survey.json
+++ b/hostiles/romulan_trader_34_survey.json
@@ -1,9 +1,6 @@
 {
   "description": "The H-Class freighter is a long-distance heavy hauler capable of transporting vast quantities of materials and goods.",
-  "attack": 98040,
-  "defense": 225000,
   "group": "romulan",
-  "health": 108000,
   "hostile_name": "Romulan Trader",
   "level": 34,
   "rarity": "common",
@@ -41,7 +38,6 @@
       "shield_health": 108000
     }
   },
-  "strength": 431040,
   "systems": [
     {
       "$ref": "systems/kaisu_33"
@@ -75,8 +71,12 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 98040,
+    "defense": 225000,
+    "health": 108000
+  }
 }

--- a/hostiles/romulan_trader_34_survey.json
+++ b/hostiles/romulan_trader_34_survey.json
@@ -1,6 +1,11 @@
 {
   "description": "The H-Class freighter is a long-distance heavy hauler capable of transporting vast quantities of materials and goods.",
   "group": "romulan",
+  "head_stats": {
+    "attack": 98040,
+    "defense": 225000,
+    "health": 108000
+  },
   "hostile_name": "Romulan Trader",
   "level": 34,
   "rarity": "common",
@@ -73,10 +78,5 @@
       "quantity": 1,
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 98040,
-    "defense": 225000,
-    "health": 108000
-  }
+  ]
 }

--- a/hostiles/romulan_trader_36_survey.json
+++ b/hostiles/romulan_trader_36_survey.json
@@ -1,6 +1,11 @@
 {
   "description": "The H-Class freighter is a long-distance heavy hauler capable of transporting vast quantities of materials and goods.",
   "group": "romulan",
+  "head_stats": {
+    "attack": 141051,
+    "defense": 313170,
+    "health": 150380
+  },
   "hostile_name": "Romulan Trader",
   "level": 36,
   "rarity": "common",
@@ -73,10 +78,5 @@
       "quantity": 1,
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 141051,
-    "defense": 313170,
-    "health": 150380
-  }
+  ]
 }

--- a/hostiles/romulan_trader_36_survey.json
+++ b/hostiles/romulan_trader_36_survey.json
@@ -1,9 +1,6 @@
 {
   "description": "The H-Class freighter is a long-distance heavy hauler capable of transporting vast quantities of materials and goods.",
-  "attack": 141051,
-  "defense": 313170,
   "group": "romulan",
-  "health": 150380,
   "hostile_name": "Romulan Trader",
   "level": 36,
   "rarity": "common",
@@ -41,7 +38,6 @@
       "shield_health": 150000
     }
   },
-  "strength": 604601,
   "systems": [
     {
       "$ref": "systems/aerimea_35"
@@ -75,8 +71,12 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 141051,
+    "defense": 313170,
+    "health": 150380
+  }
 }

--- a/hostiles/romulan_trader_41_survey.json
+++ b/hostiles/romulan_trader_41_survey.json
@@ -1,9 +1,6 @@
 {
   "description": "The H-Class freighter is a long-distance heavy hauler capable of transporting vast quantities of materials and goods.",
-  "attack": 1158050,
-  "defense": 1347415,
   "group": "romulan",
-  "health": 2278261,
   "hostile_name": "Romulan Trader",
   "level": 41,
   "rarity": "common",
@@ -45,7 +42,6 @@
       "shield_health": 2056000
     }
   },
-  "strength": 4783726,
   "systems": [
     {
       "$ref": "systems/rowla_40"
@@ -85,8 +81,12 @@
         3
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 1158050,
+    "defense": 1347415,
+    "health": 2278261
+  }
 }

--- a/hostiles/romulan_trader_41_survey.json
+++ b/hostiles/romulan_trader_41_survey.json
@@ -1,6 +1,11 @@
 {
   "description": "The H-Class freighter is a long-distance heavy hauler capable of transporting vast quantities of materials and goods.",
   "group": "romulan",
+  "head_stats": {
+    "attack": 1158050,
+    "defense": 1347415,
+    "health": 2278261
+  },
   "hostile_name": "Romulan Trader",
   "level": 41,
   "rarity": "common",
@@ -83,10 +88,5 @@
       "quantity": 1,
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 1158050,
-    "defense": 1347415,
-    "health": 2278261
-  }
+  ]
 }

--- a/hostiles/romulan_trader_42_survey.json
+++ b/hostiles/romulan_trader_42_survey.json
@@ -1,6 +1,11 @@
 {
   "description": "The H-Class freighter is a long-distance heavy hauler capable of transporting vast quantities of materials and goods.",
   "group": "romulan",
+  "head_stats": {
+    "attack": 1285261,
+    "defense": 1482165,
+    "health": 2633981
+  },
   "hostile_name": "Romulan Trader",
   "level": 42,
   "rarity": "common",
@@ -83,10 +88,5 @@
       "quantity": 1,
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 1285261,
-    "defense": 1482165,
-    "health": 2633981
-  }
+  ]
 }

--- a/hostiles/romulan_trader_42_survey.json
+++ b/hostiles/romulan_trader_42_survey.json
@@ -1,9 +1,6 @@
 {
   "description": "The H-Class freighter is a long-distance heavy hauler capable of transporting vast quantities of materials and goods.",
-  "attack": 1285261,
-  "defense": 1482165,
   "group": "romulan",
-  "health": 2633981,
   "hostile_name": "Romulan Trader",
   "level": 42,
   "rarity": "common",
@@ -45,7 +42,6 @@
       "shield_health": 2383000
     }
   },
-  "strength": 5401407,
   "systems": [
     {
       "$ref": "systems/vola_41"
@@ -85,8 +81,12 @@
         3
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 1285261,
+    "defense": 1482165,
+    "health": 2633981
+  }
 }

--- a/hostiles/romulan_trader_43_survey.json
+++ b/hostiles/romulan_trader_43_survey.json
@@ -1,9 +1,6 @@
 {
   "description": "The H-Class freighter is a long-distance heavy hauler capable of transporting vast quantities of materials and goods.",
-  "attack": 1426450,
-  "defense": 1630380,
   "group": "romulan",
-  "health": 3045261,
   "hostile_name": "Romulan Trader",
   "level": 43,
   "rarity": "common",
@@ -45,7 +42,6 @@
       "shield_health": 2763000
     }
   },
-  "strength": 6102091,
   "systems": [
     {
       "$ref": "systems/delmas_42"
@@ -91,8 +87,12 @@
         3
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 1426450,
+    "defense": 1630380,
+    "health": 3045261
+  }
 }

--- a/hostiles/romulan_trader_43_survey.json
+++ b/hostiles/romulan_trader_43_survey.json
@@ -1,6 +1,11 @@
 {
   "description": "The H-Class freighter is a long-distance heavy hauler capable of transporting vast quantities of materials and goods.",
   "group": "romulan",
+  "head_stats": {
+    "attack": 1426450,
+    "defense": 1630380,
+    "health": 3045261
+  },
   "hostile_name": "Romulan Trader",
   "level": 43,
   "rarity": "common",
@@ -89,10 +94,5 @@
       "quantity": 1,
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 1426450,
-    "defense": 1630380,
-    "health": 3045261
-  }
+  ]
 }

--- a/hostiles/romulan_trader_44_survey.json
+++ b/hostiles/romulan_trader_44_survey.json
@@ -1,6 +1,11 @@
 {
   "description": "The H-Class freighter is a long-distance heavy hauler capable of transporting vast quantities of materials and goods.",
   "group": "romulan",
+  "head_stats": {
+    "attack": 1583157,
+    "defense": 1793415,
+    "health": 3520782
+  },
   "hostile_name": "Romulan Trader",
   "level": 44,
   "rarity": "common",
@@ -89,10 +94,5 @@
       "quantity": 1,
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 1583157,
-    "defense": 1793415,
-    "health": 3520782
-  }
+  ]
 }

--- a/hostiles/romulan_trader_44_survey.json
+++ b/hostiles/romulan_trader_44_survey.json
@@ -1,9 +1,6 @@
 {
   "description": "The H-Class freighter is a long-distance heavy hauler capable of transporting vast quantities of materials and goods.",
-  "attack": 1583157,
-  "defense": 1793415,
   "group": "romulan",
-  "health": 3520782,
   "hostile_name": "Romulan Trader",
   "level": 44,
   "rarity": "common",
@@ -45,7 +42,6 @@
       "shield_health": 3203000
     }
   },
-  "strength": 6897354,
   "systems": [
     {
       "$ref": "systems/inaara_43"
@@ -91,8 +87,12 @@
         3
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 1583157,
+    "defense": 1793415,
+    "health": 3520782
+  }
 }

--- a/hostiles/romulan_trader_45_survey.json
+++ b/hostiles/romulan_trader_45_survey.json
@@ -1,6 +1,11 @@
 {
   "description": "The H-Class freighter is a long-distance heavy hauler capable of transporting vast quantities of materials and goods.",
   "group": "romulan",
+  "head_stats": {
+    "attack": 1757085,
+    "defense": 1972755,
+    "health": 4070582
+  },
   "hostile_name": "Romulan Trader",
   "level": 45,
   "rarity": "common",
@@ -89,10 +94,5 @@
       "quantity": 1,
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 1757085,
-    "defense": 1972755,
-    "health": 4070582
-  }
+  ]
 }

--- a/hostiles/romulan_trader_45_survey.json
+++ b/hostiles/romulan_trader_45_survey.json
@@ -1,9 +1,6 @@
 {
   "description": "The H-Class freighter is a long-distance heavy hauler capable of transporting vast quantities of materials and goods.",
-  "attack": 1757085,
-  "defense": 1972755,
   "group": "romulan",
-  "health": 4070582,
   "hostile_name": "Romulan Trader",
   "level": 45,
   "rarity": "common",
@@ -45,7 +42,6 @@
       "shield_health": 3714000
     }
   },
-  "strength": 7800422,
   "systems": [
     {
       "$ref": "systems/draomn_44"
@@ -91,8 +87,12 @@
         3
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 1757085,
+    "defense": 1972755,
+    "health": 4070582
+  }
 }

--- a/hostiles/romulan_trader_46_survey.json
+++ b/hostiles/romulan_trader_46_survey.json
@@ -1,9 +1,6 @@
 {
   "description": "The H-Class freighter is a long-distance heavy hauler capable of transporting vast quantities of materials and goods.",
-  "attack": 1950129,
-  "defense": 2170030,
   "group": "romulan",
-  "health": 4706268,
   "hostile_name": "Romulan Trader",
   "level": 46,
   "rarity": "common",
@@ -45,7 +42,6 @@
       "shield_health": 4305000
     }
   },
-  "strength": 8826427,
   "systems": [
     {
       "$ref": "systems/nuva_45"
@@ -85,8 +81,12 @@
         3
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 1950129,
+    "defense": 2170030,
+    "health": 4706268
+  }
 }

--- a/hostiles/romulan_trader_46_survey.json
+++ b/hostiles/romulan_trader_46_survey.json
@@ -1,6 +1,11 @@
 {
   "description": "The H-Class freighter is a long-distance heavy hauler capable of transporting vast quantities of materials and goods.",
   "group": "romulan",
+  "head_stats": {
+    "attack": 1950129,
+    "defense": 2170030,
+    "health": 4706268
+  },
   "hostile_name": "Romulan Trader",
   "level": 46,
   "rarity": "common",
@@ -83,10 +88,5 @@
       "quantity": 1,
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 1950129,
-    "defense": 2170030,
-    "health": 4706268
-  }
+  ]
 }

--- a/hostiles/romulan_transport_39_survey.json
+++ b/hostiles/romulan_transport_39_survey.json
@@ -1,6 +1,11 @@
 {
   "description": "The H-Class freighter is a long-distance heavy hauler capable of transporting vast quantities of materials and goods.",
   "group": "romulan",
+  "head_stats": {
+    "attack": 378719,
+    "defense": 857730,
+    "health": 425530
+  },
   "hostile_name": "Romulan Transport",
   "level": 39,
   "rarity": "common",
@@ -118,10 +123,5 @@
       "quantity": 1,
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 378719,
-    "defense": 857730,
-    "health": 425530
-  }
+  ]
 }

--- a/hostiles/romulan_transport_39_survey.json
+++ b/hostiles/romulan_transport_39_survey.json
@@ -1,9 +1,6 @@
 {
   "description": "The H-Class freighter is a long-distance heavy hauler capable of transporting vast quantities of materials and goods.",
-  "attack": 378719,
-  "defense": 857730,
   "group": "romulan",
-  "health": 425530,
   "hostile_name": "Romulan Transport",
   "level": 39,
   "rarity": "common",
@@ -41,7 +38,6 @@
       "shield_health": 425000
     }
   },
-  "strength": 1661979,
   "systems": [
     {
       "$ref": "systems/altanea_38"
@@ -120,8 +116,12 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 378719,
+    "defense": 857730,
+    "health": 425530
+  }
 }

--- a/hostiles/separatist_17_interceptor.json
+++ b/hostiles/separatist_17_interceptor.json
@@ -1,9 +1,6 @@
 {
   "description": "This separatist is part of a coalition that defied the Klingon Empire to start a war with its Federation and Romulan enemies.\r\nAs an Elite ship, this ship is slightly stronger than others of the same level.",
-  "attack": 13161,
-  "defense": 6110,
   "group": "",
-  "health": 5760,
   "hostile_name": "Separatist \u21ef",
   "level": 17,
   "rarity": "common",
@@ -28,7 +25,6 @@
       "shield_health": 5760
     }
   },
-  "strength": 25031,
   "systems": [
     {
       "$ref": "systems/achillon_17"
@@ -65,7 +61,6 @@
         1
       ],
       "quantity": 2,
-      "weapon_id": "K1",
       "weapon_stats": {
         "accuracy": 458,
         "armor_pierce": 2750,
@@ -97,7 +92,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_stats": {
         "accuracy": 458,
         "armor_pierce": 917,
@@ -129,8 +123,12 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "K2",
       "weapon_type": "kinetic"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 13161,
+    "defense": 6110,
+    "health": 5760
+  }
 }

--- a/hostiles/separatist_17_interceptor.json
+++ b/hostiles/separatist_17_interceptor.json
@@ -1,6 +1,11 @@
 {
   "description": "This separatist is part of a coalition that defied the Klingon Empire to start a war with its Federation and Romulan enemies.\r\nAs an Elite ship, this ship is slightly stronger than others of the same level.",
   "group": "",
+  "head_stats": {
+    "attack": 13161,
+    "defense": 6110,
+    "health": 5760
+  },
   "hostile_name": "Separatist \u21ef",
   "level": 17,
   "rarity": "common",
@@ -125,10 +130,5 @@
       "quantity": 1,
       "weapon_type": "kinetic"
     }
-  ],
-  "head_stats": {
-    "attack": 13161,
-    "defense": 6110,
-    "health": 5760
-  }
+  ]
 }

--- a/hostiles/separatist_22_interceptor.json
+++ b/hostiles/separatist_22_interceptor.json
@@ -1,6 +1,11 @@
 {
   "description": "This separatist is part of a coalition that defied the Klingon Empire to start a war with its Federation and Romulan enemies.\r\nAs an Elite ship, this ship is slightly stronger than others of the same level.",
   "group": "",
+  "head_stats": {
+    "attack": 33710,
+    "defense": 17505,
+    "health": 14400
+  },
   "hostile_name": "Separatist \u21ef",
   "level": 22,
   "rarity": "common",
@@ -125,10 +130,5 @@
       },
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 33710,
-    "defense": 17505,
-    "health": 14400
-  }
+  ]
 }

--- a/hostiles/separatist_22_interceptor.json
+++ b/hostiles/separatist_22_interceptor.json
@@ -1,9 +1,6 @@
 {
   "description": "This separatist is part of a coalition that defied the Klingon Empire to start a war with its Federation and Romulan enemies.\r\nAs an Elite ship, this ship is slightly stronger than others of the same level.",
-  "attack": 33710,
-  "defense": 17505,
   "group": "",
-  "health": 14400,
   "hostile_name": "Separatist \u21ef",
   "level": 22,
   "rarity": "common",
@@ -28,7 +25,6 @@
       "shield_health": 14000
     }
   },
-  "strength": 65615,
   "systems": [
     {
       "$ref": "systems/aesuri_22"
@@ -65,7 +61,6 @@
         1
       ],
       "quantity": 2,
-      "weapon_id": "K1",
       "weapon_stats": {
         "accuracy": 1313,
         "armor_pierce": 7875,
@@ -97,7 +92,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "K2",
       "weapon_type": "kinetic"
     },
     {
@@ -119,7 +113,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_stats": {
         "accuracy": 1313,
         "armor_pierce": 2625,
@@ -132,5 +125,10 @@
       },
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 33710,
+    "defense": 17505,
+    "health": 14400
+  }
 }

--- a/hostiles/separatist_26_battleship.json
+++ b/hostiles/separatist_26_battleship.json
@@ -1,9 +1,6 @@
 {
   "description": "This separatist is part of a coalition that defied the Klingon Empire to start a war with its Federation and Romulan enemies.\r\nAs a Boss ship, this ship is much stronger than others of the same level.",
-  "attack": 89925,
-  "defense": 441565,
   "group": "",
-  "health": 1850000,
   "hostile_name": "Separatist \u21d5",
   "level": 26,
   "rarity": "common",
@@ -28,7 +25,6 @@
       "shield_health": 200000
     }
   },
-  "strength": 2381490,
   "systems": [
     {
       "$ref": "systems/constina_26"
@@ -65,7 +61,6 @@
         0
       ],
       "quantity": 2,
-      "weapon_id": "K1",
       "weapon_stats": {
         "accuracy": 2700,
         "armor_pierce": 2700,
@@ -97,7 +92,6 @@
         0
       ],
       "quantity": 1,
-      "weapon_id": "K2",
       "weapon_type": "kinetic"
     },
     {
@@ -119,7 +113,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_stats": {
         "accuracy": 2700,
         "armor_pierce": 2700,
@@ -132,5 +125,10 @@
       },
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 89925,
+    "defense": 441565,
+    "health": 1850000
+  }
 }

--- a/hostiles/separatist_26_battleship.json
+++ b/hostiles/separatist_26_battleship.json
@@ -1,6 +1,11 @@
 {
   "description": "This separatist is part of a coalition that defied the Klingon Empire to start a war with its Federation and Romulan enemies.\r\nAs a Boss ship, this ship is much stronger than others of the same level.",
   "group": "",
+  "head_stats": {
+    "attack": 89925,
+    "defense": 441565,
+    "health": 1850000
+  },
   "hostile_name": "Separatist \u21d5",
   "level": 26,
   "rarity": "common",
@@ -125,10 +130,5 @@
       },
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 89925,
-    "defense": 441565,
-    "health": 1850000
-  }
+  ]
 }

--- a/hostiles/separatist_26_explorer.json
+++ b/hostiles/separatist_26_explorer.json
@@ -1,6 +1,11 @@
 {
   "description": "This separatist is part of a coalition that defied the Klingon Empire to start a war with its Federation and Romulan enemies.\r\nAs a Boss ship, this ship is much stronger than others of the same level.",
   "group": "",
+  "head_stats": {
+    "attack": 89925,
+    "defense": 441565,
+    "health": 1850000
+  },
   "hostile_name": "Separatist \u21d5",
   "level": 26,
   "rarity": "common",
@@ -125,10 +130,5 @@
       "quantity": 1,
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 89925,
-    "defense": 441565,
-    "health": 1850000
-  }
+  ]
 }

--- a/hostiles/separatist_26_explorer.json
+++ b/hostiles/separatist_26_explorer.json
@@ -1,9 +1,6 @@
 {
   "description": "This separatist is part of a coalition that defied the Klingon Empire to start a war with its Federation and Romulan enemies.\r\nAs a Boss ship, this ship is much stronger than others of the same level.",
-  "attack": 89925,
-  "defense": 441565,
   "group": "",
-  "health": 1850000,
   "hostile_name": "Separatist \u21d5",
   "level": 26,
   "rarity": "common",
@@ -28,7 +25,6 @@
       "shield_health": 200000
     }
   },
-  "strength": 2381490,
   "systems": [
     {
       "$ref": "systems/constina_26"
@@ -65,7 +61,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_stats": {
         "accuracy": 18900,
         "armor_pierce": 2700,
@@ -97,7 +92,6 @@
         0
       ],
       "quantity": 2,
-      "weapon_id": "E2",
       "weapon_stats": {
         "accuracy": 18900,
         "armor_pierce": 2700,
@@ -129,8 +123,12 @@
         0
       ],
       "quantity": 1,
-      "weapon_id": "E3",
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 89925,
+    "defense": 441565,
+    "health": 1850000
+  }
 }

--- a/hostiles/separatist_26_interceptor.json
+++ b/hostiles/separatist_26_interceptor.json
@@ -1,6 +1,11 @@
 {
   "description": "This separatist is part of a coalition that defied the Klingon Empire to start a war with its Federation and Romulan enemies.\r\nAs a Boss ship, this ship is much stronger than others of the same level.",
   "group": "",
+  "head_stats": {
+    "attack": 89925,
+    "defense": 441565,
+    "health": 1850000
+  },
   "hostile_name": "Separatist \u21d5",
   "level": 26,
   "rarity": "common",
@@ -125,10 +130,5 @@
       },
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 89925,
-    "defense": 441565,
-    "health": 1850000
-  }
+  ]
 }

--- a/hostiles/separatist_26_interceptor.json
+++ b/hostiles/separatist_26_interceptor.json
@@ -1,9 +1,6 @@
 {
   "description": "This separatist is part of a coalition that defied the Klingon Empire to start a war with its Federation and Romulan enemies.\r\nAs a Boss ship, this ship is much stronger than others of the same level.",
-  "attack": 89925,
-  "defense": 441565,
   "group": "",
-  "health": 1850000,
   "hostile_name": "Separatist \u21d5",
   "level": 26,
   "rarity": "common",
@@ -28,7 +25,6 @@
       "shield_health": 200000
     }
   },
-  "strength": 2381490,
   "systems": [
     {
       "$ref": "systems/constina_26"
@@ -65,7 +61,6 @@
         0
       ],
       "quantity": 2,
-      "weapon_id": "K1",
       "weapon_stats": {
         "accuracy": 2700,
         "armor_pierce": 18900,
@@ -97,7 +92,6 @@
         0
       ],
       "quantity": 1,
-      "weapon_id": "K2",
       "weapon_type": "kinetic"
     },
     {
@@ -119,7 +113,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_stats": {
         "accuracy": 2700,
         "armor_pierce": 18900,
@@ -132,5 +125,10 @@
       },
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 89925,
+    "defense": 441565,
+    "health": 1850000
+  }
 }

--- a/hostiles/sona_pirate_16_battleship.json
+++ b/hostiles/sona_pirate_16_battleship.json
@@ -1,6 +1,11 @@
 {
   "description": "This Hostile patrols the different systems of the universe, looking for easy prey",
   "group": "",
+  "head_stats": {
+    "attack": 3887,
+    "defense": 3835,
+    "health": 1735
+  },
   "hostile_name": "Sona Pirate",
   "level": 16,
   "rarity": "common",
@@ -102,10 +107,5 @@
       "quantity": 1,
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 3887,
-    "defense": 3835,
-    "health": 1735
-  }
+  ]
 }

--- a/hostiles/sona_pirate_16_battleship.json
+++ b/hostiles/sona_pirate_16_battleship.json
@@ -1,9 +1,6 @@
 {
   "description": "This Hostile patrols the different systems of the universe, looking for easy prey",
-  "attack": 3887,
-  "defense": 3835,
   "group": "",
-  "health": 1735,
   "hostile_name": "Sona Pirate",
   "level": 16,
   "rarity": "common",
@@ -28,7 +25,6 @@
       "shield_health": 1490
     }
   },
-  "strength": 9457,
   "systems": [
     {
       "$ref": "systems/rakkaus_16"
@@ -62,7 +58,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "K1",
       "weapon_type": "kinetic"
     },
     {
@@ -84,7 +79,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_type": "energy"
     },
     {
@@ -106,8 +100,12 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E2",
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 3887,
+    "defense": 3835,
+    "health": 1735
+  }
 }

--- a/hostiles/suliban_bounty_hunter_22_explorer.json
+++ b/hostiles/suliban_bounty_hunter_22_explorer.json
@@ -1,6 +1,11 @@
 {
   "description": "Khan's presence has drawn the attention of Bounty Hunters from across the galaxy. The friendlier you are with Khan and his Augments, the more of these deadly mercenaries that you will have to contend with.",
   "group": "",
+  "head_stats": {
+    "attack": 11691,
+    "defense": 13130,
+    "health": 5550
+  },
   "hostile_name": "Suliban Bounty Hunter",
   "level": 22,
   "rarity": "common",
@@ -93,10 +98,5 @@
       "quantity": 1,
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 11691,
-    "defense": 13130,
-    "health": 5550
-  }
+  ]
 }

--- a/hostiles/suliban_bounty_hunter_22_explorer.json
+++ b/hostiles/suliban_bounty_hunter_22_explorer.json
@@ -1,9 +1,6 @@
 {
   "description": "Khan's presence has drawn the attention of Bounty Hunters from across the galaxy. The friendlier you are with Khan and his Augments, the more of these deadly mercenaries that you will have to contend with.",
-  "attack": 11691,
-  "defense": 13130,
   "group": "",
-  "health": 5550,
   "hostile_name": "Suliban Bounty Hunter",
   "level": 22,
   "rarity": "common",
@@ -28,7 +25,6 @@
       "shield_health": 5700
     }
   },
-  "strength": 30371,
   "systems": [
     {
       "$ref": "systems/lydan_22"
@@ -59,7 +55,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_type": "energy"
     },
     {
@@ -78,7 +73,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E2",
       "weapon_type": "energy"
     },
     {
@@ -97,8 +91,12 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E3",
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 11691,
+    "defense": 13130,
+    "health": 5550
+  }
 }

--- a/hostiles/suliban_bounty_hunter_27_explorer.json
+++ b/hostiles/suliban_bounty_hunter_27_explorer.json
@@ -1,9 +1,6 @@
 {
   "description": "Khan's presence has drawn the attention of Bounty Hunters from across the galaxy. The friendlier you are with Khan and his Augments, the more of these deadly mercenaries that you will have to contend with.",
-  "attack": 28560,
-  "defense": 30000,
   "group": "",
-  "health": 15540,
   "hostile_name": "Suliban Bounty Hunter",
   "level": 27,
   "rarity": "common",
@@ -28,7 +25,6 @@
       "shield_health": 15000
     }
   },
-  "strength": 74100,
   "systems": [
     {
       "$ref": "systems/gealan_26"
@@ -62,7 +58,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_type": "energy"
     },
     {
@@ -81,7 +76,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E2",
       "weapon_type": "energy"
     },
     {
@@ -100,8 +94,12 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E3",
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 28560,
+    "defense": 30000,
+    "health": 15540
+  }
 }

--- a/hostiles/suliban_bounty_hunter_27_explorer.json
+++ b/hostiles/suliban_bounty_hunter_27_explorer.json
@@ -1,6 +1,11 @@
 {
   "description": "Khan's presence has drawn the attention of Bounty Hunters from across the galaxy. The friendlier you are with Khan and his Augments, the more of these deadly mercenaries that you will have to contend with.",
   "group": "",
+  "head_stats": {
+    "attack": 28560,
+    "defense": 30000,
+    "health": 15540
+  },
   "hostile_name": "Suliban Bounty Hunter",
   "level": 27,
   "rarity": "common",
@@ -96,10 +101,5 @@
       "quantity": 1,
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 28560,
-    "defense": 30000,
-    "health": 15540
-  }
+  ]
 }

--- a/hostiles/swarm_cluster_15_interceptor.json
+++ b/hostiles/swarm_cluster_15_interceptor.json
@@ -1,9 +1,6 @@
 {
   "description": "Swarm ships attack as one unit and do not show mercy.",
-  "attack": 2994,
-  "defense": 7250,
   "group": "swarm",
-  "health": 4305,
   "hostile_name": "Swarm Cluster",
   "level": 15,
   "rarity": "common",
@@ -33,7 +30,6 @@
       "shield_health": 0
     }
   },
-  "strength": 14549,
   "systems": [
     {
       "$ref": "systems/andvaris_15"
@@ -67,7 +63,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "K1",
       "weapon_stats": {
         "accuracy": 105,
         "armor_pierce": 720,
@@ -99,7 +94,6 @@
         0
       ],
       "quantity": 1,
-      "weapon_id": "K2",
       "weapon_stats": {
         "accuracy": 105,
         "armor_pierce": 720,
@@ -112,5 +106,10 @@
       },
       "weapon_type": "kinetic"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 2994,
+    "defense": 7250,
+    "health": 4305
+  }
 }

--- a/hostiles/swarm_cluster_15_interceptor.json
+++ b/hostiles/swarm_cluster_15_interceptor.json
@@ -1,6 +1,11 @@
 {
   "description": "Swarm ships attack as one unit and do not show mercy.",
   "group": "swarm",
+  "head_stats": {
+    "attack": 2994,
+    "defense": 7250,
+    "health": 4305
+  },
   "hostile_name": "Swarm Cluster",
   "level": 15,
   "rarity": "common",
@@ -106,10 +111,5 @@
       },
       "weapon_type": "kinetic"
     }
-  ],
-  "head_stats": {
-    "attack": 2994,
-    "defense": 7250,
-    "health": 4305
-  }
+  ]
 }

--- a/hostiles/swarm_cluster_16_interceptor.json
+++ b/hostiles/swarm_cluster_16_interceptor.json
@@ -1,9 +1,6 @@
 {
   "description": "Swarm ships attack as one unit and do not show mercy.",
-  "attack": 4145,
-  "defense": 9265,
   "group": "swarm",
-  "health": 8235,
   "hostile_name": "Swarm Cluster",
   "level": 16,
   "rarity": "common",
@@ -33,7 +30,6 @@
       "shield_health": 0
     }
   },
-  "strength": 21645,
   "systems": [
     {
       "$ref": "systems/caldik_16"
@@ -67,7 +63,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "K1",
       "weapon_stats": {
         "accuracy": 134,
         "armor_pierce": 920,
@@ -99,7 +94,6 @@
         0
       ],
       "quantity": 1,
-      "weapon_id": "K2",
       "weapon_stats": {
         "accuracy": 134,
         "armor_pierce": 920,
@@ -112,5 +106,10 @@
       },
       "weapon_type": "kinetic"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 4145,
+    "defense": 9265,
+    "health": 8235
+  }
 }

--- a/hostiles/swarm_cluster_16_interceptor.json
+++ b/hostiles/swarm_cluster_16_interceptor.json
@@ -1,6 +1,11 @@
 {
   "description": "Swarm ships attack as one unit and do not show mercy.",
   "group": "swarm",
+  "head_stats": {
+    "attack": 4145,
+    "defense": 9265,
+    "health": 8235
+  },
   "hostile_name": "Swarm Cluster",
   "level": 16,
   "rarity": "common",
@@ -106,10 +111,5 @@
       },
       "weapon_type": "kinetic"
     }
-  ],
-  "head_stats": {
-    "attack": 4145,
-    "defense": 9265,
-    "health": 8235
-  }
+  ]
 }

--- a/hostiles/swarm_cluster_17_interceptor.json
+++ b/hostiles/swarm_cluster_17_interceptor.json
@@ -1,6 +1,11 @@
 {
   "description": "Swarm ships attack as one unit and do not show mercy.",
   "group": "swarm",
+  "head_stats": {
+    "attack": 4982,
+    "defense": 11080,
+    "health": 18720
+  },
   "hostile_name": "Swarm Cluster",
   "level": 17,
   "rarity": "common",
@@ -103,10 +108,5 @@
       },
       "weapon_type": "kinetic"
     }
-  ],
-  "head_stats": {
-    "attack": 4982,
-    "defense": 11080,
-    "health": 18720
-  }
+  ]
 }

--- a/hostiles/swarm_cluster_17_interceptor.json
+++ b/hostiles/swarm_cluster_17_interceptor.json
@@ -1,9 +1,6 @@
 {
   "description": "Swarm ships attack as one unit and do not show mercy.",
-  "attack": 4982,
-  "defense": 11080,
   "group": "swarm",
-  "health": 18720,
   "hostile_name": "Swarm Cluster",
   "level": 17,
   "rarity": "common",
@@ -33,7 +30,6 @@
       "shield_health": 0
     }
   },
-  "strength": 34782,
   "systems": [
     {
       "$ref": "systems/altamid_17"
@@ -64,7 +60,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "K1",
       "weapon_stats": {
         "accuracy": 160,
         "armor_pierce": 1100,
@@ -96,7 +91,6 @@
         0
       ],
       "quantity": 1,
-      "weapon_id": "K2",
       "weapon_stats": {
         "accuracy": 160,
         "armor_pierce": 1100,
@@ -109,5 +103,10 @@
       },
       "weapon_type": "kinetic"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 4982,
+    "defense": 11080,
+    "health": 18720
+  }
 }

--- a/hostiles/swarm_cluster_18_interceptor.json
+++ b/hostiles/swarm_cluster_18_interceptor.json
@@ -1,6 +1,11 @@
 {
   "description": "Swarm ships attack as one unit and do not show mercy.",
   "group": "swarm",
+  "head_stats": {
+    "attack": 5872,
+    "defense": 13735,
+    "health": 34885
+  },
   "hostile_name": "Swarm Cluster",
   "level": 18,
   "rarity": "common",
@@ -103,10 +108,5 @@
       },
       "weapon_type": "kinetic"
     }
-  ],
-  "head_stats": {
-    "attack": 5872,
-    "defense": 13735,
-    "health": 34885
-  }
+  ]
 }

--- a/hostiles/swarm_cluster_18_interceptor.json
+++ b/hostiles/swarm_cluster_18_interceptor.json
@@ -1,9 +1,6 @@
 {
   "description": "Swarm ships attack as one unit and do not show mercy.",
-  "attack": 5872,
-  "defense": 13735,
   "group": "swarm",
-  "health": 34885,
   "hostile_name": "Swarm Cluster",
   "level": 18,
   "rarity": "common",
@@ -33,7 +30,6 @@
       "shield_health": 0
     }
   },
-  "strength": 54492,
   "systems": [
     {
       "$ref": "systems/herias_18"
@@ -64,7 +60,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "K1",
       "weapon_stats": {
         "accuracy": 181,
         "armor_pierce": 1240,
@@ -96,7 +91,6 @@
         0
       ],
       "quantity": 1,
-      "weapon_id": "K2",
       "weapon_stats": {
         "accuracy": 181,
         "armor_pierce": 1240,
@@ -109,5 +103,10 @@
       },
       "weapon_type": "kinetic"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 5872,
+    "defense": 13735,
+    "health": 34885
+  }
 }

--- a/hostiles/swarm_cluster_19_interceptor.json
+++ b/hostiles/swarm_cluster_19_interceptor.json
@@ -1,6 +1,11 @@
 {
   "description": "Swarm ships attack as one unit and do not show mercy.",
   "group": "swarm",
+  "head_stats": {
+    "attack": 7452,
+    "defense": 18925,
+    "health": 39345
+  },
   "hostile_name": "Swarm Cluster",
   "level": 19,
   "rarity": "common",
@@ -103,10 +108,5 @@
       },
       "weapon_type": "kinetic"
     }
-  ],
-  "head_stats": {
-    "attack": 7452,
-    "defense": 18925,
-    "health": 39345
-  }
+  ]
 }

--- a/hostiles/swarm_cluster_19_interceptor.json
+++ b/hostiles/swarm_cluster_19_interceptor.json
@@ -1,9 +1,6 @@
 {
   "description": "Swarm ships attack as one unit and do not show mercy.",
-  "attack": 7452,
-  "defense": 18925,
   "group": "swarm",
-  "health": 39345,
   "hostile_name": "Swarm Cluster",
   "level": 19,
   "rarity": "common",
@@ -33,7 +30,6 @@
       "shield_health": 0
     }
   },
-  "strength": 65722,
   "systems": [
     {
       "$ref": "systems/ezani_19"
@@ -64,7 +60,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "K1",
       "weapon_stats": {
         "accuracy": 228,
         "armor_pierce": 1566,
@@ -96,7 +91,6 @@
         0
       ],
       "quantity": 1,
-      "weapon_id": "K2",
       "weapon_stats": {
         "accuracy": 228,
         "armor_pierce": 1566,
@@ -109,5 +103,10 @@
       },
       "weapon_type": "kinetic"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 7452,
+    "defense": 18925,
+    "health": 39345
+  }
 }

--- a/hostiles/swarm_cluster_20_interceptor.json
+++ b/hostiles/swarm_cluster_20_interceptor.json
@@ -1,9 +1,6 @@
 {
   "description": "Swarm ships attack as one unit and do not show mercy.",
-  "attack": 9339,
-  "defense": 21520,
   "group": "swarm",
-  "health": 43925,
   "hostile_name": "Swarm Cluster",
   "level": 20,
   "rarity": "common",
@@ -33,7 +30,6 @@
       "shield_health": 0
     }
   },
-  "strength": 74784,
   "systems": [
     {
       "$ref": "systems/beta_vordunn_20"
@@ -64,7 +60,6 @@
         1
       ],
       "quantity": 2,
-      "weapon_id": "K1",
       "weapon_stats": {
         "accuracy": 249,
         "armor_pierce": 1710,
@@ -96,7 +91,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "K2",
       "weapon_type": "kinetic"
     },
     {
@@ -118,7 +112,6 @@
         0
       ],
       "quantity": 1,
-      "weapon_id": "K3",
       "weapon_stats": {
         "accuracy": 249,
         "armor_pierce": 1710,
@@ -131,5 +124,10 @@
       },
       "weapon_type": "kinetic"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 9339,
+    "defense": 21520,
+    "health": 43925
+  }
 }

--- a/hostiles/swarm_cluster_20_interceptor.json
+++ b/hostiles/swarm_cluster_20_interceptor.json
@@ -1,6 +1,11 @@
 {
   "description": "Swarm ships attack as one unit and do not show mercy.",
   "group": "swarm",
+  "head_stats": {
+    "attack": 9339,
+    "defense": 21520,
+    "health": 43925
+  },
   "hostile_name": "Swarm Cluster",
   "level": 20,
   "rarity": "common",
@@ -124,10 +129,5 @@
       },
       "weapon_type": "kinetic"
     }
-  ],
-  "head_stats": {
-    "attack": 9339,
-    "defense": 21520,
-    "health": 43925
-  }
+  ]
 }

--- a/hostiles/swarm_cluster_22_interceptor.json
+++ b/hostiles/swarm_cluster_22_interceptor.json
@@ -1,9 +1,6 @@
 {
   "description": "Swarm ships attack as one unit and do not show mercy.",
-  "attack": 14834,
-  "defense": 39645,
   "group": "swarm",
-  "health": 59280,
   "hostile_name": "Swarm Cluster",
   "level": 22,
   "rarity": "common",
@@ -33,7 +30,6 @@
       "shield_health": 0
     }
   },
-  "strength": 113759,
   "systems": [
     {
       "$ref": "systems/klaiz_22"
@@ -64,7 +60,6 @@
         1
       ],
       "quantity": 2,
-      "weapon_id": "K1",
       "weapon_stats": {
         "accuracy": 459,
         "armor_pierce": 3150,
@@ -96,7 +91,6 @@
         0
       ],
       "quantity": 1,
-      "weapon_id": "K3",
       "weapon_stats": {
         "accuracy": 459,
         "armor_pierce": 3150,
@@ -128,8 +122,12 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "K2",
       "weapon_type": "kinetic"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 14834,
+    "defense": 39645,
+    "health": 59280
+  }
 }

--- a/hostiles/swarm_cluster_22_interceptor.json
+++ b/hostiles/swarm_cluster_22_interceptor.json
@@ -1,6 +1,11 @@
 {
   "description": "Swarm ships attack as one unit and do not show mercy.",
   "group": "swarm",
+  "head_stats": {
+    "attack": 14834,
+    "defense": 39645,
+    "health": 59280
+  },
   "hostile_name": "Swarm Cluster",
   "level": 22,
   "rarity": "common",
@@ -124,10 +129,5 @@
       "quantity": 1,
       "weapon_type": "kinetic"
     }
-  ],
-  "head_stats": {
-    "attack": 14834,
-    "defense": 39645,
-    "health": 59280
-  }
+  ]
 }

--- a/hostiles/swarm_cluster_24_interceptor.json
+++ b/hostiles/swarm_cluster_24_interceptor.json
@@ -1,6 +1,11 @@
 {
   "description": "Swarm ships attack as one unit and do not show mercy.",
   "group": "swarm",
+  "head_stats": {
+    "attack": 19557,
+    "defense": 54195,
+    "health": 117625
+  },
   "hostile_name": "Swarm Cluster",
   "level": 24,
   "rarity": "common",
@@ -127,10 +132,5 @@
       },
       "weapon_type": "kinetic"
     }
-  ],
-  "head_stats": {
-    "attack": 19557,
-    "defense": 54195,
-    "health": 117625
-  }
+  ]
 }

--- a/hostiles/swarm_cluster_24_interceptor.json
+++ b/hostiles/swarm_cluster_24_interceptor.json
@@ -1,9 +1,6 @@
 {
   "description": "Swarm ships attack as one unit and do not show mercy.",
-  "attack": 19557,
-  "defense": 54195,
   "group": "swarm",
-  "health": 117625,
   "hostile_name": "Swarm Cluster",
   "level": 24,
   "rarity": "common",
@@ -33,7 +30,6 @@
       "shield_health": 0
     }
   },
-  "strength": 191377,
   "systems": [
     {
       "$ref": "systems/er_yozun_24"
@@ -67,7 +63,6 @@
         1
       ],
       "quantity": 2,
-      "weapon_id": "K1",
       "weapon_stats": {
         "accuracy": 604,
         "armor_pierce": 4140,
@@ -99,7 +94,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "K2",
       "weapon_type": "kinetic"
     },
     {
@@ -121,7 +115,6 @@
         0
       ],
       "quantity": 1,
-      "weapon_id": "K3",
       "weapon_stats": {
         "accuracy": 604,
         "armor_pierce": 4140,
@@ -134,5 +127,10 @@
       },
       "weapon_type": "kinetic"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 19557,
+    "defense": 54195,
+    "health": 117625
+  }
 }

--- a/hostiles/swarm_cluster_26_interceptor.json
+++ b/hostiles/swarm_cluster_26_interceptor.json
@@ -1,9 +1,6 @@
 {
   "description": "Swarm ships attack as one unit and do not show mercy.",
-  "attack": 33882,
-  "defense": 76125,
   "group": "swarm",
-  "health": 249600,
   "hostile_name": "Swarm Cluster",
   "level": 26,
   "rarity": "common",
@@ -33,7 +30,6 @@
       "shield_health": 0
     }
   },
-  "strength": 359607,
   "systems": [
     {
       "$ref": "systems/alpha_horunia_26"
@@ -67,7 +63,6 @@
         1
       ],
       "quantity": 2,
-      "weapon_id": "K1",
       "weapon_stats": {
         "accuracy": 788,
         "armor_pierce": 5400,
@@ -99,7 +94,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "K2",
       "weapon_type": "kinetic"
     },
     {
@@ -121,7 +115,6 @@
         0
       ],
       "quantity": 1,
-      "weapon_id": "K3",
       "weapon_stats": {
         "accuracy": 2363,
         "armor_pierce": 16200,
@@ -134,5 +127,10 @@
       },
       "weapon_type": "kinetic"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 33882,
+    "defense": 76125,
+    "health": 249600
+  }
 }

--- a/hostiles/swarm_cluster_26_interceptor.json
+++ b/hostiles/swarm_cluster_26_interceptor.json
@@ -1,6 +1,11 @@
 {
   "description": "Swarm ships attack as one unit and do not show mercy.",
   "group": "swarm",
+  "head_stats": {
+    "attack": 33882,
+    "defense": 76125,
+    "health": 249600
+  },
   "hostile_name": "Swarm Cluster",
   "level": 26,
   "rarity": "common",
@@ -127,10 +132,5 @@
       },
       "weapon_type": "kinetic"
     }
-  ],
-  "head_stats": {
-    "attack": 33882,
-    "defense": 76125,
-    "health": 249600
-  }
+  ]
 }

--- a/hostiles/swarm_cluster_28_interceptor.json
+++ b/hostiles/swarm_cluster_28_interceptor.json
@@ -1,9 +1,6 @@
 {
   "description": "Swarm ships attack as one unit and do not show mercy.",
-  "attack": 56594,
-  "defense": 149530,
   "group": "swarm",
-  "health": 399360,
   "hostile_name": "Swarm Cluster",
   "level": 28,
   "rarity": "common",
@@ -33,7 +30,6 @@
       "shield_health": 0
     }
   },
-  "strength": 605484,
   "systems": [
     {
       "$ref": "systems/ortek_28"
@@ -67,7 +63,6 @@
         1
       ],
       "quantity": 3,
-      "weapon_id": "K1",
       "weapon_stats": {
         "accuracy": 1444,
         "armor_pierce": 9900,
@@ -99,7 +94,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "K2",
       "weapon_type": "kinetic"
     },
     {
@@ -121,7 +115,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "K3",
       "weapon_type": "kinetic"
     },
     {
@@ -143,7 +136,6 @@
         0
       ],
       "quantity": 1,
-      "weapon_id": "K4",
       "weapon_stats": {
         "accuracy": 1444,
         "armor_pierce": 9900,
@@ -156,5 +148,10 @@
       },
       "weapon_type": "kinetic"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 56594,
+    "defense": 149530,
+    "health": 399360
+  }
 }

--- a/hostiles/swarm_cluster_28_interceptor.json
+++ b/hostiles/swarm_cluster_28_interceptor.json
@@ -1,6 +1,11 @@
 {
   "description": "Swarm ships attack as one unit and do not show mercy.",
   "group": "swarm",
+  "head_stats": {
+    "attack": 56594,
+    "defense": 149530,
+    "health": 399360
+  },
   "hostile_name": "Swarm Cluster",
   "level": 28,
   "rarity": "common",
@@ -148,10 +153,5 @@
       },
       "weapon_type": "kinetic"
     }
-  ],
-  "head_stats": {
-    "attack": 56594,
-    "defense": 149530,
-    "health": 399360
-  }
+  ]
 }

--- a/hostiles/swarm_cluster_30_interceptor.json
+++ b/hostiles/swarm_cluster_30_interceptor.json
@@ -1,6 +1,11 @@
 {
   "description": "Swarm ships attack as one unit and do not show mercy.",
   "group": "swarm",
+  "head_stats": {
+    "attack": 86070,
+    "defense": 190315,
+    "health": 678600
+  },
   "hostile_name": "Swarm Cluster",
   "level": 30,
   "rarity": "common",
@@ -148,10 +153,5 @@
       "quantity": 1,
       "weapon_type": "kinetic"
     }
-  ],
-  "head_stats": {
-    "attack": 86070,
-    "defense": 190315,
-    "health": 678600
-  }
+  ]
 }

--- a/hostiles/swarm_cluster_30_interceptor.json
+++ b/hostiles/swarm_cluster_30_interceptor.json
@@ -1,9 +1,6 @@
 {
   "description": "Swarm ships attack as one unit and do not show mercy.",
-  "attack": 86070,
-  "defense": 190315,
   "group": "swarm",
-  "health": 678600,
   "hostile_name": "Swarm Cluster",
   "level": 30,
   "rarity": "common",
@@ -33,7 +30,6 @@
       "shield_health": 0
     }
   },
-  "strength": 954985,
   "systems": [
     {
       "$ref": "systems/fontaine_30"
@@ -67,7 +63,6 @@
         1
       ],
       "quantity": 3,
-      "weapon_id": "K1",
       "weapon_stats": {
         "accuracy": 2205,
         "armor_pierce": 15120,
@@ -99,7 +94,6 @@
         0
       ],
       "quantity": 1,
-      "weapon_id": "K4",
       "weapon_stats": {
         "accuracy": 2205,
         "armor_pierce": 15120,
@@ -131,7 +125,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "K2",
       "weapon_type": "kinetic"
     },
     {
@@ -153,8 +146,12 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "K3",
       "weapon_type": "kinetic"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 86070,
+    "defense": 190315,
+    "health": 678600
+  }
 }

--- a/hostiles/swarm_cluster_32_interceptor.json
+++ b/hostiles/swarm_cluster_32_interceptor.json
@@ -1,6 +1,11 @@
 {
   "description": "Swarm ships attack as one unit and do not show mercy.",
   "group": "swarm",
+  "head_stats": {
+    "attack": 179193,
+    "defense": 299065,
+    "health": 939120
+  },
   "hostile_name": "Swarm Cluster",
   "level": 32,
   "rarity": "common",
@@ -148,10 +153,5 @@
       },
       "weapon_type": "kinetic"
     }
-  ],
-  "head_stats": {
-    "attack": 179193,
-    "defense": 299065,
-    "health": 939120
-  }
+  ]
 }

--- a/hostiles/swarm_cluster_32_interceptor.json
+++ b/hostiles/swarm_cluster_32_interceptor.json
@@ -1,9 +1,6 @@
 {
   "description": "Swarm ships attack as one unit and do not show mercy.",
-  "attack": 179193,
-  "defense": 299065,
   "group": "swarm",
-  "health": 939120,
   "hostile_name": "Swarm Cluster",
   "level": 32,
   "rarity": "common",
@@ -33,7 +30,6 @@
       "shield_health": 0
     }
   },
-  "strength": 1417378,
   "systems": [
     {
       "$ref": "systems/adelphi_32"
@@ -67,7 +63,6 @@
         1
       ],
       "quantity": 3,
-      "weapon_id": "K1",
       "weapon_stats": {
         "accuracy": 4331,
         "armor_pierce": 29700,
@@ -99,7 +94,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "K2",
       "weapon_type": "kinetic"
     },
     {
@@ -121,7 +115,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "K3",
       "weapon_type": "kinetic"
     },
     {
@@ -143,7 +136,6 @@
         0
       ],
       "quantity": 1,
-      "weapon_id": "K4",
       "weapon_stats": {
         "accuracy": 4331,
         "armor_pierce": 29700,
@@ -156,5 +148,10 @@
       },
       "weapon_type": "kinetic"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 179193,
+    "defense": 299065,
+    "health": 939120
+  }
 }

--- a/hostiles/swarm_cluster_35_interceptor.json
+++ b/hostiles/swarm_cluster_35_interceptor.json
@@ -1,6 +1,11 @@
 {
   "description": "Swarm ships attack as one unit and do not show mercy.",
   "group": "swarm",
+  "head_stats": {
+    "attack": 671225,
+    "defense": 951565,
+    "health": 2340000
+  },
   "hostile_name": "Swarm Cluster",
   "level": 35,
   "rarity": "common",
@@ -148,10 +153,5 @@
       },
       "weapon_type": "kinetic"
     }
-  ],
-  "head_stats": {
-    "attack": 671225,
-    "defense": 951565,
-    "health": 2340000
-  }
+  ]
 }

--- a/hostiles/swarm_cluster_35_interceptor.json
+++ b/hostiles/swarm_cluster_35_interceptor.json
@@ -1,9 +1,6 @@
 {
   "description": "Swarm ships attack as one unit and do not show mercy.",
-  "attack": 671225,
-  "defense": 951565,
   "group": "swarm",
-  "health": 2340000,
   "hostile_name": "Swarm Cluster",
   "level": 35,
   "rarity": "common",
@@ -33,7 +30,6 @@
       "shield_health": 0
     }
   },
-  "strength": 3962790,
   "systems": [
     {
       "$ref": "systems/dalogn_35"
@@ -67,7 +63,6 @@
         1
       ],
       "quantity": 3,
-      "weapon_id": "K1",
       "weapon_stats": {
         "accuracy": 11813,
         "armor_pierce": 81000,
@@ -99,7 +94,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "K2",
       "weapon_type": "kinetic"
     },
     {
@@ -121,7 +115,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "K3",
       "weapon_type": "kinetic"
     },
     {
@@ -143,7 +136,6 @@
         0
       ],
       "quantity": 1,
-      "weapon_id": "K4",
       "weapon_stats": {
         "accuracy": 7875,
         "armor_pierce": 54000,
@@ -156,5 +148,10 @@
       },
       "weapon_type": "kinetic"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 671225,
+    "defense": 951565,
+    "health": 2340000
+  }
 }

--- a/hostiles/swarm_cluster_37_interceptor.json
+++ b/hostiles/swarm_cluster_37_interceptor.json
@@ -1,6 +1,11 @@
 {
   "description": "Swarm ships attack as one unit and do not show mercy.",
   "group": "swarm",
+  "head_stats": {
+    "attack": 948083,
+    "defense": 1143715,
+    "health": 5718264
+  },
   "hostile_name": "Swarm Cluster",
   "level": 37,
   "rarity": "common",
@@ -161,10 +166,5 @@
       },
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 948083,
-    "defense": 1143715,
-    "health": 5718264
-  }
+  ]
 }

--- a/hostiles/swarm_cluster_37_interceptor.json
+++ b/hostiles/swarm_cluster_37_interceptor.json
@@ -1,9 +1,6 @@
 {
   "description": "Swarm ships attack as one unit and do not show mercy.",
-  "attack": 948083,
-  "defense": 1143715,
   "group": "swarm",
-  "health": 5718264,
   "hostile_name": "Swarm Cluster",
   "level": 37,
   "rarity": "common",
@@ -33,7 +30,6 @@
       "shield_health": 0
     }
   },
-  "strength": 7810062,
   "systems": [
     {
       "$ref": "systems/araxian_37"
@@ -70,7 +66,6 @@
         3
       ],
       "quantity": 2,
-      "weapon_id": "K1",
       "weapon_stats": {
         "accuracy": 32679,
         "armor_pierce": 163400,
@@ -102,7 +97,6 @@
         3
       ],
       "quantity": 1,
-      "weapon_id": "K2",
       "weapon_type": "kinetic"
     },
     {
@@ -124,7 +118,6 @@
         0
       ],
       "quantity": 1,
-      "weapon_id": "K3",
       "weapon_stats": {
         "accuracy": 32679,
         "armor_pierce": 163400,
@@ -156,7 +149,6 @@
         3
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_stats": {
         "accuracy": 32679,
         "armor_pierce": 163400,
@@ -169,5 +161,10 @@
       },
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 948083,
+    "defense": 1143715,
+    "health": 5718264
+  }
 }

--- a/hostiles/swarm_cluster_39_interceptor.json
+++ b/hostiles/swarm_cluster_39_interceptor.json
@@ -1,6 +1,11 @@
 {
   "description": "Swarm ships attack as one unit and do not show mercy.",
   "group": "swarm",
+  "head_stats": {
+    "attack": 1383166,
+    "defense": 1637265,
+    "health": 7958408
+  },
   "hostile_name": "Swarm Cluster",
   "level": 39,
   "rarity": "common",
@@ -161,10 +166,5 @@
       },
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 1383166,
-    "defense": 1637265,
-    "health": 7958408
-  }
+  ]
 }

--- a/hostiles/swarm_cluster_39_interceptor.json
+++ b/hostiles/swarm_cluster_39_interceptor.json
@@ -1,9 +1,6 @@
 {
   "description": "Swarm ships attack as one unit and do not show mercy.",
-  "attack": 1383166,
-  "defense": 1637265,
   "group": "swarm",
-  "health": 7958408,
   "hostile_name": "Swarm Cluster",
   "level": 39,
   "rarity": "common",
@@ -33,7 +30,6 @@
       "shield_health": 0
     }
   },
-  "strength": 10978839,
   "systems": [
     {
       "$ref": "systems/kiju_39"
@@ -70,7 +66,6 @@
         3
       ],
       "quantity": 2,
-      "weapon_id": "K1",
       "weapon_stats": {
         "accuracy": 45480,
         "armor_pierce": 227400,
@@ -102,7 +97,6 @@
         3
       ],
       "quantity": 1,
-      "weapon_id": "K2",
       "weapon_type": "kinetic"
     },
     {
@@ -124,7 +118,6 @@
         0
       ],
       "quantity": 1,
-      "weapon_id": "K3",
       "weapon_stats": {
         "accuracy": 54576,
         "armor_pierce": 272900,
@@ -156,7 +149,6 @@
         3
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_stats": {
         "accuracy": 54576,
         "armor_pierce": 272900,
@@ -169,5 +161,10 @@
       },
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 1383166,
+    "defense": 1637265,
+    "health": 7958408
+  }
 }

--- a/hostiles/swarm_cluster_41_interceptor.json
+++ b/hostiles/swarm_cluster_41_interceptor.json
@@ -1,9 +1,6 @@
 {
   "description": "Swarm ships attack as one unit and do not show mercy.",
-  "attack": 1690633,
-  "defense": 2039610,
   "group": "swarm",
-  "health": 10197168,
   "hostile_name": "Swarm Cluster",
   "level": 41,
   "rarity": "common",
@@ -33,7 +30,6 @@
       "shield_health": 0
     }
   },
-  "strength": 13927411,
   "systems": [
     {
       "$ref": "systems/huik_41"
@@ -67,7 +63,6 @@
         3
       ],
       "quantity": 2,
-      "weapon_id": "K1",
       "weapon_stats": {
         "accuracy": 58269,
         "armor_pierce": 291300,
@@ -99,7 +94,6 @@
         3
       ],
       "quantity": 1,
-      "weapon_id": "K2",
       "weapon_type": "kinetic"
     },
     {
@@ -121,7 +115,6 @@
         0
       ],
       "quantity": 1,
-      "weapon_id": "K3",
       "weapon_stats": {
         "accuracy": 58269,
         "armor_pierce": 291300,
@@ -153,7 +146,6 @@
         3
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_stats": {
         "accuracy": 58269,
         "armor_pierce": 291300,
@@ -166,5 +158,10 @@
       },
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 1690633,
+    "defense": 2039610,
+    "health": 10197168
+  }
 }

--- a/hostiles/swarm_cluster_41_interceptor.json
+++ b/hostiles/swarm_cluster_41_interceptor.json
@@ -1,6 +1,11 @@
 {
   "description": "Swarm ships attack as one unit and do not show mercy.",
   "group": "swarm",
+  "head_stats": {
+    "attack": 1690633,
+    "defense": 2039610,
+    "health": 10197168
+  },
   "hostile_name": "Swarm Cluster",
   "level": 41,
   "rarity": "common",
@@ -158,10 +163,5 @@
       },
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 1690633,
-    "defense": 2039610,
-    "health": 10197168
-  }
+  ]
 }

--- a/hostiles/swarm_cluster_43_interceptor.json
+++ b/hostiles/swarm_cluster_43_interceptor.json
@@ -1,6 +1,11 @@
 {
   "description": "Swarm ships attack as one unit and do not show mercy.",
   "group": "swarm",
+  "head_stats": {
+    "attack": 2088069,
+    "defense": 2544525,
+    "health": 12905791
+  },
   "hostile_name": "Swarm Cluster",
   "level": 43,
   "rarity": "common",
@@ -158,10 +163,5 @@
       },
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 2088069,
-    "defense": 2544525,
-    "health": 12905791
-  }
+  ]
 }

--- a/hostiles/swarm_cluster_43_interceptor.json
+++ b/hostiles/swarm_cluster_43_interceptor.json
@@ -1,9 +1,6 @@
 {
   "description": "Swarm ships attack as one unit and do not show mercy.",
-  "attack": 2088069,
-  "defense": 2544525,
   "group": "swarm",
-  "health": 12905791,
   "hostile_name": "Swarm Cluster",
   "level": 43,
   "rarity": "common",
@@ -33,7 +30,6 @@
       "shield_health": 0
     }
   },
-  "strength": 17538385,
   "systems": [
     {
       "$ref": "systems/miset_43"
@@ -67,7 +63,6 @@
         3
       ],
       "quantity": 2,
-      "weapon_id": "K1",
       "weapon_stats": {
         "accuracy": 73746,
         "armor_pierce": 368700,
@@ -99,7 +94,6 @@
         3
       ],
       "quantity": 1,
-      "weapon_id": "K2",
       "weapon_type": "kinetic"
     },
     {
@@ -121,7 +115,6 @@
         0
       ],
       "quantity": 1,
-      "weapon_id": "K3",
       "weapon_stats": {
         "accuracy": 66371,
         "armor_pierce": 331900,
@@ -153,7 +146,6 @@
         3
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_stats": {
         "accuracy": 66371,
         "armor_pierce": 331900,
@@ -166,5 +158,10 @@
       },
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 2088069,
+    "defense": 2544525,
+    "health": 12905791
+  }
 }

--- a/hostiles/swarm_cluster_44_interceptor.json
+++ b/hostiles/swarm_cluster_44_interceptor.json
@@ -1,6 +1,11 @@
 {
   "description": "Swarm ships attack as one unit and do not show mercy.",
   "group": "swarm",
+  "head_stats": {
+    "attack": 2491095,
+    "defense": 3005405,
+    "health": 15025437
+  },
   "hostile_name": "Swarm Cluster",
   "level": 44,
   "rarity": "common",
@@ -155,10 +160,5 @@
       "quantity": 1,
       "weapon_type": "kinetic"
     }
-  ],
-  "head_stats": {
-    "attack": 2491095,
-    "defense": 3005405,
-    "health": 15025437
-  }
+  ]
 }

--- a/hostiles/swarm_cluster_44_interceptor.json
+++ b/hostiles/swarm_cluster_44_interceptor.json
@@ -1,9 +1,6 @@
 {
   "description": "Swarm ships attack as one unit and do not show mercy.",
-  "attack": 2491095,
-  "defense": 3005405,
   "group": "swarm",
-  "health": 15025437,
   "hostile_name": "Swarm Cluster",
   "level": 44,
   "rarity": "common",
@@ -33,7 +30,6 @@
       "shield_health": 0
     }
   },
-  "strength": 20521937,
   "systems": [
     {
       "$ref": "systems/begekou_44"
@@ -64,7 +60,6 @@
         3
       ],
       "quantity": 2,
-      "weapon_id": "K1",
       "weapon_stats": {
         "accuracy": 85856,
         "armor_pierce": 429300,
@@ -96,7 +91,6 @@
         3
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_stats": {
         "accuracy": 85856,
         "armor_pierce": 429300,
@@ -128,7 +122,6 @@
         0
       ],
       "quantity": 1,
-      "weapon_id": "K3",
       "weapon_stats": {
         "accuracy": 85856,
         "armor_pierce": 429300,
@@ -160,8 +153,12 @@
         3
       ],
       "quantity": 1,
-      "weapon_id": "K2",
       "weapon_type": "kinetic"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 2491095,
+    "defense": 3005405,
+    "health": 15025437
+  }
 }

--- a/hostiles/swarm_cluster_45_interceptor.json
+++ b/hostiles/swarm_cluster_45_interceptor.json
@@ -1,6 +1,11 @@
 {
   "description": "Swarm ships attack as one unit and do not show mercy.",
   "group": "swarm",
+  "head_stats": {
+    "attack": 2990551,
+    "defense": 3607995,
+    "health": 18038036
+  },
   "hostile_name": "Swarm Cluster",
   "level": 45,
   "rarity": "common",
@@ -155,10 +160,5 @@
       "quantity": 1,
       "weapon_type": "kinetic"
     }
-  ],
-  "head_stats": {
-    "attack": 2990551,
-    "defense": 3607995,
-    "health": 18038036
-  }
+  ]
 }

--- a/hostiles/swarm_cluster_45_interceptor.json
+++ b/hostiles/swarm_cluster_45_interceptor.json
@@ -1,9 +1,6 @@
 {
   "description": "Swarm ships attack as one unit and do not show mercy.",
-  "attack": 2990551,
-  "defense": 3607995,
   "group": "swarm",
-  "health": 18038036,
   "hostile_name": "Swarm Cluster",
   "level": 45,
   "rarity": "common",
@@ -33,7 +30,6 @@
       "shield_health": 0
     }
   },
-  "strength": 24636582,
   "systems": [
     {
       "$ref": "systems/vugef_45"
@@ -64,7 +60,6 @@
         3
       ],
       "quantity": 2,
-      "weapon_id": "K1",
       "weapon_stats": {
         "accuracy": 103100,
         "armor_pierce": 515400,
@@ -96,7 +91,6 @@
         3
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_stats": {
         "accuracy": 103100,
         "armor_pierce": 515400,
@@ -128,7 +122,6 @@
         0
       ],
       "quantity": 1,
-      "weapon_id": "K3",
       "weapon_stats": {
         "accuracy": 103100,
         "armor_pierce": 515400,
@@ -160,8 +153,12 @@
         3
       ],
       "quantity": 1,
-      "weapon_id": "K2",
       "weapon_type": "kinetic"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 2990551,
+    "defense": 3607995,
+    "health": 18038036
+  }
 }

--- a/hostiles/swarm_cluster_46_interceptor.json
+++ b/hostiles/swarm_cluster_46_interceptor.json
@@ -1,6 +1,11 @@
 {
   "description": "Swarm ships attack as one unit and do not show mercy.",
   "group": "swarm",
+  "head_stats": {
+    "attack": 3560828,
+    "defense": 4296055,
+    "health": 21477889
+  },
   "hostile_name": "Swarm Cluster",
   "level": 46,
   "rarity": "common",
@@ -155,10 +160,5 @@
       "quantity": 1,
       "weapon_type": "kinetic"
     }
-  ],
-  "head_stats": {
-    "attack": 3560828,
-    "defense": 4296055,
-    "health": 21477889
-  }
+  ]
 }

--- a/hostiles/swarm_cluster_46_interceptor.json
+++ b/hostiles/swarm_cluster_46_interceptor.json
@@ -1,9 +1,6 @@
 {
   "description": "Swarm ships attack as one unit and do not show mercy.",
-  "attack": 3560828,
-  "defense": 4296055,
   "group": "swarm",
-  "health": 21477889,
   "hostile_name": "Swarm Cluster",
   "level": 46,
   "rarity": "common",
@@ -33,7 +30,6 @@
       "shield_health": 0
     }
   },
-  "strength": 29334772,
   "systems": [
     {
       "$ref": "systems/hobu_46"
@@ -64,7 +60,6 @@
         3
       ],
       "quantity": 2,
-      "weapon_id": "K1",
       "weapon_stats": {
         "accuracy": 122700,
         "armor_pierce": 613600,
@@ -96,7 +91,6 @@
         3
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_stats": {
         "accuracy": 122700,
         "armor_pierce": 613600,
@@ -128,7 +122,6 @@
         0
       ],
       "quantity": 1,
-      "weapon_id": "K3",
       "weapon_stats": {
         "accuracy": 122700,
         "armor_pierce": 613600,
@@ -160,8 +153,12 @@
         3
       ],
       "quantity": 1,
-      "weapon_id": "K2",
       "weapon_type": "kinetic"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 3560828,
+    "defense": 4296055,
+    "health": 21477889
+  }
 }

--- a/hostiles/swarm_cluster_47_interceptor.json
+++ b/hostiles/swarm_cluster_47_interceptor.json
@@ -1,9 +1,6 @@
 {
   "description": "Swarm ships attack as one unit and do not show mercy.",
-  "attack": 4765365,
-  "defense": 5749035,
   "group": "swarm",
-  "health": 28742593,
   "hostile_name": "Swarm Cluster",
   "level": 47,
   "rarity": "common",
@@ -33,7 +30,6 @@
       "shield_health": 0
     }
   },
-  "strength": 39256993,
   "systems": [
     {
       "$ref": "systems/hedex_47"
@@ -64,7 +60,6 @@
         3
       ],
       "quantity": 2,
-      "weapon_id": "K1",
       "weapon_stats": {
         "accuracy": 164200,
         "armor_pierce": 821200,
@@ -96,7 +91,6 @@
         3
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_stats": {
         "accuracy": 164200,
         "armor_pierce": 821200,
@@ -128,7 +122,6 @@
         0
       ],
       "quantity": 1,
-      "weapon_id": "K3",
       "weapon_stats": {
         "accuracy": 164200,
         "armor_pierce": 821200,
@@ -160,8 +153,12 @@
         3
       ],
       "quantity": 1,
-      "weapon_id": "K2",
       "weapon_type": "kinetic"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 4765365,
+    "defense": 5749035,
+    "health": 28742593
+  }
 }

--- a/hostiles/swarm_cluster_47_interceptor.json
+++ b/hostiles/swarm_cluster_47_interceptor.json
@@ -1,6 +1,11 @@
 {
   "description": "Swarm ships attack as one unit and do not show mercy.",
   "group": "swarm",
+  "head_stats": {
+    "attack": 4765365,
+    "defense": 5749035,
+    "health": 28742593
+  },
   "hostile_name": "Swarm Cluster",
   "level": 47,
   "rarity": "common",
@@ -155,10 +160,5 @@
       "quantity": 1,
       "weapon_type": "kinetic"
     }
-  ],
-  "head_stats": {
-    "attack": 4765365,
-    "defense": 5749035,
-    "health": 28742593
-  }
+  ]
 }

--- a/hostiles/swarm_cluster_48_interceptor.json
+++ b/hostiles/swarm_cluster_48_interceptor.json
@@ -1,6 +1,11 @@
 {
   "description": "Swarm ships attack as one unit and do not show mercy.",
   "group": "swarm",
+  "head_stats": {
+    "attack": 6473526,
+    "defense": 7809745,
+    "health": 39045332
+  },
   "hostile_name": "Swarm Cluster",
   "level": 48,
   "rarity": "common",
@@ -155,10 +160,5 @@
       "quantity": 1,
       "weapon_type": "kinetic"
     }
-  ],
-  "head_stats": {
-    "attack": 6473526,
-    "defense": 7809745,
-    "health": 39045332
-  }
+  ]
 }

--- a/hostiles/swarm_cluster_48_interceptor.json
+++ b/hostiles/swarm_cluster_48_interceptor.json
@@ -1,9 +1,6 @@
 {
   "description": "Swarm ships attack as one unit and do not show mercy.",
-  "attack": 6473526,
-  "defense": 7809745,
   "group": "swarm",
-  "health": 39045332,
   "hostile_name": "Swarm Cluster",
   "level": 48,
   "rarity": "common",
@@ -33,7 +30,6 @@
       "shield_health": 0
     }
   },
-  "strength": 53328603,
   "systems": [
     {
       "$ref": "systems/widis_48"
@@ -64,7 +60,6 @@
         3
       ],
       "quantity": 2,
-      "weapon_id": "K1",
       "weapon_stats": {
         "accuracy": 223100,
         "armor_pierce": 1115000,
@@ -96,7 +91,6 @@
         3
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_stats": {
         "accuracy": 223100,
         "armor_pierce": 1115000,
@@ -128,7 +122,6 @@
         0
       ],
       "quantity": 1,
-      "weapon_id": "K3",
       "weapon_stats": {
         "accuracy": 223100,
         "armor_pierce": 1115000,
@@ -160,8 +153,12 @@
         3
       ],
       "quantity": 1,
-      "weapon_id": "K2",
       "weapon_type": "kinetic"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 6473526,
+    "defense": 7809745,
+    "health": 39045332
+  }
 }

--- a/hostiles/swarm_cluster_49_interceptor.json
+++ b/hostiles/swarm_cluster_49_interceptor.json
@@ -1,9 +1,6 @@
 {
   "description": "Swarm ships attack as one unit and do not show mercy.",
-  "attack": 9273322,
-  "defense": 11187355,
   "group": "swarm",
-  "health": 55932161,
   "hostile_name": "Swarm Cluster",
   "level": 49,
   "rarity": "common",
@@ -33,7 +30,6 @@
       "shield_health": 0
     }
   },
-  "strength": 76392838,
   "systems": [
     {
       "$ref": "systems/raxo_49"
@@ -64,7 +60,6 @@
         3
       ],
       "quantity": 2,
-      "weapon_id": "K1",
       "weapon_stats": {
         "accuracy": 319600,
         "armor_pierce": 1598000,
@@ -96,7 +91,6 @@
         3
       ],
       "quantity": 1,
-      "weapon_id": "K2",
       "weapon_type": "kinetic"
     },
     {
@@ -118,7 +112,6 @@
         0
       ],
       "quantity": 1,
-      "weapon_id": "K3",
       "weapon_stats": {
         "accuracy": 319600,
         "armor_pierce": 1598000,
@@ -150,7 +143,6 @@
         3
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_stats": {
         "accuracy": 319600,
         "armor_pierce": 1598000,
@@ -163,5 +155,10 @@
       },
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 9273322,
+    "defense": 11187355,
+    "health": 55932161
+  }
 }

--- a/hostiles/swarm_cluster_49_interceptor.json
+++ b/hostiles/swarm_cluster_49_interceptor.json
@@ -1,6 +1,11 @@
 {
   "description": "Swarm ships attack as one unit and do not show mercy.",
   "group": "swarm",
+  "head_stats": {
+    "attack": 9273322,
+    "defense": 11187355,
+    "health": 55932161
+  },
   "hostile_name": "Swarm Cluster",
   "level": 49,
   "rarity": "common",
@@ -155,10 +160,5 @@
       },
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 9273322,
-    "defense": 11187355,
-    "health": 55932161
-  }
+  ]
 }

--- a/hostiles/swarm_cluster_50_interceptor.json
+++ b/hostiles/swarm_cluster_50_interceptor.json
@@ -1,6 +1,11 @@
 {
   "description": "Swarm ships attack as one unit and do not show mercy.",
   "group": "swarm",
+  "head_stats": {
+    "attack": 10127552,
+    "defense": 11675495,
+    "health": 131250000
+  },
   "hostile_name": "Swarm Cluster",
   "level": 50,
   "rarity": "common",
@@ -155,10 +160,5 @@
       },
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 10127552,
-    "defense": 11675495,
-    "health": 131250000
-  }
+  ]
 }

--- a/hostiles/swarm_cluster_50_interceptor.json
+++ b/hostiles/swarm_cluster_50_interceptor.json
@@ -1,9 +1,6 @@
 {
   "description": "Swarm ships attack as one unit and do not show mercy.",
-  "attack": 10127552,
-  "defense": 11675495,
   "group": "swarm",
-  "health": 131250000,
   "hostile_name": "Swarm Cluster",
   "level": 50,
   "rarity": "common",
@@ -33,7 +30,6 @@
       "shield_health": 0
     }
   },
-  "strength": 153053047,
   "systems": [
     {
       "$ref": "systems/beilum_50"
@@ -64,7 +60,6 @@
         3
       ],
       "quantity": 2,
-      "weapon_id": "K1",
       "weapon_stats": {
         "accuracy": 331200,
         "armor_pierce": 1655000,
@@ -96,7 +91,6 @@
         3
       ],
       "quantity": 1,
-      "weapon_id": "K2",
       "weapon_type": "kinetic"
     },
     {
@@ -118,7 +112,6 @@
         0
       ],
       "quantity": 1,
-      "weapon_id": "K3",
       "weapon_stats": {
         "accuracy": 347800,
         "armor_pierce": 1738000,
@@ -150,7 +143,6 @@
         3
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_stats": {
         "accuracy": 347800,
         "armor_pierce": 1738000,
@@ -163,5 +155,10 @@
       },
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 10127552,
+    "defense": 11675495,
+    "health": 131250000
+  }
 }

--- a/hostiles/unknown_alien_23_interceptor.json
+++ b/hostiles/unknown_alien_23_interceptor.json
@@ -1,6 +1,11 @@
 {
   "description": "These unknown aliens arrived in our galaxy via strange spatial anomalies. Nobody knows who they are or why they seem to be hostile.",
   "group": "",
+  "head_stats": {
+    "attack": 27691,
+    "defense": 27000,
+    "health": 12096
+  },
   "hostile_name": "Unknown Alien",
   "level": 23,
   "rarity": "common",
@@ -151,10 +156,5 @@
       "quantity": 1,
       "weapon_type": "kinetic"
     }
-  ],
-  "head_stats": {
-    "attack": 27691,
-    "defense": 27000,
-    "health": 12096
-  }
+  ]
 }

--- a/hostiles/unknown_alien_23_interceptor.json
+++ b/hostiles/unknown_alien_23_interceptor.json
@@ -1,9 +1,6 @@
 {
   "description": "These unknown aliens arrived in our galaxy via strange spatial anomalies. Nobody knows who they are or why they seem to be hostile.",
-  "attack": 27691,
-  "defense": 27000,
   "group": "",
-  "health": 12096,
   "hostile_name": "Unknown Alien",
   "level": 23,
   "rarity": "common",
@@ -33,7 +30,6 @@
       "shield_health": 12096
     }
   },
-  "strength": 66787,
   "systems": [
     {
       "$ref": "systems/amagi_23"
@@ -91,7 +87,6 @@
         1
       ],
       "quantity": 2,
-      "weapon_id": "K1",
       "weapon_stats": {
         "accuracy": 900,
         "armor_pierce": 5400,
@@ -123,7 +118,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_stats": {
         "accuracy": 900,
         "armor_pierce": 5400,
@@ -155,8 +149,12 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "K2",
       "weapon_type": "kinetic"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 27691,
+    "defense": 27000,
+    "health": 12096
+  }
 }

--- a/hostiles/unknown_alien_27_interceptor.json
+++ b/hostiles/unknown_alien_27_interceptor.json
@@ -1,6 +1,11 @@
 {
   "description": "These unknown aliens arrived in our galaxy via strange spatial anomalies. Nobody knows who they are or why they seem to be hostile.",
   "group": "",
+  "head_stats": {
+    "attack": 78743,
+    "defense": 82425,
+    "health": 32020
+  },
   "hostile_name": "Unknown Alien",
   "level": 27,
   "rarity": "common",
@@ -116,10 +121,5 @@
       "quantity": 1,
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 78743,
-    "defense": 82425,
-    "health": 32020
-  }
+  ]
 }

--- a/hostiles/unknown_alien_27_interceptor.json
+++ b/hostiles/unknown_alien_27_interceptor.json
@@ -1,9 +1,6 @@
 {
   "description": "These unknown aliens arrived in our galaxy via strange spatial anomalies. Nobody knows who they are or why they seem to be hostile.",
-  "attack": 78743,
-  "defense": 82425,
   "group": "",
-  "health": 32020,
   "hostile_name": "Unknown Alien",
   "level": 27,
   "rarity": "common",
@@ -33,7 +30,6 @@
       "shield_health": 32000
     }
   },
-  "strength": 193188,
   "systems": [
     {
       "$ref": "systems/cada_x_28"
@@ -76,7 +72,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "K1",
       "weapon_type": "kinetic"
     },
     {
@@ -98,7 +93,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "K2",
       "weapon_type": "kinetic"
     },
     {
@@ -120,8 +114,12 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 78743,
+    "defense": 82425,
+    "health": 32020
+  }
 }

--- a/hostiles/unknown_alien_29_interceptor.json
+++ b/hostiles/unknown_alien_29_interceptor.json
@@ -1,9 +1,6 @@
 {
   "description": "These unknown aliens arrived in our galaxy via strange spatial anomalies. Nobody knows who they are or why they seem to be hostile.",
-  "attack": 104192,
-  "defense": 107940,
   "group": "",
-  "health": 38640,
   "hostile_name": "Unknown Alien",
   "level": 29,
   "rarity": "common",
@@ -33,7 +30,6 @@
       "shield_health": 38000
     }
   },
-  "strength": 250772,
   "systems": [
     {
       "$ref": "systems/cada_x_28"
@@ -76,7 +72,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "K1",
       "weapon_type": "kinetic"
     },
     {
@@ -98,7 +93,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "K2",
       "weapon_type": "kinetic"
     },
     {
@@ -120,8 +114,12 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 104192,
+    "defense": 107940,
+    "health": 38640
+  }
 }

--- a/hostiles/unknown_alien_29_interceptor.json
+++ b/hostiles/unknown_alien_29_interceptor.json
@@ -1,6 +1,11 @@
 {
   "description": "These unknown aliens arrived in our galaxy via strange spatial anomalies. Nobody knows who they are or why they seem to be hostile.",
   "group": "",
+  "head_stats": {
+    "attack": 104192,
+    "defense": 107940,
+    "health": 38640
+  },
   "hostile_name": "Unknown Alien",
   "level": 29,
   "rarity": "common",
@@ -116,10 +121,5 @@
       "quantity": 1,
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 104192,
-    "defense": 107940,
-    "health": 38640
-  }
+  ]
 }

--- a/hostiles/vaaran_marauder_28_battleship.json
+++ b/hostiles/vaaran_marauder_28_battleship.json
@@ -1,6 +1,11 @@
 {
   "description": "This Hostile patrols the different systems of the universe, looking for easy prey",
   "group": "",
+  "head_stats": {
+    "attack": 40788,
+    "defense": 41250,
+    "health": 21000
+  },
   "hostile_name": "Vaaran Marauder",
   "level": 28,
   "rarity": "common",
@@ -108,10 +113,5 @@
       "quantity": 1,
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 40788,
-    "defense": 41250,
-    "health": 21000
-  }
+  ]
 }

--- a/hostiles/vaaran_marauder_28_battleship.json
+++ b/hostiles/vaaran_marauder_28_battleship.json
@@ -1,9 +1,6 @@
 {
   "description": "This Hostile patrols the different systems of the universe, looking for easy prey",
-  "attack": 40788,
-  "defense": 41250,
   "group": "",
-  "health": 21000,
   "hostile_name": "Vaaran Marauder",
   "level": 28,
   "rarity": "common",
@@ -28,7 +25,6 @@
       "shield_health": 18000
     }
   },
-  "strength": 103038,
   "systems": [
     {
       "$ref": "systems/kor_na_ron_27"
@@ -68,7 +64,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "K1",
       "weapon_type": "kinetic"
     },
     {
@@ -90,7 +85,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_type": "energy"
     },
     {
@@ -112,8 +106,12 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E2",
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 40788,
+    "defense": 41250,
+    "health": 21000
+  }
 }

--- a/hostiles/vaaran_marauder_28_explorer.json
+++ b/hostiles/vaaran_marauder_28_explorer.json
@@ -1,9 +1,6 @@
 {
   "description": "This Hostile patrols the different systems of the universe, looking for easy prey",
-  "attack": 39270,
-  "defense": 41250,
   "group": "",
-  "health": 22200,
   "hostile_name": "Vaaran Marauder",
   "level": 28,
   "rarity": "common",
@@ -28,7 +25,6 @@
       "shield_health": 22000
     }
   },
-  "strength": 102720,
   "systems": [
     {
       "$ref": "systems/kor_na_ron_27"
@@ -68,7 +64,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_type": "energy"
     },
     {
@@ -90,7 +85,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E2",
       "weapon_type": "energy"
     },
     {
@@ -112,8 +106,12 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E3",
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 39270,
+    "defense": 41250,
+    "health": 22200
+  }
 }

--- a/hostiles/vaaran_marauder_28_explorer.json
+++ b/hostiles/vaaran_marauder_28_explorer.json
@@ -1,6 +1,11 @@
 {
   "description": "This Hostile patrols the different systems of the universe, looking for easy prey",
   "group": "",
+  "head_stats": {
+    "attack": 39270,
+    "defense": 41250,
+    "health": 22200
+  },
   "hostile_name": "Vaaran Marauder",
   "level": 28,
   "rarity": "common",
@@ -108,10 +113,5 @@
       "quantity": 1,
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 39270,
-    "defense": 41250,
-    "health": 22200
-  }
+  ]
 }

--- a/hostiles/vaaran_marauder_28_interceptor.json
+++ b/hostiles/vaaran_marauder_28_interceptor.json
@@ -1,6 +1,11 @@
 {
   "description": "This Hostile patrols the different systems of the universe, looking for easy prey",
   "group": "",
+  "head_stats": {
+    "attack": 42306,
+    "defense": 41250,
+    "health": 19200
+  },
   "hostile_name": "Vaaran Marauder",
   "level": 28,
   "rarity": "common",
@@ -108,10 +113,5 @@
       "quantity": 1,
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 42306,
-    "defense": 41250,
-    "health": 19200
-  }
+  ]
 }

--- a/hostiles/vaaran_marauder_28_interceptor.json
+++ b/hostiles/vaaran_marauder_28_interceptor.json
@@ -1,9 +1,6 @@
 {
   "description": "This Hostile patrols the different systems of the universe, looking for easy prey",
-  "attack": 42306,
-  "defense": 41250,
   "group": "",
-  "health": 19200,
   "hostile_name": "Vaaran Marauder",
   "level": 28,
   "rarity": "common",
@@ -28,7 +25,6 @@
       "shield_health": 19000
     }
   },
-  "strength": 102756,
   "systems": [
     {
       "$ref": "systems/kor_na_ron_27"
@@ -68,7 +64,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "K1",
       "weapon_type": "kinetic"
     },
     {
@@ -90,7 +85,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "K2",
       "weapon_type": "kinetic"
     },
     {
@@ -112,8 +106,12 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 42306,
+    "defense": 41250,
+    "health": 19200
+  }
 }

--- a/hostiles/vaaran_marauder_32_battleship.json
+++ b/hostiles/vaaran_marauder_32_battleship.json
@@ -1,6 +1,11 @@
 {
   "description": "This Hostile patrols the different systems of the universe, looking for easy prey",
   "group": "",
+  "head_stats": {
+    "attack": 129969,
+    "defense": 123750,
+    "health": 45150
+  },
   "hostile_name": "Vaaran Marauder",
   "level": 32,
   "rarity": "common",
@@ -93,10 +98,5 @@
       "quantity": 1,
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 129969,
-    "defense": 123750,
-    "health": 45150
-  }
+  ]
 }

--- a/hostiles/vaaran_marauder_32_battleship.json
+++ b/hostiles/vaaran_marauder_32_battleship.json
@@ -1,9 +1,6 @@
 {
   "description": "This Hostile patrols the different systems of the universe, looking for easy prey",
-  "attack": 129969,
-  "defense": 123750,
   "group": "",
-  "health": 45150,
   "hostile_name": "Vaaran Marauder",
   "level": 32,
   "rarity": "common",
@@ -28,7 +25,6 @@
       "shield_health": 38000
     }
   },
-  "strength": 298869,
   "systems": [
     {
       "$ref": "systems/ifrea_3_32"
@@ -59,7 +55,6 @@
         0
       ],
       "quantity": 1,
-      "weapon_id": "K1",
       "weapon_type": "kinetic"
     },
     {
@@ -78,7 +73,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_type": "energy"
     },
     {
@@ -97,8 +91,12 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E2",
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 129969,
+    "defense": 123750,
+    "health": 45150
+  }
 }

--- a/hostiles/vaaran_marauder_32_explorer.json
+++ b/hostiles/vaaran_marauder_32_explorer.json
@@ -1,6 +1,11 @@
 {
   "description": "This Hostile patrols the different systems of the universe, looking for easy prey",
   "group": "",
+  "head_stats": {
+    "attack": 124939,
+    "defense": 123750,
+    "health": 47730
+  },
   "hostile_name": "Vaaran Marauder",
   "level": 32,
   "rarity": "common",
@@ -93,10 +98,5 @@
       "quantity": 1,
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 124939,
-    "defense": 123750,
-    "health": 47730
-  }
+  ]
 }

--- a/hostiles/vaaran_marauder_32_explorer.json
+++ b/hostiles/vaaran_marauder_32_explorer.json
@@ -1,9 +1,6 @@
 {
   "description": "This Hostile patrols the different systems of the universe, looking for easy prey",
-  "attack": 124939,
-  "defense": 123750,
   "group": "",
-  "health": 47730,
   "hostile_name": "Vaaran Marauder",
   "level": 32,
   "rarity": "common",
@@ -28,7 +25,6 @@
       "shield_health": 49000
     }
   },
-  "strength": 296419,
   "systems": [
     {
       "$ref": "systems/ifrea_3_32"
@@ -59,7 +55,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_type": "energy"
     },
     {
@@ -78,7 +73,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E2",
       "weapon_type": "energy"
     },
     {
@@ -97,8 +91,12 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E3",
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 124939,
+    "defense": 123750,
+    "health": 47730
+  }
 }

--- a/hostiles/vaaran_marauder_32_interceptor.json
+++ b/hostiles/vaaran_marauder_32_interceptor.json
@@ -1,9 +1,6 @@
 {
   "description": "This Hostile patrols the different systems of the universe, looking for easy prey",
-  "attack": 134998,
-  "defense": 123750,
   "group": "",
-  "health": 41280,
   "hostile_name": "Vaaran Marauder",
   "level": 32,
   "rarity": "common",
@@ -28,7 +25,6 @@
       "shield_health": 41000
     }
   },
-  "strength": 300028,
   "systems": [
     {
       "$ref": "systems/ifrea_3_32"
@@ -59,7 +55,6 @@
         0
       ],
       "quantity": 1,
-      "weapon_id": "K1",
       "weapon_type": "kinetic"
     },
     {
@@ -78,7 +73,6 @@
         0
       ],
       "quantity": 1,
-      "weapon_id": "K2",
       "weapon_type": "kinetic"
     },
     {
@@ -97,8 +91,12 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 134998,
+    "defense": 123750,
+    "health": 41280
+  }
 }

--- a/hostiles/vaaran_marauder_32_interceptor.json
+++ b/hostiles/vaaran_marauder_32_interceptor.json
@@ -1,6 +1,11 @@
 {
   "description": "This Hostile patrols the different systems of the universe, looking for easy prey",
   "group": "",
+  "head_stats": {
+    "attack": 134998,
+    "defense": 123750,
+    "health": 41280
+  },
   "hostile_name": "Vaaran Marauder",
   "level": 32,
   "rarity": "common",
@@ -93,10 +98,5 @@
       "quantity": 1,
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 134998,
-    "defense": 123750,
-    "health": 41280
-  }
+  ]
 }

--- a/hostiles/vaaran_marauder_36_battleship.json
+++ b/hostiles/vaaran_marauder_36_battleship.json
@@ -1,9 +1,6 @@
 {
   "description": "This Hostile patrols the different systems of the universe, looking for easy prey",
-  "attack": 290178,
-  "defense": 273365,
   "group": "",
-  "health": 95115,
   "hostile_name": "Vaaran Marauder",
   "level": 36,
   "rarity": "common",
@@ -28,7 +25,6 @@
       "shield_health": 81530
     }
   },
-  "strength": 658658,
   "systems": [
     {
       "$ref": "systems/ilmatar_35"
@@ -62,7 +58,6 @@
         1
       ],
       "quantity": 2,
-      "weapon_id": "E1",
       "weapon_stats": {
         "accuracy": 9112,
         "armor_pierce": 9112,
@@ -94,7 +89,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "K1",
       "weapon_stats": {
         "accuracy": 9112,
         "armor_pierce": 9112,
@@ -126,8 +120,12 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E2",
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 290178,
+    "defense": 273365,
+    "health": 95115
+  }
 }

--- a/hostiles/vaaran_marauder_36_battleship.json
+++ b/hostiles/vaaran_marauder_36_battleship.json
@@ -1,6 +1,11 @@
 {
   "description": "This Hostile patrols the different systems of the universe, looking for easy prey",
   "group": "",
+  "head_stats": {
+    "attack": 290178,
+    "defense": 273365,
+    "health": 95115
+  },
   "hostile_name": "Vaaran Marauder",
   "level": 36,
   "rarity": "common",
@@ -122,10 +127,5 @@
       "quantity": 1,
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 290178,
-    "defense": 273365,
-    "health": 95115
-  }
+  ]
 }

--- a/hostiles/veteran_federation_transport_40_survey.json
+++ b/hostiles/veteran_federation_transport_40_survey.json
@@ -1,9 +1,6 @@
 {
   "description": "The H-Class freighter is a long-distance heavy hauler capable of transporting vast quantities of materials and goods.",
-  "attack": 623214,
-  "defense": 1418670,
   "group": "federation",
-  "health": 709530,
   "hostile_name": "Veteran Federation Transport",
   "level": 40,
   "rarity": "common",
@@ -41,7 +38,6 @@
       "shield_health": 709000
     }
   },
-  "strength": 2751414,
   "systems": [
     {
       "$ref": "systems/alpha_centauri_39"
@@ -93,8 +89,12 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 623214,
+    "defense": 1418670,
+    "health": 709530
+  }
 }

--- a/hostiles/veteran_federation_transport_40_survey.json
+++ b/hostiles/veteran_federation_transport_40_survey.json
@@ -1,6 +1,11 @@
 {
   "description": "The H-Class freighter is a long-distance heavy hauler capable of transporting vast quantities of materials and goods.",
   "group": "federation",
+  "head_stats": {
+    "attack": 623214,
+    "defense": 1418670,
+    "health": 709530
+  },
   "hostile_name": "Veteran Federation Transport",
   "level": 40,
   "rarity": "common",
@@ -91,10 +96,5 @@
       "quantity": 1,
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 623214,
-    "defense": 1418670,
-    "health": 709530
-  }
+  ]
 }

--- a/hostiles/veteran_klingon_patrol_40_explorer.json
+++ b/hostiles/veteran_klingon_patrol_40_explorer.json
@@ -1,6 +1,11 @@
 {
   "description": "This ship is Klingon. Attacking it will result in a loss of reputation towards the Klingons and a gain of reputation towards the Federation and Romulan factions.",
   "group": "klingon",
+  "head_stats": {
+    "attack": 956529,
+    "defense": 1036425,
+    "health": 377215
+  },
   "hostile_name": "Veteran Klingon Patrol",
   "level": 40,
   "rarity": "common",
@@ -140,10 +145,5 @@
       "quantity": 1,
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 956529,
-    "defense": 1036425,
-    "health": 377215
-  }
+  ]
 }

--- a/hostiles/veteran_klingon_patrol_40_explorer.json
+++ b/hostiles/veteran_klingon_patrol_40_explorer.json
@@ -1,9 +1,6 @@
 {
   "description": "This ship is Klingon. Attacking it will result in a loss of reputation towards the Klingons and a gain of reputation towards the Federation and Romulan factions.",
-  "attack": 956529,
-  "defense": 1036425,
   "group": "klingon",
-  "health": 377215,
   "hostile_name": "Veteran Klingon Patrol",
   "level": 40,
   "rarity": "common",
@@ -41,7 +38,6 @@
       "shield_health": 387400
     }
   },
-  "strength": 2370169,
   "systems": [
     {
       "$ref": "systems/b_moth_39"
@@ -90,7 +86,6 @@
         1
       ],
       "quantity": 3,
-      "weapon_id": "E1",
       "weapon_stats": {
         "accuracy": 205855,
         "armor_pierce": 40027,
@@ -122,7 +117,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E2",
       "weapon_type": "energy"
     },
     {
@@ -144,8 +138,12 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E3",
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 956529,
+    "defense": 1036425,
+    "health": 377215
+  }
 }

--- a/hostiles/veteran_klingon_patrol_40_interceptor.json
+++ b/hostiles/veteran_klingon_patrol_40_interceptor.json
@@ -1,6 +1,11 @@
 {
   "description": "This ship is Klingon. Attacking it will result in a loss of reputation towards the Klingons and a gain of reputation towards the Federation and Romulan factions.",
   "group": "klingon",
+  "head_stats": {
+    "attack": 1133793,
+    "defense": 1122200,
+    "health": 326240
+  },
   "hostile_name": "Veteran Klingon Patrol",
   "level": 40,
   "rarity": "common",
@@ -141,10 +146,5 @@
       "quantity": 1,
       "weapon_type": "kinetic"
     }
-  ],
-  "head_stats": {
-    "attack": 1133793,
-    "defense": 1122200,
-    "health": 326240
-  }
+  ]
 }

--- a/hostiles/veteran_klingon_patrol_40_interceptor.json
+++ b/hostiles/veteran_klingon_patrol_40_interceptor.json
@@ -1,9 +1,6 @@
 {
   "description": "This ship is Klingon. Attacking it will result in a loss of reputation towards the Klingons and a gain of reputation towards the Federation and Romulan factions.",
-  "attack": 1133793,
-  "defense": 1122200,
   "group": "klingon",
-  "health": 326240,
   "hostile_name": "Veteran Klingon Patrol",
   "level": 40,
   "rarity": "common",
@@ -41,7 +38,6 @@
       "shield_health": 326200
     }
   },
-  "strength": 2582233,
   "systems": [
     {
       "$ref": "systems/balduk_39"
@@ -81,7 +77,6 @@
         1
       ],
       "quantity": 2,
-      "weapon_id": "K1",
       "weapon_stats": {
         "accuracy": 34309,
         "armor_pierce": 240165,
@@ -113,7 +108,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_stats": {
         "accuracy": 34309,
         "armor_pierce": 240165,
@@ -145,8 +139,12 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "K2",
       "weapon_type": "kinetic"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 1133793,
+    "defense": 1122200,
+    "health": 326240
+  }
 }

--- a/hostiles/veteran_klingon_transport_38_survey.json
+++ b/hostiles/veteran_klingon_transport_38_survey.json
@@ -1,9 +1,6 @@
 {
   "description": "The H-Class freighter is a long-distance heavy hauler capable of transporting vast quantities of materials and goods.",
-  "attack": 451638,
-  "defense": 1024995,
   "group": "klingon",
-  "health": 510190,
   "hostile_name": "Veteran Klingon Transport",
   "level": 38,
   "rarity": "common",
@@ -41,7 +38,6 @@
       "shield_health": 510000
     }
   },
-  "strength": 1986823,
   "systems": [
     {
       "$ref": "systems/wlb_puq_38"
@@ -96,8 +92,12 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 451638,
+    "defense": 1024995,
+    "health": 510190
+  }
 }

--- a/hostiles/veteran_klingon_transport_38_survey.json
+++ b/hostiles/veteran_klingon_transport_38_survey.json
@@ -1,6 +1,11 @@
 {
   "description": "The H-Class freighter is a long-distance heavy hauler capable of transporting vast quantities of materials and goods.",
   "group": "klingon",
+  "head_stats": {
+    "attack": 451638,
+    "defense": 1024995,
+    "health": 510190
+  },
   "hostile_name": "Veteran Klingon Transport",
   "level": 38,
   "rarity": "common",
@@ -94,10 +99,5 @@
       "quantity": 1,
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 451638,
-    "defense": 1024995,
-    "health": 510190
-  }
+  ]
 }

--- a/hostiles/veteran_romulan_patrol_40_explorer.json
+++ b/hostiles/veteran_romulan_patrol_40_explorer.json
@@ -1,9 +1,6 @@
 {
   "description": "This ship is Romulan. Attacking it will result in a loss of reputation towards the Romulans and a gain of reputation towards the Federation and Klingon factions.",
-  "attack": 1133794,
-  "defense": 1161660,
   "group": "romulan",
-  "health": 440565,
   "hostile_name": "Veteran Romulan Patrol",
   "level": 40,
   "rarity": "common",
@@ -41,7 +38,6 @@
       "shield_health": 383000
     }
   },
-  "strength": 2736019,
   "systems": [
     {
       "$ref": "systems/alatum_39"
@@ -84,7 +80,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E1",
       "weapon_type": "energy"
     },
     {
@@ -103,7 +98,6 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E2",
       "weapon_type": "energy"
     },
     {
@@ -122,8 +116,12 @@
         1
       ],
       "quantity": 1,
-      "weapon_id": "E3",
       "weapon_type": "energy"
     }
-  ]
+  ],
+  "head_stats": {
+    "attack": 1133794,
+    "defense": 1161660,
+    "health": 440565
+  }
 }

--- a/hostiles/veteran_romulan_patrol_40_explorer.json
+++ b/hostiles/veteran_romulan_patrol_40_explorer.json
@@ -1,6 +1,11 @@
 {
   "description": "This ship is Romulan. Attacking it will result in a loss of reputation towards the Romulans and a gain of reputation towards the Federation and Klingon factions.",
   "group": "romulan",
+  "head_stats": {
+    "attack": 1133794,
+    "defense": 1161660,
+    "health": 440565
+  },
   "hostile_name": "Veteran Romulan Patrol",
   "level": 40,
   "rarity": "common",
@@ -118,10 +123,5 @@
       "quantity": 1,
       "weapon_type": "energy"
     }
-  ],
-  "head_stats": {
-    "attack": 1133794,
-    "defense": 1161660,
-    "health": 440565
-  }
+  ]
 }

--- a/schemas/armadas.json
+++ b/schemas/armadas.json
@@ -11,6 +11,7 @@
     "description",
     "systems",
     "rewards",
+    "head_stats",
     "stats",
     "weapons"
   ],

--- a/schemas/hostiles.json
+++ b/schemas/hostiles.json
@@ -11,6 +11,7 @@
     "description",
     "systems",
     "rewards",
+    "head_stats",
     "stats",
     "utility",
     "weapons"
@@ -22,6 +23,11 @@
     {
       "description": "This hostile patrols...",
       "group": "borg",
+      "head_stats": {
+        "attack": 30000,
+        "defense": 10000,
+        "health": 40000
+      },
       "hostile_name": "Borg Tactical Probe",
       "level": 30,
       "rarity": "common",
@@ -81,7 +87,6 @@
             1
           ],
           "quantity": 2,
-          "weapon_id": "E1",
           "weapon_stats": {
             "accuracy": 71402,
             "armor_pierce": 82997,
@@ -117,6 +122,51 @@
       "examples": [
         "borg"
       ]
+    },
+    "head_stats": {
+      "$id": "#/properties/head_stats",
+      "title": "The head stats schema",
+      "description": "All hostile main stats.",
+      "required": [
+        "attack",
+        "defense",
+        "health"
+      ],
+      "type": "object",
+      "additionalProperties": true,
+      "default": {},
+      "properties": {
+        "attack": {
+          "$id": "#/properties/head_stats/attack",
+          "title": "The main attack schema",
+          "description": "The total main attack stats.",
+          "type": "integer",
+          "default": 0,
+          "examples": [
+            30000
+          ]
+        },
+        "defense": {
+          "$id": "#/properties/head_stats/defense",
+          "title": "The main defense schema",
+          "description": "The total main defense stats.",
+          "type": "integer",
+          "default": 0,
+          "examples": [
+            10000
+          ]
+        },
+        "health": {
+          "$id": "#/properties/head_stats/health",
+          "title": "The main health schema",
+          "description": "The total main health stats.",
+          "type": "integer",
+          "default": 0,
+          "examples": [
+            40000
+          ]
+        }
+      }
     },
     "hostile_name": {
       "$id": "#/properties/hostile_name",
@@ -476,7 +526,6 @@
             "title": "The first anyOf schema",
             "description": "Single hostile weapon instance.",
             "required": [
-              "weapon_id",
               "weapon_type",
               "quantity",
               "firing_pattern"
@@ -516,16 +565,6 @@
                 "default": 0,
                 "examples": [
                   2
-                ]
-              },
-              "weapon_id": {
-                "$id": "#/properties/weapons/items/anyOf/0/properties/weapon_id",
-                "title": "The weapon_id schema",
-                "description": "Id of the weapon, for displaying purposes.",
-                "type": "string",
-                "default": "",
-                "examples": [
-                  "E1"
                 ]
               },
               "weapon_stats": {


### PR DESCRIPTION
Following the changes in armadas:
- Removed redundant `weapon_id` key
- Grouped main stats into `head_stats`