### PR TITLE
Hotfix ships wrong initial build costs

### DIFF
--- a/ships/augur.json
+++ b/ships/augur.json
@@ -160,36 +160,25 @@
           {
             "type": "crystal",
             "grade": 3,
-            "rarity": "rare",
-            "value": 1430
+            "rarity": "common",
+            "value": 1375
           },
           {
             "type": "ore",
             "grade": 3,
-            "rarity": "uncommon",
-            "value": 11000
-          },
-          {
-            "type": "ore",
-            "grade": 3,
-            "rarity": "rare",
-            "value": 5400
+            "rarity": "common",
+            "value": 8250
           }
         ],
-        "others": [
-          {
-            "type": "3\u2605\u00a0Battleship\u00a0Parts",
-            "value": 135250
-          }
-        ],
+        "others": [],
         "resources": [
           {
             "type": "tritanium",
-            "value": 4798000000
+            "value": 9000000
           },
           {
             "type": "dilithium",
-            "value": 219500000
+            "value": 200000
           }
         ]
       },

--- a/ships/b_chor.json
+++ b/ships/b_chor.json
@@ -173,48 +173,27 @@
       "initial_build_cost": {
         "materials": [
           {
-            "type": "crystal",
-            "grade": 4,
-            "rarity": "common",
-            "value": 18160
-          },
-          {
-            "type": "crystal",
-            "grade": 4,
-            "rarity": "uncommon",
-            "value": 4730
-          },
-          {
             "type": "gas",
             "grade": 4,
             "rarity": "common",
-            "value": 7325
+            "value": 2100
           },
           {
-            "type": "gas",
+            "type": "crystal",
             "grade": 4,
-            "rarity": "uncommon",
-            "value": 2215
+            "rarity": "common",
+            "value": 6000
           }
         ],
-        "others": [
-          {
-            "type": "4\u2605\u00a0Common\u00a0Survey\u00a0Parts",
-            "value": 47005
-          },
-          {
-            "type": "4\u2605\u00a0Uncommon\u00a0Survey\u00a0Parts",
-            "value": 13480
-          }
-        ],
+        "others": [],
         "resources": [
           {
             "type": "tritanium",
-            "value": 1293700000
+            "value": 17500000
           },
           {
             "type": "dilithium",
-            "value": 70900000
+            "value": 1400000
           }
         ]
       },

--- a/ships/b_rel.json
+++ b/ships/b_rel.json
@@ -156,36 +156,25 @@
           {
             "type": "gas",
             "grade": 3,
-            "rarity": "uncommon",
+            "rarity": "common",
             "value": 4100
-          },
-          {
-            "type": "gas",
-            "grade": 3,
-            "rarity": "rare",
-            "value": 2050
           },
           {
             "type": "ore",
             "grade": 3,
-            "rarity": "rare",
-            "value": 550
+            "rarity": "common",
+            "value": 625
           }
         ],
-        "others": [
-          {
-            "type": "3\u2605\u00a0Explorer\u00a0Parts",
-            "value": 60150
-          }
-        ],
+        "others": [],
         "resources": [
           {
             "type": "tritanium",
-            "value": 959000000
+            "value": 3000000
           },
           {
             "type": "dilithium",
-            "value": 41050000
+            "value": 108000
           }
         ]
       },

--- a/ships/bortas.json
+++ b/ships/bortas.json
@@ -156,36 +156,25 @@
           {
             "type": "crystal",
             "grade": 3,
-            "rarity": "rare",
-            "value": 204
+            "rarity": "common",
+            "value": 275
           },
           {
             "type": "ore",
             "grade": 3,
-            "rarity": "uncommon",
-            "value": 1700
-          },
-          {
-            "type": "ore",
-            "grade": 3,
-            "rarity": "rare",
-            "value": 770
+            "rarity": "common",
+            "value": 2200
           }
         ],
-        "others": [
-          {
-            "type": "3\u2605\u00a0Battleship\u00a0Parts",
-            "value": 21700
-          }
-        ],
+        "others": [],
         "resources": [
           {
             "type": "tritanium",
-            "value": 324000000
+            "value": 1900000
           },
           {
             "type": "dilithium",
-            "value": 10300000
+            "value": 42500
           }
         ]
       },

--- a/ships/botany_bay.json
+++ b/ships/botany_bay.json
@@ -154,42 +154,25 @@
           {
             "type": "gas",
             "grade": 3,
-            "rarity": "uncommon",
-            "value": 5
+            "rarity": "common",
+            "value": 180
           },
           {
-            "type": "gas",
+            "type": "crystal",
             "grade": 3,
-            "rarity": "rare",
-            "value": 9
-          },
-          {
-            "type": "ore",
-            "grade": 3,
-            "rarity": "uncommon",
-            "value": 18
-          },
-          {
-            "type": "ore",
-            "grade": 3,
-            "rarity": "rare",
-            "value": 39
+            "rarity": "common",
+            "value": 725
           }
         ],
-        "others": [
-          {
-            "type": "3\u2605\u00a0Survey\u00a0Parts",
-            "value": 1510
-          }
-        ],
+        "others": [],
         "resources": [
           {
             "type": "tritanium",
-            "value": 4155000
+            "value": 800000
           },
           {
             "type": "dilithium",
-            "value": 176500
+            "value": 28000
           }
         ]
       },

--- a/ships/centurion.json
+++ b/ships/centurion.json
@@ -156,36 +156,25 @@
           {
             "type": "gas",
             "grade": 3,
-            "rarity": "uncommon",
-            "value": 1700
-          },
-          {
-            "type": "gas",
-            "grade": 3,
-            "rarity": "rare",
-            "value": 870
+            "rarity": "common",
+            "value": 2200
           },
           {
             "type": "ore",
             "grade": 3,
-            "rarity": "rare",
-            "value": 230
+            "rarity": "common",
+            "value": 275
           }
         ],
-        "others": [
-          {
-            "type": "3\u2605\u00a0Explorer\u00a0Parts",
-            "value": 23700
-          }
-        ],
+        "others": [],
         "resources": [
           {
             "type": "tritanium",
-            "value": 243000000
+            "value": 1600000
           },
           {
             "type": "dilithium",
-            "value": 18900000
+            "value": 53000
           }
         ]
       },

--- a/ships/d3_class.json
+++ b/ships/d3_class.json
@@ -156,36 +156,19 @@
           {
             "type": "crystal",
             "grade": 3,
-            "rarity": "uncommon",
-            "value": 1100
-          },
-          {
-            "type": "crystal",
-            "grade": 3,
-            "rarity": "rare",
-            "value": 420
-          },
-          {
-            "type": "gas",
-            "grade": 3,
-            "rarity": "rare",
-            "value": 117
+            "rarity": "common",
+            "value": 500
           }
         ],
-        "others": [
-          {
-            "type": "3\u2605\u00a0Interceptor\u00a0Parts",
-            "value": 16200
-          }
-        ],
+        "others": [],
         "resources": [
           {
             "type": "tritanium",
-            "value": 158100000
+            "value": 1150000
           },
           {
             "type": "dilithium",
-            "value": 4250000
+            "value": 38500
           }
         ]
       },

