### PR TITLE
TNG Arc 5 - Officer buff hotfix

### DIFF
--- a/officers/grace_chen.json
+++ b/officers/grace_chen.json
@@ -9,7 +9,7 @@
     },
     "officer_ability": {
       "name": "Energy Absorber",
-      "bonus": "{value} To energy damage dealt by enemy Hostiles",
+      "bonus": "{value} To energy damage dealt by enemy Hostiles of level 51 and under.",
       "percentage": true
     }
   },

--- a/officers/t_laan.json
+++ b/officers/t_laan.json
@@ -9,7 +9,7 @@
     },
     "officer_ability": {
       "name": "Objective Defense",
-      "bonus": "{value} to Kinetic Damage dealt by enemy Hostiles",
+      "bonus": "{value} to Kinetic Damage dealt by enemy Hostiles of level 51 and under.",
       "percentage": true
     }
   },


### PR DESCRIPTION
Scopely made a hotfix for the officer buffs of Chen and T'Laan in TNG Arc 5 due to them working on hostiles level 51 whilst the description said till level 50.