### PR TITLE
Ships - Add default impulse speed

### DIFF
--- a/ships/augur.json
+++ b/ships/augur.json
@@ -141,9 +141,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 85,
               "warp_distance": 40,
-              "warp_speed": 3,
-              "impulse_speed": 85
+              "warp_speed": 3
             }
           },
           "build_cost": {
@@ -532,9 +532,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 85,
               "warp_distance": 44,
-              "warp_speed": 3.1,
-              "impulse_speed": 85
+              "warp_speed": 3.1
             }
           },
           "build_cost": {
@@ -1002,9 +1002,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 85,
               "warp_distance": 48,
-              "warp_speed": 3.2,
-              "impulse_speed": 85
+              "warp_speed": 3.2
             }
           },
           "build_cost": {
@@ -1472,9 +1472,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 85,
               "warp_distance": 52,
-              "warp_speed": 3.3,
-              "impulse_speed": 85
+              "warp_speed": 3.3
             }
           },
           "build_cost": {
@@ -2022,9 +2022,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 85,
               "warp_distance": 56,
-              "warp_speed": 3.4,
-              "impulse_speed": 85
+              "warp_speed": 3.4
             }
           },
           "build_cost": {
@@ -2346,9 +2346,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 85,
               "warp_distance": 60,
-              "warp_speed": 3.5,
-              "impulse_speed": 85
+              "warp_speed": 3.5
             }
           },
           "build_cost": {
@@ -3077,9 +3077,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 85,
               "warp_distance": 65,
-              "warp_speed": 3.6,
-              "impulse_speed": 85
+              "warp_speed": 3.6
             }
           },
           "build_cost": {
@@ -3732,9 +3732,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 85,
               "warp_distance": 70,
-              "warp_speed": 3.7,
-              "impulse_speed": 85
+              "warp_speed": 3.7
             }
           },
           "build_cost": {
@@ -4116,9 +4116,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 85,
               "warp_distance": 75,
-              "warp_speed": 3.8,
-              "impulse_speed": 85
+              "warp_speed": 3.8
             }
           },
           "build_cost": {

--- a/ships/augur.json
+++ b/ships/augur.json
@@ -142,7 +142,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 40,
-              "warp_speed": 3
+              "warp_speed": 3,
+              "impulse_speed": 85
             }
           },
           "build_cost": {
@@ -532,7 +533,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 44,
-              "warp_speed": 3.1
+              "warp_speed": 3.1,
+              "impulse_speed": 85
             }
           },
           "build_cost": {
@@ -1001,7 +1003,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 48,
-              "warp_speed": 3.2
+              "warp_speed": 3.2,
+              "impulse_speed": 85
             }
           },
           "build_cost": {
@@ -1470,7 +1473,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 52,
-              "warp_speed": 3.3
+              "warp_speed": 3.3,
+              "impulse_speed": 85
             }
           },
           "build_cost": {
@@ -2019,7 +2023,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 56,
-              "warp_speed": 3.4
+              "warp_speed": 3.4,
+              "impulse_speed": 85
             }
           },
           "build_cost": {
@@ -2342,7 +2347,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 60,
-              "warp_speed": 3.5
+              "warp_speed": 3.5,
+              "impulse_speed": 85
             }
           },
           "build_cost": {
@@ -3072,7 +3078,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 65,
-              "warp_speed": 3.6
+              "warp_speed": 3.6,
+              "impulse_speed": 85
             }
           },
           "build_cost": {
@@ -3726,7 +3733,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 70,
-              "warp_speed": 3.7
+              "warp_speed": 3.7,
+              "impulse_speed": 85
             }
           },
           "build_cost": {
@@ -4109,7 +4117,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 75,
-              "warp_speed": 3.8
+              "warp_speed": 3.8,
+              "impulse_speed": 85
             }
           },
           "build_cost": {

--- a/ships/b_rel.json
+++ b/ships/b_rel.json
@@ -121,7 +121,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 33,
-              "warp_speed": 3.4
+              "warp_speed": 3.4,
+              "impulse_speed": 100
             }
           },
           "build_cost": {
@@ -483,7 +484,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 36,
-              "warp_speed": 3.5
+              "warp_speed": 3.5,
+              "impulse_speed": 100
             }
           },
           "build_cost": {
@@ -956,7 +958,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 39,
-              "warp_speed": 3.6
+              "warp_speed": 3.6,
+              "impulse_speed": 100
             }
           },
           "build_cost": {
@@ -1429,7 +1432,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 42,
-              "warp_speed": 3.7
+              "warp_speed": 3.7,
+              "impulse_speed": 100
             }
           },
           "build_cost": {
@@ -1982,7 +1986,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 46,
-              "warp_speed": 3.8
+              "warp_speed": 3.8,
+              "impulse_speed": 100
             }
           },
           "build_cost": {
@@ -2535,7 +2540,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 50,
-              "warp_speed": 3.9
+              "warp_speed": 3.9,
+              "impulse_speed": 100
             }
           },
           "build_cost": {
@@ -3088,7 +3094,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 54,
-              "warp_speed": 4
+              "warp_speed": 4,
+              "impulse_speed": 100
             }
           },
           "build_cost": {
@@ -3701,7 +3708,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 58,
-              "warp_speed": 4.1
+              "warp_speed": 4.1,
+              "impulse_speed": 100
             }
           },
           "build_cost": {
@@ -4314,7 +4322,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 65,
-              "warp_speed": 4.2
+              "warp_speed": 4.2,
+              "impulse_speed": 100
             }
           },
           "build_cost": {

--- a/ships/b_rel.json
+++ b/ships/b_rel.json
@@ -120,9 +120,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 100,
               "warp_distance": 33,
-              "warp_speed": 3.4,
-              "impulse_speed": 100
+              "warp_speed": 3.4
             }
           },
           "build_cost": {
@@ -483,9 +483,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 100,
               "warp_distance": 36,
-              "warp_speed": 3.5,
-              "impulse_speed": 100
+              "warp_speed": 3.5
             }
           },
           "build_cost": {
@@ -957,9 +957,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 100,
               "warp_distance": 39,
-              "warp_speed": 3.6,
-              "impulse_speed": 100
+              "warp_speed": 3.6
             }
           },
           "build_cost": {
@@ -1431,9 +1431,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 100,
               "warp_distance": 42,
-              "warp_speed": 3.7,
-              "impulse_speed": 100
+              "warp_speed": 3.7
             }
           },
           "build_cost": {
@@ -1985,9 +1985,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 100,
               "warp_distance": 46,
-              "warp_speed": 3.8,
-              "impulse_speed": 100
+              "warp_speed": 3.8
             }
           },
           "build_cost": {
@@ -2539,9 +2539,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 100,
               "warp_distance": 50,
-              "warp_speed": 3.9,
-              "impulse_speed": 100
+              "warp_speed": 3.9
             }
           },
           "build_cost": {
@@ -3093,9 +3093,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 100,
               "warp_distance": 54,
-              "warp_speed": 4,
-              "impulse_speed": 100
+              "warp_speed": 4
             }
           },
           "build_cost": {
@@ -3707,9 +3707,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 100,
               "warp_distance": 58,
-              "warp_speed": 4.1,
-              "impulse_speed": 100
+              "warp_speed": 4.1
             }
           },
           "build_cost": {
@@ -4321,9 +4321,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 100,
               "warp_distance": 65,
-              "warp_speed": 4.2,
-              "impulse_speed": 100
+              "warp_speed": 4.2
             }
           },
           "build_cost": {

--- a/ships/bortas.json
+++ b/ships/bortas.json
@@ -138,7 +138,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 28,
-              "warp_speed": 2.7
+              "warp_speed": 2.7,
+              "impulse_speed": 85
             }
           },
           "build_cost": {
@@ -488,7 +489,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 30,
-              "warp_speed": 2.8
+              "warp_speed": 2.8,
+              "impulse_speed": 85
             }
           },
           "build_cost": {
@@ -998,7 +1000,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 33,
-              "warp_speed": 2.9
+              "warp_speed": 2.9,
+              "impulse_speed": 85
             }
           },
           "build_cost": {
@@ -1467,7 +1470,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 36,
-              "warp_speed": 3
+              "warp_speed": 3,
+              "impulse_speed": 85
             }
           },
           "build_cost": {
@@ -2016,7 +2020,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 40,
-              "warp_speed": 3.1
+              "warp_speed": 3.1,
+              "impulse_speed": 85
             }
           },
           "build_cost": {
@@ -2565,7 +2570,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 45,
-              "warp_speed": 3.2
+              "warp_speed": 3.2,
+              "impulse_speed": 85
             }
           },
           "build_cost": {
@@ -3114,7 +3120,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 50,
-              "warp_speed": 3.3
+              "warp_speed": 3.3,
+              "impulse_speed": 85
             }
           },
           "build_cost": {
@@ -3723,7 +3730,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 55,
-              "warp_speed": 3.4
+              "warp_speed": 3.4,
+              "impulse_speed": 85
             }
           },
           "build_cost": {
@@ -4332,7 +4340,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 60,
-              "warp_speed": 3.5
+              "warp_speed": 3.5,
+              "impulse_speed": 85
             }
           },
           "build_cost": {

--- a/ships/bortas.json
+++ b/ships/bortas.json
@@ -137,9 +137,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 85,
               "warp_distance": 28,
-              "warp_speed": 2.7,
-              "impulse_speed": 85
+              "warp_speed": 2.7
             }
           },
           "build_cost": {
@@ -488,9 +488,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 85,
               "warp_distance": 30,
-              "warp_speed": 2.8,
-              "impulse_speed": 85
+              "warp_speed": 2.8
             }
           },
           "build_cost": {
@@ -999,9 +999,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 85,
               "warp_distance": 33,
-              "warp_speed": 2.9,
-              "impulse_speed": 85
+              "warp_speed": 2.9
             }
           },
           "build_cost": {
@@ -1469,9 +1469,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 85,
               "warp_distance": 36,
-              "warp_speed": 3,
-              "impulse_speed": 85
+              "warp_speed": 3
             }
           },
           "build_cost": {
@@ -2019,9 +2019,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 85,
               "warp_distance": 40,
-              "warp_speed": 3.1,
-              "impulse_speed": 85
+              "warp_speed": 3.1
             }
           },
           "build_cost": {
@@ -2569,9 +2569,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 85,
               "warp_distance": 45,
-              "warp_speed": 3.2,
-              "impulse_speed": 85
+              "warp_speed": 3.2
             }
           },
           "build_cost": {
@@ -3119,9 +3119,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 85,
               "warp_distance": 50,
-              "warp_speed": 3.3,
-              "impulse_speed": 85
+              "warp_speed": 3.3
             }
           },
           "build_cost": {
@@ -3729,9 +3729,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 85,
               "warp_distance": 55,
-              "warp_speed": 3.4,
-              "impulse_speed": 85
+              "warp_speed": 3.4
             }
           },
           "build_cost": {
@@ -4339,9 +4339,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 85,
               "warp_distance": 60,
-              "warp_speed": 3.5,
-              "impulse_speed": 85
+              "warp_speed": 3.5
             }
           },
           "build_cost": {

--- a/ships/centurion.json
+++ b/ships/centurion.json
@@ -121,7 +121,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 28,
-              "warp_speed": 3.2
+              "warp_speed": 3.2,
+              "impulse_speed": 100
             }
           },
           "build_cost": {
@@ -483,7 +484,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 30,
-              "warp_speed": 3.3
+              "warp_speed": 3.3,
+              "impulse_speed": 100
             }
           },
           "build_cost": {
@@ -956,7 +958,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 33,
-              "warp_speed": 3.4
+              "warp_speed": 3.4,
+              "impulse_speed": 100
             }
           },
           "build_cost": {
@@ -1429,7 +1432,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 36,
-              "warp_speed": 3.5
+              "warp_speed": 3.5,
+              "impulse_speed": 100
             }
           },
           "build_cost": {
@@ -1982,7 +1986,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 40,
-              "warp_speed": 3.6
+              "warp_speed": 3.6,
+              "impulse_speed": 100
             }
           },
           "build_cost": {
@@ -2535,7 +2540,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 45,
-              "warp_speed": 3.7
+              "warp_speed": 3.7,
+              "impulse_speed": 100
             }
           },
           "build_cost": {
@@ -3088,7 +3094,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 50,
-              "warp_speed": 3.8
+              "warp_speed": 3.8,
+              "impulse_speed": 100
             }
           },
           "build_cost": {
@@ -3701,7 +3708,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 55,
-              "warp_speed": 3.9
+              "warp_speed": 3.9,
+              "impulse_speed": 100
             }
           },
           "build_cost": {
@@ -4314,7 +4322,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 60,
-              "warp_speed": 4
+              "warp_speed": 4,
+              "impulse_speed": 100
             }
           },
           "build_cost": {

--- a/ships/centurion.json
+++ b/ships/centurion.json
@@ -120,9 +120,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 100,
               "warp_distance": 28,
-              "warp_speed": 3.2,
-              "impulse_speed": 100
+              "warp_speed": 3.2
             }
           },
           "build_cost": {
@@ -483,9 +483,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 100,
               "warp_distance": 30,
-              "warp_speed": 3.3,
-              "impulse_speed": 100
+              "warp_speed": 3.3
             }
           },
           "build_cost": {
@@ -957,9 +957,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 100,
               "warp_distance": 33,
-              "warp_speed": 3.4,
-              "impulse_speed": 100
+              "warp_speed": 3.4
             }
           },
           "build_cost": {
@@ -1431,9 +1431,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 100,
               "warp_distance": 36,
-              "warp_speed": 3.5,
-              "impulse_speed": 100
+              "warp_speed": 3.5
             }
           },
           "build_cost": {
@@ -1985,9 +1985,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 100,
               "warp_distance": 40,
-              "warp_speed": 3.6,
-              "impulse_speed": 100
+              "warp_speed": 3.6
             }
           },
           "build_cost": {
@@ -2539,9 +2539,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 100,
               "warp_distance": 45,
-              "warp_speed": 3.7,
-              "impulse_speed": 100
+              "warp_speed": 3.7
             }
           },
           "build_cost": {
@@ -3093,9 +3093,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 100,
               "warp_distance": 50,
-              "warp_speed": 3.8,
-              "impulse_speed": 100
+              "warp_speed": 3.8
             }
           },
           "build_cost": {
@@ -3707,9 +3707,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 100,
               "warp_distance": 55,
-              "warp_speed": 3.9,
-              "impulse_speed": 100
+              "warp_speed": 3.9
             }
           },
           "build_cost": {
@@ -4321,9 +4321,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 100,
               "warp_distance": 60,
-              "warp_speed": 4,
-              "impulse_speed": 100
+              "warp_speed": 4
             }
           },
           "build_cost": {

--- a/ships/ecs_fortunate.json
+++ b/ships/ecs_fortunate.json
@@ -91,7 +91,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 6,
-              "warp_speed": 1.5
+              "warp_speed": 1.5,
+              "impulse_speed": 94
             }
           },
           "build_cost": {
@@ -285,7 +286,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 8,
-              "warp_speed": 1.7
+              "warp_speed": 1.7,
+              "impulse_speed": 94
             }
           },
           "build_cost": {
@@ -593,7 +595,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 10,
-              "warp_speed": 1.9
+              "warp_speed": 1.9,
+              "impulse_speed": 94
             }
           },
           "build_cost": {
@@ -961,7 +964,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 13,
-              "warp_speed": 2
+              "warp_speed": 2,
+              "impulse_speed": 94
             }
           },
           "build_cost": {

--- a/ships/ecs_fortunate.json
+++ b/ships/ecs_fortunate.json
@@ -90,9 +90,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 94,
               "warp_distance": 6,
-              "warp_speed": 1.5,
-              "impulse_speed": 94
+              "warp_speed": 1.5
             }
           },
           "build_cost": {
@@ -285,9 +285,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 94,
               "warp_distance": 8,
-              "warp_speed": 1.7,
-              "impulse_speed": 94
+              "warp_speed": 1.7
             }
           },
           "build_cost": {
@@ -594,9 +594,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 94,
               "warp_distance": 10,
-              "warp_speed": 1.9,
-              "impulse_speed": 94
+              "warp_speed": 1.9
             }
           },
           "build_cost": {
@@ -963,9 +963,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 94,
               "warp_distance": 13,
-              "warp_speed": 2,
-              "impulse_speed": 94
+              "warp_speed": 2
             }
           },
           "build_cost": {

--- a/ships/envoy.json
+++ b/ships/envoy.json
@@ -90,9 +90,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 83,
               "warp_distance": 15,
-              "warp_speed": 1.5,
-              "impulse_speed": 83
+              "warp_speed": 1.5
             }
           },
           "build_cost": {
@@ -346,9 +346,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 83,
               "warp_distance": 16,
-              "warp_speed": 1.6,
-              "impulse_speed": 83
+              "warp_speed": 1.6
             }
           },
           "build_cost": {
@@ -753,9 +753,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 83,
               "warp_distance": 17,
-              "warp_speed": 1.7,
-              "impulse_speed": 83
+              "warp_speed": 1.7
             }
           },
           "build_cost": {
@@ -1174,9 +1174,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 83,
               "warp_distance": 18,
-              "warp_speed": 1.8,
-              "impulse_speed": 83
+              "warp_speed": 1.8
             }
           },
           "build_cost": {
@@ -1662,9 +1662,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 83,
               "warp_distance": 19,
-              "warp_speed": 1.9,
-              "impulse_speed": 83
+              "warp_speed": 1.9
             }
           },
           "build_cost": {
@@ -2150,9 +2150,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 83,
               "warp_distance": 20,
-              "warp_speed": 2,
-              "impulse_speed": 83
+              "warp_speed": 2
             }
           },
           "build_cost": {
@@ -2705,9 +2705,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 83,
               "warp_distance": 22,
-              "warp_speed": 2.5,
-              "impulse_speed": 83
+              "warp_speed": 2.5
             }
           },
           "build_cost": {

--- a/ships/envoy.json
+++ b/ships/envoy.json
@@ -91,7 +91,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 15,
-              "warp_speed": 1.5
+              "warp_speed": 1.5,
+              "impulse_speed": 83
             }
           },
           "build_cost": {
@@ -346,7 +347,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 16,
-              "warp_speed": 1.6
+              "warp_speed": 1.6,
+              "impulse_speed": 83
             }
           },
           "build_cost": {
@@ -752,7 +754,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 17,
-              "warp_speed": 1.7
+              "warp_speed": 1.7,
+              "impulse_speed": 83
             }
           },
           "build_cost": {
@@ -1172,7 +1175,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 18,
-              "warp_speed": 1.8
+              "warp_speed": 1.8,
+              "impulse_speed": 83
             }
           },
           "build_cost": {
@@ -1659,7 +1663,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 19,
-              "warp_speed": 1.9
+              "warp_speed": 1.9,
+              "impulse_speed": 83
             }
           },
           "build_cost": {
@@ -2146,7 +2151,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 20,
-              "warp_speed": 2
+              "warp_speed": 2,
+              "impulse_speed": 83
             }
           },
           "build_cost": {
@@ -2700,7 +2706,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 22,
-              "warp_speed": 2.5
+              "warp_speed": 2.5,
+              "impulse_speed": 83
             }
           },
           "build_cost": {

--- a/ships/gladius.json
+++ b/ships/gladius.json
@@ -121,7 +121,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 33,
-              "warp_speed": 2.8
+              "warp_speed": 2.8,
+              "impulse_speed": 115
             }
           },
           "build_cost": {
@@ -483,7 +484,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 36,
-              "warp_speed": 2.9
+              "warp_speed": 2.9,
+              "impulse_speed": 115
             }
           },
           "build_cost": {
@@ -956,7 +958,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 39,
-              "warp_speed": 3
+              "warp_speed": 3,
+              "impulse_speed": 115
             }
           },
           "build_cost": {
@@ -1429,7 +1432,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 42,
-              "warp_speed": 3.1
+              "warp_speed": 3.1,
+              "impulse_speed": 115
             }
           },
           "build_cost": {
@@ -1982,7 +1986,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 46,
-              "warp_speed": 3.2
+              "warp_speed": 3.2,
+              "impulse_speed": 115
             }
           },
           "build_cost": {
@@ -2535,7 +2540,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 50,
-              "warp_speed": 3.3
+              "warp_speed": 3.3,
+              "impulse_speed": 115
             }
           },
           "build_cost": {
@@ -3088,7 +3094,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 54,
-              "warp_speed": 3.4
+              "warp_speed": 3.4,
+              "impulse_speed": 115
             }
           },
           "build_cost": {
@@ -3701,7 +3708,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 58,
-              "warp_speed": 3.5
+              "warp_speed": 3.5,
+              "impulse_speed": 115
             }
           },
           "build_cost": {
@@ -4314,7 +4322,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 65,
-              "warp_speed": 3.6
+              "warp_speed": 3.6,
+              "impulse_speed": 115
             }
           },
           "build_cost": {

--- a/ships/gladius.json
+++ b/ships/gladius.json
@@ -120,9 +120,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 115,
               "warp_distance": 33,
-              "warp_speed": 2.8,
-              "impulse_speed": 115
+              "warp_speed": 2.8
             }
           },
           "build_cost": {
@@ -483,9 +483,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 115,
               "warp_distance": 36,
-              "warp_speed": 2.9,
-              "impulse_speed": 115
+              "warp_speed": 2.9
             }
           },
           "build_cost": {
@@ -957,9 +957,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 115,
               "warp_distance": 39,
-              "warp_speed": 3,
-              "impulse_speed": 115
+              "warp_speed": 3
             }
           },
           "build_cost": {
@@ -1431,9 +1431,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 115,
               "warp_distance": 42,
-              "warp_speed": 3.1,
-              "impulse_speed": 115
+              "warp_speed": 3.1
             }
           },
           "build_cost": {
@@ -1985,9 +1985,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 115,
               "warp_distance": 46,
-              "warp_speed": 3.2,
-              "impulse_speed": 115
+              "warp_speed": 3.2
             }
           },
           "build_cost": {
@@ -2539,9 +2539,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 115,
               "warp_distance": 50,
-              "warp_speed": 3.3,
-              "impulse_speed": 115
+              "warp_speed": 3.3
             }
           },
           "build_cost": {
@@ -3093,9 +3093,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 115,
               "warp_distance": 54,
-              "warp_speed": 3.4,
-              "impulse_speed": 115
+              "warp_speed": 3.4
             }
           },
           "build_cost": {
@@ -3707,9 +3707,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 115,
               "warp_distance": 58,
-              "warp_speed": 3.5,
-              "impulse_speed": 115
+              "warp_speed": 3.5
             }
           },
           "build_cost": {
@@ -4321,9 +4321,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 115,
               "warp_distance": 65,
-              "warp_speed": 3.6,
-              "impulse_speed": 115
+              "warp_speed": 3.6
             }
           },
           "build_cost": {

--- a/ships/hijacked_legionary.json
+++ b/ships/hijacked_legionary.json
@@ -103,7 +103,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 24,
-              "warp_speed": 2.5
+              "warp_speed": 2.5,
+              "impulse_speed": 85
             }
           },
           "build_cost": {
@@ -353,7 +354,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 26,
-              "warp_speed": 2.6
+              "warp_speed": 2.6,
+              "impulse_speed": 85
             }
           },
           "build_cost": {
@@ -603,7 +605,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 28,
-              "warp_speed": 2.7
+              "warp_speed": 2.7,
+              "impulse_speed": 85
             }
           },
           "build_cost": {
@@ -853,7 +856,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 30,
-              "warp_speed": 2.8
+              "warp_speed": 2.8,
+              "impulse_speed": 85
             }
           },
           "build_cost": {
@@ -1103,7 +1107,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 33,
-              "warp_speed": 2.9
+              "warp_speed": 2.9,
+              "impulse_speed": 85
             }
           },
           "build_cost": {
@@ -1353,7 +1358,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 36,
-              "warp_speed": 3
+              "warp_speed": 3,
+              "impulse_speed": 85
             }
           },
           "build_cost": {
@@ -1603,7 +1609,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 40,
-              "warp_speed": 3.1
+              "warp_speed": 3.1,
+              "impulse_speed": 85
             }
           },
           "build_cost": {
@@ -1853,7 +1860,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 45,
-              "warp_speed": 3.2
+              "warp_speed": 3.2,
+              "impulse_speed": 85
             }
           },
           "build_cost": {
@@ -2103,7 +2111,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 50,
-              "warp_speed": 3.3
+              "warp_speed": 3.3,
+              "impulse_speed": 85
             }
           },
           "build_cost": {

--- a/ships/hijacked_legionary.json
+++ b/ships/hijacked_legionary.json
@@ -102,9 +102,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 85,
               "warp_distance": 24,
-              "warp_speed": 2.5,
-              "impulse_speed": 85
+              "warp_speed": 2.5
             }
           },
           "build_cost": {
@@ -353,9 +353,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 85,
               "warp_distance": 26,
-              "warp_speed": 2.6,
-              "impulse_speed": 85
+              "warp_speed": 2.6
             }
           },
           "build_cost": {
@@ -604,9 +604,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 85,
               "warp_distance": 28,
-              "warp_speed": 2.7,
-              "impulse_speed": 85
+              "warp_speed": 2.7
             }
           },
           "build_cost": {
@@ -855,9 +855,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 85,
               "warp_distance": 30,
-              "warp_speed": 2.8,
-              "impulse_speed": 85
+              "warp_speed": 2.8
             }
           },
           "build_cost": {
@@ -1106,9 +1106,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 85,
               "warp_distance": 33,
-              "warp_speed": 2.9,
-              "impulse_speed": 85
+              "warp_speed": 2.9
             }
           },
           "build_cost": {
@@ -1357,9 +1357,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 85,
               "warp_distance": 36,
-              "warp_speed": 3,
-              "impulse_speed": 85
+              "warp_speed": 3
             }
           },
           "build_cost": {
@@ -1608,9 +1608,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 85,
               "warp_distance": 40,
-              "warp_speed": 3.1,
-              "impulse_speed": 85
+              "warp_speed": 3.1
             }
           },
           "build_cost": {
@@ -1859,9 +1859,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 85,
               "warp_distance": 45,
-              "warp_speed": 3.2,
-              "impulse_speed": 85
+              "warp_speed": 3.2
             }
           },
           "build_cost": {
@@ -2110,9 +2110,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 85,
               "warp_distance": 50,
-              "warp_speed": 3.3,
-              "impulse_speed": 85
+              "warp_speed": 3.3
             }
           },
           "build_cost": {

--- a/ships/hijacked_uss_mayflower.json
+++ b/ships/hijacked_uss_mayflower.json
@@ -119,9 +119,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 100,
               "warp_distance": 24,
-              "warp_speed": 3,
-              "impulse_speed": 100
+              "warp_speed": 3
             }
           },
           "build_cost": {
@@ -412,9 +412,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 100,
               "warp_distance": 26,
-              "warp_speed": 3.1,
-              "impulse_speed": 100
+              "warp_speed": 3.1
             }
           },
           "build_cost": {
@@ -741,9 +741,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 100,
               "warp_distance": 28,
-              "warp_speed": 3.2,
-              "impulse_speed": 100
+              "warp_speed": 3.2
             }
           },
           "build_cost": {
@@ -1070,9 +1070,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 100,
               "warp_distance": 30,
-              "warp_speed": 3.3,
-              "impulse_speed": 100
+              "warp_speed": 3.3
             }
           },
           "build_cost": {
@@ -1399,9 +1399,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 100,
               "warp_distance": 33,
-              "warp_speed": 3.4,
-              "impulse_speed": 100
+              "warp_speed": 3.4
             }
           },
           "build_cost": {
@@ -1728,9 +1728,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 100,
               "warp_distance": 36,
-              "warp_speed": 3.5,
-              "impulse_speed": 100
+              "warp_speed": 3.5
             }
           },
           "build_cost": {
@@ -2057,9 +2057,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 100,
               "warp_distance": 40,
-              "warp_speed": 3.6,
-              "impulse_speed": 100
+              "warp_speed": 3.6
             }
           },
           "build_cost": {
@@ -2386,9 +2386,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 100,
               "warp_distance": 45,
-              "warp_speed": 3.7,
-              "impulse_speed": 100
+              "warp_speed": 3.7
             }
           },
           "build_cost": {
@@ -2715,9 +2715,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 100,
               "warp_distance": 50,
-              "warp_speed": 3.8,
-              "impulse_speed": 100
+              "warp_speed": 3.8
             }
           },
           "build_cost": {

--- a/ships/hijacked_uss_mayflower.json
+++ b/ships/hijacked_uss_mayflower.json
@@ -120,7 +120,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 24,
-              "warp_speed": 3
+              "warp_speed": 3,
+              "impulse_speed": 100
             }
           },
           "build_cost": {
@@ -412,7 +413,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 26,
-              "warp_speed": 3.1
+              "warp_speed": 3.1,
+              "impulse_speed": 100
             }
           },
           "build_cost": {
@@ -740,7 +742,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 28,
-              "warp_speed": 3.2
+              "warp_speed": 3.2,
+              "impulse_speed": 100
             }
           },
           "build_cost": {
@@ -1068,7 +1071,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 30,
-              "warp_speed": 3.3
+              "warp_speed": 3.3,
+              "impulse_speed": 100
             }
           },
           "build_cost": {
@@ -1396,7 +1400,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 33,
-              "warp_speed": 3.4
+              "warp_speed": 3.4,
+              "impulse_speed": 100
             }
           },
           "build_cost": {
@@ -1724,7 +1729,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 36,
-              "warp_speed": 3.5
+              "warp_speed": 3.5,
+              "impulse_speed": 100
             }
           },
           "build_cost": {
@@ -2052,7 +2058,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 40,
-              "warp_speed": 3.6
+              "warp_speed": 3.6,
+              "impulse_speed": 100
             }
           },
           "build_cost": {
@@ -2380,7 +2387,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 45,
-              "warp_speed": 3.7
+              "warp_speed": 3.7,
+              "impulse_speed": 100
             }
           },
           "build_cost": {
@@ -2708,7 +2716,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 50,
-              "warp_speed": 3.8
+              "warp_speed": 3.8,
+              "impulse_speed": 100
             }
           },
           "build_cost": {

--- a/ships/jellyfish.json
+++ b/ships/jellyfish.json
@@ -86,7 +86,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 14,
-              "warp_speed": 2.5
+              "warp_speed": 2.5,
+              "impulse_speed": 110
             }
           },
           "build_cost": {
@@ -260,7 +261,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 15,
-              "warp_speed": 2.6
+              "warp_speed": 2.6,
+              "impulse_speed": 110
             }
           },
           "build_cost": {
@@ -367,7 +369,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 16,
-              "warp_speed": 2.7
+              "warp_speed": 2.7,
+              "impulse_speed": 110
             }
           },
           "build_cost": {
@@ -670,7 +673,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 17,
-              "warp_speed": 2.8
+              "warp_speed": 2.8,
+              "impulse_speed": 110
             }
           },
           "build_cost": {
@@ -882,7 +886,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 18,
-              "warp_speed": 2.9
+              "warp_speed": 2.9,
+              "impulse_speed": 110
             }
           },
           "build_cost": {
@@ -1108,7 +1113,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 19,
-              "warp_speed": 3
+              "warp_speed": 3,
+              "impulse_speed": 110
             }
           },
           "build_cost": {
@@ -1334,7 +1340,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 21,
-              "warp_speed": 3.1
+              "warp_speed": 3.1,
+              "impulse_speed": 110
             }
           },
           "build_cost": {

--- a/ships/jellyfish.json
+++ b/ships/jellyfish.json
@@ -85,9 +85,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 110,
               "warp_distance": 14,
-              "warp_speed": 2.5,
-              "impulse_speed": 110
+              "warp_speed": 2.5
             }
           },
           "build_cost": {
@@ -260,9 +260,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 110,
               "warp_distance": 15,
-              "warp_speed": 2.6,
-              "impulse_speed": 110
+              "warp_speed": 2.6
             }
           },
           "build_cost": {
@@ -368,9 +368,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 110,
               "warp_distance": 16,
-              "warp_speed": 2.7,
-              "impulse_speed": 110
+              "warp_speed": 2.7
             }
           },
           "build_cost": {
@@ -672,9 +672,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 110,
               "warp_distance": 17,
-              "warp_speed": 2.8,
-              "impulse_speed": 110
+              "warp_speed": 2.8
             }
           },
           "build_cost": {
@@ -885,9 +885,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 110,
               "warp_distance": 18,
-              "warp_speed": 2.9,
-              "impulse_speed": 110
+              "warp_speed": 2.9
             }
           },
           "build_cost": {
@@ -1112,9 +1112,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 110,
               "warp_distance": 19,
-              "warp_speed": 3,
-              "impulse_speed": 110
+              "warp_speed": 3
             }
           },
           "build_cost": {
@@ -1339,9 +1339,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 110,
               "warp_distance": 21,
-              "warp_speed": 3.1,
-              "impulse_speed": 110
+              "warp_speed": 3.1
             }
           },
           "build_cost": {

--- a/ships/kumari.json
+++ b/ships/kumari.json
@@ -141,9 +141,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 85,
               "warp_distance": 21,
-              "warp_speed": 2.3,
-              "impulse_speed": 85
+              "warp_speed": 2.3
             }
           },
           "build_cost": {
@@ -474,9 +474,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 85,
               "warp_distance": 22,
-              "warp_speed": 2.4,
-              "impulse_speed": 85
+              "warp_speed": 2.4
             }
           },
           "build_cost": {
@@ -989,9 +989,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 85,
               "warp_distance": 23,
-              "warp_speed": 2.5,
-              "impulse_speed": 85
+              "warp_speed": 2.5
             }
           },
           "build_cost": {
@@ -1519,9 +1519,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 85,
               "warp_distance": 24,
-              "warp_speed": 2.6,
-              "impulse_speed": 85
+              "warp_speed": 2.6
             }
           },
           "build_cost": {
@@ -2049,9 +2049,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 85,
               "warp_distance": 26,
-              "warp_speed": 2.7,
-              "impulse_speed": 85
+              "warp_speed": 2.7
             }
           },
           "build_cost": {
@@ -2579,9 +2579,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 85,
               "warp_distance": 28,
-              "warp_speed": 2.8,
-              "impulse_speed": 85
+              "warp_speed": 2.8
             }
           },
           "build_cost": {
@@ -3169,9 +3169,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 85,
               "warp_distance": 30,
-              "warp_speed": 2.9,
-              "impulse_speed": 85
+              "warp_speed": 2.9
             }
           },
           "build_cost": {
@@ -3759,9 +3759,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 85,
               "warp_distance": 32,
-              "warp_speed": 3,
-              "impulse_speed": 85
+              "warp_speed": 3
             }
           },
           "build_cost": {
@@ -4349,9 +4349,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 85,
               "warp_distance": 34,
-              "warp_speed": 3.1,
-              "impulse_speed": 85
+              "warp_speed": 3.1
             }
           },
           "build_cost": {

--- a/ships/kumari.json
+++ b/ships/kumari.json
@@ -142,7 +142,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 21,
-              "warp_speed": 2.3
+              "warp_speed": 2.3,
+              "impulse_speed": 85
             }
           },
           "build_cost": {
@@ -474,7 +475,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 22,
-              "warp_speed": 2.4
+              "warp_speed": 2.4,
+              "impulse_speed": 85
             }
           },
           "build_cost": {
@@ -988,7 +990,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 23,
-              "warp_speed": 2.5
+              "warp_speed": 2.5,
+              "impulse_speed": 85
             }
           },
           "build_cost": {
@@ -1517,7 +1520,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 24,
-              "warp_speed": 2.6
+              "warp_speed": 2.6,
+              "impulse_speed": 85
             }
           },
           "build_cost": {
@@ -2046,7 +2050,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 26,
-              "warp_speed": 2.7
+              "warp_speed": 2.7,
+              "impulse_speed": 85
             }
           },
           "build_cost": {
@@ -2575,7 +2580,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 28,
-              "warp_speed": 2.8
+              "warp_speed": 2.8,
+              "impulse_speed": 85
             }
           },
           "build_cost": {
@@ -3164,7 +3170,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 30,
-              "warp_speed": 2.9
+              "warp_speed": 2.9,
+              "impulse_speed": 85
             }
           },
           "build_cost": {
@@ -3753,7 +3760,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 32,
-              "warp_speed": 3
+              "warp_speed": 3,
+              "impulse_speed": 85
             }
           },
           "build_cost": {
@@ -4342,7 +4350,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 34,
-              "warp_speed": 3.1
+              "warp_speed": 3.1,
+              "impulse_speed": 85
             }
           },
           "build_cost": {

--- a/ships/legionary.json
+++ b/ships/legionary.json
@@ -103,9 +103,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 85,
               "warp_distance": 24,
-              "warp_speed": 2.5,
-              "impulse_speed": 85
+              "warp_speed": 2.5
             }
           },
           "build_cost": {
@@ -418,9 +418,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 85,
               "warp_distance": 26,
-              "warp_speed": 2.6,
-              "impulse_speed": 85
+              "warp_speed": 2.6
             }
           },
           "build_cost": {
@@ -818,9 +818,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 85,
               "warp_distance": 28,
-              "warp_speed": 2.7,
-              "impulse_speed": 85
+              "warp_speed": 2.7
             }
           },
           "build_cost": {
@@ -1218,9 +1218,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 85,
               "warp_distance": 30,
-              "warp_speed": 2.8,
-              "impulse_speed": 85
+              "warp_speed": 2.8
             }
           },
           "build_cost": {
@@ -1698,9 +1698,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 85,
               "warp_distance": 33,
-              "warp_speed": 2.9,
-              "impulse_speed": 85
+              "warp_speed": 2.9
             }
           },
           "build_cost": {
@@ -2178,9 +2178,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 85,
               "warp_distance": 36,
-              "warp_speed": 3,
-              "impulse_speed": 85
+              "warp_speed": 3
             }
           },
           "build_cost": {
@@ -2658,9 +2658,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 85,
               "warp_distance": 40,
-              "warp_speed": 3.1,
-              "impulse_speed": 85
+              "warp_speed": 3.1
             }
           },
           "build_cost": {
@@ -3198,9 +3198,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 85,
               "warp_distance": 45,
-              "warp_speed": 3.2,
-              "impulse_speed": 85
+              "warp_speed": 3.2
             }
           },
           "build_cost": {
@@ -3738,9 +3738,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 85,
               "warp_distance": 50,
-              "warp_speed": 3.3,
-              "impulse_speed": 85
+              "warp_speed": 3.3
             }
           },
           "build_cost": {

--- a/ships/legionary.json
+++ b/ships/legionary.json
@@ -104,7 +104,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 24,
-              "warp_speed": 2.5
+              "warp_speed": 2.5,
+              "impulse_speed": 85
             }
           },
           "build_cost": {
@@ -418,7 +419,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 26,
-              "warp_speed": 2.6
+              "warp_speed": 2.6,
+              "impulse_speed": 85
             }
           },
           "build_cost": {
@@ -817,7 +819,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 28,
-              "warp_speed": 2.7
+              "warp_speed": 2.7,
+              "impulse_speed": 85
             }
           },
           "build_cost": {
@@ -1216,7 +1219,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 30,
-              "warp_speed": 2.8
+              "warp_speed": 2.8,
+              "impulse_speed": 85
             }
           },
           "build_cost": {
@@ -1695,7 +1699,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 33,
-              "warp_speed": 2.9
+              "warp_speed": 2.9,
+              "impulse_speed": 85
             }
           },
           "build_cost": {
@@ -2174,7 +2179,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 36,
-              "warp_speed": 3
+              "warp_speed": 3,
+              "impulse_speed": 85
             }
           },
           "build_cost": {
@@ -2653,7 +2659,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 40,
-              "warp_speed": 3.1
+              "warp_speed": 3.1,
+              "impulse_speed": 85
             }
           },
           "build_cost": {
@@ -3192,7 +3199,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 45,
-              "warp_speed": 3.2
+              "warp_speed": 3.2,
+              "impulse_speed": 85
             }
           },
           "build_cost": {
@@ -3731,7 +3739,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 50,
-              "warp_speed": 3.3
+              "warp_speed": 3.3,
+              "impulse_speed": 85
             }
           },
           "build_cost": {

--- a/ships/orion_corvette.json
+++ b/ships/orion_corvette.json
@@ -71,9 +71,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 115,
               "warp_distance": 5,
-              "warp_speed": 1.5,
-              "impulse_speed": 115
+              "warp_speed": 1.5
             }
           },
           "build_cost": {
@@ -297,9 +297,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 115,
               "warp_distance": 6,
-              "warp_speed": 1.7,
-              "impulse_speed": 115
+              "warp_speed": 1.7
             }
           },
           "build_cost": {
@@ -590,9 +590,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 115,
               "warp_distance": 7,
-              "warp_speed": 1.9,
-              "impulse_speed": 115
+              "warp_speed": 1.9
             }
           },
           "build_cost": {
@@ -943,9 +943,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 115,
               "warp_distance": 8,
-              "warp_speed": 2,
-              "impulse_speed": 115
+              "warp_speed": 2
             }
           },
           "build_cost": {

--- a/ships/orion_corvette.json
+++ b/ships/orion_corvette.json
@@ -72,7 +72,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 5,
-              "warp_speed": 1.5
+              "warp_speed": 1.5,
+              "impulse_speed": 115
             }
           },
           "build_cost": {
@@ -297,7 +298,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 6,
-              "warp_speed": 1.7
+              "warp_speed": 1.7,
+              "impulse_speed": 115
             }
           },
           "build_cost": {
@@ -589,7 +591,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 7,
-              "warp_speed": 1.9
+              "warp_speed": 1.9,
+              "impulse_speed": 115
             }
           },
           "build_cost": {
@@ -941,7 +944,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 8,
-              "warp_speed": 2
+              "warp_speed": 2,
+              "impulse_speed": 115
             }
           },
           "build_cost": {

--- a/ships/realta.json
+++ b/ships/realta.json
@@ -62,7 +62,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 2,
-              "warp_speed": 1.5
+              "warp_speed": 1.5,
+              "impulse_speed": 150
             }
           },
           "build_cost": {
@@ -194,7 +195,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 3,
-              "warp_speed": 1.7
+              "warp_speed": 1.7,
+              "impulse_speed": 150
             }
           },
           "build_cost": {
@@ -336,7 +338,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 4,
-              "warp_speed": 1.9
+              "warp_speed": 1.9,
+              "impulse_speed": 150
             }
           },
           "build_cost": {
@@ -478,7 +481,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 6,
-              "warp_speed": 2
+              "warp_speed": 2,
+              "impulse_speed": 150
             }
           },
           "build_cost": {

--- a/ships/realta.json
+++ b/ships/realta.json
@@ -61,9 +61,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 150,
               "warp_distance": 2,
-              "warp_speed": 1.5,
-              "impulse_speed": 150
+              "warp_speed": 1.5
             }
           },
           "build_cost": {
@@ -194,9 +194,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 150,
               "warp_distance": 3,
-              "warp_speed": 1.7,
-              "impulse_speed": 150
+              "warp_speed": 1.7
             }
           },
           "build_cost": {
@@ -337,9 +337,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 150,
               "warp_distance": 4,
-              "warp_speed": 1.9,
-              "impulse_speed": 150
+              "warp_speed": 1.9
             }
           },
           "build_cost": {
@@ -480,9 +480,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 150,
               "warp_distance": 6,
-              "warp_speed": 2,
-              "impulse_speed": 150
+              "warp_speed": 2
             }
           },
           "build_cost": {

--- a/ships/sarcophagus.json
+++ b/ships/sarcophagus.json
@@ -136,9 +136,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 80,
               "warp_distance": 31,
-              "warp_speed": 2.7,
-              "impulse_speed": 80
+              "warp_speed": 2.7
             }
           },
           "build_cost": {
@@ -425,9 +425,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 80,
               "warp_distance": 34,
-              "warp_speed": 2.8,
-              "impulse_speed": 80
+              "warp_speed": 2.8
             }
           },
           "build_cost": {
@@ -710,9 +710,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 80,
               "warp_distance": 37,
-              "warp_speed": 2.9,
-              "impulse_speed": 80
+              "warp_speed": 2.9
             }
           },
           "build_cost": {
@@ -1015,9 +1015,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 80,
               "warp_distance": 40,
-              "warp_speed": 3,
-              "impulse_speed": 80
+              "warp_speed": 3
             }
           },
           "build_cost": {
@@ -1320,9 +1320,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 80,
               "warp_distance": 44,
-              "warp_speed": 3.1,
-              "impulse_speed": 80
+              "warp_speed": 3.1
             }
           },
           "build_cost": {
@@ -1625,9 +1625,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 80,
               "warp_distance": 48,
-              "warp_speed": 3.2,
-              "impulse_speed": 80
+              "warp_speed": 3.2
             }
           },
           "build_cost": {
@@ -1930,9 +1930,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 80,
               "warp_distance": 52,
-              "warp_speed": 3.3,
-              "impulse_speed": 80
+              "warp_speed": 3.3
             }
           },
           "build_cost": {
@@ -2235,9 +2235,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 80,
               "warp_distance": 56,
-              "warp_speed": 3.4,
-              "impulse_speed": 80
+              "warp_speed": 3.4
             }
           },
           "build_cost": {
@@ -2540,9 +2540,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 80,
               "warp_distance": 60,
-              "warp_speed": 3.5,
-              "impulse_speed": 80
+              "warp_speed": 3.5
             }
           },
           "build_cost": {
@@ -2845,9 +2845,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 80,
               "warp_distance": 75,
-              "warp_speed": 3.6,
-              "impulse_speed": 80
+              "warp_speed": 3.6
             }
           },
           "build_cost": {
@@ -3150,9 +3150,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 80,
               "warp_distance": 85,
-              "warp_speed": 3.7,
-              "impulse_speed": 80
+              "warp_speed": 3.7
             }
           },
           "build_cost": {
@@ -3455,9 +3455,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 80,
               "warp_distance": 100,
-              "warp_speed": 3.8,
-              "impulse_speed": 80
+              "warp_speed": 3.8
             }
           },
           "build_cost": {

--- a/ships/sarcophagus.json
+++ b/ships/sarcophagus.json
@@ -137,7 +137,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 31,
-              "warp_speed": 2.7
+              "warp_speed": 2.7,
+              "impulse_speed": 80
             }
           },
           "build_cost": {
@@ -425,7 +426,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 34,
-              "warp_speed": 2.8
+              "warp_speed": 2.8,
+              "impulse_speed": 80
             }
           },
           "build_cost": {
@@ -709,7 +711,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 37,
-              "warp_speed": 2.9
+              "warp_speed": 2.9,
+              "impulse_speed": 80
             }
           },
           "build_cost": {
@@ -1013,7 +1016,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 40,
-              "warp_speed": 3
+              "warp_speed": 3,
+              "impulse_speed": 80
             }
           },
           "build_cost": {
@@ -1317,7 +1321,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 44,
-              "warp_speed": 3.1
+              "warp_speed": 3.1,
+              "impulse_speed": 80
             }
           },
           "build_cost": {
@@ -1621,7 +1626,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 48,
-              "warp_speed": 3.2
+              "warp_speed": 3.2,
+              "impulse_speed": 80
             }
           },
           "build_cost": {
@@ -1925,7 +1931,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 52,
-              "warp_speed": 3.3
+              "warp_speed": 3.3,
+              "impulse_speed": 80
             }
           },
           "build_cost": {
@@ -2229,7 +2236,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 56,
-              "warp_speed": 3.4
+              "warp_speed": 3.4,
+              "impulse_speed": 80
             }
           },
           "build_cost": {
@@ -2533,7 +2541,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 60,
-              "warp_speed": 3.5
+              "warp_speed": 3.5,
+              "impulse_speed": 80
             }
           },
           "build_cost": {
@@ -2837,7 +2846,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 75,
-              "warp_speed": 3.6
+              "warp_speed": 3.6,
+              "impulse_speed": 80
             }
           },
           "build_cost": {
@@ -3141,7 +3151,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 85,
-              "warp_speed": 3.7
+              "warp_speed": 3.7,
+              "impulse_speed": 80
             }
           },
           "build_cost": {
@@ -3445,7 +3456,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 100,
-              "warp_speed": 3.8
+              "warp_speed": 3.8,
+              "impulse_speed": 80
             }
           },
           "build_cost": {

--- a/ships/talla.json
+++ b/ships/talla.json
@@ -108,7 +108,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 13,
-              "warp_speed": 1.5
+              "warp_speed": 1.5,
+              "impulse_speed": 94
             }
           },
           "build_cost": {
@@ -358,7 +359,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 14,
-              "warp_speed": 1.6
+              "warp_speed": 1.6,
+              "impulse_speed": 94
             }
           },
           "build_cost": {
@@ -724,7 +726,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 15,
-              "warp_speed": 1.7
+              "warp_speed": 1.7,
+              "impulse_speed": 94
             }
           },
           "build_cost": {
@@ -1097,7 +1100,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 16,
-              "warp_speed": 1.8
+              "warp_speed": 1.8,
+              "impulse_speed": 94
             }
           },
           "build_cost": {
@@ -1530,7 +1534,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 17,
-              "warp_speed": 1.9
+              "warp_speed": 1.9,
+              "impulse_speed": 94
             }
           },
           "build_cost": {
@@ -1977,7 +1982,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 18,
-              "warp_speed": 2
+              "warp_speed": 2,
+              "impulse_speed": 94
             }
           },
           "build_cost": {
@@ -2484,7 +2490,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 19,
-              "warp_speed": 2.5
+              "warp_speed": 2.5,
+              "impulse_speed": 94
             }
           },
           "build_cost": {

--- a/ships/talla.json
+++ b/ships/talla.json
@@ -107,9 +107,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 94,
               "warp_distance": 13,
-              "warp_speed": 1.5,
-              "impulse_speed": 94
+              "warp_speed": 1.5
             }
           },
           "build_cost": {
@@ -358,9 +358,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 94,
               "warp_distance": 14,
-              "warp_speed": 1.6,
-              "impulse_speed": 94
+              "warp_speed": 1.6
             }
           },
           "build_cost": {
@@ -725,9 +725,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 94,
               "warp_distance": 15,
-              "warp_speed": 1.7,
-              "impulse_speed": 94
+              "warp_speed": 1.7
             }
           },
           "build_cost": {
@@ -1099,9 +1099,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 94,
               "warp_distance": 16,
-              "warp_speed": 1.8,
-              "impulse_speed": 94
+              "warp_speed": 1.8
             }
           },
           "build_cost": {
@@ -1533,9 +1533,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 94,
               "warp_distance": 17,
-              "warp_speed": 1.9,
-              "impulse_speed": 94
+              "warp_speed": 1.9
             }
           },
           "build_cost": {
@@ -1981,9 +1981,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 94,
               "warp_distance": 18,
-              "warp_speed": 2,
-              "impulse_speed": 94
+              "warp_speed": 2
             }
           },
           "build_cost": {
@@ -2489,9 +2489,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 94,
               "warp_distance": 19,
-              "warp_speed": 2.5,
-              "impulse_speed": 94
+              "warp_speed": 2.5
             }
           },
           "build_cost": {

--- a/ships/turas.json
+++ b/ships/turas.json
@@ -72,7 +72,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 11,
-              "warp_speed": 2.5
+              "warp_speed": 2.5,
+              "impulse_speed": 110
             }
           },
           "build_cost": {
@@ -326,7 +327,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 12,
-              "warp_speed": 2.6
+              "warp_speed": 2.6,
+              "impulse_speed": 110
             }
           },
           "build_cost": {
@@ -696,7 +698,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 13,
-              "warp_speed": 2.7
+              "warp_speed": 2.7,
+              "impulse_speed": 110
             }
           },
           "build_cost": {
@@ -1066,7 +1069,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 14,
-              "warp_speed": 2.8
+              "warp_speed": 2.8,
+              "impulse_speed": 110
             }
           },
           "build_cost": {
@@ -1503,7 +1507,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 15,
-              "warp_speed": 2.9
+              "warp_speed": 2.9,
+              "impulse_speed": 110
             }
           },
           "build_cost": {
@@ -1954,7 +1959,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 16,
-              "warp_speed": 3
+              "warp_speed": 3,
+              "impulse_speed": 110
             }
           },
           "build_cost": {
@@ -2465,7 +2471,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 17,
-              "warp_speed": 3.1
+              "warp_speed": 3.1,
+              "impulse_speed": 110
             }
           },
           "build_cost": {

--- a/ships/turas.json
+++ b/ships/turas.json
@@ -71,9 +71,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 110,
               "warp_distance": 11,
-              "warp_speed": 2.5,
-              "impulse_speed": 110
+              "warp_speed": 2.5
             }
           },
           "build_cost": {
@@ -326,9 +326,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 110,
               "warp_distance": 12,
-              "warp_speed": 2.6,
-              "impulse_speed": 110
+              "warp_speed": 2.6
             }
           },
           "build_cost": {
@@ -697,9 +697,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 110,
               "warp_distance": 13,
-              "warp_speed": 2.7,
-              "impulse_speed": 110
+              "warp_speed": 2.7
             }
           },
           "build_cost": {
@@ -1068,9 +1068,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 110,
               "warp_distance": 14,
-              "warp_speed": 2.8,
-              "impulse_speed": 110
+              "warp_speed": 2.8
             }
           },
           "build_cost": {
@@ -1506,9 +1506,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 110,
               "warp_distance": 15,
-              "warp_speed": 2.9,
-              "impulse_speed": 110
+              "warp_speed": 2.9
             }
           },
           "build_cost": {
@@ -1958,9 +1958,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 110,
               "warp_distance": 16,
-              "warp_speed": 3,
-              "impulse_speed": 110
+              "warp_speed": 3
             }
           },
           "build_cost": {
@@ -2470,9 +2470,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 110,
               "warp_distance": 17,
-              "warp_speed": 3.1,
-              "impulse_speed": 110
+              "warp_speed": 3.1
             }
           },
           "build_cost": {

--- a/ships/uss_discovery.json
+++ b/ships/uss_discovery.json
@@ -119,9 +119,9 @@
           "name": "Spore Drive",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 90,
               "warp_distance": 20,
-              "warp_speed": 3.1,
-              "impulse_speed": 90
+              "warp_speed": 3.1
             }
           },
           "build_cost": {
@@ -409,9 +409,9 @@
           "name": "Spore Drive",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 90,
               "warp_distance": 21,
-              "warp_speed": 3.2,
-              "impulse_speed": 90
+              "warp_speed": 3.2
             }
           },
           "build_cost": {
@@ -754,9 +754,9 @@
           "name": "Spore Drive",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 90,
               "warp_distance": 22,
-              "warp_speed": 3.3,
-              "impulse_speed": 90
+              "warp_speed": 3.3
             }
           },
           "build_cost": {
@@ -1099,9 +1099,9 @@
           "name": "Spore Drive",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 90,
               "warp_distance": 23,
-              "warp_speed": 3.4,
-              "impulse_speed": 90
+              "warp_speed": 3.4
             }
           },
           "build_cost": {
@@ -1401,9 +1401,9 @@
           "name": "Spore Drive",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 90,
               "warp_distance": 24,
-              "warp_speed": 3.5,
-              "impulse_speed": 90
+              "warp_speed": 3.5
             }
           },
           "build_cost": {
@@ -1825,9 +1825,9 @@
           "name": "Spore Drive",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 90,
               "warp_distance": 25,
-              "warp_speed": 3.6,
-              "impulse_speed": 90
+              "warp_speed": 3.6
             }
           },
           "build_cost": {
@@ -2188,9 +2188,9 @@
           "name": "Spore Drive",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 90,
               "warp_distance": 26,
-              "warp_speed": 3.7,
-              "impulse_speed": 90
+              "warp_speed": 3.7
             }
           },
           "build_cost": {
@@ -2555,9 +2555,9 @@
           "name": "Spore Drive",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 90,
               "warp_distance": 28,
-              "warp_speed": 3.8,
-              "impulse_speed": 90
+              "warp_speed": 3.8
             }
           },
           "build_cost": {
@@ -2922,9 +2922,9 @@
           "name": "Spore Drive",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 90,
               "warp_distance": 30,
-              "warp_speed": 3.9,
-              "impulse_speed": 90
+              "warp_speed": 3.9
             }
           },
           "build_cost": {

--- a/ships/uss_discovery.json
+++ b/ships/uss_discovery.json
@@ -120,7 +120,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 20,
-              "warp_speed": 3.1
+              "warp_speed": 3.1,
+              "impulse_speed": 90
             }
           },
           "build_cost": {
@@ -409,7 +410,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 21,
-              "warp_speed": 3.2
+              "warp_speed": 3.2,
+              "impulse_speed": 90
             }
           },
           "build_cost": {
@@ -753,7 +755,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 22,
-              "warp_speed": 3.3
+              "warp_speed": 3.3,
+              "impulse_speed": 90
             }
           },
           "build_cost": {
@@ -1097,7 +1100,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 23,
-              "warp_speed": 3.4
+              "warp_speed": 3.4,
+              "impulse_speed": 90
             }
           },
           "build_cost": {
@@ -1398,7 +1402,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 24,
-              "warp_speed": 3.5
+              "warp_speed": 3.5,
+              "impulse_speed": 90
             }
           },
           "build_cost": {
@@ -1821,7 +1826,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 25,
-              "warp_speed": 3.6
+              "warp_speed": 3.6,
+              "impulse_speed": 90
             }
           },
           "build_cost": {
@@ -2183,7 +2189,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 26,
-              "warp_speed": 3.7
+              "warp_speed": 3.7,
+              "impulse_speed": 90
             }
           },
           "build_cost": {
@@ -2549,7 +2556,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 28,
-              "warp_speed": 3.8
+              "warp_speed": 3.8,
+              "impulse_speed": 90
             }
           },
           "build_cost": {
@@ -2915,7 +2923,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 30,
-              "warp_speed": 3.9
+              "warp_speed": 3.9,
+              "impulse_speed": 90
             }
           },
           "build_cost": {

--- a/ships/uss_enterprise.json
+++ b/ships/uss_enterprise.json
@@ -125,7 +125,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 40,
-              "warp_speed": 4
+              "warp_speed": 4,
+              "impulse_speed": 100
             }
           },
           "build_cost": {
@@ -487,7 +488,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 44,
-              "warp_speed": 4.1
+              "warp_speed": 4.1,
+              "impulse_speed": 100
             }
           },
           "build_cost": {
@@ -960,7 +962,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 48,
-              "warp_speed": 4.2
+              "warp_speed": 4.2,
+              "impulse_speed": 100
             }
           },
           "build_cost": {
@@ -1433,7 +1436,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 52,
-              "warp_speed": 4.3
+              "warp_speed": 4.3,
+              "impulse_speed": 100
             }
           },
           "build_cost": {
@@ -1805,7 +1809,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 56,
-              "warp_speed": 4.4
+              "warp_speed": 4.4,
+              "impulse_speed": 100
             }
           },
           "build_cost": {
@@ -2358,7 +2363,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 60,
-              "warp_speed": 4.5
+              "warp_speed": 4.5,
+              "impulse_speed": 100
             }
           },
           "build_cost": {
@@ -3092,7 +3098,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 65,
-              "warp_speed": 4.6
+              "warp_speed": 4.6,
+              "impulse_speed": 100
             }
           },
           "build_cost": {
@@ -3705,7 +3712,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 70,
-              "warp_speed": 4.7
+              "warp_speed": 4.7,
+              "impulse_speed": 100
             }
           },
           "build_cost": {
@@ -4137,7 +4145,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 75,
-              "warp_speed": 4.8
+              "warp_speed": 4.8,
+              "impulse_speed": 100
             }
           },
           "build_cost": {

--- a/ships/uss_enterprise.json
+++ b/ships/uss_enterprise.json
@@ -124,9 +124,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 100,
               "warp_distance": 40,
-              "warp_speed": 4,
-              "impulse_speed": 100
+              "warp_speed": 4
             }
           },
           "build_cost": {
@@ -487,9 +487,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 100,
               "warp_distance": 44,
-              "warp_speed": 4.1,
-              "impulse_speed": 100
+              "warp_speed": 4.1
             }
           },
           "build_cost": {
@@ -961,9 +961,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 100,
               "warp_distance": 48,
-              "warp_speed": 4.2,
-              "impulse_speed": 100
+              "warp_speed": 4.2
             }
           },
           "build_cost": {
@@ -1435,9 +1435,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 100,
               "warp_distance": 52,
-              "warp_speed": 4.3,
-              "impulse_speed": 100
+              "warp_speed": 4.3
             }
           },
           "build_cost": {
@@ -1808,9 +1808,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 100,
               "warp_distance": 56,
-              "warp_speed": 4.4,
-              "impulse_speed": 100
+              "warp_speed": 4.4
             }
           },
           "build_cost": {
@@ -2362,9 +2362,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 100,
               "warp_distance": 60,
-              "warp_speed": 4.5,
-              "impulse_speed": 100
+              "warp_speed": 4.5
             }
           },
           "build_cost": {
@@ -3097,9 +3097,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 100,
               "warp_distance": 65,
-              "warp_speed": 4.6,
-              "impulse_speed": 100
+              "warp_speed": 4.6
             }
           },
           "build_cost": {
@@ -3711,9 +3711,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 100,
               "warp_distance": 70,
-              "warp_speed": 4.7,
-              "impulse_speed": 100
+              "warp_speed": 4.7
             }
           },
           "build_cost": {
@@ -4144,9 +4144,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 100,
               "warp_distance": 75,
-              "warp_speed": 4.8,
-              "impulse_speed": 100
+              "warp_speed": 4.8
             }
           },
           "build_cost": {

--- a/ships/uss_franklin.json
+++ b/ships/uss_franklin.json
@@ -86,9 +86,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 100,
               "warp_distance": 13,
-              "warp_speed": 2.6,
-              "impulse_speed": 100
+              "warp_speed": 2.6
             }
           },
           "build_cost": {
@@ -387,9 +387,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 100,
               "warp_distance": 15,
-              "warp_speed": 2.7,
-              "impulse_speed": 100
+              "warp_speed": 2.7
             }
           },
           "build_cost": {
@@ -785,9 +785,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 100,
               "warp_distance": 18,
-              "warp_speed": 2.8,
-              "impulse_speed": 100
+              "warp_speed": 2.8
             }
           },
           "build_cost": {
@@ -1077,9 +1077,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 100,
               "warp_distance": 22,
-              "warp_speed": 3,
-              "impulse_speed": 100
+              "warp_speed": 3
             }
           },
           "build_cost": {
@@ -1472,9 +1472,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 100,
               "warp_distance": 23,
-              "warp_speed": 3.1,
-              "impulse_speed": 100
+              "warp_speed": 3.1
             }
           },
           "build_cost": {
@@ -1867,9 +1867,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 100,
               "warp_distance": 24,
-              "warp_speed": 3.2,
-              "impulse_speed": 100
+              "warp_speed": 3.2
             }
           },
           "build_cost": {
@@ -2282,9 +2282,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 100,
               "warp_distance": 25,
-              "warp_speed": 3.3,
-              "impulse_speed": 100
+              "warp_speed": 3.3
             }
           },
           "build_cost": {
@@ -2697,9 +2697,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 100,
               "warp_distance": 26,
-              "warp_speed": 3.4,
-              "impulse_speed": 100
+              "warp_speed": 3.4
             }
           },
           "build_cost": {
@@ -3112,9 +3112,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 100,
               "warp_distance": 27,
-              "warp_speed": 3.6,
-              "impulse_speed": 100
+              "warp_speed": 3.6
             }
           },
           "build_cost": {

--- a/ships/uss_franklin.json
+++ b/ships/uss_franklin.json
@@ -87,7 +87,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 13,
-              "warp_speed": 2.6
+              "warp_speed": 2.6,
+              "impulse_speed": 100
             }
           },
           "build_cost": {
@@ -387,7 +388,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 15,
-              "warp_speed": 2.7
+              "warp_speed": 2.7,
+              "impulse_speed": 100
             }
           },
           "build_cost": {
@@ -784,7 +786,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 18,
-              "warp_speed": 2.8
+              "warp_speed": 2.8,
+              "impulse_speed": 100
             }
           },
           "build_cost": {
@@ -1075,7 +1078,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 22,
-              "warp_speed": 3
+              "warp_speed": 3,
+              "impulse_speed": 100
             }
           },
           "build_cost": {
@@ -1469,7 +1473,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 23,
-              "warp_speed": 3.1
+              "warp_speed": 3.1,
+              "impulse_speed": 100
             }
           },
           "build_cost": {
@@ -1863,7 +1868,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 24,
-              "warp_speed": 3.2
+              "warp_speed": 3.2,
+              "impulse_speed": 100
             }
           },
           "build_cost": {
@@ -2277,7 +2283,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 25,
-              "warp_speed": 3.3
+              "warp_speed": 3.3,
+              "impulse_speed": 100
             }
           },
           "build_cost": {
@@ -2691,7 +2698,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 26,
-              "warp_speed": 3.4
+              "warp_speed": 3.4,
+              "impulse_speed": 100
             }
           },
           "build_cost": {
@@ -3105,7 +3113,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 27,
-              "warp_speed": 3.6
+              "warp_speed": 3.6,
+              "impulse_speed": 100
             }
           },
           "build_cost": {

--- a/ships/uss_franklin_a.json
+++ b/ships/uss_franklin_a.json
@@ -119,9 +119,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 100,
               "warp_distance": 75,
-              "warp_speed": 2.6,
-              "impulse_speed": 100
+              "warp_speed": 2.6
             }
           },
           "build_cost": {
@@ -432,9 +432,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 100,
               "warp_distance": 80,
-              "warp_speed": 2.7,
-              "impulse_speed": 100
+              "warp_speed": 2.7
             }
           },
           "build_cost": {
@@ -782,9 +782,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 100,
               "warp_distance": 85,
-              "warp_speed": 2.8,
-              "impulse_speed": 100
+              "warp_speed": 2.8
             }
           },
           "build_cost": {
@@ -1132,9 +1132,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 100,
               "warp_distance": 90,
-              "warp_speed": 3,
-              "impulse_speed": 100
+              "warp_speed": 3
             }
           },
           "build_cost": {
@@ -1476,9 +1476,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 100,
               "warp_distance": 100,
-              "warp_speed": 3.1,
-              "impulse_speed": 100
+              "warp_speed": 3.1
             }
           },
           "build_cost": {
@@ -1814,9 +1814,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 100,
               "warp_distance": 105,
-              "warp_speed": 3.2,
-              "impulse_speed": 100
+              "warp_speed": 3.2
             }
           },
           "build_cost": {
@@ -2164,9 +2164,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 100,
               "warp_distance": 110,
-              "warp_speed": 3.3,
-              "impulse_speed": 100
+              "warp_speed": 3.3
             }
           },
           "build_cost": {
@@ -2514,9 +2514,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 100,
               "warp_distance": 120,
-              "warp_speed": 3.4,
-              "impulse_speed": 100
+              "warp_speed": 3.4
             }
           },
           "build_cost": {
@@ -2659,9 +2659,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 100,
               "warp_distance": 130,
-              "warp_speed": 3.6,
-              "impulse_speed": 100
+              "warp_speed": 3.6
             }
           },
           "build_cost": {
@@ -3214,9 +3214,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 100,
               "warp_distance": 140,
-              "warp_speed": 3.6,
-              "impulse_speed": 100
+              "warp_speed": 3.6
             }
           },
           "build_cost": {
@@ -3564,9 +3564,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 100,
               "warp_distance": 150,
-              "warp_speed": 3.6,
-              "impulse_speed": 100
+              "warp_speed": 3.6
             }
           },
           "build_cost": {
@@ -3914,9 +3914,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 100,
               "warp_distance": 165,
-              "warp_speed": 3.6,
-              "impulse_speed": 100
+              "warp_speed": 3.6
             }
           },
           "build_cost": {

--- a/ships/uss_franklin_a.json
+++ b/ships/uss_franklin_a.json
@@ -120,7 +120,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 75,
-              "warp_speed": 2.6
+              "warp_speed": 2.6,
+              "impulse_speed": 100
             }
           },
           "build_cost": {
@@ -432,7 +433,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 80,
-              "warp_speed": 2.7
+              "warp_speed": 2.7,
+              "impulse_speed": 100
             }
           },
           "build_cost": {
@@ -781,7 +783,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 85,
-              "warp_speed": 2.8
+              "warp_speed": 2.8,
+              "impulse_speed": 100
             }
           },
           "build_cost": {
@@ -1130,7 +1133,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 90,
-              "warp_speed": 3
+              "warp_speed": 3,
+              "impulse_speed": 100
             }
           },
           "build_cost": {
@@ -1473,7 +1477,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 100,
-              "warp_speed": 3.1
+              "warp_speed": 3.1,
+              "impulse_speed": 100
             }
           },
           "build_cost": {
@@ -1810,7 +1815,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 105,
-              "warp_speed": 3.2
+              "warp_speed": 3.2,
+              "impulse_speed": 100
             }
           },
           "build_cost": {
@@ -2159,7 +2165,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 110,
-              "warp_speed": 3.3
+              "warp_speed": 3.3,
+              "impulse_speed": 100
             }
           },
           "build_cost": {
@@ -2508,7 +2515,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 120,
-              "warp_speed": 3.4
+              "warp_speed": 3.4,
+              "impulse_speed": 100
             }
           },
           "build_cost": {
@@ -2652,7 +2660,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 130,
-              "warp_speed": 3.6
+              "warp_speed": 3.6,
+              "impulse_speed": 100
             }
           },
           "build_cost": {
@@ -3206,7 +3215,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 140,
-              "warp_speed": 3.6
+              "warp_speed": 3.6,
+              "impulse_speed": 100
             }
           },
           "build_cost": {
@@ -3555,7 +3565,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 150,
-              "warp_speed": 3.6
+              "warp_speed": 3.6,
+              "impulse_speed": 100
             }
           },
           "build_cost": {
@@ -3904,7 +3915,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 165,
-              "warp_speed": 3.6
+              "warp_speed": 3.6,
+              "impulse_speed": 100
             }
           },
           "build_cost": {

--- a/ships/uss_intrepid.json
+++ b/ships/uss_intrepid.json
@@ -155,7 +155,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 33,
-              "warp_speed": 2.8
+              "warp_speed": 2.8,
+              "impulse_speed": 85
             }
           },
           "build_cost": {
@@ -587,7 +588,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 36,
-              "warp_speed": 2.9
+              "warp_speed": 2.9,
+              "impulse_speed": 85
             }
           },
           "build_cost": {
@@ -1126,7 +1128,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 39,
-              "warp_speed": 3
+              "warp_speed": 3,
+              "impulse_speed": 85
             }
           },
           "build_cost": {
@@ -1665,7 +1668,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 42,
-              "warp_speed": 3.1
+              "warp_speed": 3.1,
+              "impulse_speed": 85
             }
           },
           "build_cost": {
@@ -2284,7 +2288,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 46,
-              "warp_speed": 3.2
+              "warp_speed": 3.2,
+              "impulse_speed": 85
             }
           },
           "build_cost": {
@@ -2903,7 +2908,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 50,
-              "warp_speed": 3.3
+              "warp_speed": 3.3,
+              "impulse_speed": 85
             }
           },
           "build_cost": {
@@ -3522,7 +3528,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 54,
-              "warp_speed": 3.4
+              "warp_speed": 3.4,
+              "impulse_speed": 85
             }
           },
           "build_cost": {
@@ -4201,7 +4208,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 58,
-              "warp_speed": 3.5
+              "warp_speed": 3.5,
+              "impulse_speed": 85
             }
           },
           "build_cost": {
@@ -4880,7 +4888,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 65,
-              "warp_speed": 3.6
+              "warp_speed": 3.6,
+              "impulse_speed": 85
             }
           },
           "build_cost": {

--- a/ships/uss_intrepid.json
+++ b/ships/uss_intrepid.json
@@ -154,9 +154,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 85,
               "warp_distance": 33,
-              "warp_speed": 2.8,
-              "impulse_speed": 85
+              "warp_speed": 2.8
             }
           },
           "build_cost": {
@@ -587,9 +587,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 85,
               "warp_distance": 36,
-              "warp_speed": 2.9,
-              "impulse_speed": 85
+              "warp_speed": 2.9
             }
           },
           "build_cost": {
@@ -1127,9 +1127,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 85,
               "warp_distance": 39,
-              "warp_speed": 3,
-              "impulse_speed": 85
+              "warp_speed": 3
             }
           },
           "build_cost": {
@@ -1667,9 +1667,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 85,
               "warp_distance": 42,
-              "warp_speed": 3.1,
-              "impulse_speed": 85
+              "warp_speed": 3.1
             }
           },
           "build_cost": {
@@ -2287,9 +2287,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 85,
               "warp_distance": 46,
-              "warp_speed": 3.2,
-              "impulse_speed": 85
+              "warp_speed": 3.2
             }
           },
           "build_cost": {
@@ -2907,9 +2907,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 85,
               "warp_distance": 50,
-              "warp_speed": 3.3,
-              "impulse_speed": 85
+              "warp_speed": 3.3
             }
           },
           "build_cost": {
@@ -3527,9 +3527,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 85,
               "warp_distance": 54,
-              "warp_speed": 3.4,
-              "impulse_speed": 85
+              "warp_speed": 3.4
             }
           },
           "build_cost": {
@@ -4207,9 +4207,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 85,
               "warp_distance": 58,
-              "warp_speed": 3.5,
-              "impulse_speed": 85
+              "warp_speed": 3.5
             }
           },
           "build_cost": {
@@ -4887,9 +4887,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 85,
               "warp_distance": 65,
-              "warp_speed": 3.6,
-              "impulse_speed": 85
+              "warp_speed": 3.6
             }
           },
           "build_cost": {

--- a/ships/uss_mayflower.json
+++ b/ships/uss_mayflower.json
@@ -120,9 +120,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 100,
               "warp_distance": 24,
-              "warp_speed": 3,
-              "impulse_speed": 100
+              "warp_speed": 3
             }
           },
           "build_cost": {
@@ -477,9 +477,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 100,
               "warp_distance": 26,
-              "warp_speed": 3.1,
-              "impulse_speed": 100
+              "warp_speed": 3.1
             }
           },
           "build_cost": {
@@ -951,9 +951,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 100,
               "warp_distance": 28,
-              "warp_speed": 3.2,
-              "impulse_speed": 100
+              "warp_speed": 3.2
             }
           },
           "build_cost": {
@@ -1425,9 +1425,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 100,
               "warp_distance": 30,
-              "warp_speed": 3.3,
-              "impulse_speed": 100
+              "warp_speed": 3.3
             }
           },
           "build_cost": {
@@ -1979,9 +1979,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 100,
               "warp_distance": 33,
-              "warp_speed": 3.4,
-              "impulse_speed": 100
+              "warp_speed": 3.4
             }
           },
           "build_cost": {
@@ -2533,9 +2533,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 100,
               "warp_distance": 36,
-              "warp_speed": 3.5,
-              "impulse_speed": 100
+              "warp_speed": 3.5
             }
           },
           "build_cost": {
@@ -3087,9 +3087,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 100,
               "warp_distance": 40,
-              "warp_speed": 3.6,
-              "impulse_speed": 100
+              "warp_speed": 3.6
             }
           },
           "build_cost": {
@@ -3701,9 +3701,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 100,
               "warp_distance": 45,
-              "warp_speed": 3.7,
-              "impulse_speed": 100
+              "warp_speed": 3.7
             }
           },
           "build_cost": {
@@ -4315,9 +4315,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 100,
               "warp_distance": 50,
-              "warp_speed": 3.8,
-              "impulse_speed": 100
+              "warp_speed": 3.8
             }
           },
           "build_cost": {

--- a/ships/uss_mayflower.json
+++ b/ships/uss_mayflower.json
@@ -121,7 +121,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 24,
-              "warp_speed": 3
+              "warp_speed": 3,
+              "impulse_speed": 100
             }
           },
           "build_cost": {
@@ -477,7 +478,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 26,
-              "warp_speed": 3.1
+              "warp_speed": 3.1,
+              "impulse_speed": 100
             }
           },
           "build_cost": {
@@ -950,7 +952,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 28,
-              "warp_speed": 3.2
+              "warp_speed": 3.2,
+              "impulse_speed": 100
             }
           },
           "build_cost": {
@@ -1423,7 +1426,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 30,
-              "warp_speed": 3.3
+              "warp_speed": 3.3,
+              "impulse_speed": 100
             }
           },
           "build_cost": {
@@ -1976,7 +1980,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 33,
-              "warp_speed": 3.4
+              "warp_speed": 3.4,
+              "impulse_speed": 100
             }
           },
           "build_cost": {
@@ -2529,7 +2534,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 36,
-              "warp_speed": 3.5
+              "warp_speed": 3.5,
+              "impulse_speed": 100
             }
           },
           "build_cost": {
@@ -3082,7 +3088,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 40,
-              "warp_speed": 3.6
+              "warp_speed": 3.6,
+              "impulse_speed": 100
             }
           },
           "build_cost": {
@@ -3695,7 +3702,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 45,
-              "warp_speed": 3.7
+              "warp_speed": 3.7,
+              "impulse_speed": 100
             }
           },
           "build_cost": {
@@ -4308,7 +4316,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 50,
-              "warp_speed": 3.8
+              "warp_speed": 3.8,
+              "impulse_speed": 100
             }
           },
           "build_cost": {

--- a/ships/uss_newton.json
+++ b/ships/uss_newton.json
@@ -123,9 +123,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 72,
               "warp_distance": 140,
-              "warp_speed": 3.5,
-              "impulse_speed": 72
+              "warp_speed": 3.5
             }
           },
           "build_cost": {
@@ -436,9 +436,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 72,
               "warp_distance": 150,
-              "warp_speed": 3.6,
-              "impulse_speed": 72
+              "warp_speed": 3.6
             }
           },
           "build_cost": {
@@ -846,9 +846,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 72,
               "warp_distance": 160,
-              "warp_speed": 3.7,
-              "impulse_speed": 72
+              "warp_speed": 3.7
             }
           },
           "build_cost": {
@@ -1268,9 +1268,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 72,
               "warp_distance": 170,
-              "warp_speed": 3.8,
-              "impulse_speed": 72
+              "warp_speed": 3.8
             }
           },
           "build_cost": {
@@ -1690,9 +1690,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 72,
               "warp_distance": 180,
-              "warp_speed": 3.9,
-              "impulse_speed": 72
+              "warp_speed": 3.9
             }
           },
           "build_cost": {
@@ -2112,9 +2112,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 72,
               "warp_distance": 190,
-              "warp_speed": 4,
-              "impulse_speed": 72
+              "warp_speed": 4
             }
           },
           "build_cost": {
@@ -2534,9 +2534,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 72,
               "warp_distance": 200,
-              "warp_speed": 4.1,
-              "impulse_speed": 72
+              "warp_speed": 4.1
             }
           },
           "build_cost": {
@@ -2956,9 +2956,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 72,
               "warp_distance": 205,
-              "warp_speed": 4.2,
-              "impulse_speed": 72
+              "warp_speed": 4.2
             }
           },
           "build_cost": {
@@ -3378,9 +3378,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 72,
               "warp_distance": 210,
-              "warp_speed": 4.3,
-              "impulse_speed": 72
+              "warp_speed": 4.3
             }
           },
           "build_cost": {
@@ -3800,9 +3800,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 72,
               "warp_distance": 215,
-              "warp_speed": 4.4,
-              "impulse_speed": 72
+              "warp_speed": 4.4
             }
           },
           "build_cost": {
@@ -4222,9 +4222,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 72,
               "warp_distance": 220,
-              "warp_speed": 4.5,
-              "impulse_speed": 72
+              "warp_speed": 4.5
             }
           },
           "build_cost": {
@@ -4644,9 +4644,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 72,
               "warp_distance": 225,
-              "warp_speed": 4.6,
-              "impulse_speed": 72
+              "warp_speed": 4.6
             }
           },
           "build_cost": {

--- a/ships/uss_newton.json
+++ b/ships/uss_newton.json
@@ -124,7 +124,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 140,
-              "warp_speed": 3.5
+              "warp_speed": 3.5,
+              "impulse_speed": 72
             }
           },
           "build_cost": {
@@ -436,7 +437,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 150,
-              "warp_speed": 3.6
+              "warp_speed": 3.6,
+              "impulse_speed": 72
             }
           },
           "build_cost": {
@@ -845,7 +847,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 160,
-              "warp_speed": 3.7
+              "warp_speed": 3.7,
+              "impulse_speed": 72
             }
           },
           "build_cost": {
@@ -1266,7 +1269,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 170,
-              "warp_speed": 3.8
+              "warp_speed": 3.8,
+              "impulse_speed": 72
             }
           },
           "build_cost": {
@@ -1687,7 +1691,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 180,
-              "warp_speed": 3.9
+              "warp_speed": 3.9,
+              "impulse_speed": 72
             }
           },
           "build_cost": {
@@ -2108,7 +2113,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 190,
-              "warp_speed": 4
+              "warp_speed": 4,
+              "impulse_speed": 72
             }
           },
           "build_cost": {
@@ -2529,7 +2535,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 200,
-              "warp_speed": 4.1
+              "warp_speed": 4.1,
+              "impulse_speed": 72
             }
           },
           "build_cost": {
@@ -2950,7 +2957,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 205,
-              "warp_speed": 4.2
+              "warp_speed": 4.2,
+              "impulse_speed": 72
             }
           },
           "build_cost": {
@@ -3371,7 +3379,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 210,
-              "warp_speed": 4.3
+              "warp_speed": 4.3,
+              "impulse_speed": 72
             }
           },
           "build_cost": {
@@ -3792,7 +3801,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 215,
-              "warp_speed": 4.4
+              "warp_speed": 4.4,
+              "impulse_speed": 72
             }
           },
           "build_cost": {
@@ -4213,7 +4223,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 220,
-              "warp_speed": 4.5
+              "warp_speed": 4.5,
+              "impulse_speed": 72
             }
           },
           "build_cost": {
@@ -4634,7 +4645,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 225,
-              "warp_speed": 4.6
+              "warp_speed": 4.6,
+              "impulse_speed": 72
             }
           },
           "build_cost": {

--- a/ships/vahklas.json
+++ b/ships/vahklas.json
@@ -91,7 +91,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 19,
-              "warp_speed": 3
+              "warp_speed": 3,
+              "impulse_speed": 100
             }
           },
           "build_cost": {
@@ -370,7 +371,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 20,
-              "warp_speed": 3.1
+              "warp_speed": 3.1,
+              "impulse_speed": 100
             }
           },
           "build_cost": {
@@ -773,7 +775,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 21,
-              "warp_speed": 3.2
+              "warp_speed": 3.2,
+              "impulse_speed": 100
             }
           },
           "build_cost": {
@@ -1236,7 +1239,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 22,
-              "warp_speed": 3.3
+              "warp_speed": 3.3,
+              "impulse_speed": 100
             }
           },
           "build_cost": {
@@ -1748,7 +1752,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 23,
-              "warp_speed": 3.4
+              "warp_speed": 3.4,
+              "impulse_speed": 100
             }
           },
           "build_cost": {
@@ -2162,7 +2167,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 24,
-              "warp_speed": 3.5
+              "warp_speed": 3.5,
+              "impulse_speed": 100
             }
           },
           "build_cost": {
@@ -2644,7 +2650,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 26,
-              "warp_speed": 3.6
+              "warp_speed": 3.6,
+              "impulse_speed": 100
             }
           },
           "build_cost": {
@@ -3208,7 +3215,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 28,
-              "warp_speed": 3.7
+              "warp_speed": 3.7,
+              "impulse_speed": 100
             }
           },
           "build_cost": {
@@ -3780,7 +3788,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 30,
-              "warp_speed": 3.8
+              "warp_speed": 3.8,
+              "impulse_speed": 100
             }
           },
           "build_cost": {

--- a/ships/vahklas.json
+++ b/ships/vahklas.json
@@ -90,9 +90,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 100,
               "warp_distance": 19,
-              "warp_speed": 3,
-              "impulse_speed": 100
+              "warp_speed": 3
             }
           },
           "build_cost": {
@@ -370,9 +370,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 100,
               "warp_distance": 20,
-              "warp_speed": 3.1,
-              "impulse_speed": 100
+              "warp_speed": 3.1
             }
           },
           "build_cost": {
@@ -774,9 +774,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 100,
               "warp_distance": 21,
-              "warp_speed": 3.2,
-              "impulse_speed": 100
+              "warp_speed": 3.2
             }
           },
           "build_cost": {
@@ -1238,9 +1238,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 100,
               "warp_distance": 22,
-              "warp_speed": 3.3,
-              "impulse_speed": 100
+              "warp_speed": 3.3
             }
           },
           "build_cost": {
@@ -1751,9 +1751,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 100,
               "warp_distance": 23,
-              "warp_speed": 3.4,
-              "impulse_speed": 100
+              "warp_speed": 3.4
             }
           },
           "build_cost": {
@@ -2166,9 +2166,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 100,
               "warp_distance": 24,
-              "warp_speed": 3.5,
-              "impulse_speed": 100
+              "warp_speed": 3.5
             }
           },
           "build_cost": {
@@ -2649,9 +2649,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 100,
               "warp_distance": 26,
-              "warp_speed": 3.6,
-              "impulse_speed": 100
+              "warp_speed": 3.6
             }
           },
           "build_cost": {
@@ -3214,9 +3214,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 100,
               "warp_distance": 28,
-              "warp_speed": 3.7,
-              "impulse_speed": 100
+              "warp_speed": 3.7
             }
           },
           "build_cost": {
@@ -3787,9 +3787,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 100,
               "warp_distance": 30,
-              "warp_speed": 3.8,
-              "impulse_speed": 100
+              "warp_speed": 3.8
             }
           },
           "build_cost": {

--- a/ships/valdore.json
+++ b/ships/valdore.json
@@ -140,9 +140,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 85,
               "warp_distance": 85,
-              "warp_speed": 4.3,
-              "impulse_speed": 85
+              "warp_speed": 4.3
             }
           },
           "build_cost": {
@@ -489,9 +489,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 85,
               "warp_distance": 100,
-              "warp_speed": 4.4,
-              "impulse_speed": 85
+              "warp_speed": 4.4
             }
           },
           "build_cost": {
@@ -905,9 +905,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 85,
               "warp_distance": 105,
-              "warp_speed": 4.5,
-              "impulse_speed": 85
+              "warp_speed": 4.5
             }
           },
           "build_cost": {
@@ -1061,9 +1061,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 85,
               "warp_distance": 125,
-              "warp_speed": 4.6,
-              "impulse_speed": 85
+              "warp_speed": 4.6
             }
           },
           "build_cost": {
@@ -1487,9 +1487,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 85,
               "warp_distance": 140,
-              "warp_speed": 4.7,
-              "impulse_speed": 85
+              "warp_speed": 4.7
             }
           },
           "build_cost": {
@@ -1913,9 +1913,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 85,
               "warp_distance": 150,
-              "warp_speed": 4.8,
-              "impulse_speed": 85
+              "warp_speed": 4.8
             }
           },
           "build_cost": {
@@ -2339,9 +2339,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 85,
               "warp_distance": 160,
-              "warp_speed": 4.9,
-              "impulse_speed": 85
+              "warp_speed": 4.9
             }
           },
           "build_cost": {
@@ -2765,9 +2765,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 85,
               "warp_distance": 170,
-              "warp_speed": 5,
-              "impulse_speed": 85
+              "warp_speed": 5
             }
           },
           "build_cost": {
@@ -3461,9 +3461,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 85,
               "warp_distance": 180,
-              "warp_speed": 5.1,
-              "impulse_speed": 85
+              "warp_speed": 5.1
             }
           },
           "build_cost": {
@@ -3887,9 +3887,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 85,
               "warp_distance": 190,
-              "warp_speed": 5.2,
-              "impulse_speed": 85
+              "warp_speed": 5.2
             }
           },
           "build_cost": {
@@ -4313,9 +4313,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 85,
               "warp_distance": 200,
-              "warp_speed": 5.3,
-              "impulse_speed": 85
+              "warp_speed": 5.3
             }
           },
           "build_cost": {
@@ -4739,9 +4739,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 85,
               "warp_distance": 210,
-              "warp_speed": 5.4,
-              "impulse_speed": 85
+              "warp_speed": 5.4
             }
           },
           "build_cost": {

--- a/ships/valdore.json
+++ b/ships/valdore.json
@@ -141,7 +141,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 85,
-              "warp_speed": 4.3
+              "warp_speed": 4.3,
+              "impulse_speed": 85
             }
           },
           "build_cost": {
@@ -489,7 +490,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 100,
-              "warp_speed": 4.4
+              "warp_speed": 4.4,
+              "impulse_speed": 85
             }
           },
           "build_cost": {
@@ -904,7 +906,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 105,
-              "warp_speed": 4.5
+              "warp_speed": 4.5,
+              "impulse_speed": 85
             }
           },
           "build_cost": {
@@ -1059,7 +1062,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 125,
-              "warp_speed": 4.6
+              "warp_speed": 4.6,
+              "impulse_speed": 85
             }
           },
           "build_cost": {
@@ -1484,7 +1488,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 140,
-              "warp_speed": 4.7
+              "warp_speed": 4.7,
+              "impulse_speed": 85
             }
           },
           "build_cost": {
@@ -1909,7 +1914,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 150,
-              "warp_speed": 4.8
+              "warp_speed": 4.8,
+              "impulse_speed": 85
             }
           },
           "build_cost": {
@@ -2334,7 +2340,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 160,
-              "warp_speed": 4.9
+              "warp_speed": 4.9,
+              "impulse_speed": 85
             }
           },
           "build_cost": {
@@ -2759,7 +2766,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 170,
-              "warp_speed": 5
+              "warp_speed": 5,
+              "impulse_speed": 85
             }
           },
           "build_cost": {
@@ -3454,7 +3462,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 180,
-              "warp_speed": 5.1
+              "warp_speed": 5.1,
+              "impulse_speed": 85
             }
           },
           "build_cost": {
@@ -3879,7 +3888,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 190,
-              "warp_speed": 5.2
+              "warp_speed": 5.2,
+              "impulse_speed": 85
             }
           },
           "build_cost": {
@@ -4304,7 +4314,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 200,
-              "warp_speed": 5.3
+              "warp_speed": 5.3,
+              "impulse_speed": 85
             }
           },
           "build_cost": {
@@ -4729,7 +4740,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 210,
-              "warp_speed": 5.4
+              "warp_speed": 5.4,
+              "impulse_speed": 85
             }
           },
           "build_cost": {

--- a/ships/vi_dar.json
+++ b/ships/vi_dar.json
@@ -153,9 +153,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 120,
               "warp_distance": 25,
-              "warp_speed": 2.4,
-              "impulse_speed": 120
+              "warp_speed": 2.4
             }
           },
           "build_cost": {
@@ -522,9 +522,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 120,
               "warp_distance": 27,
-              "warp_speed": 2.5,
-              "impulse_speed": 120
+              "warp_speed": 2.5
             }
           },
           "build_cost": {
@@ -957,9 +957,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 120,
               "warp_distance": 29,
-              "warp_speed": 2.6,
-              "impulse_speed": 120
+              "warp_speed": 2.6
             }
           },
           "build_cost": {
@@ -1392,9 +1392,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 120,
               "warp_distance": 31,
-              "warp_speed": 2.7,
-              "impulse_speed": 120
+              "warp_speed": 2.7
             }
           },
           "build_cost": {
@@ -1827,9 +1827,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 120,
               "warp_distance": 33,
-              "warp_speed": 2.8,
-              "impulse_speed": 120
+              "warp_speed": 2.8
             }
           },
           "build_cost": {
@@ -2262,9 +2262,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 120,
               "warp_distance": 35,
-              "warp_speed": 2.9,
-              "impulse_speed": 120
+              "warp_speed": 2.9
             }
           },
           "build_cost": {
@@ -2697,9 +2697,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 120,
               "warp_distance": 37,
-              "warp_speed": 3,
-              "impulse_speed": 120
+              "warp_speed": 3
             }
           },
           "build_cost": {
@@ -3132,9 +3132,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 120,
               "warp_distance": 39,
-              "warp_speed": 3.1,
-              "impulse_speed": 120
+              "warp_speed": 3.1
             }
           },
           "build_cost": {
@@ -3567,9 +3567,9 @@
           "name": "Warp Engines",
           "additional_info": {
             "warp_info": {
+              "impulse_speed": 120,
               "warp_distance": 41,
-              "warp_speed": 3.2,
-              "impulse_speed": 120
+              "warp_speed": 3.2
             }
           },
           "build_cost": {

--- a/ships/vi_dar.json
+++ b/ships/vi_dar.json
@@ -154,7 +154,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 25,
-              "warp_speed": 2.4
+              "warp_speed": 2.4,
+              "impulse_speed": 120
             }
           },
           "build_cost": {
@@ -522,7 +523,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 27,
-              "warp_speed": 2.5
+              "warp_speed": 2.5,
+              "impulse_speed": 120
             }
           },
           "build_cost": {
@@ -956,7 +958,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 29,
-              "warp_speed": 2.6
+              "warp_speed": 2.6,
+              "impulse_speed": 120
             }
           },
           "build_cost": {
@@ -1390,7 +1393,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 31,
-              "warp_speed": 2.7
+              "warp_speed": 2.7,
+              "impulse_speed": 120
             }
           },
           "build_cost": {
@@ -1824,7 +1828,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 33,
-              "warp_speed": 2.8
+              "warp_speed": 2.8,
+              "impulse_speed": 120
             }
           },
           "build_cost": {
@@ -2258,7 +2263,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 35,
-              "warp_speed": 2.9
+              "warp_speed": 2.9,
+              "impulse_speed": 120
             }
           },
           "build_cost": {
@@ -2692,7 +2698,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 37,
-              "warp_speed": 3
+              "warp_speed": 3,
+              "impulse_speed": 120
             }
           },
           "build_cost": {
@@ -3126,7 +3133,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 39,
-              "warp_speed": 3.1
+              "warp_speed": 3.1,
+              "impulse_speed": 120
             }
           },
           "build_cost": {
@@ -3560,7 +3568,8 @@
           "additional_info": {
             "warp_info": {
               "warp_distance": 41,
-              "warp_speed": 3.2
+              "warp_speed": 3.2,
+              "impulse_speed": 120
             }
           },
           "build_cost": {


### PR DESCRIPTION
Add default impulse speed to ships without impulse engine component. The ship embed code already takes this field into account.