### PR TITLE
Add missing generator building levels

### DIFF
--- a/buildings/dilithium_generator_b.json
+++ b/buildings/dilithium_generator_b.json
@@ -48,6 +48,369 @@
     },
     {
       "bonuses": {
+        "bonus1": 2,
+        "bonus2": 4
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 500
+          },
+          {
+            "type": "tritanium",
+            "value": 350
+          }
+        ]
+      },
+      "build_time": 120,
+      "increased_power": 10,
+      "level": 2,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 2
+        },
+        {
+          "name": "Dilithium Generator A",
+          "level": 2
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 6,
+        "bonus2": 6
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 600
+          },
+          {
+            "type": "tritanium",
+            "value": 400
+          }
+        ]
+      },
+      "build_time": 210,
+      "increased_power": 12,
+      "level": 3,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 3
+        },
+        {
+          "name": "Dilithium Generator A",
+          "level": 3
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 13,
+        "bonus2": 8
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 700
+          },
+          {
+            "type": "tritanium",
+            "value": 450
+          }
+        ]
+      },
+      "build_time": 300,
+      "increased_power": 13,
+      "level": 4,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 4
+        },
+        {
+          "name": "Dilithium Generator A",
+          "level": 4
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 24,
+        "bonus2": 12
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 800
+          },
+          {
+            "type": "tritanium",
+            "value": 500
+          }
+        ]
+      },
+      "build_time": 540,
+      "increased_power": 15,
+      "level": 5,
+      "requirements": [
+        {
+          "name": "Dilithium Generator A",
+          "level": 5
+        },
+        {
+          "name": "Operations",
+          "level": 5
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 36,
+        "bonus2": 15
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 1000
+          },
+          {
+            "type": "tritanium",
+            "value": 550
+          }
+        ]
+      },
+      "build_time": 900,
+      "increased_power": 20,
+      "level": 6,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 6
+        },
+        {
+          "name": "Dilithium Generator A",
+          "level": 6
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 48,
+        "bonus2": 17
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 1200
+          },
+          {
+            "type": "tritanium",
+            "value": 600
+          }
+        ]
+      },
+      "build_time": 1680,
+      "increased_power": 20,
+      "level": 7,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 7
+        },
+        {
+          "name": "Dilithium Generator A",
+          "level": 7
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 64,
+        "bonus2": 20
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 1400
+          },
+          {
+            "type": "tritanium",
+            "value": 650
+          }
+        ]
+      },
+      "build_time": 2400,
+      "increased_power": 30,
+      "level": 8,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 8
+        },
+        {
+          "name": "Dilithium Generator A",
+          "level": 8
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 79,
+        "bonus2": 22
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 1600
+          },
+          {
+            "type": "tritanium",
+            "value": 700
+          }
+        ]
+      },
+      "build_time": 3600,
+      "increased_power": 40,
+      "level": 9,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 9
+        },
+        {
+          "name": "Dilithium Generator A",
+          "level": 9
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 150,
+        "bonus2": 37
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 2000
+          },
+          {
+            "type": "tritanium",
+            "value": 1500
+          }
+        ]
+      },
+      "build_time": 3960,
+      "increased_power": 40,
+      "level": 10,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 10
+        },
+        {
+          "name": "Dilithium Generator A",
+          "level": 10
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 170,
+        "bonus2": 40
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 2720
+          },
+          {
+            "type": "tritanium",
+            "value": 2000
+          }
+        ]
+      },
+      "build_time": 4080,
+      "increased_power": 50,
+      "level": 11,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 11
+        },
+        {
+          "name": "Dilithium Generator A",
+          "level": 11
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 44,
+        "bonus2": 195
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 3740
+          },
+          {
+            "type": "tritanium",
+            "value": 2750
+          }
+        ]
+      },
+      "build_time": 7500,
+      "increased_power": 70,
+      "level": 12,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 12
+        },
+        {
+          "name": "Dilithium Generator A",
+          "level": 12
+        }
+      ]
+    },
+    {
+      "bonuses": {
         "bonus1": 230,
         "bonus2": 48
       },

--- a/buildings/dilithium_generator_d.json
+++ b/buildings/dilithium_generator_d.json
@@ -104,7 +104,7 @@
       "level": 3,
       "requirements": [
         {
-         "name": "Operations",
+          "name": "Operations",
           "level": 3
         },
         {
@@ -550,7 +550,7 @@
     },
     {
       "bonuses": {
-         "bonus1": 70,
+        "bonus1": 70,
         "bonus2": 460
       },
       "build_costs": {

--- a/buildings/dilithium_generator_d.json
+++ b/buildings/dilithium_generator_d.json
@@ -82,6 +82,39 @@
     },
     {
       "bonuses": {
+        "bonus1": 6,
+        "bonus2": 6
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 600
+          },
+          {
+            "type": "tritanium",
+            "value": 400
+          }
+        ]
+      },
+      "build_time": 210,
+      "increased_power": 12,
+      "level": 3,
+      "requirements": [
+        {
+          "name": "Dilithium Generator B",
+          "level": 3
+        },
+        {
+          "name": "Operations",
+          "level": 3
+        }
+      ]
+    },
+    {
+      "bonuses": {
         "bonus1": 13,
         "bonus2": 8
       },
@@ -113,6 +146,72 @@
         }
       ],
       "rewards": []
+    },
+    {
+      "bonuses": {
+        "bonus1": 12,
+        "bonus2": 24
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 800
+          },
+          {
+            "type": "tritanium",
+            "value": 500
+          }
+        ]
+      },
+      "build_time": 540,
+      "increased_power": 15,
+      "level": 5,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 5
+        },
+        {
+          "name": "Dilithium Generator B",
+          "level": 5
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 36,
+        "bonus2": 15
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 1000
+          },
+          {
+            "type": "tritanium",
+            "value": 550
+          }
+        ]
+      },
+      "build_time": 900,
+      "increased_power": 20,
+      "level": 6,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 6
+        },
+        {
+          "name": "Dilithium Generator B",
+          "level": 6
+        }
+      ]
     },
     {
       "bonuses": {
@@ -252,6 +351,105 @@
     },
     {
       "bonuses": {
+        "bonus1": 40,
+        "bonus2": 170
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 2720
+          },
+          {
+            "type": "tritanium",
+            "value": 2000
+          }
+        ]
+      },
+      "build_time": 4080,
+      "increased_power": 50,
+      "level": 11,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 11
+        },
+        {
+          "name": "Dilithium Generator B",
+          "level": 11
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 195,
+        "bonus2": 44
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 3740
+          },
+          {
+            "type": "tritanium",
+            "value": 2750
+          }
+        ]
+      },
+      "build_time": 7500,
+      "increased_power": 70,
+      "level": 12,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 12
+        },
+        {
+          "name": "Dilithium Generator B",
+          "level": 12
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 230,
+        "bonus2": 48
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 5440
+          },
+          {
+            "type": "tritanium",
+            "value": 4000
+          }
+        ]
+      },
+      "build_time": 11100,
+      "increased_power": 70,
+      "level": 13,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 13
+        },
+        {
+          "name": "Dilithium Generator B",
+          "level": 13
+        }
+      ]
+    },
+    {
+      "bonuses": {
         "bonus1": 280,
         "bonus2": 52
       },
@@ -283,6 +481,72 @@
         }
       ],
       "rewards": []
+    },
+    {
+      "bonuses": {
+        "bonus1": 355,
+        "bonus2": 61
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 10200
+          },
+          {
+            "type": "tritanium",
+            "value": 7500
+          }
+        ]
+      },
+      "build_time": 19800,
+      "increased_power": 85,
+      "level": 15,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 15
+        },
+        {
+          "name": "Dilithium Generator B",
+          "level": 15
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 66,
+        "bonus2": 410
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 13600
+          },
+          {
+            "type": "tritanium",
+            "value": 10000
+          }
+        ]
+      },
+      "build_time": 23040,
+      "increased_power": 125,
+      "level": 16,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 16
+        },
+        {
+          "name": "Dilithium Generator B",
+          "level": 16
+        }
+      ]
     },
     {
       "bonuses": {
@@ -320,6 +584,72 @@
     },
     {
       "bonuses": {
+        "bonus1": 530,
+        "bonus2": 74
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 27200
+          },
+          {
+            "type": "tritanium",
+            "value": 20000
+          }
+        ]
+      },
+      "build_time": 38160,
+      "increased_power": 150,
+      "level": 18,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 18
+        },
+        {
+          "name": "Dilithium Generator B",
+          "level": 18
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 590,
+        "bonus2": 78
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 40800
+          },
+          {
+            "type": "tritanium",
+            "value": 30000
+          }
+        ]
+      },
+      "build_time": 55440,
+      "increased_power": 175,
+      "level": 19,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 19
+        },
+        {
+          "name": "Dilithium Generator B",
+          "level": 19
+        }
+      ]
+    },
+    {
+      "bonuses": {
         "bonus1": 780,
         "bonus2": 98
       },
@@ -351,6 +681,39 @@
         }
       ],
       "rewards": []
+    },
+    {
+      "bonuses": {
+        "bonus1": 860,
+        "bonus2": 105
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 97308
+          },
+          {
+            "type": "tritanium",
+            "value": 71550
+          }
+        ]
+      },
+      "build_time": 76320,
+      "increased_power": 250,
+      "level": 21,
+      "requirements": [
+        {
+          "name": "Dilithium Generator B",
+          "level": 21
+        },
+        {
+          "name": "Operations",
+          "level": 21
+        }
+      ]
     },
     {
       "bonuses": {
@@ -453,6 +816,72 @@
         }
       ],
       "rewards": []