--- a/ships/d4_class.json
+++ b/ships/d4_class.json
@@ -160,36 +160,25 @@
           {
             "type": "crystal",
             "grade": 3,
-            "rarity": "uncommon",
-            "value": 11000
-          },
-          {
-            "type": "crystal",
-            "grade": 3,
-            "rarity": "rare",
-            "value": 4200
+            "rarity": "common",
+            "value": 8250
           },
           {
             "type": "gas",
             "grade": 3,
-            "rarity": "rare",
-            "value": 1155
+            "rarity": "common",
+            "value": 1375
           }
         ],
-        "others": [
-          {
-            "type": "3\u2605\u00a0Interceptor\u00a0Parts",
-            "value": 108250
-          }
-        ],
+        "others": [],
         "resources": [
           {
             "type": "tritanium",
-            "value": 6636000000
+            "value": 7500000
           },
           {
             "type": "dilithium",
-            "value": 89400000
+            "value": 250000
           }
         ]
       },

--- a/ships/ecs_fortunate.json
+++ b/ships/ecs_fortunate.json
@@ -139,16 +139,11 @@
       ],
       "initial_build_cost": {
         "materials": [],
-        "others": [
-          {
-            "type": "1\u2605\u00a0Survey\u00a0Parts",
-            "value": 45
-          }
-        ],
+        "others": [],
         "resources": [
           {
             "type": "tritanium",
-            "value": 5950
+            "value": 750
           }
         ]
       },

--- a/ships/ecs_horizon.json
+++ b/ships/ecs_horizon.json
@@ -155,52 +155,16 @@
         }
       ],
       "initial_build_cost": {
-        "materials": [
-          {
-            "type": "crystal",
-            "grade": 3,
-            "rarity": "uncommon",
-            "value": 690
-          },
-          {
-            "type": "crystal",
-            "grade": 3,
-            "rarity": "rare",
-            "value": 17
-          },
-          {
-            "type": "gas",
-            "grade": 3,
-            "rarity": "common",
-            "value": 450
-          },
-          {
-            "type": "gas",
-            "grade": 3,
-            "rarity": "uncommon",
-            "value": 170
-          },
-          {
-            "type": "gas",
-            "grade": 3,
-            "rarity": "rare",
-            "value": 3
-          }
-        ],
-        "others": [
-          {
-            "type": "3\u2605\u00a0Survey\u00a0Parts",
-            "value": 3430
-          }
-        ],
+        "materials": [],
+        "others": [],
         "resources": [
           {
             "type": "tritanium",
-            "value": 43700000
+            "value": 800000
           },
           {
             "type": "dilithium",
-            "value": 2420000
+            "value": 28000
           }
         ]
       },

--- a/ships/envoy.json
+++ b/ships/envoy.json
@@ -138,34 +138,12 @@
         }
       ],
       "initial_build_cost": {
-        "materials": [
-          {
-            "type": "crystal",
-            "grade": 2,
-            "rarity": "common",
-            "value": 2025
-          },
-          {
-            "type": "crystal",
-            "grade": 2,
-            "rarity": "uncommon",
-            "value": 655
-          }
-        ],
-        "others": [
-          {
-            "type": "2\u2605\u00a0Survey\u00a0Parts",
-            "value": 1290
-          }
-        ],
+        "materials": [],
+        "others": [],
         "resources": [
           {
             "type": "tritanium",
-            "value": 991000
-          },
-          {
-            "type": "dilithium",
-            "value": 77500
+            "value": 21000
           }
         ]
       },

--- a/ships/ferengi_d_vor.json
+++ b/ships/ferengi_d_vor.json
@@ -230,7 +230,7 @@
             "materials": [],
             "others": [
               {
-                "type": "D",
+                "type": "D'Vor Parts",
                 "value": 50
               }
             ],
@@ -272,7 +272,7 @@
             "materials": [],
             "others": [
               {
-                "type": "D",
+                "type": "D'Vor Parts",
                 "value": 190
               }
             ],
@@ -308,7 +308,7 @@
             "materials": [],
             "others": [
               {
-                "type": "D",
+                "type": "D'Vor Parts",
                 "value": 270
               }
             ],
@@ -340,7 +340,7 @@
             "materials": [],
             "others": [
               {
-                "type": "D",
+                "type": "D'Vor Parts",
                 "value": 110
               }
             ],
@@ -380,7 +380,7 @@
             "materials": [],
             "others": [
               {
-                "type": "D",
+                "type": "D'Vor Parts",
                 "value": 110
               }
             ],
@@ -415,7 +415,7 @@
             "materials": [],
             "others": [
               {
-                "type": "D",
+                "type": "D'Vor Parts",
                 "value": 270
               }
             ],
@@ -511,7 +511,7 @@
             "materials": [],
             "others": [
               {
-                "type": "D",
+                "type": "D'Vor Parts",
                 "value": 110
               }
             ],
@@ -553,7 +553,7 @@
             "materials": [],
             "others": [
               {
-                "type": "D",
+                "type": "D'Vor Parts",
                 "value": 390
               }
             ],
@@ -589,7 +589,7 @@
             "materials": [],
             "others": [
               {
-                "type": "D",
+                "type": "D'Vor Parts",
                 "value": 540
               }
             ],
@@ -621,7 +621,7 @@
             "materials": [],
             "others": [
               {
-                "type": "D",
+                "type": "D'Vor Parts",
                 "value": 220
               }
             ],
@@ -661,7 +661,7 @@
             "materials": [],
             "others": [
               {
-                "type": "D",
+                "type": "D'Vor Parts",
                 "value": 220
               }
             ],
@@ -696,7 +696,7 @@
             "materials": [],
             "others": [
               {
-                "type": "D",
+                "type": "D'Vor Parts",
                 "value": 520
               }
             ],
@@ -792,7 +792,7 @@
             "materials": [],
             "others": [
               {
-                "type": "D",
+                "type": "D'Vor Parts",
                 "value": 160
               }
             ],
@@ -834,7 +834,7 @@
             "materials": [],
             "others": [
               {
-                "type": "D",
+                "type": "D'Vor Parts",
                 "value": 580
               }
             ],
@@ -870,7 +870,7 @@
             "materials": [],
             "others": [
               {
-                "type": "D",
+                "type": "D'Vor Parts",
                 "value": 810
               }
             ],
@@ -902,7 +902,7 @@
             "materials": [],
             "others": [
               {
-                "type": "D",
+                "type": "D'Vor Parts",
                 "value": 320
               }
             ],
@@ -942,7 +942,7 @@
             "materials": [],
             "others": [
               {
-                "type": "D",
+                "type": "D'Vor Parts",
                 "value": 320
               }
             ],
@@ -977,7 +977,7 @@
             "materials": [],
             "others": [
               {
-                "type": "D",
+                "type": "D'Vor Parts",
                 "value": 810
               }
             ],
@@ -1073,7 +1073,7 @@
             "materials": [],
             "others": [
               {
-                "type": "D",
+                "type": "D'Vor Parts",
                 "value": 220
               }
             ],
@@ -1115,7 +1115,7 @@
             "materials": [],
             "others": [
               {
-                "type": "D",
+                "type": "D'Vor Parts",
                 "value": 770
               }
             ],
@@ -1151,7 +1151,7 @@
             "materials": [],
             "others": [
               {
-                "type": "D",
+                "type": "D'Vor Parts",
                 "value": 1080
               }
             ],
@@ -1183,7 +1183,7 @@
             "materials": [],
             "others": [
               {
-                "type": "D",
+                "type": "D'Vor Parts",
                 "value": 430
               }
             ],