+    },
+    {
+      "bonuses": {
+        "bonus1": 1250,
+        "bonus2": 145
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 636480
+          },
+          {
+            "type": "tritanium",
+            "value": 468000
+          }
+        ]
+      },
+      "build_time": 158400,
+      "increased_power": 400,
+      "level": 25,
+      "requirements": [
+        {
+          "name": "Dilithium Generator B",
+          "level": 25
+        },
+        {
+          "name": "Operations",
+          "level": 25
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 1290,
+        "bonus2": 150
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 994500
+          },
+          {
+            "type": "tritanium",
+            "value": 731250
+          }
+        ]
+      },
+      "build_time": 216000,
+      "increased_power": 300,
+      "level": 26,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 26
+        },
+        {
+          "name": "Dilithium Generator B",
+          "level": 26
+        }
+      ]
     },
     {
       "bonuses": {

--- a/buildings/dilithium_generator_e.json
+++ b/buildings/dilithium_generator_e.json
@@ -48,6 +48,1260 @@
     },
     {
       "bonuses": {
+        "bonus1": 2,
+        "bonus2": 4
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 500
+          },
+          {
+            "type": "tritanium",
+            "value": 350
+          }
+        ]
+      },
+      "build_time": 120,
+      "increased_power": 10,
+      "level": 2,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 2
+        },
+        {
+          "name": "Dilithium Generator C",
+          "level": 2
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 6,
+        "bonus2": 6
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 600
+          },
+          {
+            "type": "tritanium",
+            "value": 400
+          }
+        ]
+      },
+      "build_time": 210,
+      "increased_power": 12,
+      "level": 3,
+      "requirements": [
+        {
+          "name": "Dilithium Generator C",
+          "level": 3
+        },
+        {
+          "name": "Operations",
+          "level": 3
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 8,
+        "bonus2": 13
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 700
+          },
+          {
+            "type": "tritanium",
+            "value": 450
+          }
+        ]
+      },
+      "build_time": 300,
+      "increased_power": 13,
+      "level": 4,
+      "requirements": [
+        {
+          "name": "Dilithium Generator C",
+          "level": 4
+        },
+        {
+          "name": "Operations",
+          "level": 4
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 24,
+        "bonus2": 12
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 800
+          },
+          {
+            "type": "tritanium",
+            "value": 500
+          }
+        ]
+      },
+      "build_time": 540,
+      "increased_power": 15,
+      "level": 5,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 5
+        },
+        {
+          "name": "Dilithium Generator C",
+          "level": 5
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 36,
+        "bonus2": 15
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 1000
+          },
+          {
+            "type": "tritanium",
+            "value": 550
+          }
+        ]
+      },
+      "build_time": 900,
+      "increased_power": 20,
+      "level": 6,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 6
+        },
+        {
+          "name": "Dilithium Generator C",
+          "level": 6
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 48,
+        "bonus2": 17
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 1200
+          },
+          {
+            "type": "tritanium",
+            "value": 600
+          }
+        ]
+      },
+      "build_time": 1680,
+      "increased_power": 20,
+      "level": 7,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 7
+        },
+        {
+          "name": "Dilithium Generator C",
+          "level": 7
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 64,
+        "bonus2": 20
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 1400
+          },
+          {
+            "type": "tritanium",
+            "value": 650
+          }
+        ]
+      },
+      "build_time": 2400,
+      "increased_power": 30,
+      "level": 8,
+      "requirements": [
+        {
+          "name": "Dilithium Generator C",
+          "level": 8
+        },
+        {
+          "name": "Operations",
+          "level": 8
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 79,
+        "bonus2": 22
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 1600
+          },
+          {
+            "type": "tritanium",
+            "value": 700
+          }
+        ]
+      },
+      "build_time": 3600,
+      "increased_power": 40,
+      "level": 9,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 9
+        },
+        {
+          "name": "Dilithium Generator C",
+          "level": 9
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 150,
+        "bonus2": 37
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 2000
+          },
+          {
+            "type": "tritanium",
+            "value": 1500
+          }
+        ]
+      },
+      "build_time": 3960,
+      "increased_power": 40,
+      "level": 10,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 10
+        },
+        {
+          "name": "Dilithium Generator C",
+          "level": 10
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 170,
+        "bonus2": 40
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 2720
+          },
+          {
+            "type": "tritanium",
+            "value": 2000
+          }
+        ]
+      },
+      "build_time": 4080,
+      "increased_power": 50,
+      "level": 11,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 11
+        },
+        {
+          "name": "Dilithium Generator C",
+          "level": 11
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 44,
+        "bonus2": 195
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 3740
+          },
+          {
+            "type": "tritanium",
+            "value": 2750
+          }
+        ]
+      },
+      "build_time": 7500,
+      "increased_power": 70,
+      "level": 12,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 12
+        },
+        {
+          "name": "Dilithium Generator C",
+          "level": 12
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 230,
+        "bonus2": 48
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 5440
+          },
+          {
+            "type": "tritanium",
+            "value": 4000
+          }
+        ]
+      },
+      "build_time": 11100,
+      "increased_power": 70,
+      "level": 13,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 13
+        },
+        {
+          "name": "Dilithium Generator C",
+          "level": 13
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 280,
+        "bonus2": 52
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 7480
+          },
+          {
+            "type": "tritanium",
+            "value": 5500
+          }
+        ]
+      },
+      "build_time": 15300,
+      "increased_power": 90,
+      "level": 14,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 14
+        },
+        {
+          "name": "Dilithium Generator C",
+          "level": 14
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 355,
+        "bonus2": 61
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 10200
+          },
+          {
+            "type": "tritanium",
+            "value": 7500
+          }
+        ]
+      },
+      "build_time": 19800,
+      "increased_power": 85,
+      "level": 15,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 15
+        },
+        {
+          "name": "Dilithium Generator C",
+          "level": 15
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 410,
+        "bonus2": 66
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 13600
+          },
+          {
+            "type": "tritanium",
+            "value": 10000
+          }
+        ]
+      },
+      "build_time": 23040,
+      "increased_power": 125,
+      "level": 16,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 16
+        },
+        {
+          "name": "Dilithium Generator C",
+          "level": 16
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 460,
+        "bonus2": 70
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 19040
+          },
+          {
+            "type": "tritanium",
+            "value": 14000
+          }
+        ]
+      },
+      "build_time": 25200,
+      "increased_power": 125,
+      "level": 17,
+      "requirements": [
+        {
+          "name": "Dilithium Generator C",
+          "level": 17
+        },
+        {
+          "name": "Operations",
+          "level": 17
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 530,
+        "bonus2": 74
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 27200
+          },
+          {
+            "type": "tritanium",
+            "value": 20000
+          }
+        ]
+      },
+      "build_time": 38160,
+      "increased_power": 150,
+      "level": 18,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 18
+        },
+        {
+          "name": "Dilithium Generator C",
+          "level": 18
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 590,
+        "bonus2": 78
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 40800
+          },
+          {
+            "type": "tritanium",
+            "value": 30000
+          }
+        ]
+      },
+      "build_time": 55440,
+      "increased_power": 175,
+      "level": 19,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 19
+        },
+        {
+          "name": "Dilithium Generator C",
+          "level": 19
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 780,
+        "bonus2": 98
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 57800
+          },
+          {
+            "type": "tritanium",
+            "value": 42500
+          }
+        ]
+      },
+      "build_time": 83520,
+      "increased_power": 200,
+      "level": 20,
+      "requirements": [
+        {
+          "name": "Dilithium Generator C",
+          "level": 20
+        },
+        {
+          "name": "Operations",
+          "level": 20
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 860,
+        "bonus2": 105
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 97308
+          },
+          {
+            "type": "tritanium",
+            "value": 71550
+          }
+        ]
+      },
+      "build_time": 76320,
+      "increased_power": 250,
+      "level": 21,
+      "requirements": [
+        {
+          "name": "Dilithium Generator C",
+          "level": 21
+        },
+        {
+          "name": "Operations",
+          "level": 21
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 900,
+        "bonus2": 110
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 151368
+          },
+          {
+            "type": "tritanium",
+            "value": 111300
+          }
+        ]
+      },
+      "build_time": 118800,
+      "increased_power": 200,
+      "level": 22,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 22
+        },
+        {
+          "name": "Dilithium Generator C",
+          "level": 22
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 970,
+        "bonus2": 115
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 249084
+          },
+          {
+            "type": "tritanium",
+            "value": 183150
+          }
+        ]
+      },
+      "build_time": 139680,
+      "increased_power": 300,
+      "level": 23,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 23
+        },
+        {
+          "name": "Dilithium Generator C",
+          "level": 23
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 1010,
+        "bonus2": 120
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 392496
+          },
+          {
+            "type": "tritanium",
+            "value": 288600
+          }
+        ]
+      },
+      "build_time": 171360,
+      "increased_power": 200,
+      "level": 24,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 24
+        },
+        {
+          "name": "Dilithium Generator C",
+          "level": 24
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 1250,
+        "bonus2": 145
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 636480
+          },
+          {
+            "type": "tritanium",
+            "value": 468000
+          }
+        ]
+      },
+      "build_time": 158400,
+      "increased_power": 400,
+      "level": 25,
+      "requirements": [
+        {
+          "name": "Dilithium Generator C",
+          "level": 25
+        },
+        {
+          "name": "Operations",
+          "level": 25
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 1290,
+        "bonus2": 150
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 994500
+          },
+          {
+            "type": "tritanium",
+            "value": 731250
+          }
+        ]
+      },
+      "build_time": 216000,
+      "increased_power": 300,
+      "level": 26,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 26
+        },
+        {
+          "name": "Dilithium Generator C",
+          "level": 26
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 1360,
+        "bonus2": 155
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 1517760
+          },
+          {
+            "type": "tritanium",
+            "value": 1116000
+          }
+        ]
+      },
+      "build_time": 244800,
+      "increased_power": 400,
+      "level": 27,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 27
+        },
+        {
+          "name": "Dilithium Generator C",
+          "level": 27
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 160,
+        "bonus2": 1400
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 2276640
+          },
+          {
+            "type": "tritanium",
+            "value": 1674000
+          }
+        ]
+      },
+      "build_time": 285120,
+      "increased_power": 400,
+      "level": 28,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 28
+        },
+        {
+          "name": "Dilithium Generator C",
+          "level": 28
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 165,
+        "bonus2": 1475
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 3624400
+          },
+          {
+            "type": "tritanium",
+            "value": 2665000
+          }
+        ]
+      },
+      "build_time": 313920,
+      "increased_power": 500,
+      "level": 29,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 29
+        },
+        {
+          "name": "Dilithium Generator C",
+          "level": 29
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 195,
+        "bonus2": 1750
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 5304000
+          },
+          {
+            "type": "tritanium",
+            "value": 3900000
+          }
+        ]
+      },
+      "build_time": 339840,
+      "increased_power": 400,
+      "level": 30,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 30
+        },
+        {
+          "name": "Dilithium Generator C",
+          "level": 30
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 205,
+        "bonus2": 1850
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 8384400
+          },
+          {
+            "type": "tritanium",
+            "value": 6165000
+          }
+        ]
+      },
+      "build_time": 446400,
+      "increased_power": 550,
+      "level": 31,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 31
+        },
+        {
+          "name": "Dilithium Generator C",
+          "level": 31
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 210,
+        "bonus2": 2052
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 12110800
+          },
+          {
+            "type": "tritanium",
+            "value": 8905000
+          }
+        ]
+      },
+      "build_time": 436320,
+      "increased_power": 500,
+      "level": 32,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 32
+        },
+        {
+          "name": "Dilithium Generator C",
+          "level": 32
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 215,
+        "bonus2": 2233
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 18734000
+          },
+          {
+            "type": "tritanium",
+            "value": 13775000
+          }
+        ]
+      },
+      "build_time": 633600,
+      "increased_power": 750,
+      "level": 33,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 33
+        },
+        {
+          "name": "Dilithium Generator C",
+          "level": 33
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 225,
+        "bonus2": 2349
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 29580000
+          },
+          {
+            "type": "tritanium",
+            "value": 21750000
+          }
+        ]
+      },
+      "build_time": 839520,
+      "increased_power": 500,
+      "level": 34,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 34
+        },
+        {
+          "name": "Dilithium Generator C",
+          "level": 34
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 260,
+        "bonus2": 2914
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 45777600
+          },
+          {
+            "type": "tritanium",
+            "value": 33660000
+          }
+        ]
+      },
+      "build_time": 1107360,
+      "increased_power": 750,
+      "level": 35,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 35
+        },
+        {
+          "name": "Dilithium Generator C",
+          "level": 35
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 3159,
+        "bonus2": 265
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 64504800
+          },
+          {
+            "type": "tritanium",
+            "value": 47430000
+          }
+        ]
+      },
+      "build_time": 1414080,
+      "increased_power": 750,
+      "level": 36,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 36
+        },
+        {
+          "name": "Dilithium Generator C",
+          "level": 36
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 3292,
+        "bonus2": 275
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 99144000
+          },
+          {
+            "type": "tritanium",
+            "value": 72900000
+          }
+        ]
+      },
+      "build_time": 1461600,
+      "increased_power": 750,
+      "level": 37,
+      "requirements": [
+        {
+          "name": "Dilithium Generator C",
+          "level": 37
+        },
+        {
+          "name": "Operations",
+          "level": 37
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 3586,
+        "bonus2": 280
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 154224000
+          },
+          {
+            "type": "tritanium",
+            "value": 113400000
+          }
+        ]
+      },
+      "build_time": 2370240,
+      "increased_power": 1000,
+      "level": 38,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 38
+        },
+        {
+          "name": "Dilithium Generator C",
+          "level": 38
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 3978,
+        "bonus2": 290
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 263160000
+          },
+          {
+            "type": "tritanium",
+            "value": 193500000
+          }
+        ]
+      },
+      "build_time": 3146400,
+      "increased_power": 750,
+      "level": 39,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 39
+        },
+        {
+          "name": "Dilithium Generator C",
+          "level": 39
+        }
+      ]
+    },
+    {
+      "bonuses": {
         "bonus1": 5011,
         "bonus2": 365
       },

--- a/buildings/parsteel_generator_d.json
+++ b/buildings/parsteel_generator_d.json
@@ -354,6 +354,72 @@
     },
     {
       "bonuses": {
+        "bonus1": 1320,
+        "bonus2": 11900
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 100
+          },
+          {
+            "type": "dilithium",
+            "value": 20
+          }
+        ]
+      },
+      "build_time": 1020,
+      "increased_power": 50,
+      "level": 11,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 11
+        },
+        {
+          "name": "Parsteel Generator B",
+          "level": 11
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 15200,
+        "bonus2": 1450
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 138
+          },
+          {
+            "type": "dilithium",
+            "value": 55
+          }
+        ]
+      },
+      "build_time": 1800,
+      "increased_power": 70,
+      "level": 12,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 12
+        },
+        {
+          "name": "Parsteel Generator B",
+          "level": 12
+        }
+      ]
+    },
+    {
+      "bonuses": {
         "bonus1": 1550,
         "bonus2": 17800
       },
@@ -385,6 +451,171 @@
         }
       ],
       "rewards": []
+    },
+    {
+      "bonuses": {
+        "bonus1": 1675,
+        "bonus2": 21750
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 275
+          },
+          {
+            "type": "dilithium",
+            "value": 220
+          }
+        ]
+      },
+      "build_time": 3840,
+      "increased_power": 90,
+      "level": 14,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 14
+        },
+        {
+          "name": "Parsteel Generator B",
+          "level": 14
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 25250,
+        "bonus2": 1800
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 375
+          },
+          {
+            "type": "dilithium",
+            "value": 375
+          }
+        ]
+      },
+      "build_time": 4920,
+      "increased_power": 85,
+      "level": 15,
+      "requirements": [
+        {
+          "name": "Parsteel Generator B",
+          "level": 15
+        },
+        {
+          "name": "Operations",
+          "level": 15
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 1925,
+        "bonus2": 29000
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 500
+          },
+          {
+            "type": "dilithium",
+            "value": 500
+          }
+        ]
+      },
+      "build_time": 5700,
+      "increased_power": 125,
+      "level": 16,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 16
+        },
+        {
+          "name": "Parsteel Generator B",
+          "level": 16
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 2050,
+        "bonus2": 33750
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 700
+          },
+          {
+            "type": "dilithium",
+            "value": 700
+          }
+        ]
+      },
+      "build_time": 6300,
+      "increased_power": 125,
+      "level": 17,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 17
+        },
+        {
+          "name": "Parsteel Generator B",
+          "level": 17
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 2175,
+        "bonus2": 38000
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 1000
+          },
+          {
+            "type": "dilithium",
+            "value": 1000
+          }
+        ]
+      },
+      "build_time": 9600,
+      "increased_power": 150,
+      "level": 18,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 18
+        },
+        {
+          "name": "Parsteel Generator B",
+          "level": 18
+        }
+      ]
     },
     {
       "bonuses": {
@@ -453,6 +684,39 @@
         }
       ],
       "rewards": []
+    },
+    {
+      "bonuses": {
+        "bonus1": 59000,
+        "bonus2": 2950
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 3578
+          },
+          {
+            "type": "dilithium",
+            "value": 3578
+          }
+        ]
+      },
+      "build_time": 18900,
+      "increased_power": 250,
+      "level": 21,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 21
+        },
+        {
+          "name": "Parsteel Generator B",
+          "level": 21
+        }
+      ]
     },
     {
       "bonuses": {

--- a/buildings/parsteel_generator_f.json
+++ b/buildings/parsteel_generator_f.json
@@ -184,6 +184,1194 @@
     },
     {
       "bonuses": {
+        "bonus1": 600,
+        "bonus2": 2700
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 350
+          },
+          {
+            "type": "tritanium",
+            "value": 200
+          }
+        ]
+      },
+      "build_time": 330,
+      "increased_power": 20,
+      "level": 6,
+      "requirements": [
+        {
+          "name": "Parsteel Generator D",
+          "level": 6
+        },
+        {
+          "name": "Operations",
+          "level": 6
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 700,
+        "bonus2": 3850
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 700
+          },
+          {
+            "type": "tritanium",
+            "value": 250
+          }
+        ]
+      },
+      "build_time": 420,
+      "increased_power": 20,
+      "level": 7,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 7
+        },
+        {
+          "name": "Parsteel Generator D",
+          "level": 7
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 800,
+        "bonus2": 5200
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 1200
+          },
+          {
+            "type": "tritanium",
+            "value": 300
+          }
+        ]
+      },
+      "build_time": 600,
+      "increased_power": 30,
+      "level": 8,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 8
+        },
+        {
+          "name": "Parsteel Generator D",
+          "level": 8
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 900,
+        "bonus2": 6300
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 2500
+          },
+          {
+            "type": "tritanium",
+            "value": 350
+          }
+        ]
+      },
+      "build_time": 900,
+      "increased_power": 40,
+      "level": 9,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 9
+        },
+        {
+          "name": "Parsteel Generator D",
+          "level": 9
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 1200,
+        "bonus2": 9600
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 2800
+          },
+          {
+            "type": "tritanium",
+            "value": 450
+          }
+        ]
+      },
+      "build_time": 960,
+      "increased_power": 40,
+      "level": 10,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 10
+        },
+        {
+          "name": "Parsteel Generator D",
+          "level": 10
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 1320,
+        "bonus2": 11900
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 100
+          },
+          {
+            "type": "dilithium",
+            "value": 20
+          }
+        ]
+      },
+      "build_time": 1020,
+      "increased_power": 50,
+      "level": 11,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 11
+        },
+        {
+          "name": "Parsteel Generator D",
+          "level": 11
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 1450,
+        "bonus2": 15200
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 138
+          },
+          {
+            "type": "dilithium",
+            "value": 55
+          }
+        ]
+      },
+      "build_time": 1800,
+      "increased_power": 70,
+      "level": 12,
+      "requirements": [
+        {
+          "name": "Parsteel Generator D",
+          "level": 12
+        },
+        {
+          "name": "Operations",
+          "level": 12
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 1550,
+        "bonus2": 17800
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 200
+          },
+          {
+            "type": "dilithium",
+            "value": 120
+          }
+        ]
+      },
+      "build_time": 2760,
+      "increased_power": 70,
+      "level": 13,
+      "requirements": [
+        {
+          "name": "Parsteel Generator D",
+          "level": 13
+        },
+        {
+          "name": "Operations",
+          "level": 13
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 1675,
+        "bonus2": 21750
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 275
+          },
+          {
+            "type": "dilithium",
+            "value": 220
+          }
+        ]
+      },
+      "build_time": 3840,
+      "increased_power": 90,
+      "level": 14,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 14
+        },
+        {
+          "name": "Parsteel Generator D",
+          "level": 14
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 1800,
+        "bonus2": 25250
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 375
+          },
+          {
+            "type": "dilithium",
+            "value": 375
+          }
+        ]
+      },
+      "build_time": 4920,
+      "increased_power": 85,
+      "level": 15,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 15
+        },
+        {
+          "name": "Parsteel Generator D",
+          "level": 15
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 1925,
+        "bonus2": 29000
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 500
+          },
+          {
+            "type": "dilithium",
+            "value": 500
+          }
+        ]
+      },
+      "build_time": 5700,
+      "increased_power": 125,
+      "level": 16,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 16
+        },
+        {
+          "name": "Parsteel Generator D",
+          "level": 16
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 33750,
+        "bonus2": 2050
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 700
+          },
+          {
+            "type": "dilithium",
+            "value": 700
+          }
+        ]
+      },
+      "build_time": 6300,
+      "increased_power": 125,
+      "level": 17,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 17
+        },
+        {
+          "name": "Parsteel Generator D",
+          "level": 17
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 2175,
+        "bonus2": 38000
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 1000
+          },
+          {
+            "type": "dilithium",
+            "value": 1000
+          }
+        ]
+      },
+      "build_time": 9600,
+      "increased_power": 150,
+      "level": 18,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 18
+        },
+        {
+          "name": "Parsteel Generator D",
+          "level": 18
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 2300,
+        "bonus2": 43750
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 1500
+          },
+          {
+            "type": "dilithium",
+            "value": 1500
+          }
+        ]
+      },
+      "build_time": 13800,
+      "increased_power": 175,
+      "level": 19,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 19
+        },
+        {
+          "name": "Parsteel Generator D",
+          "level": 19
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 2825,
+        "bonus2": 56500
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 2125
+          },
+          {
+            "type": "dilithium",
+            "value": 2125
+          }
+        ]
+      },
+      "build_time": 20880,
+      "increased_power": 200,
+      "level": 20,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 20
+        },
+        {
+          "name": "Parsteel Generator D",
+          "level": 20
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 2950,
+        "bonus2": 59000
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 3578
+          },
+          {
+            "type": "dilithium",
+            "value": 3578
+          }
+        ]
+      },
+      "build_time": 18900,
+      "increased_power": 250,
+      "level": 21,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 21
+        },
+        {
+          "name": "Parsteel Generator D",
+          "level": 21
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 3100,
+        "bonus2": 62000
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 5565
+          },
+          {
+            "type": "dilithium",
+            "value": 5565
+          }
+        ]
+      },
+      "build_time": 29520,
+      "increased_power": 200,
+      "level": 22,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 22
+        },
+        {
+          "name": "Parsteel Generator D",
+          "level": 22
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 3225,
+        "bonus2": 64500
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 9158
+          },
+          {
+            "type": "dilithium",
+            "value": 9158
+          }
+        ]
+      },
+      "build_time": 35280,
+      "increased_power": 300,
+      "level": 23,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 23
+        },
+        {
+          "name": "Parsteel Generator D",
+          "level": 23
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 3375,
+        "bonus2": 67500
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 14430
+          },
+          {
+            "type": "dilithium",
+            "value": 14430
+          }
+        ]
+      },
+      "build_time": 43200,
+      "increased_power": 200,
+      "level": 24,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 24
+        },
+        {
+          "name": "Parsteel Generator D",
+          "level": 24
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 4025,
+        "bonus2": 80500
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 23400
+          },
+          {
+            "type": "dilithium",
+            "value": 23400
+          }
+        ]
+      },
+      "build_time": 39600,
+      "increased_power": 400,
+      "level": 25,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 25
+        },
+        {
+          "name": "Parsteel Generator D",
+          "level": 25
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 83500,
+        "bonus2": 4175
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 36563
+          },
+          {
+            "type": "dilithium",
+            "value": 36563
+          }
+        ]
+      },
+      "build_time": 54000,
+      "increased_power": 300,
+      "level": 26,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 26
+        },
+        {
+          "name": "Parsteel Generator D",
+          "level": 26
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 4350,
+        "bonus2": 87000
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 55800
+          },
+          {
+            "type": "dilithium",
+            "value": 55800
+          }
+        ]
+      },
+      "build_time": 61200,
+      "increased_power": 400,
+      "level": 27,
+      "requirements": [
+        {
+          "name": "Parsteel Generator D",
+          "level": 27
+        },
+        {
+          "name": "Operations",
+          "level": 27
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 4500,
+        "bonus2": 90000
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 83700
+          },
+          {
+            "type": "dilithium",
+            "value": 83700
+          }
+        ]
+      },
+      "build_time": 71280,
+      "increased_power": 400,
+      "level": 28,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 28
+        },
+        {
+          "name": "Parsteel Generator D",
+          "level": 28
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 4675,
+        "bonus2": 93500
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 133250
+          },
+          {
+            "type": "dilithium",
+            "value": 133250
+          }
+        ]
+      },
+      "build_time": 78480,
+      "increased_power": 500,
+      "level": 29,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 29
+        },
+        {
+          "name": "Parsteel Generator D",
+          "level": 29
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 108000,
+        "bonus2": 5400
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 195000
+          },
+          {
+            "type": "dilithium",
+            "value": 195000
+          }
+        ]
+      },
+      "build_time": 84960,
+      "increased_power": 400,
+      "level": 30,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 30
+        },
+        {
+          "name": "Parsteel Generator D",
+          "level": 30
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 5600,
+        "bonus2": 112000
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 308250
+          },
+          {
+            "type": "dilithium",
+            "value": 308250
+          }
+        ]
+      },
+      "build_time": 111600,
+      "increased_power": 550,
+      "level": 31,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 31
+        },
+        {
+          "name": "Parsteel Generator D",
+          "level": 31
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 5800,
+        "bonus2": 125280
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 445250
+          },
+          {
+            "type": "dilithium",
+            "value": 445250
+          }
+        ]
+      },
+      "build_time": 109440,
+      "increased_power": 500,
+      "level": 32,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 32
+        },
+        {
+          "name": "Parsteel Generator D",
+          "level": 32
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 6000,
+        "bonus2": 139200
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 688750
+          },
+          {
+            "type": "dilithium",
+            "value": 688750
+          }
+        ]
+      },
+      "build_time": 158400,
+      "increased_power": 750,
+      "level": 33,
+      "requirements": [
+        {
+          "name": "Parsteel Generator D",
+          "level": 33
+        },
+        {
+          "name": "Operations",
+          "level": 33
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 143840,
+        "bonus2": 6200
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 1087500
+          },
+          {
+            "type": "dilithium",
+            "value": 1087500
+          }
+        ]
+      },
+      "build_time": 210240,
+      "increased_power": 500,
+      "level": 34,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 34
+        },
+        {
+          "name": "Parsteel Generator D",
+          "level": 34
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 7000,
+        "bonus2": 173600
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 1683000
+          },
+          {
+            "type": "dilithium",
+            "value": 1683000
+          }
+        ]
+      },
+      "build_time": 276480,
+      "increased_power": 750,
+      "level": 35,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 35
+        },
+        {
+          "name": "Parsteel Generator D",
+          "level": 35
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 7300,
+        "bonus2": 194180
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 2371500
+          },
+          {
+            "type": "dilithium",
+            "value": 2371500
+          }
+        ]
+      },
+      "build_time": 354240,
+      "increased_power": 750,
+      "level": 36,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 36
+        },
+        {
+          "name": "Parsteel Generator D",
+          "level": 36
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 7500,
+        "bonus2": 199500
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 3645000
+          },
+          {
+            "type": "dilithium",
+            "value": 3645000
+          }
+        ]
+      },
+      "build_time": 365760,
+      "increased_power": 750,
+      "level": 37,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 37
+        },
+        {
+          "name": "Parsteel Generator D",
+          "level": 37
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 7700,
+        "bonus2": 218680
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 5670000
+          },
+          {
+            "type": "dilithium",
+            "value": 5670000
+          }
+        ]
+      },
+      "build_time": 593280,
+      "increased_power": 1000,
+      "level": 38,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 38
+        },
+        {
+          "name": "Parsteel Generator D",
+          "level": 38
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 7900,
+        "bonus2": 241740
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 9675000
+          },
+          {
+            "type": "dilithium",
+            "value": 9675000
+          }
+        ]
+      },
+      "build_time": 786240,
+      "increased_power": 750,
+      "level": 39,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 39
+        },
+        {
+          "name": "Parsteel Generator D",
+          "level": 39
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 8900,
+        "bonus2": 272340
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 15050000
+          },
+          {
+            "type": "dilithium",
+            "value": 15050000
+          }
+        ]
+      },
+      "build_time": 1396800,
+      "increased_power": 1000,
+      "level": 40,
+      "requirements": [
+        {
+          "name": "Parsteel Generator D",
+          "level": 40
+        },
+        {
+          "name": "Operations",
+          "level": 40
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 9100,
+        "bonus2": 300300
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 21500000
+          },
+          {
+            "type": "dilithium",
+            "value": 21500000
+          }
+        ]
+      },
+      "build_time": 1308960,
+      "increased_power": 1000,
+      "level": 41,
+      "requirements": [
+        {
+          "name": "Parsteel Generator D",
+          "level": 41
+        },
+        {
+          "name": "Operations",
+          "level": 41
+        }
+      ]
+    },
+    {
+      "bonuses": {
         "bonus1": 9300,
         "bonus2": 336660
       },

--- a/buildings/parsteel_generator_g.json
+++ b/buildings/parsteel_generator_g.json
@@ -164,6 +164,1454 @@
     },
     {
       "bonuses": {
+        "bonus1": 600,
+        "bonus2": 2700
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 350
+          }
+        ]
+      },
+      "build_time": 330,
+      "increased_power": 20,
+      "level": 6,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 6
+        },
+        {
+          "name": "Parsteel Generator E",
+          "level": 6
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 700,
+        "bonus2": 3850
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 700
+          },
+          {
+            "type": "tritanium",
+            "value": 5
+          }
+        ]
+      },
+      "build_time": 420,
+      "increased_power": 20,
+      "level": 7,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 7
+        },
+        {
+          "name": "Parsteel Generator E",
+          "level": 7
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 800,
+        "bonus2": 5200
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 1200
+          },
+          {
+            "type": "tritanium",
+            "value": 15
+          }
+        ]
+      },
+      "build_time": 600,
+      "increased_power": 30,
+      "level": 8,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 8
+        },
+        {
+          "name": "Parsteel Generator E",
+          "level": 8
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 900,
+        "bonus2": 6300
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 2500
+          },
+          {
+            "type": "tritanium",
+            "value": 38
+          }
+        ]
+      },
+      "build_time": 900,
+      "increased_power": 40,
+      "level": 9,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 9
+        },
+        {
+          "name": "Parsteel Generator E",
+          "level": 9
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 1200,
+        "bonus2": 9600
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 2800
+          },
+          {
+            "type": "tritanium",
+            "value": 75
+          }
+        ]
+      },
+      "build_time": 960,
+      "increased_power": 40,
+      "level": 10,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 10
+        },
+        {
+          "name": "Parsteel Generator E",
+          "level": 10
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 11900,
+        "bonus2": 1320
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 100
+          },
+          {
+            "type": "dilithium",
+            "value": 20
+          }
+        ]
+      },
+      "build_time": 1020,
+      "increased_power": 50,
+      "level": 11,
+      "requirements": [
+        {
+          "name": "Parsteel Generator E",
+          "level": 11
+        },
+        {
+          "name": "Operations",
+          "level": 11
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 1450,
+        "bonus2": 15200
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 138
+          },
+          {
+            "type": "dilithium",
+            "value": 55
+          }
+        ]
+      },
+      "build_time": 1800,
+      "increased_power": 70,
+      "level": 12,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 12
+        },
+        {
+          "name": "Parsteel Generator E",
+          "level": 12
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 1550,
+        "bonus2": 17800
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 200
+          },
+          {
+            "type": "dilithium",
+            "value": 120
+          }
+        ]
+      },
+      "build_time": 2760,
+      "increased_power": 70,
+      "level": 13,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 13
+        },
+        {
+          "name": "Parsteel Generator E",
+          "level": 13
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 1675,
+        "bonus2": 21750
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 275
+          },
+          {
+            "type": "dilithium",
+            "value": 220
+          }
+        ]
+      },
+      "build_time": 3840,
+      "increased_power": 90,
+      "level": 14,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 14
+        },
+        {
+          "name": "Parsteel Generator E",
+          "level": 14
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 25250,
+        "bonus2": 1800
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 375
+          },
+          {
+            "type": "dilithium",
+            "value": 375
+          }
+        ]
+      },
+      "build_time": 4920,
+      "increased_power": 85,
+      "level": 15,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 15
+        },
+        {
+          "name": "Parsteel Generator E",
+          "level": 15
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 1925,
+        "bonus2": 29000
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 500
+          },
+          {
+            "type": "dilithium",
+            "value": 500
+          }
+        ]
+      },
+      "build_time": 5700,
+      "increased_power": 125,
+      "level": 16,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 16
+        },
+        {
+          "name": "Parsteel Generator E",
+          "level": 16
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 2050,
+        "bonus2": 33750
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 700
+          },
+          {
+            "type": "dilithium",
+            "value": 700
+          }
+        ]
+      },
+      "build_time": 6300,
+      "increased_power": 125,
+      "level": 17,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 17
+        },
+        {
+          "name": "Parsteel Generator E",
+          "level": 17
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 2175,
+        "bonus2": 38000
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 1000
+          },
+          {
+            "type": "dilithium",
+            "value": 1000
+          }
+        ]
+      },
+      "build_time": 9600,
+      "increased_power": 150,
+      "level": 18,
+      "requirements": [
+        {
+          "name": "Parsteel Generator E",
+          "level": 18
+        },
+        {
+          "name": "Operations",
+          "level": 18
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 2300,
+        "bonus2": 43750
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 1500
+          },
+          {
+            "type": "dilithium",
+            "value": 1500
+          }
+        ]
+      },
+      "build_time": 13800,
+      "increased_power": 175,
+      "level": 19,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 19
+        },
+        {
+          "name": "Parsteel Generator E",
+          "level": 19
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 56500,
+        "bonus2": 2825
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 2125
+          },
+          {
+            "type": "dilithium",
+            "value": 2125
+          }
+        ]
+      },
+      "build_time": 20880,
+      "increased_power": 200,
+      "level": 20,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 20
+        },
+        {
+          "name": "Parsteel Generator E",
+          "level": 20
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 2950,
+        "bonus2": 59000
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 3578
+          },
+          {
+            "type": "dilithium",
+            "value": 3578
+          }
+        ]
+      },
+      "build_time": 18900,
+      "increased_power": 250,
+      "level": 21,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 21
+        },
+        {
+          "name": "Parsteel Generator E",
+          "level": 21
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 3100,
+        "bonus2": 62000
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 5565
+          },
+          {
+            "type": "dilithium",
+            "value": 5565
+          }
+        ]
+      },
+      "build_time": 29520,
+      "increased_power": 200,
+      "level": 22,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 22
+        },
+        {
+          "name": "Parsteel Generator E",
+          "level": 22
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 3225,
+        "bonus2": 64500
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 9158
+          },
+          {
+            "type": "dilithium",
+            "value": 9158
+          }
+        ]
+      },
+      "build_time": 35280,
+      "increased_power": 300,
+      "level": 23,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 23
+        },
+        {
+          "name": "Parsteel Generator E",
+          "level": 23
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 3375,
+        "bonus2": 67500
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 14430
+          },
+          {
+            "type": "dilithium",
+            "value": 14430
+          }
+        ]
+      },
+      "build_time": 43200,
+      "increased_power": 200,
+      "level": 24,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 24
+        },
+        {
+          "name": "Parsteel Generator E",
+          "level": 24
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 4025,
+        "bonus2": 80500
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 23400
+          },
+          {
+            "type": "dilithium",
+            "value": 23400
+          }
+        ]
+      },
+      "build_time": 39600,
+      "increased_power": 400,
+      "level": 25,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 25
+        },
+        {
+          "name": "Parsteel Generator E",
+          "level": 25
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 4175,
+        "bonus2": 83500
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 36563
+          },
+          {
+            "type": "dilithium",
+            "value": 36563
+          }
+        ]
+      },
+      "build_time": 54000,
+      "increased_power": 300,
+      "level": 26,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 26
+        },
+        {
+          "name": "Parsteel Generator E",
+          "level": 26
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 4350,
+        "bonus2": 87000
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 55800
+          },
+          {
+            "type": "dilithium",
+            "value": 55800
+          }
+        ]
+      },
+      "build_time": 61200,
+      "increased_power": 400,
+      "level": 27,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 27
+        },
+        {
+          "name": "Parsteel Generator E",
+          "level": 27
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 4500,
+        "bonus2": 90000
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 83700
+          },
+          {
+            "type": "dilithium",
+            "value": 83700
+          }
+        ]
+      },
+      "build_time": 71280,
+      "increased_power": 400,
+      "level": 28,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 28
+        },
+        {
+          "name": "Parsteel Generator E",
+          "level": 28
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 4675,
+        "bonus2": 93500
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 133250
+          },
+          {
+            "type": "dilithium",
+            "value": 133250
+          }
+        ]
+      },
+      "build_time": 78480,
+      "increased_power": 500,
+      "level": 29,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 29
+        },
+        {
+          "name": "Parsteel Generator E",
+          "level": 29
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 108000,
+        "bonus2": 5400
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 195000
+          },
+          {
+            "type": "dilithium",
+            "value": 195000
+          }
+        ]
+      },
+      "build_time": 84960,
+      "increased_power": 400,
+      "level": 30,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 30
+        },
+        {
+          "name": "Parsteel Generator E",
+          "level": 30
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 5600,
+        "bonus2": 112000
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 308250
+          },
+          {
+            "type": "dilithium",
+            "value": 308250
+          }
+        ]
+      },
+      "build_time": 111600,
+      "increased_power": 550,
+      "level": 31,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 31
+        },
+        {
+          "name": "Parsteel Generator E",
+          "level": 31
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 5800,
+        "bonus2": 125280
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 445250
+          },
+          {
+            "type": "dilithium",
+            "value": 445250
+          }
+        ]
+      },
+      "build_time": 109440,
+      "increased_power": 500,
+      "level": 32,
+      "requirements": [
+        {
+          "name": "Parsteel Generator E",
+          "level": 32
+        },
+        {
+          "name": "Operations",
+          "level": 32
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 139200,
+        "bonus2": 6000
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 688750
+          },
+          {
+            "type": "dilithium",
+            "value": 688750
+          }
+        ]
+      },
+      "build_time": 158400,
+      "increased_power": 750,
+      "level": 33,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 33
+        },
+        {
+          "name": "Parsteel Generator E",
+          "level": 33
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 6200,
+        "bonus2": 143840
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 1087500
+          },
+          {
+            "type": "dilithium",
+            "value": 1087500
+          }
+        ]
+      },
+      "build_time": 210240,
+      "increased_power": 500,
+      "level": 34,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 34
+        },
+        {
+          "name": "Parsteel Generator E",
+          "level": 34
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 7000,
+        "bonus2": 173600
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 1683000
+          },
+          {
+            "type": "dilithium",
+            "value": 1683000
+          }
+        ]
+      },
+      "build_time": 276480,
+      "increased_power": 750,
+      "level": 35,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 35
+        },
+        {
+          "name": "Parsteel Generator E",
+          "level": 35
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 7300,
+        "bonus2": 194180
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 2371500
+          },
+          {
+            "type": "dilithium",
+            "value": 2371500
+          }
+        ]
+      },
+      "build_time": 354240,
+      "increased_power": 750,
+      "level": 36,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 36
+        },
+        {
+          "name": "Parsteel Generator E",
+          "level": 36
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 7500,
+        "bonus2": 199500
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 3645000
+          },
+          {
+            "type": "dilithium",
+            "value": 3645000
+          }
+        ]
+      },
+      "build_time": 365760,
+      "increased_power": 750,
+      "level": 37,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 37
+        },
+        {
+          "name": "Parsteel Generator E",
+          "level": 37
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 7700,
+        "bonus2": 218680
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 5670000
+          },
+          {
+            "type": "dilithium",
+            "value": 5670000
+          }
+        ]
+      },
+      "build_time": 593280,
+      "increased_power": 1000,
+      "level": 38,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 38
+        },
+        {
+          "name": "Parsteel Generator E",
+          "level": 38
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 7900,
+        "bonus2": 241740
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 9675000
+          },
+          {
+            "type": "dilithium",
+            "value": 9675000
+          }
+        ]
+      },
+      "build_time": 786240,
+      "increased_power": 750,
+      "level": 39,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 39
+        },
+        {
+          "name": "Parsteel Generator E",
+          "level": 39
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 272340,
+        "bonus2": 8900
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 15050000
+          },
+          {
+            "type": "dilithium",
+            "value": 15050000
+          }
+        ]
+      },
+      "build_time": 1396800,
+      "increased_power": 1000,
+      "level": 40,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 40
+        },
+        {
+          "name": "Parsteel Generator E",
+          "level": 40
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 9100,
+        "bonus2": 300300
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 21500000
+          },
+          {
+            "type": "dilithium",
+            "value": 21500000
+          }
+        ]
+      },
+      "build_time": 1308960,
+      "increased_power": 1000,
+      "level": 41,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 41
+        },
+        {
+          "name": "Parsteel Generator E",
+          "level": 41
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 9300,
+        "bonus2": 336660
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 32025000
+          },
+          {
+            "type": "dilithium",
+            "value": 32025000
+          }
+        ]
+      },
+      "build_time": 2011680,
+      "increased_power": 1000,
+      "level": 42,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 42
+        },
+        {
+          "name": "Parsteel Generator E",
+          "level": 42
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 9500,
+        "bonus2": 343900
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 45750000
+          },
+          {
+            "type": "dilithium",
+            "value": 45750000
+          }
+        ]
+      },
+      "build_time": 2656800,
+      "increased_power": 1250,
+      "level": 43,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 43
+        },
+        {
+          "name": "Parsteel Generator E",
+          "level": 43
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 392000,
+        "bonus2": 9800
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 68625000
+          },
+          {
+            "type": "dilithium",
+            "value": 68625000
+          }
+        ]
+      },
+      "build_time": 3468960,
+      "increased_power": 1250,
+      "level": 44,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 44
+        },
+        {
+          "name": "Parsteel Generator E",
+          "level": 44
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 11300,
+        "bonus2": 508500
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 97500000
+          },
+          {
+            "type": "dilithium",
+            "value": 97500000
+          }
+        ]
+      },
+      "build_time": 4478400,
+      "increased_power": 1250,
+      "level": 45,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 45
+        },
+        {
+          "name": "Parsteel Generator E",
+          "level": 45
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 11600,
+        "bonus2": 522000
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 134062500
+          },
+          {
+            "type": "dilithium",
+            "value": 134062500
+          }
+        ]
+      },
+      "build_time": 5724000,
+      "increased_power": 1250,
+      "level": 46,
+      "requirements": [
+        {
+          "name": "Parsteel Generator E",
+          "level": 46
+        },
+        {
+          "name": "Operations",
+          "level": 46
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 11800,
+        "bonus2": 531000
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 195000000
+          },
+          {
+            "type": "dilithium",
+            "value": 195000000
+          }
+        ]
+      },
+      "build_time": 7251840,
+      "increased_power": 1500,
+      "level": 47,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 47
+        },
+        {
+          "name": "Parsteel Generator E",
+          "level": 47
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 12100,
+        "bonus2": 544500
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 315000000
+          },
+          {
+            "type": "dilithium",
+            "value": 315000000
+          }
+        ]
+      },
+      "build_time": 9109440,
+      "increased_power": 1500,
+      "level": 48,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 48
+        },
+        {
+          "name": "Parsteel Generator E",
+          "level": 48
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 12300,
+        "bonus2": 553500
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 525000000
+          },
+          {
+            "type": "dilithium",
+            "value": 525000000
+          }
+        ]
+      },
+      "build_time": 11358720,
+      "increased_power": 1500,
+      "level": 49,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 49
+        },
+        {
+          "name": "Parsteel Generator E",
+          "level": 49
+        }
+      ]
+    },
+    {
+      "bonuses": {
         "bonus1": 15100,
         "bonus2": 679500
       },

--- a/buildings/parsteel_generator_h.json
+++ b/buildings/parsteel_generator_h.json
@@ -164,6 +164,1454 @@
     },
     {
       "bonuses": {
+        "bonus1": 600,
+        "bonus2": 2700
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 350
+          }
+        ]
+      },
+      "build_time": 330,
+      "increased_power": 20,
+      "level": 6,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 6
+        },
+        {
+          "name": "Parsteel Generator F",
+          "level": 6
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 3850,
+        "bonus2": 700
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 700
+          },
+          {
+            "type": "tritanium",
+            "value": 5
+          }
+        ]
+      },
+      "build_time": 420,
+      "increased_power": 20,
+      "level": 7,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 7
+        },
+        {
+          "name": "Parsteel Generator F",
+          "level": 7
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 800,
+        "bonus2": 5200
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 1200
+          },
+          {
+            "type": "tritanium",
+            "value": 15
+          }
+        ]
+      },
+      "build_time": 600,
+      "increased_power": 30,
+      "level": 8,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 8
+        },
+        {
+          "name": "Parsteel Generator F",
+          "level": 8
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 900,
+        "bonus2": 6300
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 2500
+          },
+          {
+            "type": "tritanium",
+            "value": 38
+          }
+        ]
+      },
+      "build_time": 900,
+      "increased_power": 40,
+      "level": 9,
+      "requirements": [
+        {
+          "name": "Parsteel Generator F",
+          "level": 9
+        },
+        {
+          "name": "Operations",
+          "level": 9
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 1200,
+        "bonus2": 9600
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 2800
+          },
+          {
+            "type": "tritanium",
+            "value": 75
+          }
+        ]
+      },
+      "build_time": 960,
+      "increased_power": 40,
+      "level": 10,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 10
+        },
+        {
+          "name": "Parsteel Generator F",
+          "level": 10
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 1320,
+        "bonus2": 11900
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 100
+          },
+          {
+            "type": "dilithium",
+            "value": 20
+          }
+        ]
+      },
+      "build_time": 1020,
+      "increased_power": 50,
+      "level": 11,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 11
+        },
+        {
+          "name": "Parsteel Generator F",
+          "level": 11
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 1450,
+        "bonus2": 15200
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 138
+          },
+          {
+            "type": "dilithium",
+            "value": 55
+          }
+        ]
+      },
+      "build_time": 1800,
+      "increased_power": 70,
+      "level": 12,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 12
+        },
+        {
+          "name": "Parsteel Generator F",
+          "level": 12
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 1550,
+        "bonus2": 17800
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 200
+          },
+          {
+            "type": "dilithium",
+            "value": 120
+          }
+        ]
+      },
+      "build_time": 2760,
+      "increased_power": 70,
+      "level": 13,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 13
+        },
+        {
+          "name": "Parsteel Generator F",
+          "level": 13
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 1675,
+        "bonus2": 21750
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 275
+          },
+          {
+            "type": "dilithium",
+            "value": 220
+          }
+        ]
+      },
+      "build_time": 3840,
+      "increased_power": 90,
+      "level": 14,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 14
+        },
+        {
+          "name": "Parsteel Generator F",
+          "level": 14
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 25250,
+        "bonus2": 1800
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 375
+          },
+          {
+            "type": "dilithium",
+            "value": 375
+          }
+        ]
+      },
+      "build_time": 4920,
+      "increased_power": 85,
+      "level": 15,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 15
+        },
+        {
+          "name": "Parsteel Generator F",
+          "level": 15
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 1925,
+        "bonus2": 29000
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 500
+          },
+          {
+            "type": "dilithium",
+            "value": 500
+          }
+        ]
+      },
+      "build_time": 5700,
+      "increased_power": 125,
+      "level": 16,
+      "requirements": [
+        {
+          "name": "Parsteel Generator F",
+          "level": 16
+        },
+        {
+          "name": "Operations",
+          "level": 16
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 2050,
+        "bonus2": 33750
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 700
+          },
+          {
+            "type": "dilithium",
+            "value": 700
+          }
+        ]
+      },
+      "build_time": 6300,
+      "increased_power": 125,
+      "level": 17,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 17
+        },
+        {
+          "name": "Parsteel Generator F",
+          "level": 17
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 2175,
+        "bonus2": 38000
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 1000
+          },
+          {
+            "type": "dilithium",
+            "value": 1000
+          }
+        ]
+      },
+      "build_time": 9600,
+      "increased_power": 150,
+      "level": 18,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 18
+        },
+        {
+          "name": "Parsteel Generator F",
+          "level": 18
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 2300,
+        "bonus2": 43750
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 1500
+          },
+          {
+            "type": "dilithium",
+            "value": 1500
+          }
+        ]
+      },
+      "build_time": 13800,
+      "increased_power": 175,
+      "level": 19,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 19
+        },
+        {
+          "name": "Parsteel Generator F",
+          "level": 19
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 2825,
+        "bonus2": 56500
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 2125
+          },
+          {
+            "type": "dilithium",
+            "value": 2125
+          }
+        ]
+      },
+      "build_time": 20880,
+      "increased_power": 200,
+      "level": 20,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 20
+        },
+        {
+          "name": "Parsteel Generator F",
+          "level": 20
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 2950,
+        "bonus2": 59000
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 3578
+          },
+          {
+            "type": "dilithium",
+            "value": 3578
+          }
+        ]
+      },
+      "build_time": 18900,
+      "increased_power": 250,
+      "level": 21,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 21
+        },
+        {
+          "name": "Parsteel Generator F",
+          "level": 21
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 3100,
+        "bonus2": 62000
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 5565
+          },
+          {
+            "type": "dilithium",
+            "value": 5565
+          }
+        ]
+      },
+      "build_time": 29520,
+      "increased_power": 200,
+      "level": 22,
+      "requirements": [
+        {
+          "name": "Parsteel Generator F",
+          "level": 22
+        },
+        {
+          "name": "Operations",
+          "level": 22
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 64500,
+        "bonus2": 3225
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 9158
+          },
+          {
+            "type": "dilithium",
+            "value": 9158
+          }
+        ]
+      },
+      "build_time": 35280,
+      "increased_power": 300,
+      "level": 23,
+      "requirements": [
+        {
+          "name": "Parsteel Generator F",
+          "level": 23
+        },
+        {
+          "name": "Operations",
+          "level": 23
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 3375,
+        "bonus2": 67500
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 14430
+          },
+          {
+            "type": "dilithium",
+            "value": 14430
+          }
+        ]
+      },
+      "build_time": 43200,
+      "increased_power": 200,
+      "level": 24,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 24
+        },
+        {
+          "name": "Parsteel Generator F",
+          "level": 24
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 4025,
+        "bonus2": 80500
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 23400
+          },
+          {
+            "type": "dilithium",
+            "value": 23400
+          }
+        ]
+      },
+      "build_time": 39600,
+      "increased_power": 400,
+      "level": 25,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 25
+        },
+        {
+          "name": "Parsteel Generator F",
+          "level": 25
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 4175,
+        "bonus2": 83500
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 36563
+          },
+          {
+            "type": "dilithium",
+            "value": 36563
+          }
+        ]
+      },
+      "build_time": 54000,
+      "increased_power": 300,
+      "level": 26,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 26
+        },
+        {
+          "name": "Parsteel Generator F",
+          "level": 26
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 87000,
+        "bonus2": 4350
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 55800
+          },
+          {
+            "type": "dilithium",
+            "value": 55800
+          }
+        ]
+      },
+      "build_time": 61200,
+      "increased_power": 400,
+      "level": 27,
+      "requirements": [
+        {
+          "name": "Parsteel Generator F",
+          "level": 27
+        },
+        {
+          "name": "Operations",
+          "level": 27
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 90000,
+        "bonus2": 4500
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 83700
+          },
+          {
+            "type": "dilithium",
+            "value": 83700
+          }
+        ]
+      },
+      "build_time": 71280,
+      "increased_power": 400,
+      "level": 28,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 28
+        },
+        {
+          "name": "Parsteel Generator F",
+          "level": 28
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 4675,
+        "bonus2": 93500
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 133250
+          },
+          {
+            "type": "dilithium",
+            "value": 133250
+          }
+        ]
+      },
+      "build_time": 78480,
+      "increased_power": 500,
+      "level": 29,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 29
+        },
+        {
+          "name": "Parsteel Generator F",
+          "level": 29
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 5400,
+        "bonus2": 108000
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 195000
+          },
+          {
+            "type": "dilithium",
+            "value": 195000
+          }
+        ]
+      },
+      "build_time": 84960,
+      "increased_power": 400,
+      "level": 30,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 30
+        },
+        {
+          "name": "Parsteel Generator F",
+          "level": 30
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 5600,
+        "bonus2": 112000
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 308250
+          },
+          {
+            "type": "dilithium",
+            "value": 308250
+          }
+        ]
+      },
+      "build_time": 111600,
+      "increased_power": 550,
+      "level": 31,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 31
+        },
+        {
+          "name": "Parsteel Generator F",
+          "level": 31
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 125280,
+        "bonus2": 5800
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 445250
+          },
+          {
+            "type": "dilithium",
+            "value": 445250
+          }
+        ]
+      },
+      "build_time": 109440,
+      "increased_power": 500,
+      "level": 32,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 32
+        },
+        {
+          "name": "Parsteel Generator F",
+          "level": 32
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 6000,
+        "bonus2": 139200
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 688750
+          },
+          {
+            "type": "dilithium",
+            "value": 688750
+          }
+        ]
+      },
+      "build_time": 158400,
+      "increased_power": 750,
+      "level": 33,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 33
+        },
+        {
+          "name": "Parsteel Generator F",
+          "level": 33
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 6200,
+        "bonus2": 143840
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 1087500
+          },
+          {
+            "type": "dilithium",
+            "value": 1087500
+          }
+        ]
+      },
+      "build_time": 210240,
+      "increased_power": 500,
+      "level": 34,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 34
+        },
+        {
+          "name": "Parsteel Generator F",
+          "level": 34
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 7000,
+        "bonus2": 173600
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 1683000
+          },
+          {
+            "type": "dilithium",
+            "value": 1683000
+          }
+        ]
+      },
+      "build_time": 276480,
+      "increased_power": 750,
+      "level": 35,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 35
+        },
+        {
+          "name": "Parsteel Generator F",
+          "level": 35
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 7300,
+        "bonus2": 194180
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 2371500
+          },
+          {
+            "type": "dilithium",
+            "value": 2371500
+          }
+        ]
+      },
+      "build_time": 354240,
+      "increased_power": 750,
+      "level": 36,
+      "requirements": [
+        {
+          "name": "Parsteel Generator F",
+          "level": 36
+        },
+        {
+          "name": "Operations",
+          "level": 36
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 7500,
+        "bonus2": 199500
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 3645000
+          },
+          {
+            "type": "dilithium",
+            "value": 3645000
+          }
+        ]
+      },
+      "build_time": 365760,
+      "increased_power": 750,
+      "level": 37,
+      "requirements": [
+        {
+          "name": "Parsteel Generator F",
+          "level": 37
+        },
+        {
+          "name": "Operations",
+          "level": 37
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 7700,
+        "bonus2": 218680
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 5670000
+          },
+          {
+            "type": "dilithium",
+            "value": 5670000
+          }
+        ]
+      },
+      "build_time": 593280,
+      "increased_power": 1000,
+      "level": 38,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 38
+        },
+        {
+          "name": "Parsteel Generator F",
+          "level": 38
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 7900,
+        "bonus2": 241740
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 9675000
+          },
+          {
+            "type": "dilithium",
+            "value": 9675000
+          }
+        ]
+      },
+      "build_time": 786240,
+      "increased_power": 750,
+      "level": 39,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 39
+        },
+        {
+          "name": "Parsteel Generator F",
+          "level": 39
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 272340,
+        "bonus2": 8900
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 15050000
+          },
+          {
+            "type": "dilithium",
+            "value": 15050000
+          }
+        ]
+      },
+      "build_time": 1396800,
+      "increased_power": 1000,
+      "level": 40,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 40
+        },
+        {
+          "name": "Parsteel Generator F",
+          "level": 40
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 9100,
+        "bonus2": 300300
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 21500000
+          },
+          {
+            "type": "dilithium",
+            "value": 21500000
+          }
+        ]
+      },
+      "build_time": 1308960,
+      "increased_power": 1000,
+      "level": 41,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 41
+        },
+        {
+          "name": "Parsteel Generator F",
+          "level": 41
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 9300,
+        "bonus2": 336660
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 32025000
+          },
+          {
+            "type": "dilithium",
+            "value": 32025000
+          }
+        ]
+      },
+      "build_time": 2011680,
+      "increased_power": 1000,
+      "level": 42,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 42
+        },
+        {
+          "name": "Parsteel Generator F",
+          "level": 42
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 9500,
+        "bonus2": 343900
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 45750000
+          },
+          {
+            "type": "dilithium",
+            "value": 45750000
+          }
+        ]
+      },
+      "build_time": 2656800,
+      "increased_power": 1250,
+      "level": 43,
+      "requirements": [
+        {
+          "name": "Parsteel Generator F",
+          "level": 43
+        },
+        {
+          "name": "Operations",
+          "level": 43
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 392000,
+        "bonus2": 9800
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 68625000
+          },
+          {
+            "type": "dilithium",
+            "value": 68625000
+          }
+        ]
+      },
+      "build_time": 3468960,
+      "increased_power": 1250,
+      "level": 44,
+      "requirements": [
+        {
+          "name": "Parsteel Generator F",
+          "level": 44
+        },
+        {
+          "name": "Operations",
+          "level": 44
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 508500,
+        "bonus2": 11300
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 97500000
+          },
+          {
+            "type": "dilithium",
+            "value": 97500000
+          }
+        ]
+      },
+      "build_time": 4478400,
+      "increased_power": 1250,
+      "level": 45,
+      "requirements": [
+        {
+          "name": "Parsteel Generator F",
+          "level": 45
+        },
+        {
+          "name": "Operations",
+          "level": 45
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 522000,
+        "bonus2": 11600
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 134062500
+          },
+          {
+            "type": "dilithium",
+            "value": 134062500
+          }
+        ]
+      },
+      "build_time": 5724000,
+      "increased_power": 1250,
+      "level": 46,
+      "requirements": [
+        {
+          "name": "Parsteel Generator F",
+          "level": 46
+        },
+        {
+          "name": "Operations",
+          "level": 46
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 531000,
+        "bonus2": 11800
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 195000000
+          },
+          {
+            "type": "dilithium",
+            "value": 195000000
+          }
+        ]
+      },
+      "build_time": 7251840,
+      "increased_power": 1500,
+      "level": 47,
+      "requirements": [
+        {
+          "name": "Parsteel Generator F",
+          "level": 47
+        },
+        {
+          "name": "Operations",
+          "level": 47
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 544500,
+        "bonus2": 12100
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 315000000
+          },
+          {
+            "type": "dilithium",
+            "value": 315000000
+          }
+        ]
+      },
+      "build_time": 9109440,
+      "increased_power": 1500,
+      "level": 48,
+      "requirements": [
+        {
+          "name": "Parsteel Generator F",
+          "level": 48
+        },
+        {
+          "name": "Operations",
+          "level": 48
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 553500,
+        "bonus2": 12300
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 525000000
+          },
+          {
+            "type": "dilithium",
+            "value": 525000000
+          }
+        ]
+      },
+      "build_time": 11358720,
+      "increased_power": 1500,
+      "level": 49,
+      "requirements": [
+        {
+          "name": "Parsteel Generator F",
+          "level": 49
+        },
+        {
+          "name": "Operations",
+          "level": 49
+        }
+      ]
+    },
+    {
+      "bonuses": {
         "bonus1": 679500,
         "bonus2": 15100
       },

--- a/buildings/tritanium_generator_b.json
+++ b/buildings/tritanium_generator_b.json
@@ -14,6 +14,180 @@
   "levels": [
     {
       "bonuses": {
+        "bonus1": 8,
+        "bonus2": 15
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 300
+          }
+        ]
+      },
+      "build_time": 30,
+      "increased_power": 10,
+      "level": 1,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 7
+        },
+        {
+          "name": "Tritanium Generator A",
+          "level": 1
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 30,
+        "bonus2": 30
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 400
+          }
+        ]
+      },
+      "build_time": 60,
+      "increased_power": 10,
+      "level": 2,
+      "requirements": [
+        {
+          "name": "Tritanium Generator A",
+          "level": 2
+        },
+        {
+          "name": "Operations",
+          "level": 7
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 68,
+        "bonus2": 45
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 600
+          }
+        ]
+      },
+      "build_time": 120,
+      "increased_power": 12,
+      "level": 3,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 7
+        },
+        {
+          "name": "Tritanium Generator A",
+          "level": 3
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 60,
+        "bonus2": 150
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 1000
+          }
+        ]
+      },
+      "build_time": 150,
+      "increased_power": 13,
+      "level": 4,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 7
+        },
+        {
+          "name": "Tritanium Generator A",
+          "level": 4
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 225,
+        "bonus2": 75
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 1600
+          }
+        ]
+      },
+      "build_time": 270,
+      "increased_power": 15,
+      "level": 5,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 7
+        },
+        {
+          "name": "Tritanium Generator A",
+          "level": 5
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 91,
+        "bonus2": 320
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 2500
+          }
+        ]
+      },
+      "build_time": 450,
+      "increased_power": 20,
+      "level": 6,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 7
+        },
+        {
+          "name": "Tritanium Generator A",
+          "level": 6
+        }
+      ]
+    },
+    {
+      "bonuses": {
         "bonus1": 420,
         "bonus2": 105
       },

--- a/buildings/tritanium_generator_c.json
+++ b/buildings/tritanium_generator_c.json
@@ -48,6 +48,171 @@
     },
     {
       "bonuses": {
+        "bonus1": 30,
+        "bonus2": 30
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 400
+          },
+          {
+            "type": "dilithium",
+            "value": 360
+          }
+        ]
+      },
+      "build_time": 60,
+      "increased_power": 10,
+      "level": 2,
+      "requirements": [
+        {
+          "name": "Tritanium Generator A",
+          "level": 2
+        },
+        {
+          "name": "Operations",
+          "level": 2
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 45,
+        "bonus2": 68
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 600
+          },
+          {
+            "type": "dilithium",
+            "value": 320
+          }
+        ]
+      },
+      "build_time": 120,
+      "increased_power": 12,
+      "level": 3,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 3
+        },
+        {
+          "name": "Tritanium Generator A",
+          "level": 3
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 60,
+        "bonus2": 150
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 1000
+          },
+          {
+            "type": "dilithium",
+            "value": 280
+          }
+        ]
+      },
+      "build_time": 150,
+      "increased_power": 13,
+      "level": 4,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 4
+        },
+        {
+          "name": "Tritanium Generator A",
+          "level": 4
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 225,
+        "bonus2": 75
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 1600
+          },
+          {
+            "type": "dilithium",
+            "value": 240
+          }
+        ]
+      },
+      "build_time": 270,
+      "increased_power": 15,
+      "level": 5,
+      "requirements": [
+        {
+          "name": "Tritanium Generator A",
+          "level": 5
+        },
+        {
+          "name": "Operations",
+          "level": 5
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 320,
+        "bonus2": 91
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 2500
+          },
+          {
+            "type": "dilithium",
+            "value": 200
+          }
+        ]
+      },
+      "build_time": 450,
+      "increased_power": 20,
+      "level": 6,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 6
+        },
+        {
+          "name": "Tritanium Generator A",
+          "level": 6
+        }
+      ]
+    },
+    {
+      "bonuses": {
         "bonus1": 105,
         "bonus2": 420
       },
@@ -218,6 +383,39 @@
     },
     {
       "bonuses": {
+        "bonus1": 220,
+        "bonus2": 1650
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 9350
+          },
+          {
+            "type": "dilithium",
+            "value": 22
+          }
+        ]
+      },
+      "build_time": 3720,
+      "increased_power": 70,
+      "level": 12,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 12
+        },
+        {
+          "name": "Tritanium Generator A",
+          "level": 12
+        }
+      ]
+    },
+    {
+      "bonuses": {
         "bonus1": 235,
         "bonus2": 2000
       },
@@ -283,6 +481,105 @@
         }
       ],
       "rewards": []