@@ -1223,7 +1223,7 @@
             "materials": [],
             "others": [
               {
-                "type": "D",
+                "type": "D'Vor Parts",
                 "value": 430
               }
             ],
@@ -1258,7 +1258,7 @@
             "materials": [],
             "others": [
               {
-                "type": "D",
+                "type": "D'Vor Parts",
                 "value": 1070
               }
             ],
@@ -1339,7 +1339,7 @@
             "materials": [],
             "others": [
               {
-                "type": "D",
+                "type": "D'Vor Parts",
                 "value": 5400
               }
             ],
@@ -1392,7 +1392,7 @@
             "materials": [],
             "others": [
               {
-                "type": "D",
+                "type": "D'Vor Parts",
                 "value": 1500
               }
             ],
@@ -1432,7 +1432,7 @@
             "materials": [],
             "others": [
               {
-                "type": "D",
+                "type": "D'Vor Parts",
                 "value": 7500
               }
             ],
@@ -1464,7 +1464,7 @@
             "materials": [],
             "others": [
               {
-                "type": "D",
+                "type": "D'Vor Parts",
                 "value": 3000
               }
             ],
@@ -1504,7 +1504,7 @@
             "materials": [],
             "others": [
               {
-                "type": "D",
+                "type": "D'Vor Parts",
                 "value": 3000
               }
             ],
@@ -1539,7 +1539,7 @@
             "materials": [],
             "others": [
               {
-                "type": "D",
+                "type": "D'Vor Parts",
                 "value": 7600
               }
             ],
@@ -1635,7 +1635,7 @@
             "materials": [],
             "others": [
               {
-                "type": "D",
+                "type": "D'Vor Parts",
                 "value": 2300
               }
             ],
@@ -1677,7 +1677,7 @@
             "materials": [],
             "others": [
               {
-                "type": "D",
+                "type": "D'Vor Parts",
                 "value": 8100
               }
             ],
@@ -1713,7 +1713,7 @@
             "materials": [],
             "others": [
               {
-                "type": "D",
+                "type": "D'Vor Parts",
                 "value": 11300
               }
             ],
@@ -1745,7 +1745,7 @@
             "materials": [],
             "others": [
               {
-                "type": "D",
+                "type": "D'Vor Parts",
                 "value": 4500
               }
             ],
@@ -1785,7 +1785,7 @@
             "materials": [],
             "others": [
               {
-                "type": "D",
+                "type": "D'Vor Parts",
                 "value": 4500
               }
             ],
@@ -1820,7 +1820,7 @@
             "materials": [],
             "others": [
               {
-                "type": "D",
+                "type": "D'Vor Parts",
                 "value": 11300
               }
             ],
@@ -1916,7 +1916,7 @@
             "materials": [],
             "others": [
               {
-                "type": "D",
+                "type": "D'Vor Parts",
                 "value": 9100
               }
             ],
@@ -1958,7 +1958,7 @@
             "materials": [],
             "others": [
               {
-                "type": "D",
+                "type": "D'Vor Parts",
                 "value": 32900
               }
             ],
@@ -1994,7 +1994,7 @@
             "materials": [],
             "others": [
               {
-                "type": "D",
+                "type": "D'Vor Parts",
                 "value": 45700
               }
             ],
@@ -2026,7 +2026,7 @@
             "materials": [],
             "others": [
               {
-                "type": "D",
+                "type": "D'Vor Parts",
                 "value": 18300
               }
             ],
@@ -2066,7 +2066,7 @@
             "materials": [],
             "others": [
               {
-                "type": "D",
+                "type": "D'Vor Parts",
                 "value": 18300
               }
             ],
@@ -2101,7 +2101,7 @@
             "materials": [],
             "others": [
               {
-                "type": "D",
+                "type": "D'Vor Parts",
                 "value": 45700
               }
             ],
@@ -2197,7 +2197,7 @@
             "materials": [],
             "others": [
               {
-                "type": "D",
+                "type": "D'Vor Parts",
                 "value": 13700
               }
             ],
@@ -2239,7 +2239,7 @@
             "materials": [],
             "others": [
               {
-                "type": "D",
+                "type": "D'Vor Parts",
                 "value": 49400
               }
             ],
@@ -2275,7 +2275,7 @@
             "materials": [],
             "others": [
               {
-                "type": "D",
+                "type": "D'Vor Parts",
                 "value": 68500
               }
             ],
@@ -2307,7 +2307,7 @@
             "materials": [],
             "others": [
               {
-                "type": "D",
+                "type": "D'Vor Parts",
                 "value": 27400
               }
             ],
@@ -2347,7 +2347,7 @@
             "materials": [],
             "others": [
               {
-                "type": "D",
+                "type": "D'Vor Parts",
                 "value": 27400
               }
             ],
@@ -2382,7 +2382,7 @@
             "materials": [],
             "others": [
               {
-                "type": "D",
+                "type": "D'Vor Parts",
                 "value": 68600
               }
             ],

--- a/ships/ferengi_d_vor.json
+++ b/ships/ferengi_d_vor.json
@@ -155,11 +155,11 @@
         "resources": [
           {
             "type": "tritanium",
-            "value": 28900000
+            "value": 320000
           },
           {
             "type": "dilithium",
-            "value": 1238000
+            "value": 11250
           }
         ]
       },

--- a/ships/gladius.json
+++ b/ships/gladius.json
@@ -156,36 +156,25 @@
           {
             "type": "crystal",
             "grade": 3,
-            "rarity": "uncommon",
+            "rarity": "common",
             "value": 4100
-          },
-          {
-            "type": "crystal",
-            "grade": 3,
-            "rarity": "rare",
-            "value": 2050
           },
           {
             "type": "gas",
             "grade": 3,
-            "rarity": "rare",
-            "value": 550
+            "rarity": "common",
+            "value": 625
           }
         ],
-        "others": [
-          {
-            "type": "3\u2605\u00a0Interceptor\u00a0Parts",
-            "value": 60150
-          }
-        ],
+        "others": [],
         "resources": [
           {
             "type": "tritanium",
-            "value": 1462000000
+            "value": 3750000
           },
           {
             "type": "dilithium",
-            "value": 24300000
+            "value": 90000
           }
         ]
       },

--- a/ships/hegh_ta.json
+++ b/ships/hegh_ta.json
@@ -246,40 +246,25 @@
           {
             "type": "crystal",
             "grade": 4,
-            "rarity": "uncommon",
-            "value": 340850
-          },
-          {
-            "type": "crystal",
-            "grade": 4,
-            "rarity": "rare",
-            "value": 115900
+            "rarity": "common",
+            "value": 9000
           },
           {
             "type": "gas",
             "grade": 4,
-            "rarity": "rare",
-            "value": 74320
+            "rarity": "common",
+            "value": 3150
           }
         ],
-        "others": [
-          {
-            "type": "4\u2605\u00a0Common\u00a0Interceptor\u00a0Parts",
-            "value": 2939710
-          },
-          {
-            "type": "4\u2605\u00a0Uncommon\u00a0Interceptor\u00a0Parts",
-            "value": 790320
-          }
-        ],
+        "others": [],
         "resources": [
           {
             "type": "tritanium",
-            "value": 624382000000
+            "value": 275000000
           },
           {
             "type": "dilithium",
-            "value": 27164000000
+            "value": 12000000
           }
         ]
       },