+    },
+    {
+      "bonuses": {
+        "bonus1": 275,
+        "bonus2": 2750
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 25500
+          },
+          {
+            "type": "dilithium",
+            "value": 150
+          }
+        ]
+      },
+      "build_time": 9900,
+      "increased_power": 85,
+      "level": 15,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 15
+        },
+        {
+          "name": "Tritanium Generator A",
+          "level": 15
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 290,
+        "bonus2": 3200
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 34000
+          },
+          {
+            "type": "dilithium",
+            "value": 200
+          }
+        ]
+      },
+      "build_time": 11700,
+      "increased_power": 125,
+      "level": 16,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 16
+        },
+        {
+          "name": "Tritanium Generator A",
+          "level": 16
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 310,
+        "bonus2": 3575
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 47600
+          },
+          {
+            "type": "dilithium",
+            "value": 280
+          }
+        ]
+      },
+      "build_time": 12600,
+      "increased_power": 125,
+      "level": 17,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 17
+        },
+        {
+          "name": "Tritanium Generator A",
+          "level": 17
+        }
+      ]
     },
     {
       "bonuses": {

--- a/buildings/tritanium_generator_e.json
+++ b/buildings/tritanium_generator_e.json
@@ -44,6 +44,399 @@
     },
     {
       "bonuses": {
+        "bonus1": 30,
+        "bonus2": 30
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 400
+          }
+        ]
+      },
+      "build_time": 60,
+      "increased_power": 10,
+      "level": 2,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 2
+        },
+        {
+          "name": "Tritanium Generator C",
+          "level": 2
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 45,
+        "bonus2": 68
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 600
+          }
+        ]
+      },
+      "build_time": 120,
+      "increased_power": 12,
+      "level": 3,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 3
+        },
+        {
+          "name": "Tritanium Generator C",
+          "level": 3
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 60,
+        "bonus2": 150
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 1000
+          }
+        ]
+      },
+      "build_time": 150,
+      "increased_power": 13,
+      "level": 4,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 4
+        },
+        {
+          "name": "Tritanium Generator C",
+          "level": 4
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 75,
+        "bonus2": 225
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 1600
+          }
+        ]
+      },
+      "build_time": 270,
+      "increased_power": 15,
+      "level": 5,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 5
+        },
+        {
+          "name": "Tritanium Generator C",
+          "level": 5
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 91,
+        "bonus2": 320
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 2500
+          }
+        ]
+      },
+      "build_time": 450,
+      "increased_power": 20,
+      "level": 6,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 6
+        },
+        {
+          "name": "Tritanium Generator C",
+          "level": 6
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 420,
+        "bonus2": 105
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 3500
+          }
+        ]
+      },
+      "build_time": 840,
+      "increased_power": 20,
+      "level": 7,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 7
+        },
+        {
+          "name": "Tritanium Generator C",
+          "level": 7
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 120,
+        "bonus2": 600
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 4250
+          }
+        ]
+      },
+      "build_time": 1200,
+      "increased_power": 30,
+      "level": 8,
+      "requirements": [
+        {
+          "name": "Tritanium Generator C",
+          "level": 8
+        },
+        {
+          "name": "Operations",
+          "level": 8
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 135,
+        "bonus2": 740
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 5000
+          }
+        ]
+      },
+      "build_time": 1800,
+      "increased_power": 40,
+      "level": 9,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 9
+        },
+        {
+          "name": "Tritanium Generator C",
+          "level": 9
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 180,
+        "bonus2": 1080
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 6000
+          }
+        ]
+      },
+      "build_time": 1920,
+      "increased_power": 40,
+      "level": 10,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 10
+        },
+        {
+          "name": "Tritanium Generator C",
+          "level": 10
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 200,
+        "bonus2": 1400
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 6800
+          },
+          {
+            "type": "dilithium",
+            "value": 8
+          }
+        ]
+      },
+      "build_time": 2040,
+      "increased_power": 50,
+      "level": 11,
+      "requirements": [
+        {
+          "name": "Tritanium Generator C",
+          "level": 11
+        },
+        {
+          "name": "Operations",
+          "level": 11
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 220,
+        "bonus2": 1650
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 9350
+          },
+          {
+            "type": "dilithium",
+            "value": 22
+          }
+        ]
+      },
+      "build_time": 3720,
+      "increased_power": 70,
+      "level": 12,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 12
+        },
+        {
+          "name": "Tritanium Generator C",
+          "level": 12
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 235,
+        "bonus2": 2000
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 13600
+          },
+          {
+            "type": "dilithium",
+            "value": 48
+          }
+        ]
+      },
+      "build_time": 5400,
+      "increased_power": 70,
+      "level": 13,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 13
+        },
+        {
+          "name": "Tritanium Generator C",
+          "level": 13
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 255,
+        "bonus2": 2300
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 18700
+          },
+          {
+            "type": "dilithium",
+            "value": 88
+          }
+        ]
+      },
+      "build_time": 7800,
+      "increased_power": 90,
+      "level": 14,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 14
+        },
+        {
+          "name": "Tritanium Generator C",
+          "level": 14
+        }
+      ]
+    },
+    {
+      "bonuses": {
         "bonus1": 275,
         "bonus2": 2750
       },
@@ -75,6 +468,138 @@
         }
       ],
       "rewards": []
+    },
+    {
+      "bonuses": {
+        "bonus1": 290,
+        "bonus2": 3200
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 34000
+          },
+          {
+            "type": "dilithium",
+            "value": 200
+          }
+        ]
+      },
+      "build_time": 11700,
+      "increased_power": 125,
+      "level": 16,
+      "requirements": [
+        {
+          "name": "Tritanium Generator C",
+          "level": 16
+        },
+        {
+          "name": "Operations",
+          "level": 16
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 310,
+        "bonus2": 3575
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 47600
+          },
+          {
+            "type": "dilithium",
+            "value": 280
+          }
+        ]
+      },
+      "build_time": 12600,
+      "increased_power": 125,
+      "level": 17,
+      "requirements": [
+        {
+          "name": "Tritanium Generator C",
+          "level": 17
+        },
+        {
+          "name": "Operations",
+          "level": 17
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 330,
+        "bonus2": 4125
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 68000
+          },
+          {
+            "type": "dilithium",
+            "value": 400
+          }
+        ]
+      },
+      "build_time": 19200,
+      "increased_power": 150,
+      "level": 18,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 18
+        },
+        {
+          "name": "Tritanium Generator C",
+          "level": 18
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 345,
+        "bonus2": 4475
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 102000
+          },
+          {
+            "type": "dilithium",
+            "value": 600
+          }
+        ]
+      },
+      "build_time": 28080,
+      "increased_power": 175,
+      "level": 19,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 19
+        },
+        {
+          "name": "Tritanium Generator C",
+          "level": 19
+        }
+      ]
     },
     {
       "bonuses": {
@@ -112,6 +637,105 @@
     },
     {
       "bonuses": {
+        "bonus1": 450,
+        "bonus2": 6300
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 243270
+          },
+          {
+            "type": "dilithium",
+            "value": 1431
+          }
+        ]
+      },
+      "build_time": 38160,
+      "increased_power": 250,
+      "level": 21,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 21
+        },
+        {
+          "name": "Tritanium Generator C",
+          "level": 21
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 470,
+        "bonus2": 6600
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 378420
+          },
+          {
+            "type": "dilithium",
+            "value": 2226
+          }
+        ]
+      },
+      "build_time": 59040,
+      "increased_power": 200,
+      "level": 22,
+      "requirements": [
+        {
+          "name": "Tritanium Generator C",
+          "level": 22
+        },
+        {
+          "name": "Operations",
+          "level": 22
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 490,
+        "bonus2": 6900
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 622710
+          },
+          {
+            "type": "dilithium",
+            "value": 3663
+          }
+        ]
+      },
+      "build_time": 69840,
+      "increased_power": 300,
+      "level": 23,
+      "requirements": [
+        {
+          "name": "Tritanium Generator C",
+          "level": 23
+        },
+        {
+          "name": "Operations",
+          "level": 23
+        }
+      ]
+    },
+    {
+      "bonuses": {
         "bonus1": 510,
         "bonus2": 7100
       },
@@ -146,6 +770,369 @@
     },
     {
       "bonuses": {
+        "bonus1": 610,
+        "bonus2": 8500
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 1591200
+          },
+          {
+            "type": "dilithium",
+            "value": 9360
+          }
+        ]
+      },
+      "build_time": 79200,
+      "increased_power": 400,
+      "level": 25,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 25
+        },
+        {
+          "name": "Tritanium Generator C",
+          "level": 25
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 640,
+        "bonus2": 9000
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 2486250
+          },
+          {
+            "type": "dilithium",
+            "value": 14625
+          }
+        ]
+      },
+      "build_time": 108000,
+      "increased_power": 300,
+      "level": 26,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 26
+        },
+        {
+          "name": "Tritanium Generator C",
+          "level": 26
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 9200,
+        "bonus2": 660
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 3794400
+          },
+          {
+            "type": "dilithium",
+            "value": 22320
+          }
+        ]
+      },
+      "build_time": 122400,
+      "increased_power": 400,
+      "level": 27,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 27
+        },
+        {
+          "name": "Tritanium Generator C",
+          "level": 27
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 680,
+        "bonus2": 9500
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 5691600
+          },
+          {
+            "type": "dilithium",
+            "value": 33480
+          }
+        ]
+      },
+      "build_time": 142560,
+      "increased_power": 400,
+      "level": 28,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 28
+        },
+        {
+          "name": "Tritanium Generator C",
+          "level": 28
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 9900,
+        "bonus2": 710
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 9061000
+          },
+          {
+            "type": "dilithium",
+            "value": 53300
+          }
+        ]
+      },
+      "build_time": 156960,
+      "increased_power": 500,
+      "level": 29,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 29
+        },
+        {
+          "name": "Tritanium Generator C",
+          "level": 29
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 820,
+        "bonus2": 11500
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 13260000
+          },
+          {
+            "type": "dilithium",
+            "value": 78000
+          }
+        ]
+      },
+      "build_time": 169920,
+      "increased_power": 400,
+      "level": 30,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 30
+        },
+        {
+          "name": "Tritanium Generator C",
+          "level": 30
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 850,
+        "bonus2": 11900
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 20961000
+          },
+          {
+            "type": "dilithium",
+            "value": 123300
+          }
+        ]
+      },
+      "build_time": 223200,
+      "increased_power": 550,
+      "level": 31,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 31
+        },
+        {
+          "name": "Tritanium Generator C",
+          "level": 31
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 13284,
+        "bonus2": 880
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 30277000
+          },
+          {
+            "type": "dilithium",
+            "value": 178100
+          }
+        ]
+      },
+      "build_time": 218880,
+      "increased_power": 500,
+      "level": 32,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 32
+        },
+        {
+          "name": "Tritanium Generator C",
+          "level": 32
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 910,
+        "bonus2": 14732
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 46835000
+          },
+          {
+            "type": "dilithium",
+            "value": 275500
+          }
+        ]
+      },
+      "build_time": 316800,
+      "increased_power": 750,
+      "level": 33,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 33
+        },
+        {
+          "name": "Tritanium Generator C",
+          "level": 33
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 940,
+        "bonus2": 15312
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 73950000
+          },
+          {
+            "type": "dilithium",
+            "value": 435000
+          }
+        ]
+      },
+      "build_time": 420480,
+      "increased_power": 500,
+      "level": 34,
+      "requirements": [
+        {
+          "name": "Tritanium Generator C",
+          "level": 34
+        },
+        {
+          "name": "Operations",
+          "level": 34
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 18600,
+        "bonus2": 1070
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 114444000
+          },
+          {
+            "type": "dilithium",
+            "value": 673200
+          }
+        ]
+      },
+      "build_time": 552960,
+      "increased_power": 750,
+      "level": 35,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 35
+        },
+        {
+          "name": "Tritanium Generator C",
+          "level": 35
+        }
+      ]
+    },
+    {
+      "bonuses": {
         "bonus1": 1100,
         "bonus2": 20482
       },
@@ -177,6 +1164,39 @@
         }
       ],
       "rewards": []