--- a/ships/hijacked_d3_class.json
+++ b/ships/hijacked_d3_class.json
@@ -155,36 +155,24 @@
           {
             "type": "crystal",
             "grade": 3,
-            "rarity": "uncommon",
-            "value": 1100
-          },
-          {
-            "type": "crystal",
-            "grade": 3,
-            "rarity": "rare",
-            "value": 420
-          },
-          {
-            "type": "gas",
-            "grade": 3,
-            "rarity": "rare",
-            "value": 117
+            "rarity": "common",
+            "value": 500
           }
         ],
         "others": [
           {
-            "type": "3\u2605\u00a0Interceptor\u00a0Parts",
-            "value": 16200
+            "type": "Common\u00a0Plutonium",
+            "value": 200
           }
         ],
         "resources": [
           {
             "type": "tritanium",
-            "value": 158100000
+            "value": 1150000
           },
           {
             "type": "dilithium",
-            "value": 4250000
+            "value": 38500
           }
         ]
       },

--- a/ships/hijacked_legionary.json
+++ b/ships/hijacked_legionary.json
@@ -119,38 +119,26 @@
       "initial_build_cost": {
         "materials": [
           {
-            "type": "crystal",
-            "grade": 3,
-            "rarity": "rare",
-            "value": 144
-          },
-          {
             "type": "ore",
             "grade": 3,
-            "rarity": "uncommon",
-            "value": 1100
-          },
-          {
-            "type": "ore",
-            "grade": 3,
-            "rarity": "rare",
-            "value": 540
+            "rarity": "common",
+            "value": 500
           }
         ],
         "others": [
           {
-            "type": "3\u2605\u00a0Battleship\u00a0Parts",
-            "value": 20300
+            "type": "Common\u00a0Plutonium",
+            "value": 200
           }
         ],
         "resources": [
           {
             "type": "tritanium",
-            "value": 228900000
+            "value": 1300000
           },
           {
             "type": "dilithium",
-            "value": 10530000
+            "value": 30000
           }
         ]
       },

--- a/ships/hijacked_uss_mayflower.json
+++ b/ships/hijacked_uss_mayflower.json
@@ -155,36 +155,24 @@
           {
             "type": "gas",
             "grade": 3,
-            "rarity": "uncommon",
-            "value": 1100
-          },
-          {
-            "type": "gas",
-            "grade": 3,
-            "rarity": "rare",
-            "value": 570
-          },
-          {
-            "type": "ore",
-            "grade": 3,
-            "rarity": "rare",
-            "value": 153
+            "rarity": "common",
+            "value": 500
           }
         ],
         "others": [
           {
-            "type": "3\u2605\u00a0Explorer\u00a0Parts",
-            "value": 21100
+            "type": "Common\u00a0Plutonium",
+            "value": 200
           }
         ],
         "resources": [
           {
             "type": "tritanium",
-            "value": 130800000
+            "value": 890000
           },
           {
             "type": "dilithium",
-            "value": 11350000
+            "value": 42500
           }
         ]
       },

--- a/ships/iss_jellyfish.json
+++ b/ships/iss_jellyfish.json
@@ -187,48 +187,27 @@
       "initial_build_cost": {
         "materials": [
           {
-            "type": "gas",
-            "grade": 4,
-            "rarity": "common",
-            "value": 160205
-          },
-          {
-            "type": "gas",
-            "grade": 4,
-            "rarity": "uncommon",
-            "value": 101365
-          },
-          {
             "type": "ore",
             "grade": 4,
             "rarity": "common",
-            "value": 56230
+            "value": 3000
           },
           {
-            "type": "ore",
+            "type": "gas",
             "grade": 4,
-            "rarity": "uncommon",
-            "value": 48020
+            "rarity": "common",
+            "value": 5000
           }
         ],
-        "others": [
-          {
-            "type": "4\u2605\u00a0Common\u00a0Explorer\u00a0Parts",
-            "value": 841080
-          },
-          {
-            "type": "4\u2605\u00a0Uncommon\u00a0Explorer\u00a0Parts",
-            "value": 225525
-          }
-        ],
+        "others": [],
         "resources": [
           {
             "type": "tritanium",
-            "value": 18249000000
+            "value": 16000000
           },
           {
             "type": "dilithium",
-            "value": 634585000
+            "value": 800000
           }
         ]
       },

--- a/ships/jellyfish.json
+++ b/ships/jellyfish.json
@@ -117,28 +117,12 @@
         }
       ],
       "initial_build_cost": {
-        "materials": [
-          {
-            "type": "gas",
-            "grade": 2,
-            "rarity": "common",
-            "value": 2175
-          }
-        ],
-        "others": [
-          {
-            "type": "2\u2605\u00a0Explorer\u00a0Parts",
-            "value": 358
-          }
-        ],
+        "materials": [],
+        "others": [],
         "resources": [
           {
             "type": "tritanium",
-            "value": 88500
-          },
-          {
-            "type": "dilithium",
-            "value": 7200
+            "value": 60000
           }
         ]
       },

--- a/ships/k_t_inga.json
+++ b/ships/k_t_inga.json
@@ -176,40 +176,25 @@
           {
             "type": "crystal",
             "grade": 4,
-            "rarity": "rare",
-            "value": 24670
+            "rarity": "common",
+            "value": 2450
           },
           {
             "type": "ore",
             "grade": 4,
-            "rarity": "uncommon",
-            "value": 131095
-          },
-          {
-            "type": "ore",
-            "grade": 4,
-            "rarity": "rare",
-            "value": 42025
+            "rarity": "common",
+            "value": 7000
           }
         ],
-        "others": [
-          {
-            "type": "4\u2605\u00a0Common\u00a0Battleship\u00a0Parts",
-            "value": 1160130
-          },
-          {
-            "type": "4\u2605\u00a0Uncommon\u00a0Battleship\u00a0Parts",
-            "value": 311735
-          }
-        ],
+        "others": [],
         "resources": [
           {
             "type": "tritanium",
-            "value": 196424800000
+            "value": 25000000
           },
           {
             "type": "dilithium",
-            "value": 8199200000
+            "value": 1600000
           }
         ]
       },

--- a/ships/k_vort.json
+++ b/ships/k_vort.json
@@ -155,42 +155,25 @@
           {
             "type": "crystal",
             "grade": 3,
-            "rarity": "uncommon",
-            "value": 8000
-          },
-          {
-            "type": "crystal",
-            "grade": 3,
-            "rarity": "rare",
-            "value": 1415
+            "rarity": "common",
+            "value": 2500
           },
           {
             "type": "gas",
             "grade": 3,
-            "rarity": "uncommon",
-            "value": 1200
-          },
-          {
-            "type": "gas",
-            "grade": 3,
-            "rarity": "rare",
-            "value": 330
+            "rarity": "common",
+            "value": 625
           }
         ],
-        "others": [
-          {
-            "type": "3\u2605\u00a0Survey\u00a0Parts",
-            "value": 34300
-          }
-        ],
+        "others": [],
         "resources": [
           {
             "type": "tritanium",
-            "value": 1201000000
+            "value": 6000000
           },
           {
             "type": "dilithium",
-            "value": 64050000
+            "value": 144000
           }
         ]
       },

--- a/ships/kehra.json
+++ b/ships/kehra.json
@@ -156,52 +156,16 @@
         }
       ],
       "initial_build_cost": {
-        "materials": [
-          {
-            "type": "crystal",
-            "grade": 3,
-            "rarity": "common",
-            "value": 1000
-          },
-          {
-            "type": "crystal",
-            "grade": 3,
-            "rarity": "uncommon",
-            "value": 300
-          },
-          {
-            "type": "crystal",
-            "grade": 3,
-            "rarity": "rare",
-            "value": 17
-          },
-          {
-            "type": "gas",
-            "grade": 3,
-            "rarity": "uncommon",
-            "value": 115
-          },
-          {
-            "type": "gas",
-            "grade": 3,
-            "rarity": "rare",
-            "value": 3
-          }
-        ],
-        "others": [
-          {
-            "type": "3\u2605\u00a0Interceptor\u00a0Parts",
-            "value": 1885
-          }
-        ],
+        "materials": [],
+        "others": [],
         "resources": [
           {
             "type": "tritanium",
-            "value": 14400000
+            "value": 250000
           },
           {
             "type": "dilithium",
-            "value": 516000
+            "value": 10000
           }
         ]
       },

--- a/ships/korinar.json
+++ b/ships/korinar.json
@@ -210,40 +210,25 @@
           {
             "type": "gas",
             "grade": 4,
-            "rarity": "uncommon",
-            "value": 221250
-          },
-          {
-            "type": "gas",
-            "grade": 4,
-            "rarity": "rare",
-            "value": 73210
+            "rarity": "common",
+            "value": 8000
           },
           {
             "type": "ore",
             "grade": 4,
-            "rarity": "rare",
-            "value": 44195
+            "rarity": "common",
+            "value": 2800
           }
         ],
-        "others": [
-          {
-            "type": "4\u2605\u00a0Common\u00a0Explorer\u00a0Parts",
-            "value": 1910815
-          },
-          {
-            "type": "4\u2605\u00a0Uncommon\u00a0Explorer\u00a0Parts",
-            "value": 513215
-          }
-        ],
+        "others": [],
         "resources": [
           {
             "type": "tritanium",
-            "value": 405848200000
+            "value": 100000000
           },
           {
             "type": "dilithium",
-            "value": 17656600000
+            "value": 3800000
           }
         ]
       },

--- a/ships/kumari.json
+++ b/ships/kumari.json
@@ -156,40 +156,16 @@
         }
       ],
       "initial_build_cost": {
-        "materials": [
-          {
-            "type": "crystal",
-            "grade": 3,
-            "rarity": "rare",
-            "value": 48
-          },
-          {
-            "type": "ore",
-            "grade": 3,
-            "rarity": "uncommon",
-            "value": 525
-          },
-          {
-            "type": "ore",
-            "grade": 3,
-            "rarity": "rare",
-            "value": 176
-          }
-        ],
-        "others": [
-          {
-            "type": "3\u2605\u00a0Battleship\u00a0Parts",
-            "value": 11300
-          }
-        ],
+        "materials": [],
+        "others": [],
         "resources": [
           {
             "type": "tritanium",
-            "value": 99400000
+            "value": 880000
           },
           {
             "type": "dilithium",
-            "value": 6755000
+            "value": 35000
           }
         ]
       },

--- a/ships/legionary.json
+++ b/ships/legionary.json
@@ -120,38 +120,21 @@
       "initial_build_cost": {
         "materials": [
           {
-            "type": "crystal",
-            "grade": 3,
-            "rarity": "rare",
-            "value": 144
-          },
-          {
             "type": "ore",
             "grade": 3,
-            "rarity": "uncommon",
-            "value": 1100
-          },
-          {
-            "type": "ore",
-            "grade": 3,
-            "rarity": "rare",
-            "value": 540
+            "rarity": "common",
+            "value": 500
           }
         ],
-        "others": [
-          {
-            "type": "3\u2605\u00a0Battleship\u00a0Parts",
-            "value": 20300
-          }
-        ],
+        "others": [],
         "resources": [
           {
             "type": "tritanium",
-            "value": 228900000
+            "value": 1300000
           },
           {
             "type": "dilithium",
-            "value": 10530000
+            "value": 30000
           }
         ]
       },

--- a/ships/north_star.json
+++ b/ships/north_star.json
@@ -151,46 +151,16 @@
         }
       ],
       "initial_build_cost": {
-        "materials": [
-          {
-            "type": "crystal",
-            "grade": 3,
-            "rarity": "uncommon",
-            "value": 120
-          },
-          {
-            "type": "crystal",
-            "grade": 3,
-            "rarity": "rare",
-            "value": 22
-          },
-          {
-            "type": "gas",
-            "grade": 3,
-            "rarity": "uncommon",
-            "value": 50
-          },
-          {
-            "type": "gas",
-            "grade": 3,
-            "rarity": "rare",
-            "value": 10
-          }
-        ],
-        "others": [
-          {
-            "type": "3\u2605\u00a0Survey\u00a0Parts",
-            "value": 5370
-          }
-        ],
+        "materials": [],
+        "others": [],
         "resources": [
           {
             "type": "tritanium",
-            "value": 28050000
+            "value": 520000
           },
           {
             "type": "dilithium",
-            "value": 4965000
+            "value": 30000
           }
         ]
       },

--- a/ships/orion_corvette.json
+++ b/ships/orion_corvette.json
@@ -104,16 +104,11 @@
       ],
       "initial_build_cost": {
         "materials": [],
-        "others": [
-          {
-            "type": "1\u2605\u00a0Battleship\u00a0Parts",
-            "value": 42
-          }
-        ],
+        "others": [],
         "resources": [
           {
             "type": "tritanium",
-            "value": 7100
+            "value": 800
           }
         ]
       },

--- a/ships/phindra.json
+++ b/ships/phindra.json
@@ -122,34 +122,12 @@
         }
       ],
       "initial_build_cost": {
-        "materials": [
-          {
-            "type": "crystal",
-            "grade": 2,
-            "rarity": "common",
-            "value": 450
-          },
-          {
-            "type": "crystal",
-            "grade": 2,
-            "rarity": "uncommon",
-            "value": 570
-          }
-        ],
-        "others": [
-          {
-            "type": "2\u2605\u00a0Interceptor\u00a0Parts",
-            "value": 688
-          }
-        ],
+        "materials": [],
+        "others": [],
         "resources": [
           {
             "type": "tritanium",
-            "value": 178500
-          },
-          {
-            "type": "dilithium",
-            "value": 7700
+            "value": 6500
           }
         ]
       },

--- a/ships/pilum.json
+++ b/ships/pilum.json
@@ -177,29 +177,24 @@
             "type": "crystal",
             "grade": 4,
             "rarity": "common",
-            "value": 39905
+            "value": 8000
           },
           {
             "type": "gas",
             "grade": 4,
             "rarity": "common",
-            "value": 23360
+            "value": 2800
           }
         ],
-        "others": [
-          {
-            "type": "4\u2605\u00a0Common\u00a0Interceptor\u00a0Parts",
-            "value": 79230
-          }
-        ],
+        "others": [],
         "resources": [
           {
             "type": "tritanium",
-            "value": 8174500000
+            "value": 100000000
           },
           {
             "type": "dilithium",
-            "value": 294600000
+            "value": 3800000
           }
         ]
       },

--- a/ships/realta.json
+++ b/ships/realta.json
@@ -94,16 +94,11 @@
       ],
       "initial_build_cost": {
         "materials": [],
-        "others": [
-          {
-            "type": "1\u2605\u00a0Explorer\u00a0Parts",
-            "value": 63
-          }
-        ],
+        "others": [],
         "resources": [
           {
             "type": "tritanium",
-            "value": 510
+            "value": 500
           }
         ]
       },