+    },
+    {
+      "bonuses": {
+        "bonus1": 1130,
+        "bonus2": 21014
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 247860000
+          },
+          {
+            "type": "dilithium",
+            "value": 1458000
+          }
+        ]
+      },
+      "build_time": 731520,
+      "increased_power": 750,
+      "level": 37,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 37
+        },
+        {
+          "name": "Tritanium Generator C",
+          "level": 37
+        }
+      ]
     },
     {
       "bonuses": {

--- a/buildings/tritanium_generator_f.json
+++ b/buildings/tritanium_generator_f.json
@@ -44,6 +44,1488 @@
     },
     {
       "bonuses": {
+        "bonus1": 30,
+        "bonus2": 30
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 400
+          }
+        ]
+      },
+      "build_time": 60,
+      "increased_power": 10,
+      "level": 2,
+      "requirements": [
+        {
+          "name": "Tritanium Generator D",
+          "level": 2
+        },
+        {
+          "name": "Operations",
+          "level": 2
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 68,
+        "bonus2": 45
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 600
+          }
+        ]
+      },
+      "build_time": 120,
+      "increased_power": 12,
+      "level": 3,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 3
+        },
+        {
+          "name": "Tritanium Generator D",
+          "level": 3
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 60,
+        "bonus2": 150
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 1000
+          }
+        ]
+      },
+      "build_time": 150,
+      "increased_power": 13,
+      "level": 4,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 4
+        },
+        {
+          "name": "Tritanium Generator D",
+          "level": 4
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 75,
+        "bonus2": 225
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 1600
+          }
+        ]
+      },
+      "build_time": 270,
+      "increased_power": 15,
+      "level": 5,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 5
+        },
+        {
+          "name": "Tritanium Generator D",
+          "level": 5
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 91,
+        "bonus2": 320
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 2500
+          }
+        ]
+      },
+      "build_time": 450,
+      "increased_power": 20,
+      "level": 6,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 6
+        },
+        {
+          "name": "Tritanium Generator D",
+          "level": 6
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 105,
+        "bonus2": 420
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 3500
+          }
+        ]
+      },
+      "build_time": 840,
+      "increased_power": 20,
+      "level": 7,
+      "requirements": [
+        {
+          "name": "Tritanium Generator D",
+          "level": 7
+        },
+        {
+          "name": "Operations",
+          "level": 7
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 120,
+        "bonus2": 600
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 4250
+          }
+        ]
+      },
+      "build_time": 1200,
+      "increased_power": 30,
+      "level": 8,
+      "requirements": [
+        {
+          "name": "Tritanium Generator D",
+          "level": 8
+        },
+        {
+          "name": "Operations",
+          "level": 8
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 135,
+        "bonus2": 740
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 5000
+          }
+        ]
+      },
+      "build_time": 1800,
+      "increased_power": 40,
+      "level": 9,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 9
+        },
+        {
+          "name": "Tritanium Generator D",
+          "level": 9
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 1080,
+        "bonus2": 180
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 6000
+          }
+        ]
+      },
+      "build_time": 1920,
+      "increased_power": 40,
+      "level": 10,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 10
+        },
+        {
+          "name": "Tritanium Generator D",
+          "level": 10
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 200,
+        "bonus2": 1400
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 6800
+          },
+          {
+            "type": "dilithium",
+            "value": 8
+          }
+        ]
+      },
+      "build_time": 2040,
+      "increased_power": 50,
+      "level": 11,
+      "requirements": [
+        {
+          "name": "Tritanium Generator D",
+          "level": 11
+        },
+        {
+          "name": "Operations",
+          "level": 11
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 1650,
+        "bonus2": 220
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 9350
+          },
+          {
+            "type": "dilithium",
+            "value": 22
+          }
+        ]
+      },
+      "build_time": 3720,
+      "increased_power": 70,
+      "level": 12,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 12
+        },
+        {
+          "name": "Tritanium Generator D",
+          "level": 12
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 235,
+        "bonus2": 2000
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 13600
+          },
+          {
+            "type": "dilithium",
+            "value": 48
+          }
+        ]
+      },
+      "build_time": 5400,
+      "increased_power": 70,
+      "level": 13,
+      "requirements": [
+        {
+          "name": "Tritanium Generator D",
+          "level": 13
+        },
+        {
+          "name": "Operations",
+          "level": 13
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 255,
+        "bonus2": 2300
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 18700
+          },
+          {
+            "type": "dilithium",
+            "value": 88
+          }
+        ]
+      },
+      "build_time": 7800,
+      "increased_power": 90,
+      "level": 14,
+      "requirements": [
+        {
+          "name": "Tritanium Generator D",
+          "level": 14
+        },
+        {
+          "name": "Operations",
+          "level": 14
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 275,
+        "bonus2": 2750
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 25500
+          },
+          {
+            "type": "dilithium",
+            "value": 150
+          }
+        ]
+      },
+      "build_time": 9900,
+      "increased_power": 85,
+      "level": 15,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 15
+        },
+        {
+          "name": "Tritanium Generator D",
+          "level": 15
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 290,
+        "bonus2": 3200
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 34000
+          },
+          {
+            "type": "dilithium",
+            "value": 200
+          }
+        ]
+      },
+      "build_time": 11700,
+      "increased_power": 125,
+      "level": 16,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 16
+        },
+        {
+          "name": "Tritanium Generator D",
+          "level": 16
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 310,
+        "bonus2": 3575
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 47600
+          },
+          {
+            "type": "dilithium",
+            "value": 280
+          }
+        ]
+      },
+      "build_time": 12600,
+      "increased_power": 125,
+      "level": 17,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 17
+        },
+        {
+          "name": "Tritanium Generator D",
+          "level": 17
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 330,
+        "bonus2": 4125
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 68000
+          },
+          {
+            "type": "dilithium",
+            "value": 400
+          }
+        ]
+      },
+      "build_time": 19200,
+      "increased_power": 150,
+      "level": 18,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 18
+        },
+        {
+          "name": "Tritanium Generator D",
+          "level": 18
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 345,
+        "bonus2": 4475
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 102000
+          },
+          {
+            "type": "dilithium",
+            "value": 600
+          }
+        ]
+      },
+      "build_time": 28080,
+      "increased_power": 175,
+      "level": 19,
+      "requirements": [
+        {
+          "name": "Tritanium Generator D",
+          "level": 19
+        },
+        {
+          "name": "Operations",
+          "level": 19
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 425,
+        "bonus2": 6000
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 144500
+          },
+          {
+            "type": "dilithium",
+            "value": 850
+          }
+        ]
+      },
+      "build_time": 41760,
+      "increased_power": 200,
+      "level": 20,
+      "requirements": [
+        {
+          "name": "Tritanium Generator D",
+          "level": 20
+        },
+        {
+          "name": "Operations",
+          "level": 20
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 450,
+        "bonus2": 6300
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 243270
+          },
+          {
+            "type": "dilithium",
+            "value": 1431
+          }
+        ]
+      },
+      "build_time": 38160,
+      "increased_power": 250,
+      "level": 21,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 21
+        },
+        {
+          "name": "Tritanium Generator D",
+          "level": 21
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 470,
+        "bonus2": 6600
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 378420
+          },
+          {
+            "type": "dilithium",
+            "value": 2226
+          }
+        ]
+      },
+      "build_time": 59040,
+      "increased_power": 200,
+      "level": 22,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 22
+        },
+        {
+          "name": "Tritanium Generator D",
+          "level": 22
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 490,
+        "bonus2": 6900
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 622710
+          },
+          {
+            "type": "dilithium",
+            "value": 3663
+          }
+        ]
+      },
+      "build_time": 69840,
+      "increased_power": 300,
+      "level": 23,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 23
+        },
+        {
+          "name": "Tritanium Generator D",
+          "level": 23
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 7100,
+        "bonus2": 510
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 981240
+          },
+          {
+            "type": "dilithium",
+            "value": 5772
+          }
+        ]
+      },
+      "build_time": 85680,
+      "increased_power": 200,
+      "level": 24,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 24
+        },
+        {
+          "name": "Tritanium Generator D",
+          "level": 24
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 8500,
+        "bonus2": 610
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 1591200
+          },
+          {
+            "type": "dilithium",
+            "value": 9360
+          }
+        ]
+      },
+      "build_time": 79200,
+      "increased_power": 400,
+      "level": 25,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 25
+        },
+        {
+          "name": "Tritanium Generator D",
+          "level": 25
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 640,
+        "bonus2": 9000
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 2486250
+          },
+          {
+            "type": "dilithium",
+            "value": 14625
+          }
+        ]
+      },
+      "build_time": 108000,
+      "increased_power": 300,
+      "level": 26,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 26
+        },
+        {
+          "name": "Tritanium Generator D",
+          "level": 26
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 9200,
+        "bonus2": 660
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 3794400
+          },
+          {
+            "type": "dilithium",
+            "value": 22320
+          }
+        ]
+      },
+      "build_time": 122400,
+      "increased_power": 400,
+      "level": 27,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 27
+        },
+        {
+          "name": "Tritanium Generator D",
+          "level": 27
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 680,
+        "bonus2": 9500
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 5691600
+          },
+          {
+            "type": "dilithium",
+            "value": 33480
+          }
+        ]
+      },
+      "build_time": 142560,
+      "increased_power": 400,
+      "level": 28,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 28
+        },
+        {
+          "name": "Tritanium Generator D",
+          "level": 28
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 710,
+        "bonus2": 9900
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 9061000
+          },
+          {
+            "type": "dilithium",
+            "value": 53300
+          }
+        ]
+      },
+      "build_time": 156960,
+      "increased_power": 500,
+      "level": 29,
+      "requirements": [
+        {
+          "name": "Tritanium Generator D",
+          "level": 29
+        },
+        {
+          "name": "Operations",
+          "level": 29
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 820,
+        "bonus2": 11500
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 13260000
+          },
+          {
+            "type": "dilithium",
+            "value": 78000
+          }
+        ]
+      },
+      "build_time": 169920,
+      "increased_power": 400,
+      "level": 30,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 30
+        },
+        {
+          "name": "Tritanium Generator D",
+          "level": 30
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 850,
+        "bonus2": 11900
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 20961000
+          },
+          {
+            "type": "dilithium",
+            "value": 123300
+          }
+        ]
+      },
+      "build_time": 223200,
+      "increased_power": 550,
+      "level": 31,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 31
+        },
+        {
+          "name": "Tritanium Generator D",
+          "level": 31
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 880,
+        "bonus2": 13284
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 30277000
+          },
+          {
+            "type": "dilithium",
+            "value": 178100
+          }
+        ]
+      },
+      "build_time": 218880,
+      "increased_power": 500,
+      "level": 32,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 32
+        },
+        {
+          "name": "Tritanium Generator D",
+          "level": 32
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 14732,
+        "bonus2": 910
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 46835000
+          },
+          {
+            "type": "dilithium",
+            "value": 275500
+          }
+        ]
+      },
+      "build_time": 316800,
+      "increased_power": 750,
+      "level": 33,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 33
+        },
+        {
+          "name": "Tritanium Generator D",
+          "level": 33
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 940,
+        "bonus2": 15312
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 73950000
+          },
+          {
+            "type": "dilithium",
+            "value": 435000
+          }
+        ]
+      },
+      "build_time": 420480,
+      "increased_power": 500,
+      "level": 34,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 34
+        },
+        {
+          "name": "Tritanium Generator D",
+          "level": 34
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 1070,
+        "bonus2": 18600
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 114444000
+          },
+          {
+            "type": "dilithium",
+            "value": 673200
+          }
+        ]
+      },
+      "build_time": 552960,
+      "increased_power": 750,
+      "level": 35,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 35
+        },
+        {
+          "name": "Tritanium Generator D",
+          "level": 35
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 1100,
+        "bonus2": 20482
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 161262000
+          },
+          {
+            "type": "dilithium",
+            "value": 948600
+          }
+        ]
+      },
+      "build_time": 707040,
+      "increased_power": 750,
+      "level": 36,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 36
+        },
+        {
+          "name": "Tritanium Generator D",
+          "level": 36
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 1130,
+        "bonus2": 21014
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 247860000
+          },
+          {
+            "type": "dilithium",
+            "value": 1458000
+          }
+        ]
+      },
+      "build_time": 731520,
+      "increased_power": 750,
+      "level": 37,
+      "requirements": [
+        {
+          "name": "Tritanium Generator D",
+          "level": 37
+        },
+        {
+          "name": "Operations",
+          "level": 37
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 23004,
+        "bonus2": 1160
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 385560000
+          },
+          {
+            "type": "dilithium",
+            "value": 2268000
+          }
+        ]
+      },
+      "build_time": 1185120,
+      "increased_power": 1000,
+      "level": 38,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 38
+        },
+        {
+          "name": "Tritanium Generator D",
+          "level": 38
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 1190,
+        "bonus2": 25551
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 657900000
+          },
+          {
+            "type": "dilithium",
+            "value": 3870000
+          }
+        ]
+      },
+      "build_time": 1573920,
+      "increased_power": 750,
+      "level": 39,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 39
+        },
+        {
+          "name": "Tritanium Generator D",
+          "level": 39
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 28917,
+        "bonus2": 1350
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 2865520000
+          },
+          {
+            "type": "dilithium",
+            "value": 6020000
+          }
+        ]
+      },
+      "build_time": 2792160,
+      "increased_power": 1000,
+      "level": 40,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 40
+        },
+        {
+          "name": "Tritanium Generator D",
+          "level": 40
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 1380,
+        "bonus2": 31845
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 2924000000
+          },
+          {
+            "type": "dilithium",
+            "value": 8600000
+          }
+        ]
+      },
+      "build_time": 2616480,
+      "increased_power": 1000,
+      "level": 41,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 41
+        },
+        {
+          "name": "Tritanium Generator D",
+          "level": 41
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 36200,
+        "bonus2": 1425
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 4355400000
+          },
+          {
+            "type": "dilithium",
+            "value": 12810000
+          }
+        ]
+      },
+      "build_time": 4023360,
+      "increased_power": 1000,
+      "level": 42,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 42
+        },
+        {
+          "name": "Tritanium Generator D",
+          "level": 42
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 1450,
+        "bonus2": 36653
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 6222000000
+          },
+          {
+            "type": "dilithium",
+            "value": 18300000
+          }
+        ]
+      },
+      "build_time": 5315040,
+      "increased_power": 1250,
+      "level": 43,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 43
+        },
+        {
+          "name": "Tritanium Generator D",
+          "level": 43
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 1475,
+        "bonus2": 41500
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 9333000000
+          },
+          {
+            "type": "dilithium",
+            "value": 27450000
+          }
+        ]
+      },
+      "build_time": 6937920,
+      "increased_power": 1250,
+      "level": 44,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 44
+        },
+        {
+          "name": "Tritanium Generator D",
+          "level": 44
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 1725,
+        "bonus2": 54563
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 13260000000
+          },
+          {
+            "type": "dilithium",
+            "value": 39000000
+          }
+        ]
+      },
+      "build_time": 8955360,
+      "increased_power": 1250,
+      "level": 45,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 45
+        },
+        {
+          "name": "Tritanium Generator D",
+          "level": 45
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 1750,
+        "bonus2": 55125
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 18232500000
+          },
+          {
+            "type": "dilithium",
+            "value": 53625000
+          }
+        ]
+      },
+      "build_time": 11448000,
+      "increased_power": 1250,
+      "level": 46,
+      "requirements": [
+        {
+          "name": "Tritanium Generator D",
+          "level": 46
+        },
+        {
+          "name": "Operations",
+          "level": 46
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 1800,
+        "bonus2": 56813
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 26520000000
+          },
+          {
+            "type": "dilithium",
+            "value": 78000000
+          }
+        ]
+      },
+      "build_time": 14502240,
+      "increased_power": 1500,
+      "level": 47,
+      "requirements": [
+        {
+          "name": "Tritanium Generator D",
+          "level": 47
+        },
+        {
+          "name": "Operations",
+          "level": 47
+        }
+      ]
+    },
+    {
+      "bonuses": {
         "bonus1": 1850,
         "bonus2": 58500
       },

--- a/buildings/tritanium_generator_g.json
+++ b/buildings/tritanium_generator_g.json
@@ -14,6 +14,1583 @@
   "levels": [
     {
       "bonuses": {
+        "bonus1": 15,
+        "bonus2": 8
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 300
+          }
+        ]
+      },
+      "build_time": 30,
+      "increased_power": 10,
+      "level": 1,
+      "requirements": [
+        {
+          "name": "Tritanium Generator E",
+          "level": 1
+        },
+        {
+          "name": "Operations",
+          "level": 50
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 30,
+        "bonus2": 30
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 400
+          }
+        ]
+      },
+      "build_time": 60,
+      "increased_power": 10,
+      "level": 2,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 2
+        },
+        {
+          "name": "Tritanium Generator E",
+          "level": 2
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 45,
+        "bonus2": 68
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 600
+          }
+        ]
+      },
+      "build_time": 120,
+      "increased_power": 12,
+      "level": 3,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 3
+        },
+        {
+          "name": "Tritanium Generator E",
+          "level": 3
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 60,
+        "bonus2": 150
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 1000
+          }
+        ]
+      },
+      "build_time": 150,
+      "increased_power": 13,
+      "level": 4,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 4
+        },
+        {
+          "name": "Tritanium Generator E",
+          "level": 4
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 225,
+        "bonus2": 75
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 1600
+          }
+        ]
+      },
+      "build_time": 270,
+      "increased_power": 15,
+      "level": 5,
+      "requirements": [
+        {
+          "name": "Tritanium Generator E",
+          "level": 5
+        },
+        {
+          "name": "Operations",
+          "level": 5
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 91,
+        "bonus2": 320
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 2500
+          }
+        ]
+      },
+      "build_time": 450,
+      "increased_power": 20,
+      "level": 6,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 6
+        },
+        {
+          "name": "Tritanium Generator E",
+          "level": 6
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 420,
+        "bonus2": 105
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 3500
+          }
+        ]
+      },
+      "build_time": 840,
+      "increased_power": 20,
+      "level": 7,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 7
+        },
+        {
+          "name": "Tritanium Generator E",
+          "level": 7
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 120,
+        "bonus2": 600
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 4250
+          }
+        ]
+      },
+      "build_time": 1200,
+      "increased_power": 30,
+      "level": 8,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 8
+        },
+        {
+          "name": "Tritanium Generator E",
+          "level": 8
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 740,
+        "bonus2": 135
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 5000
+          }
+        ]
+      },
+      "build_time": 1800,
+      "increased_power": 40,
+      "level": 9,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 9
+        },
+        {
+          "name": "Tritanium Generator E",
+          "level": 9
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 180,
+        "bonus2": 1080
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 6000
+          }
+        ]
+      },
+      "build_time": 1920,
+      "increased_power": 40,
+      "level": 10,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 10
+        },
+        {
+          "name": "Tritanium Generator E",
+          "level": 10
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 200,
+        "bonus2": 1400
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 6800
+          },
+          {
+            "type": "dilithium",
+            "value": 8
+          }
+        ]
+      },
+      "build_time": 2040,
+      "increased_power": 50,
+      "level": 11,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 11
+        },
+        {
+          "name": "Tritanium Generator E",
+          "level": 11
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 220,
+        "bonus2": 1650
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 9350
+          },
+          {
+            "type": "dilithium",
+            "value": 22
+          }
+        ]
+      },
+      "build_time": 3720,
+      "increased_power": 70,
+      "level": 12,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 12
+        },
+        {
+          "name": "Tritanium Generator E",
+          "level": 12
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 2000,
+        "bonus2": 235
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 13600
+          },
+          {
+            "type": "dilithium",
+            "value": 48
+          }
+        ]
+      },
+      "build_time": 5400,
+      "increased_power": 70,
+      "level": 13,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 13
+        },
+        {
+          "name": "Tritanium Generator E",
+          "level": 13
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 255,
+        "bonus2": 2300
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 18700
+          },
+          {
+            "type": "dilithium",
+            "value": 88
+          }
+        ]
+      },
+      "build_time": 7800,
+      "increased_power": 90,
+      "level": 14,
+      "requirements": [
+        {
+          "name": "Tritanium Generator E",
+          "level": 14
+        },
+        {
+          "name": "Operations",
+          "level": 14
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 275,
+        "bonus2": 2750
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 25500
+          },
+          {
+            "type": "dilithium",
+            "value": 150
+          }
+        ]
+      },
+      "build_time": 9900,
+      "increased_power": 85,
+      "level": 15,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 15
+        },
+        {
+          "name": "Tritanium Generator E",
+          "level": 15
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 3200,
+        "bonus2": 290
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 34000
+          },
+          {
+            "type": "dilithium",
+            "value": 200
+          }
+        ]
+      },
+      "build_time": 11700,
+      "increased_power": 125,
+      "level": 16,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 16
+        },
+        {
+          "name": "Tritanium Generator E",
+          "level": 16
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 3575,
+        "bonus2": 310
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 47600
+          },
+          {
+            "type": "dilithium",
+            "value": 280
+          }
+        ]
+      },
+      "build_time": 12600,
+      "increased_power": 125,
+      "level": 17,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 17
+        },
+        {
+          "name": "Tritanium Generator E",
+          "level": 17
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 4125,
+        "bonus2": 330
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 68000
+          },
+          {
+            "type": "dilithium",
+            "value": 400
+          }
+        ]
+      },
+      "build_time": 19200,
+      "increased_power": 150,
+      "level": 18,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 18
+        },
+        {
+          "name": "Tritanium Generator E",
+          "level": 18
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 345,
+        "bonus2": 4475
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 102000
+          },
+          {
+            "type": "dilithium",
+            "value": 600
+          }
+        ]
+      },
+      "build_time": 28080,
+      "increased_power": 175,
+      "level": 19,
+      "requirements": [
+        {
+          "name": "Tritanium Generator E",
+          "level": 19
+        },
+        {
+          "name": "Operations",
+          "level": 19
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 6000,
+        "bonus2": 425
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 144500
+          },
+          {
+            "type": "dilithium",
+            "value": 850
+          }
+        ]
+      },
+      "build_time": 41760,
+      "increased_power": 200,
+      "level": 20,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 20
+        },
+        {
+          "name": "Tritanium Generator E",
+          "level": 20
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 6300,
+        "bonus2": 450
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 243270
+          },
+          {
+            "type": "dilithium",
+            "value": 1431
+          }
+        ]
+      },
+      "build_time": 38160,
+      "increased_power": 250,
+      "level": 21,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 21
+        },
+        {
+          "name": "Tritanium Generator E",
+          "level": 21
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 6600,
+        "bonus2": 470
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 378420
+          },
+          {
+            "type": "dilithium",
+            "value": 2226
+          }
+        ]
+      },
+      "build_time": 59040,
+      "increased_power": 200,
+      "level": 22,
+      "requirements": [
+        {
+          "name": "Tritanium Generator E",
+          "level": 22
+        },
+        {
+          "name": "Operations",
+          "level": 22
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 6900,
+        "bonus2": 490
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 622710
+          },
+          {
+            "type": "dilithium",
+            "value": 3663
+          }
+        ]
+      },
+      "build_time": 69840,
+      "increased_power": 300,
+      "level": 23,
+      "requirements": [
+        {
+          "name": "Tritanium Generator E",
+          "level": 23
+        },
+        {
+          "name": "Operations",
+          "level": 23
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 7100,
+        "bonus2": 510
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 981240
+          },
+          {
+            "type": "dilithium",
+            "value": 5772
+          }
+        ]
+      },
+      "build_time": 85680,
+      "increased_power": 200,
+      "level": 24,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 24
+        },
+        {
+          "name": "Tritanium Generator E",
+          "level": 24
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 8500,
+        "bonus2": 610
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 1591200
+          },
+          {
+            "type": "dilithium",
+            "value": 9360
+          }
+        ]
+      },
+      "build_time": 79200,
+      "increased_power": 400,
+      "level": 25,
+      "requirements": [
+        {
+          "name": "Tritanium Generator E",
+          "level": 25
+        },
+        {
+          "name": "Operations",
+          "level": 25
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 9000,
+        "bonus2": 640
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 2486250
+          },
+          {
+            "type": "dilithium",
+            "value": 14625
+          }
+        ]
+      },
+      "build_time": 108000,
+      "increased_power": 300,
+      "level": 26,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 26
+        },
+        {
+          "name": "Tritanium Generator E",
+          "level": 26
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 9200,
+        "bonus2": 660
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 3794400
+          },
+          {
+            "type": "dilithium",
+            "value": 22320
+          }
+        ]
+      },
+      "build_time": 122400,
+      "increased_power": 400,
+      "level": 27,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 27
+        },
+        {
+          "name": "Tritanium Generator E",
+          "level": 27
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 9500,
+        "bonus2": 680
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 5691600
+          },
+          {
+            "type": "dilithium",
+            "value": 33480
+          }
+        ]
+      },
+      "build_time": 142560,
+      "increased_power": 400,
+      "level": 28,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 28
+        },
+        {
+          "name": "Tritanium Generator E",
+          "level": 28
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 9900,
+        "bonus2": 710
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 9061000
+          },
+          {
+            "type": "dilithium",
+            "value": 53300
+          }
+        ]
+      },
+      "build_time": 156960,
+      "increased_power": 500,
+      "level": 29,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 29
+        },
+        {
+          "name": "Tritanium Generator E",
+          "level": 29
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 820,
+        "bonus2": 11500
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 13260000
+          },
+          {
+            "type": "dilithium",
+            "value": 78000
+          }
+        ]
+      },
+      "build_time": 169920,
+      "increased_power": 400,
+      "level": 30,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 30
+        },
+        {
+          "name": "Tritanium Generator E",
+          "level": 30
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 11900,
+        "bonus2": 850
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 20961000
+          },
+          {
+            "type": "dilithium",
+            "value": 123300
+          }
+        ]
+      },
+      "build_time": 223200,
+      "increased_power": 550,
+      "level": 31,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 31
+        },
+        {
+          "name": "Tritanium Generator E",
+          "level": 31
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 13284,
+        "bonus2": 880
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 30277000
+          },
+          {
+            "type": "dilithium",
+            "value": 178100
+          }
+        ]
+      },
+      "build_time": 218880,
+      "increased_power": 500,
+      "level": 32,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 32
+        },
+        {
+          "name": "Tritanium Generator E",
+          "level": 32
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 14732,
+        "bonus2": 910
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 46835000
+          },
+          {
+            "type": "dilithium",
+            "value": 275500
+          }
+        ]
+      },
+      "build_time": 316800,
+      "increased_power": 750,
+      "level": 33,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 33
+        },
+        {
+          "name": "Tritanium Generator E",
+          "level": 33
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 940,
+        "bonus2": 15312
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 73950000
+          },
+          {
+            "type": "dilithium",
+            "value": 435000
+          }
+        ]
+      },
+      "build_time": 420480,
+      "increased_power": 500,
+      "level": 34,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 34
+        },
+        {
+          "name": "Tritanium Generator E",
+          "level": 34
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 18600,
+        "bonus2": 1070
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 114444000
+          },
+          {
+            "type": "dilithium",
+            "value": 673200
+          }
+        ]
+      },
+      "build_time": 552960,
+      "increased_power": 750,
+      "level": 35,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 35
+        },
+        {
+          "name": "Tritanium Generator E",
+          "level": 35
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 20482,
+        "bonus2": 1100
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 161262000
+          },
+          {
+            "type": "dilithium",
+            "value": 948600
+          }
+        ]
+      },
+      "build_time": 707040,
+      "increased_power": 750,
+      "level": 36,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 36
+        },
+        {
+          "name": "Tritanium Generator E",
+          "level": 36
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 21014,
+        "bonus2": 1130
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 247860000
+          },
+          {
+            "type": "dilithium",
+            "value": 1458000
+          }
+        ]
+      },
+      "build_time": 731520,
+      "increased_power": 750,
+      "level": 37,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 37
+        },
+        {
+          "name": "Tritanium Generator E",
+          "level": 37
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 23004,
+        "bonus2": 1160
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 385560000
+          },
+          {
+            "type": "dilithium",
+            "value": 2268000
+          }
+        ]
+      },
+      "build_time": 1185120,
+      "increased_power": 1000,
+      "level": 38,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 38
+        },
+        {
+          "name": "Tritanium Generator E",
+          "level": 38
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 25551,
+        "bonus2": 1190
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 657900000
+          },
+          {
+            "type": "dilithium",
+            "value": 3870000
+          }
+        ]
+      },
+      "build_time": 1573920,
+      "increased_power": 750,
+      "level": 39,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 39
+        },
+        {
+          "name": "Tritanium Generator E",
+          "level": 39
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 28917,
+        "bonus2": 1350
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 2865520000
+          },
+          {
+            "type": "dilithium",
+            "value": 6020000
+          }
+        ]
+      },
+      "build_time": 2792160,
+      "increased_power": 1000,
+      "level": 40,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 40
+        },
+        {
+          "name": "Tritanium Generator E",
+          "level": 40
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 31845,
+        "bonus2": 1380
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 2924000000
+          },
+          {
+            "type": "dilithium",
+            "value": 8600000
+          }
+        ]
+      },
+      "build_time": 2616480,
+      "increased_power": 1000,
+      "level": 41,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 41
+        },
+        {
+          "name": "Tritanium Generator E",
+          "level": 41
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 36200,
+        "bonus2": 1425
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 4355400000
+          },
+          {
+            "type": "dilithium",
+            "value": 12810000
+          }
+        ]
+      },
+      "build_time": 4023360,
+      "increased_power": 1000,
+      "level": 42,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 42
+        },
+        {
+          "name": "Tritanium Generator E",
+          "level": 42
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 36653,
+        "bonus2": 1450
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 6222000000
+          },
+          {
+            "type": "dilithium",
+            "value": 18300000
+          }
+        ]
+      },
+      "build_time": 5315040,
+      "increased_power": 1250,
+      "level": 43,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 43
+        },
+        {
+          "name": "Tritanium Generator E",
+          "level": 43
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 41500,
+        "bonus2": 1475
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 9333000000
+          },
+          {
+            "type": "dilithium",
+            "value": 27450000
+          }
+        ]
+      },
+      "build_time": 6937920,
+      "increased_power": 1250,
+      "level": 44,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 44
+        },
+        {
+          "name": "Tritanium Generator E",
+          "level": 44
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 54563,
+        "bonus2": 1725
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 13260000000
+          },
+          {
+            "type": "dilithium",
+            "value": 39000000
+          }
+        ]
+      },
+      "build_time": 8955360,
+      "increased_power": 1250,
+      "level": 45,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 45
+        },
+        {
+          "name": "Tritanium Generator E",
+          "level": 45
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 55125,
+        "bonus2": 1750
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 18232500000
+          },
+          {
+            "type": "dilithium",
+            "value": 53625000
+          }
+        ]
+      },
+      "build_time": 11448000,
+      "increased_power": 1250,
+      "level": 46,
+      "requirements": [
+        {
+          "name": "Tritanium Generator E",
+          "level": 46
+        },
+        {
+          "name": "Operations",
+          "level": 46
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 56813,
+        "bonus2": 1800
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 26520000000
+          },
+          {
+            "type": "dilithium",
+            "value": 78000000
+          }
+        ]
+      },
+      "build_time": 14502240,
+      "increased_power": 1500,
+      "level": 47,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 47
+        },
+        {
+          "name": "Tritanium Generator E",
+          "level": 47
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 58500,
+        "bonus2": 1850
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 42840000000
+          },
+          {
+            "type": "dilithium",
+            "value": 126000000
+          }
+        ]
+      },
+      "build_time": 18220320,
+      "increased_power": 1500,
+      "level": 48,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 48
+        },
+        {
+          "name": "Tritanium Generator E",
+          "level": 48
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 59063,
+        "bonus2": 1875
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 71400000000
+          },
+          {
+            "type": "dilithium",
+            "value": 210000000
+          }
+        ]
+      },
+      "build_time": 22717440,
+      "increased_power": 1500,
+      "level": 49,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 49
+        },
+        {
+          "name": "Tritanium Generator E",
+          "level": 49
+        }
+      ]
+    },
+    {
+      "bonuses": {
         "bonus1": 2300,
         "bonus2": 72563
       },

--- a/buildings/tritanium_generator_h.json
+++ b/buildings/tritanium_generator_h.json
@@ -14,6 +14,1583 @@
   "levels": [
     {
       "bonuses": {
+        "bonus1": 8,
+        "bonus2": 15
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 300
+          }
+        ]
+      },
+      "build_time": 30,
+      "increased_power": 10,
+      "level": 1,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 50
+        },
+        {
+          "name": "Tritanium Generator F",
+          "level": 1
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 30,
+        "bonus2": 30
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 400
+          }
+        ]
+      },
+      "build_time": 60,
+      "increased_power": 10,
+      "level": 2,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 2
+        },
+        {
+          "name": "Tritanium Generator F",
+          "level": 2
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 68,
+        "bonus2": 45
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 600
+          }
+        ]
+      },
+      "build_time": 120,
+      "increased_power": 12,
+      "level": 3,
+      "requirements": [
+        {
+          "name": "Tritanium Generator F",
+          "level": 3
+        },
+        {
+          "name": "Operations",
+          "level": 3
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 150,
+        "bonus2": 60
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 1000
+          }
+        ]
+      },
+      "build_time": 150,
+      "increased_power": 13,
+      "level": 4,
+      "requirements": [
+        {
+          "name": "Tritanium Generator F",
+          "level": 4
+        },
+        {
+          "name": "Operations",
+          "level": 4
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 225,
+        "bonus2": 75
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 1600
+          }
+        ]
+      },
+      "build_time": 270,
+      "increased_power": 15,
+      "level": 5,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 5
+        },
+        {
+          "name": "Tritanium Generator F",
+          "level": 5
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 320,
+        "bonus2": 91
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 2500
+          }
+        ]
+      },
+      "build_time": 450,
+      "increased_power": 20,
+      "level": 6,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 6
+        },
+        {
+          "name": "Tritanium Generator F",
+          "level": 6
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 420,
+        "bonus2": 105
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 3500
+          }
+        ]
+      },
+      "build_time": 840,
+      "increased_power": 20,
+      "level": 7,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 7
+        },
+        {
+          "name": "Tritanium Generator F",
+          "level": 7
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 600,
+        "bonus2": 120
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 4250
+          }
+        ]
+      },
+      "build_time": 1200,
+      "increased_power": 30,
+      "level": 8,
+      "requirements": [
+        {
+          "name": "Tritanium Generator F",
+          "level": 8
+        },
+        {
+          "name": "Operations",
+          "level": 8
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 740,
+        "bonus2": 135
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 5000
+          }
+        ]
+      },
+      "build_time": 1800,
+      "increased_power": 40,
+      "level": 9,
+      "requirements": [
+        {
+          "name": "Tritanium Generator F",
+          "level": 9
+        },
+        {
+          "name": "Operations",
+          "level": 9
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 180,
+        "bonus2": 1080
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 6000
+          }
+        ]
+      },
+      "build_time": 1920,
+      "increased_power": 40,
+      "level": 10,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 10
+        },
+        {
+          "name": "Tritanium Generator F",
+          "level": 10
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 1400,
+        "bonus2": 200
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 6800
+          },
+          {
+            "type": "dilithium",
+            "value": 8
+          }
+        ]
+      },
+      "build_time": 2040,
+      "increased_power": 50,
+      "level": 11,
+      "requirements": [
+        {
+          "name": "Tritanium Generator F",
+          "level": 11
+        },
+        {
+          "name": "Operations",
+          "level": 11
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 1650,
+        "bonus2": 220
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 9350
+          },
+          {
+            "type": "dilithium",
+            "value": 22
+          }
+        ]
+      },
+      "build_time": 3720,
+      "increased_power": 70,
+      "level": 12,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 12
+        },
+        {
+          "name": "Tritanium Generator F",
+          "level": 12
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 2000,
+        "bonus2": 235
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 13600
+          },
+          {
+            "type": "dilithium",
+            "value": 48
+          }
+        ]
+      },
+      "build_time": 5400,
+      "increased_power": 70,
+      "level": 13,
+      "requirements": [
+        {
+          "name": "Tritanium Generator F",
+          "level": 13
+        },
+        {
+          "name": "Operations",
+          "level": 13
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 2300,
+        "bonus2": 255
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 18700
+          },
+          {
+            "type": "dilithium",
+            "value": 88
+          }
+        ]
+      },
+      "build_time": 7800,
+      "increased_power": 90,
+      "level": 14,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 14
+        },
+        {
+          "name": "Tritanium Generator F",
+          "level": 14
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 2750,
+        "bonus2": 275
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 25500
+          },
+          {
+            "type": "dilithium",
+            "value": 150
+          }
+        ]
+      },
+      "build_time": 9900,
+      "increased_power": 85,
+      "level": 15,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 15
+        },
+        {
+          "name": "Tritanium Generator F",
+          "level": 15
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 3200,
+        "bonus2": 290
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 34000
+          },
+          {
+            "type": "dilithium",
+            "value": 200
+          }
+        ]
+      },
+      "build_time": 11700,
+      "increased_power": 125,
+      "level": 16,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 16
+        },
+        {
+          "name": "Tritanium Generator F",
+          "level": 16
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 310,
+        "bonus2": 3575
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 47600
+          },
+          {
+            "type": "dilithium",
+            "value": 280
+          }
+        ]
+      },
+      "build_time": 12600,
+      "increased_power": 125,
+      "level": 17,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 17
+        },
+        {
+          "name": "Tritanium Generator F",
+          "level": 17
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 330,
+        "bonus2": 4125
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 68000
+          },
+          {
+            "type": "dilithium",
+            "value": 400
+          }
+        ]
+      },
+      "build_time": 19200,
+      "increased_power": 150,
+      "level": 18,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 18
+        },
+        {
+          "name": "Tritanium Generator F",
+          "level": 18
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 4475,
+        "bonus2": 345
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 102000
+          },
+          {
+            "type": "dilithium",
+            "value": 600
+          }
+        ]
+      },
+      "build_time": 28080,
+      "increased_power": 175,
+      "level": 19,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 19
+        },
+        {
+          "name": "Tritanium Generator F",
+          "level": 19
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 6000,
+        "bonus2": 425
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 144500
+          },
+          {
+            "type": "dilithium",
+            "value": 850
+          }
+        ]
+      },
+      "build_time": 41760,
+      "increased_power": 200,
+      "level": 20,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 20
+        },
+        {
+          "name": "Tritanium Generator F",
+          "level": 20
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 6300,
+        "bonus2": 450
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 243270
+          },
+          {
+            "type": "dilithium",
+            "value": 1431
+          }
+        ]
+      },
+      "build_time": 38160,
+      "increased_power": 250,
+      "level": 21,
+      "requirements": [
+        {
+          "name": "Tritanium Generator F",
+          "level": 21
+        },
+        {
+          "name": "Operations",
+          "level": 21
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 6600,
+        "bonus2": 470
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 378420
+          },
+          {
+            "type": "dilithium",
+            "value": 2226
+          }
+        ]
+      },
+      "build_time": 59040,
+      "increased_power": 200,
+      "level": 22,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 22
+        },
+        {
+          "name": "Tritanium Generator F",
+          "level": 22
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 490,
+        "bonus2": 6900
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 622710
+          },
+          {
+            "type": "dilithium",
+            "value": 3663
+          }
+        ]
+      },
+      "build_time": 69840,
+      "increased_power": 300,
+      "level": 23,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 23
+        },
+        {
+          "name": "Tritanium Generator F",
+          "level": 23
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 7100,
+        "bonus2": 510
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 981240
+          },
+          {
+            "type": "dilithium",
+            "value": 5772
+          }
+        ]
+      },
+      "build_time": 85680,
+      "increased_power": 200,
+      "level": 24,
+      "requirements": [
+        {
+          "name": "Tritanium Generator F",
+          "level": 24
+        },
+        {
+          "name": "Operations",
+          "level": 24
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 8500,
+        "bonus2": 610
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 1591200
+          },
+          {
+            "type": "dilithium",
+            "value": 9360
+          }
+        ]
+      },
+      "build_time": 79200,
+      "increased_power": 400,
+      "level": 25,
+      "requirements": [
+        {
+          "name": "Tritanium Generator F",
+          "level": 25
+        },
+        {
+          "name": "Operations",
+          "level": 25
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 9000,
+        "bonus2": 640
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 2486250
+          },
+          {
+            "type": "dilithium",
+            "value": 14625
+          }
+        ]
+      },
+      "build_time": 108000,
+      "increased_power": 300,
+      "level": 26,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 26
+        },
+        {
+          "name": "Tritanium Generator F",
+          "level": 26
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 9200,
+        "bonus2": 660
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 3794400
+          },
+          {
+            "type": "dilithium",
+            "value": 22320
+          }
+        ]
+      },
+      "build_time": 122400,
+      "increased_power": 400,
+      "level": 27,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 27
+        },
+        {
+          "name": "Tritanium Generator F",
+          "level": 27
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 9500,
+        "bonus2": 680
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 5691600
+          },
+          {
+            "type": "dilithium",
+            "value": 33480
+          }
+        ]
+      },
+      "build_time": 142560,
+      "increased_power": 400,
+      "level": 28,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 28
+        },
+        {
+          "name": "Tritanium Generator F",
+          "level": 28
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 710,
+        "bonus2": 9900
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 9061000
+          },
+          {
+            "type": "dilithium",
+            "value": 53300
+          }
+        ]
+      },
+      "build_time": 156960,
+      "increased_power": 500,
+      "level": 29,
+      "requirements": [
+        {
+          "name": "Tritanium Generator F",
+          "level": 29
+        },
+        {
+          "name": "Operations",
+          "level": 29
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 11500,
+        "bonus2": 820
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 13260000
+          },
+          {
+            "type": "dilithium",
+            "value": 78000
+          }
+        ]
+      },
+      "build_time": 169920,
+      "increased_power": 400,
+      "level": 30,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 30
+        },
+        {
+          "name": "Tritanium Generator F",
+          "level": 30
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 11900,
+        "bonus2": 850
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 20961000
+          },
+          {
+            "type": "dilithium",
+            "value": 123300
+          }
+        ]
+      },
+      "build_time": 223200,
+      "increased_power": 550,
+      "level": 31,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 31
+        },
+        {
+          "name": "Tritanium Generator F",
+          "level": 31
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 13284,
+        "bonus2": 880
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 30277000
+          },
+          {
+            "type": "dilithium",
+            "value": 178100
+          }
+        ]
+      },
+      "build_time": 218880,
+      "increased_power": 500,
+      "level": 32,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 32
+        },
+        {
+          "name": "Tritanium Generator F",
+          "level": 32
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 14732,
+        "bonus2": 910
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 46835000
+          },
+          {
+            "type": "dilithium",
+            "value": 275500
+          }
+        ]
+      },
+      "build_time": 316800,
+      "increased_power": 750,
+      "level": 33,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 33
+        },
+        {
+          "name": "Tritanium Generator F",
+          "level": 33
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 15312,
+        "bonus2": 940
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 73950000
+          },
+          {
+            "type": "dilithium",
+            "value": 435000
+          }
+        ]
+      },
+      "build_time": 420480,
+      "increased_power": 500,
+      "level": 34,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 34
+        },
+        {
+          "name": "Tritanium Generator F",
+          "level": 34
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 1070,
+        "bonus2": 18600
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 114444000
+          },
+          {
+            "type": "dilithium",
+            "value": 673200
+          }
+        ]
+      },
+      "build_time": 552960,
+      "increased_power": 750,
+      "level": 35,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 35
+        },
+        {
+          "name": "Tritanium Generator F",
+          "level": 35
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 20482,
+        "bonus2": 1100
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 161262000
+          },
+          {
+            "type": "dilithium",
+            "value": 948600
+          }
+        ]
+      },
+      "build_time": 707040,
+      "increased_power": 750,
+      "level": 36,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 36
+        },
+        {
+          "name": "Tritanium Generator F",
+          "level": 36
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 21014,
+        "bonus2": 1130
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 247860000
+          },
+          {
+            "type": "dilithium",
+            "value": 1458000
+          }
+        ]
+      },
+      "build_time": 731520,
+      "increased_power": 750,
+      "level": 37,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 37
+        },
+        {
+          "name": "Tritanium Generator F",
+          "level": 37
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 23004,
+        "bonus2": 1160
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 385560000
+          },
+          {
+            "type": "dilithium",
+            "value": 2268000
+          }
+        ]
+      },
+      "build_time": 1185120,
+      "increased_power": 1000,
+      "level": 38,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 38
+        },
+        {
+          "name": "Tritanium Generator F",
+          "level": 38
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 25551,
+        "bonus2": 1190
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 657900000
+          },
+          {
+            "type": "dilithium",
+            "value": 3870000
+          }
+        ]
+      },
+      "build_time": 1573920,
+      "increased_power": 750,
+      "level": 39,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 39
+        },
+        {
+          "name": "Tritanium Generator F",
+          "level": 39
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 1350,
+        "bonus2": 28917
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 2865520000
+          },
+          {
+            "type": "dilithium",
+            "value": 6020000
+          }
+        ]
+      },
+      "build_time": 2792160,
+      "increased_power": 1000,
+      "level": 40,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 40
+        },
+        {
+          "name": "Tritanium Generator F",
+          "level": 40
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 1380,
+        "bonus2": 31845
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 2924000000
+          },
+          {
+            "type": "dilithium",
+            "value": 8600000
+          }
+        ]
+      },
+      "build_time": 2616480,
+      "increased_power": 1000,
+      "level": 41,
+      "requirements": [
+        {
+          "name": "Tritanium Generator F",
+          "level": 41
+        },
+        {
+          "name": "Operations",
+          "level": 41
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 36200,
+        "bonus2": 1425
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 4355400000
+          },
+          {
+            "type": "dilithium",
+            "value": 12810000
+          }
+        ]
+      },
+      "build_time": 4023360,
+      "increased_power": 1000,
+      "level": 42,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 42
+        },
+        {
+          "name": "Tritanium Generator F",
+          "level": 42
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 36653,
+        "bonus2": 1450
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 6222000000
+          },
+          {
+            "type": "dilithium",
+            "value": 18300000
+          }
+        ]
+      },
+      "build_time": 5315040,
+      "increased_power": 1250,
+      "level": 43,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 43
+        },
+        {
+          "name": "Tritanium Generator F",
+          "level": 43
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 41500,
+        "bonus2": 1475
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 9333000000
+          },
+          {
+            "type": "dilithium",
+            "value": 27450000
+          }
+        ]
+      },
+      "build_time": 6937920,
+      "increased_power": 1250,
+      "level": 44,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 44
+        },
+        {
+          "name": "Tritanium Generator F",
+          "level": 44
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 54563,
+        "bonus2": 1725
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 13260000000
+          },
+          {
+            "type": "dilithium",
+            "value": 39000000
+          }
+        ]
+      },
+      "build_time": 8955360,
+      "increased_power": 1250,
+      "level": 45,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 45
+        },
+        {
+          "name": "Tritanium Generator F",
+          "level": 45
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 1750,
+        "bonus2": 55125
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 18232500000
+          },
+          {
+            "type": "dilithium",
+            "value": 53625000
+          }
+        ]
+      },
+      "build_time": 11448000,
+      "increased_power": 1250,
+      "level": 46,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 46
+        },
+        {
+          "name": "Tritanium Generator F",
+          "level": 46
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 56813,
+        "bonus2": 1800
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 26520000000
+          },
+          {
+            "type": "dilithium",
+            "value": 78000000
+          }
+        ]
+      },
+      "build_time": 14502240,
+      "increased_power": 1500,
+      "level": 47,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 47
+        },
+        {
+          "name": "Tritanium Generator F",
+          "level": 47
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 58500,
+        "bonus2": 1850
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 42840000000
+          },
+          {
+            "type": "dilithium",
+            "value": 126000000
+          }
+        ]
+      },
+      "build_time": 18220320,
+      "increased_power": 1500,
+      "level": 48,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 48
+        },
+        {
+          "name": "Tritanium Generator F",
+          "level": 48
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 59063,
+        "bonus2": 1875
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 71400000000
+          },
+          {
+            "type": "dilithium",
+            "value": 210000000
+          }
+        ]
+      },
+      "build_time": 22717440,
+      "increased_power": 1500,
+      "level": 49,
+      "requirements": [
+        {
+          "name": "Operations",
+          "level": 49
+        },
+        {
+          "name": "Tritanium Generator F",
+          "level": 49
+        }
+      ]
+    },
+    {
+      "bonuses": {
         "bonus1": 72563,
         "bonus2": 2300
       },


### PR DESCRIPTION
Following #69 

- All missing Parsteel Generators levels
- All missing Tritanium Generators levels
- Missing Dilithium Generators levels for B, D, E (dup)