--- a/ships/sarcophagus.json
+++ b/ships/sarcophagus.json
@@ -156,41 +156,24 @@
             "type": "crystal",
             "grade": 3,
             "rarity": "common",
-            "value": 400
-          },
-          {
-            "type": "crystal",
-            "grade": 3,
-            "rarity": "uncommon",
-            "value": 80
+            "value": 250
           },
           {
             "type": "ore",
             "grade": 3,
             "rarity": "common",
-            "value": 1600
-          },
-          {
-            "type": "ore",
-            "grade": 3,
-            "rarity": "uncommon",
-            "value": 280
+            "value": 1000
           }
         ],
-        "others": [
-          {
-            "type": "3\u2605\u00a0Battleship\u00a0Parts",
-            "value": 710
-          }
-        ],
+        "others": [],
         "resources": [
           {
             "type": "tritanium",
-            "value": 9000000
+            "value": 1400000
           },
           {
             "type": "dilithium",
-            "value": 274000
+            "value": 82500
           }
         ]
       },

--- a/ships/separatist_d3_class.json
+++ b/ships/separatist_d3_class.json
@@ -155,36 +155,19 @@
           {
             "type": "crystal",
             "grade": 3,
-            "rarity": "uncommon",
-            "value": 1100
-          },
-          {
-            "type": "crystal",
-            "grade": 3,
-            "rarity": "rare",
-            "value": 420
-          },
-          {
-            "type": "gas",
-            "grade": 3,
-            "rarity": "rare",
-            "value": 117
+            "rarity": "common",
+            "value": 500
           }
         ],
-        "others": [
-          {
-            "type": "3\u2605\u00a0Interceptor\u00a0Parts",
-            "value": 16200
-          }
-        ],
+        "others": [],
         "resources": [
           {
             "type": "tritanium",
-            "value": 158100000
+            "value": 1150000
           },
           {
             "type": "dilithium",
-            "value": 4250000
+            "value": 38500
           }
         ]
       },

--- a/ships/stella.json
+++ b/ships/stella.json
@@ -155,17 +155,17 @@
       ],
       "initial_build_cost": {
         "materials": [],
-        "others": [
+        "others": [],
+        "resources": [
           {
-            "type": "Rare\u00a0Uranium",
-            "value": 14992
+            "type": "tritanium",
+            "value": 800000
           },
           {
-            "type": "Uncommon\u00a0Uranium",
-            "value": 74000
+            "type": "dilithium",
+            "value": 28000
           }
-        ],
-        "resources": []
+        ]
       },
       "levels": [
         {

--- a/ships/talla.json
+++ b/ships/talla.json
@@ -122,34 +122,12 @@
         }
       ],
       "initial_build_cost": {
-        "materials": [
-          {
-            "type": "ore",
-            "grade": 2,
-            "rarity": "common",
-            "value": 875
-          },
-          {
-            "type": "ore",
-            "grade": 2,
-            "rarity": "uncommon",
-            "value": 1115
-          }
-        ],
-        "others": [
-          {
-            "type": "2\u2605\u00a0Battleship\u00a0Parts",
-            "value": 1440
-          }
-        ],
+        "materials": [],
+        "others": [],
         "resources": [
           {
             "type": "tritanium",
-            "value": 218500
-          },
-          {
-            "type": "dilithium",
-            "value": 33750
+            "value": 22000
           }
         ]
       },

--- a/ships/tribune.json
+++ b/ships/tribune.json
@@ -212,40 +212,25 @@
           {
             "type": "crystal",
             "grade": 4,
-            "rarity": "uncommon",
-            "value": 48850
+            "rarity": "common",
+            "value": 3150
           },
           {
             "type": "ore",
             "grade": 4,
             "rarity": "common",
-            "value": 402515
-          },
-          {
-            "type": "ore",
-            "grade": 4,
-            "rarity": "uncommon",
-            "value": 115530
+            "value": 9000
           }
         ],
-        "others": [
-          {
-            "type": "4\u2605\u00a0Common\u00a0Battleship\u00a0Parts",
-            "value": 999840
-          },
-          {
-            "type": "4\u2605\u00a0Uncommon\u00a0Battleship\u00a0Parts",
-            "value": 271870
-          }
-        ],
+        "others": [],
         "resources": [
           {
             "type": "tritanium",
-            "value": 169286200000
+            "value": 275000000
           },
           {
             "type": "dilithium",
-            "value": 7066500000
+            "value": 12000000
           }
         ]
       },

--- a/ships/turas.json
+++ b/ships/turas.json
@@ -122,34 +122,12 @@
         }
       ],
       "initial_build_cost": {
-        "materials": [
-          {
-            "type": "gas",
-            "grade": 2,
-            "rarity": "common",
-            "value": 600
-          },
-          {
-            "type": "gas",
-            "grade": 2,
-            "rarity": "uncommon",
-            "value": 790
-          }
-        ],
-        "others": [
-          {
-            "type": "2\u2605\u00a0Explorer\u00a0Parts",
-            "value": 974
-          }
-        ],
+        "materials": [],
+        "others": [],
         "resources": [
           {
             "type": "tritanium",
-            "value": 156000
-          },
-          {
-            "type": "dilithium",
-            "value": 23800
+            "value": 12500
           }
         ]
       },

--- a/ships/uss_antares.json
+++ b/ships/uss_antares.json
@@ -156,41 +156,24 @@
             "type": "crystal",
             "grade": 3,
             "rarity": "common",
-            "value": 12000
-          },
-          {
-            "type": "crystal",
-            "grade": 3,
-            "rarity": "uncommon",
-            "value": 2200
+            "value": 2500
           },
           {
             "type": "gas",
             "grade": 3,
             "rarity": "common",
-            "value": 2700
-          },
-          {
-            "type": "gas",
-            "grade": 3,
-            "rarity": "uncommon",
-            "value": 480
+            "value": 625
           }
         ],
-        "others": [
-          {
-            "type": "3\u2605\u00a0Survey\u00a0Parts",
-            "value": 3430
-          }
-        ],
+        "others": [],
         "resources": [
           {
             "type": "tritanium",
-            "value": 81900000
+            "value": 4900000
           },
           {
             "type": "dilithium",
-            "value": 4670000
+            "value": 171000
           }
         ]
       },

--- a/ships/uss_discovery.json
+++ b/ships/uss_discovery.json
@@ -154,43 +154,20 @@
         "materials": [
           {
             "type": "gas",
-            "grade": 3,
+            "grade": 2,
             "rarity": "common",
-            "value": 1245
-          },
-          {
-            "type": "gas",
-            "grade": 3,
-            "rarity": "uncommon",
-            "value": 310
-          },
-          {
-            "type": "ore",
-            "grade": 3,
-            "rarity": "common",
-            "value": 435
-          },
-          {
-            "type": "ore",
-            "grade": 3,
-            "rarity": "uncommon",
-            "value": 170
+            "value": 50
           }
         ],
-        "others": [
-          {
-            "type": "3\u2605\u00a0Explorer\u00a0Parts",
-            "value": 230
-          }
-        ],
+        "others": [],
         "resources": [
           {
             "type": "tritanium",
-            "value": 112000000
+            "value": 500000
           },
           {
             "type": "dilithium",
-            "value": 1457000
+            "value": 20000
           }
         ]
       },

--- a/ships/uss_enterprise.json
+++ b/ships/uss_enterprise.json
@@ -164,38 +164,21 @@
             "value": 8250
           },
           {
-            "type": "gas",
-            "grade": 3,
-            "rarity": "uncommon",
-            "value": 10600
-          },
-          {
             "type": "ore",
             "grade": 3,
             "rarity": "common",
-            "value": 7500
-          },
-          {
-            "type": "ore",
-            "grade": 3,
-            "rarity": "uncommon",
-            "value": 2275
+            "value": 1375
           }
         ],
-        "others": [
-          {
-            "type": "3\u2605\u00a0Explorer\u00a0Parts",
-            "value": 11225
-          }
-        ],
+        "others": [],
         "resources": [
           {
             "type": "tritanium",
-            "value": 411400000
+            "value": 6000000
           },
           {
             "type": "dilithium",
-            "value": 22750000
+            "value": 300000
           }
         ]
       },

--- a/ships/uss_enterprise_a.json
+++ b/ships/uss_enterprise_a.json
@@ -212,40 +212,25 @@
           {
             "type": "gas",
             "grade": 4,
-            "rarity": "uncommon",
-            "value": 340440
-          },
-          {
-            "type": "gas",
-            "grade": 4,
-            "rarity": "rare",
-            "value": 113300
+            "rarity": "common",
+            "value": 9000
           },
           {
             "type": "ore",
             "grade": 4,
-            "rarity": "rare",
-            "value": 69195
+            "rarity": "common",
+            "value": 3150
           }
         ],
-        "others": [
-          {
-            "type": "4\u2605\u00a0Common\u00a0Explorer\u00a0Parts",
-            "value": 2939700
-          },
-          {
-            "type": "4\u2605\u00a0Uncommon\u00a0Explorer\u00a0Parts",
-            "value": 789640
-          }
-        ],
+        "others": [],
         "resources": [
           {
             "type": "tritanium",
-            "value": 624382000000
+            "value": 275000000
           },
           {
             "type": "dilithium",
-            "value": 27164000000
+            "value": 12000000
           }
         ]
       },

--- a/ships/uss_franklin.json
+++ b/ships/uss_franklin.json
@@ -120,32 +120,26 @@
       "initial_build_cost": {
         "materials": [
           {
-            "type": "crystal",
-            "grade": 3,
-            "rarity": "common",
-            "value": 2000
-          },
-          {
             "type": "gas",
-            "grade": 3,
+            "grade": 2,
             "rarity": "common",
-            "value": 3320
+            "value": 50
           }
         ],
         "others": [
           {
-            "type": "3\u2605\u00a0Explorer\u00a0Parts",
-            "value": 11700
+            "type": "Frequency\u00a0Modulators",
+            "value": 300
           }
         ],
         "resources": [
           {
             "type": "tritanium",
-            "value": 75000000
+            "value": 35000
           },
           {
             "type": "dilithium",
-            "value": 7350000
+            "value": 1400
           }
         ]
       },

--- a/ships/uss_franklin_a.json
+++ b/ships/uss_franklin_a.json
@@ -156,30 +156,30 @@
             "type": "crystal",
             "grade": 3,
             "rarity": "common",
-            "value": 2740
+            "value": 300
           },
           {
             "type": "crystal",
             "grade": 3,
-            "rarity": "rare",
-            "value": 95
+            "rarity": "uncommon",
+            "value": 30
           },
           {
             "type": "gas",
             "grade": 3,
-            "rarity": "uncommon",
-            "value": 234
+            "rarity": "common",
+            "value": 50
           }
         ],
         "others": [],
         "resources": [
           {
             "type": "tritanium",
-            "value": 540000000
+            "value": 20000000
           },
           {
             "type": "dilithium",
-            "value": 3290000
+            "value": 300000
           }
         ]
       },

--- a/ships/uss_hydra.json
+++ b/ships/uss_hydra.json
@@ -176,29 +176,24 @@
             "type": "gas",
             "grade": 4,
             "rarity": "common",
-            "value": 9770
+            "value": 6000
           },
           {
             "type": "ore",
             "grade": 4,
             "rarity": "common",
-            "value": 5720
+            "value": 2100
           }
         ],
-        "others": [
-          {
-            "type": "4\u2605\u00a0Common\u00a0Survey\u00a0Parts",
-            "value": 22685
-          }
-        ],
+        "others": [],
         "resources": [
           {
             "type": "tritanium",
-            "value": 480000000
+            "value": 17500000
           },
           {
             "type": "dilithium",
-            "value": 19300000
+            "value": 1400000
           }
         ]
       },

--- a/ships/uss_intrepid.json
+++ b/ships/uss_intrepid.json
@@ -190,36 +190,25 @@
           {
             "type": "crystal",
             "grade": 3,
-            "rarity": "rare",
-            "value": 590
+            "rarity": "common",
+            "value": 625
           },
           {
             "type": "ore",
             "grade": 3,
-            "rarity": "uncommon",
+            "rarity": "common",
             "value": 4100
-          },
-          {
-            "type": "ore",
-            "grade": 3,
-            "rarity": "rare",
-            "value": 2175
           }
         ],
-        "others": [
-          {
-            "type": "3\u2605\u00a0Battleship\u00a0Parts",
-            "value": 62650
-          }
-        ],
+        "others": [],
         "resources": [
           {
             "type": "tritanium",
-            "value": 822000000
+            "value": 4500000
           },
           {
             "type": "dilithium",
-            "value": 53200000
+            "value": 72000
           }
         ]
       },

--- a/ships/uss_kelvin.json
+++ b/ships/uss_kelvin.json
@@ -176,40 +176,25 @@
           {
             "type": "crystal",
             "grade": 4,
-            "rarity": "uncommon",
-            "value": 131090
-          },
-          {
-            "type": "crystal",
-            "grade": 4,
-            "rarity": "rare",
-            "value": 42025
+            "rarity": "common",
+            "value": 7000
           },
           {
             "type": "gas",
             "grade": 4,
-            "rarity": "rare",
-            "value": 24665
+            "rarity": "common",
+            "value": 2450
           }
         ],
-        "others": [
-          {
-            "type": "4\u2605\u00a0Common\u00a0Interceptor\u00a0Parts",
-            "value": 1160135
-          },
-          {
-            "type": "4\u2605\u00a0Uncommon\u00a0Interceptor\u00a0Parts",
-            "value": 311730
-          }
-        ],
+        "others": [],
         "resources": [
           {
             "type": "tritanium",
-            "value": 196424800000
+            "value": 25000000
           },
           {
             "type": "dilithium",
-            "value": 8199200000
+            "value": 1600000
           }
         ]
       },

--- a/ships/uss_mayflower.json
+++ b/ships/uss_mayflower.json
@@ -156,36 +156,19 @@
           {
             "type": "gas",
             "grade": 3,
-            "rarity": "uncommon",
-            "value": 1100
-          },
-          {
-            "type": "gas",
-            "grade": 3,
-            "rarity": "rare",
-            "value": 570
-          },
-          {
-            "type": "ore",
-            "grade": 3,
-            "rarity": "rare",
-            "value": 153
+            "rarity": "common",
+            "value": 500
           }
         ],
-        "others": [
-          {
-            "type": "3\u2605\u00a0Explorer\u00a0Parts",
-            "value": 21100
-          }
-        ],
+        "others": [],
         "resources": [
           {
             "type": "tritanium",
-            "value": 130800000
+            "value": 890000
           },
           {
             "type": "dilithium",
-            "value": 11350000
+            "value": 42500
           }
         ]
       },

--- a/ships/uss_newton.json
+++ b/ships/uss_newton.json
@@ -176,40 +176,25 @@
           {
             "type": "crystal",
             "grade": 4,
-            "rarity": "rare",
-            "value": 47420
+            "rarity": "common",
+            "value": 2800
           },
           {
             "type": "ore",
             "grade": 4,
-            "rarity": "uncommon",
-            "value": 221520
-          },
-          {
-            "type": "ore",
-            "grade": 4,
-            "rarity": "rare",
-            "value": 74845
+            "rarity": "common",
+            "value": 8000
           }
         ],
-        "others": [
-          {
-            "type": "4\u2605\u00a0Common\u00a0Battleship\u00a0Parts",
-            "value": 1910810
-          },
-          {
-            "type": "4\u2605\u00a0Uncommon\u00a0Battleship\u00a0Parts",
-            "value": 513650
-          }
-        ],
+        "others": [],
         "resources": [
           {
             "type": "tritanium",
-            "value": 405848200000
+            "value": 100000000
           },
           {
             "type": "dilithium",
-            "value": 17656500000
+            "value": 3800000
           }
         ]
       },

--- a/ships/vahklas.json
+++ b/ships/vahklas.json
@@ -122,52 +122,16 @@
         }
       ],
       "initial_build_cost": {
-        "materials": [
-          {
-            "type": "gas",
-            "grade": 3,
-            "rarity": "common",
-            "value": 1375
-          },
-          {
-            "type": "gas",
-            "grade": 3,
-            "rarity": "uncommon",
-            "value": 425
-          },
-          {
-            "type": "gas",
-            "grade": 3,
-            "rarity": "rare",
-            "value": 24
-          },
-          {
-            "type": "ore",
-            "grade": 3,
-            "rarity": "uncommon",
-            "value": 152
-          },
-          {
-            "type": "ore",
-            "grade": 3,
-            "rarity": "rare",
-            "value": 6
-          }
-        ],
-        "others": [
-          {
-            "type": "3\u2605\u00a0Explorer\u00a0Parts",
-            "value": 2810
-          }
-        ],
+        "materials": [],
+        "others": [],
         "resources": [
           {
             "type": "tritanium",
-            "value": 19750000
+            "value": 500000
           },
           {
             "type": "dilithium",
-            "value": 1925000
+            "value": 20000
           }
         ]
       },

--- a/ships/valdore.json
+++ b/ships/valdore.json
@@ -177,45 +177,24 @@
             "type": "gas",
             "grade": 4,
             "rarity": "common",
-            "value": 37660
-          },
-          {
-            "type": "gas",
-            "grade": 4,
-            "rarity": "uncommon",
-            "value": 10220
+            "value": 7000
           },
           {
             "type": "ore",
             "grade": 4,
             "rarity": "common",
-            "value": 14115
-          },
-          {
-            "type": "ore",
-            "grade": 4,
-            "rarity": "uncommon",
-            "value": 5390
+            "value": 2450
           }
         ],
-        "others": [
-          {
-            "type": "4\u2605\u00a0Common\u00a0Explorer\u00a0Parts",
-            "value": 95390
-          },
-          {
-            "type": "4\u2605\u00a0Uncommon\u00a0Explorer\u00a0Parts",
-            "value": 27340
-          }
-        ],
+        "others": [],
         "resources": [
           {
             "type": "tritanium",
-            "value": 3527900000
+            "value": 25000000
           },
           {
             "type": "dilithium",
-            "value": 187900000
+            "value": 1600000
           }
         ]
       },

--- a/ships/valkis.json
+++ b/ships/valkis.json
@@ -156,41 +156,24 @@
             "type": "crystal",
             "grade": 3,
             "rarity": "common",
-            "value": 12000
-          },
-          {
-            "type": "crystal",
-            "grade": 3,
-            "rarity": "uncommon",
-            "value": 2200
+            "value": 2500
           },
           {
             "type": "gas",
             "grade": 3,
             "rarity": "common",
-            "value": 2700
-          },
-          {
-            "type": "gas",
-            "grade": 3,
-            "rarity": "uncommon",
-            "value": 480
+            "value": 625
           }
         ],
-        "others": [
-          {
-            "type": "3\u2605\u00a0Survey\u00a0Parts",
-            "value": 3430
-          }
-        ],
+        "others": [],
         "resources": [
           {
             "type": "tritanium",
-            "value": 81900000
+            "value": 7150000
           },
           {
             "type": "dilithium",
-            "value": 4670000
+            "value": 117000
           }
         ]
       },

--- a/ships/vi_dar.json
+++ b/ships/vi_dar.json
@@ -185,58 +185,16 @@
         }
       ],
       "initial_build_cost": {
-        "materials": [
-          {
-            "type": "crystal",
-            "grade": 3,
-            "rarity": "common",
-            "value": 1587
-          },
-          {
-            "type": "crystal",
-            "grade": 3,
-            "rarity": "uncommon",
-            "value": 371
-          },
-          {
-            "type": "crystal",
-            "grade": 3,
-            "rarity": "rare",
-            "value": 42
-          },
-          {
-            "type": "gas",
-            "grade": 3,
-            "rarity": "common",
-            "value": 358
-          },
-          {
-            "type": "gas",
-            "grade": 3,
-            "rarity": "uncommon",
-            "value": 86
-          },
-          {
-            "type": "gas",
-            "grade": 3,
-            "rarity": "rare",
-            "value": 10
-          }
-        ],
-        "others": [
-          {
-            "type": "3\u2605\u00a0Interceptor\u00a0Parts",
-            "value": 2299
-          }
-        ],
+        "materials": [],
+        "others": [],
         "resources": [
           {
             "type": "tritanium",
-            "value": 13798500
+            "value": 700000
           },
           {
             "type": "dilithium",
-            "value": 689925
+            "value": 20000
           }
         ]
       },

--- a/ships/vorta_vor.json
+++ b/ships/vorta_vor.json
@@ -173,48 +173,27 @@
       "initial_build_cost": {
         "materials": [
           {
-            "type": "crystal",
-            "grade": 4,
-            "rarity": "common",
-            "value": 7325
-          },
-          {
-            "type": "crystal",
-            "grade": 4,
-            "rarity": "uncommon",
-            "value": 2215
-          },
-          {
             "type": "ore",
             "grade": 4,
             "rarity": "common",
-            "value": 18160
+            "value": 6000
           },
           {
-            "type": "ore",
+            "type": "crystal",
             "grade": 4,
-            "rarity": "uncommon",
-            "value": 4730
+            "rarity": "common",
+            "value": 2100
           }
         ],
-        "others": [
-          {
-            "type": "4\u2605\u00a0Common\u00a0Survey\u00a0Parts",
-            "value": 47005
-          },
-          {
-            "type": "4\u2605\u00a0Uncommon\u00a0Survey\u00a0Parts",
-            "value": 13480
-          }
-        ],
+        "others": [],
         "resources": [
           {
             "type": "tritanium",
-            "value": 1293700000
+            "value": 17500000
           },
           {
             "type": "dilithium",
-            "value": 70900000
+            "value": 1400000
           }
         ]
       },


### PR DESCRIPTION
- Update all ships with the correct initial build costs, originals were equal to the last tier.
- Fix parsing problem with D'Vor blueprints cost name