### PR TITLE
Patch35 - Building levels 51 - 55

### DIFF
--- a/buildings/academy.json
+++ b/buildings/academy.json
@@ -2,7 +2,7 @@
   "description": "Here is where your Officers stay when they are not assigned. Promote and Level your Officers via the Officer Screen.",
   "bonuses": {
     "bonus1": {
-      "name": "Officer Stats Bonus",
+      "name": "officer stats bonus",
       "percentage": true
     }
   },
@@ -10,7 +10,7 @@
   "levels": [
     {
       "bonuses": {
-        "bonus1": 1
+        "bonus1": 0.01
       },
       "build_costs": {
         "materials": [],
@@ -20,12 +20,11 @@
       "build_time": 0,
       "increased_power": 0,
       "level": 1,
-      "requirements": [],
-      "rewards": []
+      "requirements": []
     },
     {
       "bonuses": {
-        "bonus1": 2
+        "bonus1": 0.02
       },
       "build_costs": {
         "materials": [],
@@ -42,20 +41,20 @@
       "level": 2,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 3
         }
       ],
       "rewards": [
         {
-          "type": "Recruit\u00a0Token",
+          "type": "recruit token",
           "value": 10
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 3
+        "bonus1": 0.03
       },
       "build_costs": {
         "materials": [],
@@ -72,20 +71,20 @@
       "level": 3,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 3
         }
       ],
       "rewards": [
         {
-          "type": "Recruit\u00a0Token",
+          "type": "recruit token",
           "value": 15
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 4
+        "bonus1": 0.04
       },
       "build_costs": {
         "materials": [],
@@ -102,20 +101,20 @@
       "level": 4,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 4
         }
       ],
       "rewards": [
         {
-          "type": "Recruit\u00a0Token",
+          "type": "recruit token",
           "value": 20
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 5
+        "bonus1": 0.05
       },
       "build_costs": {
         "materials": [],
@@ -132,20 +131,20 @@
       "level": 5,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 5
         }
       ],
       "rewards": [
         {
-          "type": "Recruit\u00a0Token",
+          "type": "recruit token",
           "value": 25
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 6
+        "bonus1": 0.06
       },
       "build_costs": {
         "materials": [],
@@ -162,20 +161,20 @@
       "level": 6,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 6
         }
       ],
       "rewards": [
         {
-          "type": "Recruit\u00a0Token",
+          "type": "recruit token",
           "value": 30
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 7
+        "bonus1": 0.07
       },
       "build_costs": {
         "materials": [],
@@ -192,20 +191,20 @@
       "level": 7,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 7
         }
       ],
       "rewards": [
         {
-          "type": "Recruit\u00a0Token",
+          "type": "recruit token",
           "value": 35
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 8
+        "bonus1": 0.08
       },
       "build_costs": {
         "materials": [],
@@ -222,20 +221,20 @@
       "level": 8,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 8
         }
       ],
       "rewards": [
         {
-          "type": "Recruit\u00a0Token",
+          "type": "recruit token",
           "value": 40
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 9
+        "bonus1": 0.09
       },
       "build_costs": {
         "materials": [],
@@ -252,20 +251,20 @@
       "level": 9,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 9
         }
       ],
       "rewards": [
         {
-          "type": "Premium\u00a0Recruit\u00a0Token",
+          "type": "premium recruit token",
           "value": 75
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 10
+        "bonus1": 0.1
       },
       "build_costs": {
         "materials": [],
@@ -282,20 +281,20 @@
       "level": 10,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 10
         }
       ],
       "rewards": [
         {
-          "type": "Premium\u00a0Recruit\u00a0Token",
+          "type": "premium recruit token",
           "value": 75
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 11
+        "bonus1": 0.11
       },
       "build_costs": {
         "materials": [],
@@ -312,20 +311,20 @@
       "level": 11,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 11
         }
       ],
       "rewards": [
         {
-          "type": "Recruit\u00a0Token",
+          "type": "recruit token",
           "value": 60
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 12
+        "bonus1": 0.12
       },
       "build_costs": {
         "materials": [],
@@ -342,20 +341,20 @@
       "level": 12,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 12
         }
       ],
       "rewards": [
         {
-          "type": "Recruit\u00a0Token",
+          "type": "recruit token",
           "value": 60
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 13
+        "bonus1": 0.13
       },
       "build_costs": {
         "materials": [],
@@ -372,20 +371,20 @@
       "level": 13,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 13
         }
       ],
       "rewards": [
         {
-          "type": "Recruit\u00a0Token",
+          "type": "recruit token",
           "value": 60
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 14
+        "bonus1": 0.14
       },
       "build_costs": {
         "materials": [],
@@ -402,20 +401,20 @@
       "level": 14,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 14
         }
       ],
       "rewards": [
         {
-          "type": "Recruit\u00a0Token",
+          "type": "recruit token",
           "value": 60
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 15
+        "bonus1": 0.15
       },
       "build_costs": {
         "materials": [],
@@ -432,20 +431,20 @@
       "level": 15,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 15
         }
       ],
       "rewards": [
         {
-          "type": "Premium\u00a0Recruit\u00a0Token",
+          "type": "premium recruit token",
           "value": 200
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 16
+        "bonus1": 0.16
       },
       "build_costs": {
         "materials": [],
@@ -462,20 +461,20 @@
       "level": 16,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 16
         }
       ],
       "rewards": [
         {
-          "type": "Ultra\u00a0Recruit\u00a0Token",
+          "type": "ultra recruit token",
           "value": 200
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 17
+        "bonus1": 0.17
       },
       "build_costs": {
         "materials": [
@@ -499,20 +498,20 @@
       "level": 17,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 17
         }
       ],
       "rewards": [
         {
-          "type": "Premium\u00a0Recruit\u00a0Token",
+          "type": "premium recruit token",
           "value": 200
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 18
+        "bonus1": 0.18
       },
       "build_costs": {
         "materials": [
@@ -536,20 +535,20 @@
       "level": 18,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 18
         }
       ],
       "rewards": [
         {
-          "type": "Ultra\u00a0Recruit\u00a0Token",
+          "type": "ultra recruit token",
           "value": 200
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 19
+        "bonus1": 0.19
       },
       "build_costs": {
         "materials": [
@@ -573,20 +572,20 @@
       "level": 19,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 19
         }
       ],
       "rewards": [
         {
-          "type": "Premium\u00a0Recruit\u00a0Token",
+          "type": "premium recruit token",
           "value": 200
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 20
+        "bonus1": 0.2
       },
       "build_costs": {
         "materials": [],
@@ -603,20 +602,20 @@
       "level": 20,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 20
         }
       ],
       "rewards": [
         {
-          "type": "Ultra\u00a0Recruit\u00a0Token",
+          "type": "ultra recruit token",
           "value": 400
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 21
+        "bonus1": 0.21
       },
       "build_costs": {
         "materials": [],
@@ -633,20 +632,20 @@
       "level": 21,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 21
         }
       ],
       "rewards": [
         {
-          "type": "Premium\u00a0Recruit\u00a0Token",
+          "type": "premium recruit token",
           "value": 200
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 22
+        "bonus1": 0.22
       },
       "build_costs": {
         "materials": [],
@@ -663,20 +662,20 @@
       "level": 22,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 22
         }
       ],
       "rewards": [
         {
-          "type": "Premium\u00a0Recruit\u00a0Token",
+          "type": "premium recruit token",
           "value": 200
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 23
+        "bonus1": 0.23
       },
       "build_costs": {
         "materials": [],
@@ -693,24 +692,24 @@
       "level": 23,
       "requirements": [
         {
-          "name": "Scrapyard",
-          "level": 1
+          "name": "operations",
+          "level": 23
         },
         {
-          "name": "Operations",
-          "level": 23
+          "name": "scrapyard",
+          "level": 1
         }
       ],
       "rewards": [
         {
-          "type": "Ultra\u00a0Recruit\u00a0Token",
+          "type": "ultra recruit token",
           "value": 400
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 24
+        "bonus1": 0.24
       },
       "build_costs": {
         "materials": [
@@ -734,34 +733,34 @@
       "level": 24,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 24
         }
       ],
       "rewards": [
         {
-          "type": "Premium\u00a0Recruit\u00a0Token",
+          "type": "premium recruit token",
           "value": 200
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 25
+        "bonus1": 0.25
       },
       "build_costs": {
         "materials": [
           {
             "type": "ore",
             "grade": 3,
-            "rarity": "common",
-            "value": 190
+            "rarity": "uncommon",
+            "value": 2
           },
           {
             "type": "ore",
             "grade": 3,
-            "rarity": "uncommon",
-            "value": 2
+            "rarity": "common",
+            "value": 190
           }
         ],
         "others": [],
@@ -777,38 +776,38 @@
       "level": 25,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 25
         },
         {
-          "name": "Scrapyard",
+          "name": "scrapyard",
           "level": 2
         }
       ],
       "rewards": [
         {
-          "type": "Ultra\u00a0Recruit\u00a0Token",
+          "type": "ultra recruit token",
           "value": 400
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 26
+        "bonus1": 0.26
       },
       "build_costs": {
         "materials": [
           {
             "type": "ore",
             "grade": 3,
-            "rarity": "common",
-            "value": 230
+            "rarity": "uncommon",
+            "value": 5
           },
           {
             "type": "ore",
             "grade": 3,
-            "rarity": "uncommon",
-            "value": 5
+            "rarity": "common",
+            "value": 230
           }
         ],
         "others": [],
@@ -824,20 +823,20 @@
       "level": 26,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 26
         }
       ],
       "rewards": [
         {
-          "type": "Premium\u00a0Recruit\u00a0Token",
+          "type": "premium recruit token",
           "value": 200
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 27
+        "bonus1": 0.27
       },
       "build_costs": {
         "materials": [
@@ -861,38 +860,38 @@
       "level": 27,
       "requirements": [
         {
-          "name": "Scrapyard",
-          "level": 3
+          "name": "operations",
+          "level": 27
         },
         {
-          "name": "Operations",
-          "level": 27
+          "name": "scrapyard",
+          "level": 3
         }
       ],
       "rewards": [
         {
-          "type": "Ultra\u00a0Recruit\u00a0Token",
+          "type": "ultra recruit token",
           "value": 400
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 28
+        "bonus1": 0.28
       },
       "build_costs": {
         "materials": [
           {
             "type": "ore",
             "grade": 3,
-            "rarity": "common",
-            "value": 360
+            "rarity": "uncommon",
+            "value": 17
           },
           {
             "type": "ore",
             "grade": 3,
-            "rarity": "uncommon",
-            "value": 17
+            "rarity": "common",
+            "value": 360
           }
         ],
         "others": [],
@@ -908,20 +907,20 @@
       "level": 28,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 28
         }
       ],
       "rewards": [
         {
-          "type": "Premium\u00a0Recruit\u00a0Token",
+          "type": "premium recruit token",
           "value": 200
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 29
+        "bonus1": 0.29
       },
       "build_costs": {
         "materials": [
@@ -951,24 +950,24 @@
       "level": 29,
       "requirements": [
         {
-          "name": "Scrapyard",
-          "level": 4
+          "name": "operations",
+          "level": 29
         },
         {
-          "name": "Operations",
-          "level": 29
+          "name": "scrapyard",
+          "level": 4
         }
       ],
       "rewards": [
         {
-          "type": "Ultra\u00a0Recruit\u00a0Token",
+          "type": "ultra recruit token",
           "value": 400
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 30
+        "bonus1": 0.3
       },
       "build_costs": {
         "materials": [
@@ -992,34 +991,34 @@
       "level": 30,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 30
         }
       ],
       "rewards": [
         {
-          "type": "Premium\u00a0Recruit\u00a0Token",
+          "type": "premium recruit token",
           "value": 200
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 31
+        "bonus1": 0.31
       },
       "build_costs": {
         "materials": [
           {
             "type": "ore",
             "grade": 3,
-            "rarity": "common",
-            "value": 700
+            "rarity": "uncommon",
+            "value": 50
           },
           {
             "type": "ore",
             "grade": 3,
-            "rarity": "uncommon",
-            "value": 50
+            "rarity": "common",
+            "value": 700
           }
         ],
         "others": [],
@@ -1035,24 +1034,24 @@
       "level": 31,
       "requirements": [
         {
-          "name": "Scrapyard",
-          "level": 5
+          "name": "operations",
+          "level": 31
         },
         {
-          "name": "Operations",
-          "level": 31
+          "name": "scrapyard",
+          "level": 5
         }
       ],
       "rewards": [
         {
-          "type": "Ultra\u00a0Recruit\u00a0Token",
+          "type": "ultra recruit token",
           "value": 400
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 32
+        "bonus1": 0.32
       },
       "build_costs": {
         "materials": [
@@ -1082,20 +1081,20 @@
       "level": 32,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 32
         }
       ],
       "rewards": [
         {
-          "type": "Premium\u00a0Recruit\u00a0Token",
+          "type": "premium recruit token",
           "value": 200
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 33
+        "bonus1": 0.33
       },
       "build_costs": {
         "materials": [
@@ -1125,24 +1124,24 @@
       "level": 33,
       "requirements": [
         {
-          "name": "Scrapyard",
-          "level": 6
+          "name": "operations",
+          "level": 33
         },
         {
-          "name": "Operations",
-          "level": 33
+          "name": "scrapyard",
+          "level": 6
         }
       ],
       "rewards": [
         {
-          "type": "Ultra\u00a0Recruit\u00a0Token",
+          "type": "ultra recruit token",
           "value": 400
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 34
+        "bonus1": 0.34
       },
       "build_costs": {
         "materials": [
@@ -1166,20 +1165,20 @@
       "level": 34,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 34
         }
       ],
       "rewards": [
         {
-          "type": "Premium\u00a0Recruit\u00a0Token",
+          "type": "premium recruit token",
           "value": 200
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 35
+        "bonus1": 0.35
       },
       "build_costs": {
         "materials": [
@@ -1209,38 +1208,38 @@
       "level": 35,
       "requirements": [
         {
-          "name": "Scrapyard",
-          "level": 7
+          "name": "operations",
+          "level": 35
         },
         {
-          "name": "Operations",
-          "level": 35
+          "name": "scrapyard",
+          "level": 7
         }
       ],
       "rewards": [
         {
-          "type": "Ultra\u00a0Recruit\u00a0Token",
+          "type": "ultra recruit token",
           "value": 400
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 36
+        "bonus1": 0.36
       },
       "build_costs": {
         "materials": [
           {
             "type": "ore",
             "grade": 3,
-            "rarity": "common",
-            "value": 1600
+            "rarity": "uncommon",
+            "value": 150
           },
           {
             "type": "ore",
             "grade": 3,
-            "rarity": "uncommon",
-            "value": 150
+            "rarity": "common",
+            "value": 1600
           }
         ],
         "others": [],
@@ -1256,20 +1255,20 @@
       "level": 36,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 36
         }
       ],
       "rewards": [
         {
-          "type": "Premium\u00a0Recruit\u00a0Token",
+          "type": "premium recruit token",
           "value": 200
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 37
+        "bonus1": 0.37
       },
       "build_costs": {
         "materials": [
@@ -1299,24 +1298,24 @@
       "level": 37,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 37
         },
         {
-          "name": "Scrapyard",
+          "name": "scrapyard",
           "level": 8
         }
       ],
       "rewards": [
         {
-          "type": "Ultra\u00a0Recruit\u00a0Token",
+          "type": "ultra recruit token",
           "value": 400
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 38
+        "bonus1": 0.38
       },
       "build_costs": {
         "materials": [
@@ -1346,20 +1345,20 @@
       "level": 38,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 38
         }
       ],
       "rewards": [
         {
-          "type": "Premium\u00a0Recruit\u00a0Token",
+          "type": "premium recruit token",
           "value": 200
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 39
+        "bonus1": 0.39
       },
       "build_costs": {
         "materials": [
@@ -1389,24 +1388,24 @@
       "level": 39,
       "requirements": [
         {
-          "name": "Scrapyard",
-          "level": 9
+          "name": "operations",
+          "level": 39
         },
         {
-          "name": "Operations",
-          "level": 39
+          "name": "scrapyard",
+          "level": 9
         }
       ],
       "rewards": [
         {
-          "type": "Ultra\u00a0Recruit\u00a0Token",
+          "type": "ultra recruit token",
           "value": 400
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 40
+        "bonus1": 0.4
       },
       "build_costs": {
         "materials": [
@@ -1430,24 +1429,24 @@
       "level": 40,
       "requirements": [
         {
-          "name": "Scrapyard",
-          "level": 10
+          "name": "operations",
+          "level": 40
         },
         {
-          "name": "Operations",
-          "level": 40
+          "name": "scrapyard",
+          "level": 10
         }
       ],
       "rewards": [
         {
-          "type": "Premium\u00a0Recruit\u00a0Token",
+          "type": "premium recruit token",
           "value": 300
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 43
+        "bonus1": 0.43
       },
       "build_costs": {
         "materials": [
@@ -1477,34 +1476,34 @@
       "level": 41,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 41
         }
       ],
       "rewards": [
         {
-          "type": "Ultra\u00a0Recruit\u00a0Token",
+          "type": "ultra recruit token",
           "value": 500
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 46
+        "bonus1": 0.46
       },
       "build_costs": {
         "materials": [
           {
             "type": "ore",
             "grade": 4,
-            "rarity": "uncommon",
-            "value": 6000
+            "rarity": "rare",
+            "value": 1500
           },
           {
             "type": "ore",
             "grade": 4,
-            "rarity": "rare",
-            "value": 1500
+            "rarity": "uncommon",
+            "value": 6000
           }
         ],
         "others": [],
@@ -1520,38 +1519,38 @@
       "level": 42,
       "requirements": [
         {
-          "name": "Scrapyard",
-          "level": 15
+          "name": "operations",
+          "level": 42
         },
         {
-          "name": "Operations",
-          "level": 42
+          "name": "scrapyard",
+          "level": 15
         }
       ],
       "rewards": [
         {
-          "type": "Premium\u00a0Recruit\u00a0Token",
+          "type": "premium recruit token",
           "value": 300
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 49
+        "bonus1": 0.49
       },
       "build_costs": {
         "materials": [
           {
             "type": "ore",
             "grade": 4,
-            "rarity": "common",
-            "value": 78500
+            "rarity": "uncommon",
+            "value": 8000
           },
           {
             "type": "ore",
             "grade": 4,
-            "rarity": "uncommon",
-            "value": 8000
+            "rarity": "common",
+            "value": 78500
           }
         ],
         "others": [],
@@ -1567,34 +1566,34 @@
       "level": 43,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 43
         }
       ],
       "rewards": [
         {
-          "type": "Ultra\u00a0Recruit\u00a0Token",
+          "type": "ultra recruit token",
           "value": 500
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 52
+        "bonus1": 0.52
       },
       "build_costs": {
         "materials": [
           {
             "type": "ore",
             "grade": 4,
-            "rarity": "uncommon",
-            "value": 30000
+            "rarity": "rare",
+            "value": 3000
           },
           {
             "type": "ore",
             "grade": 4,
-            "rarity": "rare",
-            "value": 3000
+            "rarity": "uncommon",
+            "value": 30000
           }
         ],
         "others": [],
@@ -1610,24 +1609,24 @@
       "level": 44,
       "requirements": [
         {
-          "name": "Scrapyard",
-          "level": 20
+          "name": "operations",
+          "level": 44
         },
         {
-          "name": "Operations",
-          "level": 44
+          "name": "scrapyard",
+          "level": 20
         }
       ],
       "rewards": [
         {
-          "type": "Premium\u00a0Recruit\u00a0Token",
+          "type": "premium recruit token",
           "value": 300
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 55
+        "bonus1": 0.55
       },
       "build_costs": {
         "materials": [
@@ -1657,20 +1656,20 @@
       "level": 45,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 45
         }
       ],
       "rewards": [
         {
-          "type": "Ultra\u00a0Recruit\u00a0Token",
+          "type": "ultra recruit token",
           "value": 500
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 58
+        "bonus1": 0.58
       },
       "build_costs": {
         "materials": [
@@ -1700,38 +1699,38 @@
       "level": 46,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 46
         },
         {
-          "name": "Scrapyard",
+          "name": "scrapyard",
           "level": 25
         }
       ],
       "rewards": [
         {
-          "type": "Premium\u00a0Recruit\u00a0Token",
+          "type": "premium recruit token",
           "value": 300
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 62
+        "bonus1": 0.62
       },
       "build_costs": {
         "materials": [
           {
             "type": "ore",
             "grade": 4,
-            "rarity": "common",
-            "value": 25000
+            "rarity": "uncommon",
+            "value": 8000
           },
           {
             "type": "ore",
             "grade": 4,
-            "rarity": "uncommon",
-            "value": 8000
+            "rarity": "common",
+            "value": 25000
           }
         ],
         "others": [],
@@ -1747,34 +1746,34 @@
       "level": 47,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 47
         }
       ],
       "rewards": [
         {
-          "type": "Ultra\u00a0Recruit\u00a0Token",
+          "type": "ultra recruit token",
           "value": 500
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 66
+        "bonus1": 0.66
       },
       "build_costs": {
         "materials": [
           {
             "type": "ore",
             "grade": 4,
-            "rarity": "uncommon",
-            "value": 3000
+            "rarity": "rare",
+            "value": 1000
           },
           {
             "type": "ore",
             "grade": 4,
-            "rarity": "rare",
-            "value": 1000
+            "rarity": "uncommon",
+            "value": 3000
           }
         ],
         "others": [],
@@ -1790,24 +1789,24 @@
       "level": 48,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 48
         },
         {
-          "name": "Scrapyard",
+          "name": "scrapyard",
           "level": 30
         }
       ],
       "rewards": [
         {
-          "type": "Premium\u00a0Recruit\u00a0Token",
+          "type": "premium recruit token",
           "value": 300
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 70
+        "bonus1": 0.7
       },
       "build_costs": {
         "materials": [
@@ -1837,20 +1836,20 @@
       "level": 49,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 49
         }
       ],
       "rewards": [
         {
-          "type": "Ultra\u00a0Recruit\u00a0Token",
+          "type": "ultra recruit token",
           "value": 500
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 75
+        "bonus1": 0.75
       },
       "build_costs": {
         "materials": [],
@@ -1867,14 +1866,237 @@
       "level": 50,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 50
         }
       ],
       "rewards": [
         {
-          "type": "Premium\u00a0Recruit\u00a0Token",
+          "type": "premium recruit token",
           "value": 300
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 0.8
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "ore",
+            "grade": 5,
+            "rarity": "common",
+            "value": 15500
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 1869660000000
+          }
+        ]
+      },
+      "build_time": 119252160,
+      "increased_power": 5000,
+      "level": 51,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 51
+        },
+        {
+          "name": "shuttle bay",
+          "level": 10
+        }
+      ],
+      "rewards": [
+        {
+          "type": "ultra recruit token",
+          "value": 600
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 0.85
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "ore",
+            "grade": 5,
+            "rarity": "uncommon",
+            "value": 10000
+          },
+          {
+            "type": "ore",
+            "grade": 5,
+            "rarity": "common",
+            "value": 28200
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 3381300000000
+          }
+        ]
+      },
+      "build_time": 126407520,
+      "increased_power": 6000,
+      "level": 52,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 52
+        },
+        {
+          "name": "shuttle bay",
+          "level": 20
+        }
+      ],
+      "rewards": [
+        {
+          "type": "premium recruit token",
+          "value": 450
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 0.9
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "ore",
+            "grade": 5,
+            "rarity": "uncommon",
+            "value": 23200
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 5679360000000
+          }
+        ]
+      },
+      "build_time": 133992000,
+      "increased_power": 5000,
+      "level": 53,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 53
+        },
+        {
+          "name": "shuttle bay",
+          "level": 30
+        }
+      ],
+      "rewards": [
+        {
+          "type": "ultra recruit token",
+          "value": 600
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 0.95
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "ore",
+            "grade": 5,
+            "rarity": "uncommon",
+            "value": 36000
+          },
+          {
+            "type": "ore",
+            "grade": 5,
+            "rarity": "rare",
+            "value": 6500
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 8519040000000
+          }
+        ]
+      },
+      "build_time": 142031520,
+      "increased_power": 6000,
+      "level": 54,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 54
+        },
+        {
+          "name": "shuttle bay",
+          "level": 40
+        }
+      ],
+      "rewards": [
+        {
+          "type": "premium recruit token",
+          "value": 450
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 1.0
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "ore",
+            "grade": 5,
+            "rarity": "uncommon",
+            "value": 57600
+          },
+          {
+            "type": "ore",
+            "grade": 5,
+            "rarity": "rare",
+            "value": 7300
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 14479920000000
+          }
+        ]
+      },
+      "build_time": 150553440,
+      "increased_power": 6000,
+      "level": 55,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 55
+        },
+        {
+          "name": "shuttle bay",
+          "level": 50
+        }
+      ],
+      "rewards": [
+        {
+          "type": "ultra recruit token",
+          "value": 600
         }
       ]
     }

--- a/buildings/armada_control_center.json
+++ b/buildings/armada_control_center.json
@@ -2,11 +2,11 @@
   "description": "The Armada Control Center allows you to initiate Armada attacks on hostile targets. Upgrade the Center to increase the number of allied ships that can join your Armada attacks.",
   "bonuses": {
     "bonus1": {
-      "name": "Armada Damage Bonus",
+      "name": "armada damage bonus",
       "percentage": true
     },
     "bonus2": {
-      "name": "Armada Size",
+      "name": "armada size",
       "percentage": false
     }
   },
@@ -14,24 +14,24 @@
   "levels": [
     {
       "bonuses": {
-        "bonus1": 2,
-        "bonus2": 2
+        "bonus1": 0.02,
+        "bonus2": 2.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 75471
+            "type": "dilithium",
+            "value": 7547
           },
           {
             "type": "tritanium",
             "value": 56603
           },
           {
-            "type": "dilithium",
-            "value": 7547
+            "type": "parsteel",
+            "value": 75471
           }
         ]
       },
@@ -40,25 +40,25 @@
       "level": 1,
       "requirements": [
         {
-          "name": "Unlock Armada Control Center",
-          "level": 1
+          "name": "operations",
+          "level": 23
         },
         {
-          "name": "Operations",
-          "level": 23
+          "name": "unlock armada control center",
+          "level": 1
         }
       ],
       "rewards": [
         {
-          "type": "Armada\u00a0Directives",
+          "type": "armada directives",
           "value": 5
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 4,
-        "bonus2": 2
+        "bonus1": 0.04,
+        "bonus2": 2.0
       },
       "build_costs": {
         "materials": [],
@@ -69,12 +69,12 @@
             "value": 79443
           },
           {
-            "type": "tritanium",
-            "value": 59582
-          },
-          {
             "type": "dilithium",
             "value": 7944
+          },
+          {
+            "type": "tritanium",
+            "value": 59582
           }
         ]
       },
@@ -83,30 +83,26 @@
       "level": 2,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 23
         }
       ],
       "rewards": [
         {
-          "type": "Armada\u00a0Directives",
+          "type": "armada directives",
           "value": 5
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 6,
-        "bonus2": 2
+        "bonus1": 0.06,
+        "bonus2": 2.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
-          {
-            "type": "parsteel",
-            "value": 83624
-          },
           {
             "type": "tritanium",
             "value": 62718
@@ -114,6 +110,10 @@
           {
             "type": "dilithium",
             "value": 8362
+          },
+          {
+            "type": "parsteel",
+            "value": 83624
           }
         ]
       },
@@ -122,33 +122,33 @@
       "level": 3,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 23
         }
       ],
       "rewards": [
         {
-          "type": "Armada\u00a0Directives",
+          "type": "armada directives",
           "value": 10
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 8,
-        "bonus2": 2
+        "bonus1": 0.08,
+        "bonus2": 2.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 88025
-          },
-          {
             "type": "tritanium",
             "value": 66019
+          },
+          {
+            "type": "parsteel",
+            "value": 88025
           },
           {
             "type": "dilithium",
@@ -161,33 +161,33 @@
       "level": 4,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 23
         }
       ],
       "rewards": [
         {
-          "type": "Armada\u00a0Directives",
+          "type": "armada directives",
           "value": 10
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 10,
-        "bonus2": 2
+        "bonus1": 0.1,
+        "bonus2": 2.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 92658
-          },
-          {
             "type": "tritanium",
             "value": 69494
+          },
+          {
+            "type": "parsteel",
+            "value": 92658
           },
           {
             "type": "dilithium",
@@ -200,33 +200,33 @@
       "level": 5,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 23
         }
       ],
       "rewards": [
         {
-          "type": "Armada\u00a0Directives",
+          "type": "armada directives",
           "value": 15
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 12,
-        "bonus2": 2
+        "bonus1": 0.12,
+        "bonus2": 2.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 97535
-          },
-          {
             "type": "tritanium",
             "value": 73151
+          },
+          {
+            "type": "parsteel",
+            "value": 97535
           },
           {
             "type": "dilithium",
@@ -239,26 +239,30 @@
       "level": 6,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 23
         }
       ],
       "rewards": [
         {
-          "type": "Armada\u00a0Directives",
+          "type": "armada directives",
           "value": 15
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 14,
-        "bonus2": 2
+        "bonus1": 0.14,
+        "bonus2": 2.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
+          {
+            "type": "dilithium",
+            "value": 10267
+          },
           {
             "type": "parsteel",
             "value": 102668
@@ -266,10 +270,6 @@
           {
             "type": "tritanium",
             "value": 77001
-          },
-          {
-            "type": "dilithium",
-            "value": 10267
           }
         ]
       },
@@ -278,37 +278,37 @@
       "level": 7,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 23
         }
       ],
       "rewards": [
         {
-          "type": "Armada\u00a0Directives",
+          "type": "armada directives",
           "value": 20
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 16,
-        "bonus2": 2
+        "bonus1": 0.16,
+        "bonus2": 2.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 108072
+            "type": "dilithium",
+            "value": 10807
           },
           {
             "type": "tritanium",
             "value": 81054
           },
           {
-            "type": "dilithium",
-            "value": 10807
+            "type": "parsteel",
+            "value": 108072
           }
         ]
       },
@@ -317,30 +317,26 @@
       "level": 8,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 23
         }
       ],
       "rewards": [
         {
-          "type": "Armada\u00a0Directives",
+          "type": "armada directives",
           "value": 20
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 18,
-        "bonus2": 2
+        "bonus1": 0.18,
+        "bonus2": 2.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
-          {
-            "type": "parsteel",
-            "value": 113760
-          },
           {
             "type": "tritanium",
             "value": 85320
@@ -348,6 +344,10 @@
           {
             "type": "dilithium",
             "value": 11376
+          },
+          {
+            "type": "parsteel",
+            "value": 113760
           }
         ]
       },
@@ -356,27 +356,27 @@
       "level": 9,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 23
         }
       ],
       "rewards": [
         {
-          "type": "Armada\u00a0Directives",
+          "type": "armada directives",
           "value": 25
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 20,
-        "bonus2": 3
+        "bonus1": 0.2,
+        "bonus2": 3.0
       },
       "build_costs": {
         "materials": [],
         "others": [
           {
-            "type": "Armada\u00a0Tactical\u00a0Core",
+            "type": "armada tactical core",
             "value": 200
           }
         ],
@@ -400,42 +400,42 @@
       "level": 10,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 23
         }
       ],
       "rewards": [
         {
-          "type": "Armada\u00a0Directives",
+          "type": "armada directives",
           "value": 25
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 22,
-        "bonus2": 3
+        "bonus1": 0.22,
+        "bonus2": 3.0
       },
       "build_costs": {
         "materials": [],
         "others": [
           {
-            "type": "Armada\u00a0Tactical\u00a0Core",
+            "type": "armada tactical core",
             "value": 251
           }
         ],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 126050
+            "type": "dilithium",
+            "value": 12605
           },
           {
             "type": "tritanium",
             "value": 94537
           },
           {
-            "type": "dilithium",
-            "value": 12605
+            "type": "parsteel",
+            "value": 126050
           }
         ]
       },
@@ -444,27 +444,27 @@
       "level": 11,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 23
         }
       ],
       "rewards": [
         {
-          "type": "Armada\u00a0Directives",
+          "type": "armada directives",
           "value": 30
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 24,
-        "bonus2": 3
+        "bonus1": 0.24,
+        "bonus2": 3.0
       },
       "build_costs": {
         "materials": [],
         "others": [
           {
-            "type": "Armada\u00a0Tactical\u00a0Core",
+            "type": "armada tactical core",
             "value": 312
           }
         ],
@@ -488,35 +488,31 @@
       "level": 12,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 23
         }
       ],
       "rewards": [
         {
-          "type": "Armada\u00a0Directives",
+          "type": "armada directives",
           "value": 35
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 26,
-        "bonus2": 3
+        "bonus1": 0.26,
+        "bonus2": 3.0
       },
       "build_costs": {
         "materials": [],
         "others": [
           {
-            "type": "Armada\u00a0Tactical\u00a0Core",
+            "type": "armada tactical core",
             "value": 388
           }
         ],
         "resources": [
-          {
-            "type": "parsteel",
-            "value": 139667
-          },
           {
             "type": "tritanium",
             "value": 104751
@@ -524,6 +520,10 @@
           {
             "type": "dilithium",
             "value": 13967
+          },
+          {
+            "type": "parsteel",
+            "value": 139667
           }
         ]
       },
@@ -532,35 +532,31 @@
       "level": 13,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 23
         }
       ],
       "rewards": [
         {
-          "type": "Armada\u00a0Directives",
+          "type": "armada directives",
           "value": 40
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 28,
-        "bonus2": 3
+        "bonus1": 0.28,
+        "bonus2": 3.0
       },
       "build_costs": {
         "materials": [],
         "others": [
           {
-            "type": "Armada\u00a0Tactical\u00a0Core",
+            "type": "armada tactical core",
             "value": 482
           }
         ],
         "resources": [
-          {
-            "type": "parsteel",
-            "value": 147018
-          },
           {
             "type": "tritanium",
             "value": 110264
@@ -568,6 +564,10 @@
           {
             "type": "dilithium",
             "value": 14702
+          },
+          {
+            "type": "parsteel",
+            "value": 147018
           }
         ]
       },
@@ -576,42 +576,42 @@
       "level": 14,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 23
         }
       ],
       "rewards": [
         {
-          "type": "Armada\u00a0Directives",
+          "type": "armada directives",
           "value": 45
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 30,
-        "bonus2": 3
+        "bonus1": 0.3,
+        "bonus2": 3.0
       },
       "build_costs": {
         "materials": [],
         "others": [
           {
-            "type": "Armada\u00a0Tactical\u00a0Core",
+            "type": "armada tactical core",
             "value": 599
           }
         ],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 154756
+            "type": "dilithium",
+            "value": 15476
           },
           {
             "type": "tritanium",
             "value": 116067
           },
           {
-            "type": "dilithium",
-            "value": 15476
+            "type": "parsteel",
+            "value": 154756
           }
         ]
       },
@@ -620,31 +620,35 @@
       "level": 15,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 23
         }
       ],
       "rewards": [
         {
-          "type": "Armada\u00a0Directives",
+          "type": "armada directives",
           "value": 50
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 32,
-        "bonus2": 3
+        "bonus1": 0.32,
+        "bonus2": 3.0
       },
       "build_costs": {
         "materials": [],
         "others": [
           {
-            "type": "Armada\u00a0Tactical\u00a0Core",
+            "type": "armada tactical core",
             "value": 744
           }
         ],
         "resources": [
+          {
+            "type": "dilithium",
+            "value": 16290
+          },
           {
             "type": "parsteel",
             "value": 162901
@@ -652,10 +656,6 @@
           {
             "type": "tritanium",
             "value": 122176
-          },
-          {
-            "type": "dilithium",
-            "value": 16290
           }
         ]
       },
@@ -664,35 +664,31 @@
       "level": 16,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 23
         }
       ],
       "rewards": [
         {
-          "type": "Armada\u00a0Directives",
+          "type": "armada directives",
           "value": 55
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 34,
-        "bonus2": 3
+        "bonus1": 0.34,
+        "bonus2": 3.0
       },
       "build_costs": {
         "materials": [],
         "others": [
           {
-            "type": "Armada\u00a0Tactical\u00a0Core",
+            "type": "armada tactical core",
             "value": 942
           }
         ],
         "resources": [
-          {
-            "type": "parsteel",
-            "value": 171475
-          },
           {
             "type": "tritanium",
             "value": 128606
@@ -700,6 +696,10 @@
           {
             "type": "dilithium",
             "value": 17148
+          },
+          {
+            "type": "parsteel",
+            "value": 171475
           }
         ]
       },
@@ -708,27 +708,27 @@
       "level": 17,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 23
         }
       ],
       "rewards": [
         {
-          "type": "Armada\u00a0Directives",
+          "type": "armada directives",
           "value": 60
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 36,
-        "bonus2": 3
+        "bonus1": 0.36,
+        "bonus2": 3.0
       },
       "build_costs": {
         "materials": [],
         "others": [
           {
-            "type": "Armada\u00a0Tactical\u00a0Core",
+            "type": "armada tactical core",
             "value": 1228
           }
         ],
@@ -738,12 +738,12 @@
             "value": 180500
           },
           {
-            "type": "tritanium",
-            "value": 135375
-          },
-          {
             "type": "dilithium",
             "value": 18050
+          },
+          {
+            "type": "tritanium",
+            "value": 135375
           }
         ]
       },
@@ -752,42 +752,42 @@
       "level": 18,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 23
         }
       ],
       "rewards": [
         {
-          "type": "Armada\u00a0Directives",
+          "type": "armada directives",
           "value": 70
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 38,
-        "bonus2": 3
+        "bonus1": 0.38,
+        "bonus2": 3.0
       },
       "build_costs": {
         "materials": [],
         "others": [
           {
-            "type": "Armada\u00a0Tactical\u00a0Core",
+            "type": "armada tactical core",
             "value": 1643
           }
         ],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 190000
+            "type": "dilithium",
+            "value": 19000
           },
           {
             "type": "tritanium",
             "value": 142500
           },
           {
-            "type": "dilithium",
-            "value": 19000
+            "type": "parsteel",
+            "value": 190000
           }
         ]
       },
@@ -796,42 +796,42 @@
       "level": 19,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 23
         }
       ],
       "rewards": [
         {
-          "type": "Armada\u00a0Directives",
+          "type": "armada directives",
           "value": 85
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 40,
-        "bonus2": 4
+        "bonus1": 0.4,
+        "bonus2": 4.0
       },
       "build_costs": {
         "materials": [],
         "others": [
           {
-            "type": "Armada\u00a0Tactical\u00a0Core",
+            "type": "armada tactical core",
             "value": 2454
           }
         ],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 200000
+            "type": "dilithium",
+            "value": 20000
           },
           {
             "type": "tritanium",
             "value": 150000
           },
           {
-            "type": "dilithium",
-            "value": 20000
+            "type": "parsteel",
+            "value": 200000
           }
         ]
       },
@@ -840,31 +840,35 @@
       "level": 20,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 23
         }
       ],
       "rewards": [
         {
-          "type": "Armada\u00a0Directives",
+          "type": "armada directives",
           "value": 100
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 42,
-        "bonus2": 4
+        "bonus1": 0.42,
+        "bonus2": 4.0
       },
       "build_costs": {
         "materials": [],
         "others": [
           {
-            "type": "Armada\u00a0Tactical\u00a0Core",
+            "type": "armada tactical core",
             "value": 2581
           }
         ],
         "resources": [
+          {
+            "type": "dilithium",
+            "value": 22000
+          },
           {
             "type": "parsteel",
             "value": 260000
@@ -872,10 +876,6 @@
           {
             "type": "tritanium",
             "value": 170000
-          },
-          {
-            "type": "dilithium",
-            "value": 22000
           }
         ]
       },
@@ -884,27 +884,27 @@
       "level": 21,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 23
         }
       ],
       "rewards": [
         {
-          "type": "Armada\u00a0Directives",
+          "type": "armada directives",
           "value": 110
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 44,
-        "bonus2": 4
+        "bonus1": 0.44,
+        "bonus2": 4.0
       },
       "build_costs": {
         "materials": [],
         "others": [
           {
-            "type": "Armada\u00a0Tactical\u00a0Core",
+            "type": "armada tactical core",
             "value": 2837
           }
         ],
@@ -928,31 +928,35 @@
       "level": 22,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 23
         }
       ],
       "rewards": [
         {
-          "type": "Armada\u00a0Directives",
+          "type": "armada directives",
           "value": 120
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 46,
-        "bonus2": 4
+        "bonus1": 0.46,
+        "bonus2": 4.0
       },
       "build_costs": {
         "materials": [],
         "others": [
           {
-            "type": "Armada\u00a0Tactical\u00a0Core",
+            "type": "armada tactical core",
             "value": 3187
           }
         ],
         "resources": [
+          {
+            "type": "dilithium",
+            "value": 32000
+          },
           {
             "type": "parsteel",
             "value": 490000
@@ -960,10 +964,6 @@
           {
             "type": "tritanium",
             "value": 250000
-          },
-          {
-            "type": "dilithium",
-            "value": 32000
           }
         ]
       },
@@ -972,27 +972,27 @@
       "level": 23,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 23
         }
       ],
       "rewards": [
         {
-          "type": "Armada\u00a0Directives",
+          "type": "armada directives",
           "value": 130
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 48,
-        "bonus2": 4
+        "bonus1": 0.48,
+        "bonus2": 4.0
       },
       "build_costs": {
         "materials": [],
         "others": [
           {
-            "type": "Armada\u00a0Tactical\u00a0Core",
+            "type": "armada tactical core",
             "value": 3657
           }
         ],
@@ -1016,21 +1016,21 @@
       "level": 24,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 24
         }
       ],
       "rewards": [
         {
-          "type": "Armada\u00a0Directives",
+          "type": "armada directives",
           "value": 140
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 50,
-        "bonus2": 4
+        "bonus1": 0.5,
+        "bonus2": 4.0
       },
       "build_costs": {
         "materials": [
@@ -1043,7 +1043,7 @@
         ],
         "others": [
           {
-            "type": "Armada\u00a0Tactical\u00a0Core",
+            "type": "armada tactical core",
             "value": 4282
           }
         ],
@@ -1053,12 +1053,12 @@
             "value": 795600
           },
           {
-            "type": "tritanium",
-            "value": 468000
-          },
-          {
             "type": "dilithium",
             "value": 50000
+          },
+          {
+            "type": "tritanium",
+            "value": 468000
           }
         ]
       },
@@ -1067,21 +1067,21 @@
       "level": 25,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 25
         }
       ],
       "rewards": [
         {
-          "type": "Armada\u00a0Directives",
+          "type": "armada directives",
           "value": 150
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 52,
-        "bonus2": 4
+        "bonus1": 0.52,
+        "bonus2": 4.0
       },
       "build_costs": {
         "materials": [
@@ -1094,7 +1094,7 @@
         ],
         "others": [
           {
-            "type": "Armada\u00a0Tactical\u00a0Core",
+            "type": "armada tactical core",
             "value": 5117
           }
         ],
@@ -1104,12 +1104,12 @@
             "value": 1243125
           },
           {
-            "type": "tritanium",
-            "value": 731250
-          },
-          {
             "type": "dilithium",
             "value": 73125
+          },
+          {
+            "type": "tritanium",
+            "value": 731250
           }
         ]
       },
@@ -1118,21 +1118,21 @@
       "level": 26,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 26
         }
       ],
       "rewards": [
         {
-          "type": "Armada\u00a0Directives",
+          "type": "armada directives",
           "value": 160
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 54,
-        "bonus2": 4
+        "bonus1": 0.54,
+        "bonus2": 4.0
       },
       "build_costs": {
         "materials": [
@@ -1145,18 +1145,18 @@
         ],
         "others": [
           {
-            "type": "Armada\u00a0Tactical\u00a0Core",
+            "type": "armada tactical core",
             "value": 6421
           }
         ],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 1897200
-          },
-          {
             "type": "tritanium",
             "value": 1116000
+          },
+          {
+            "type": "parsteel",
+            "value": 1897200
           },
           {
             "type": "dilithium",
@@ -1169,21 +1169,21 @@
       "level": 27,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 27
         }
       ],
       "rewards": [
         {
-          "type": "Armada\u00a0Directives",
+          "type": "armada directives",
           "value": 170
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 56,
-        "bonus2": 4
+        "bonus1": 0.56,
+        "bonus2": 4.0
       },
       "build_costs": {
         "materials": [
@@ -1196,11 +1196,15 @@
         ],
         "others": [
           {
-            "type": "Armada\u00a0Tactical\u00a0Core",
+            "type": "armada tactical core",
             "value": 8440
           }
         ],
         "resources": [
+          {
+            "type": "dilithium",
+            "value": 167400
+          },
           {
             "type": "parsteel",
             "value": 2845800
@@ -1208,10 +1212,6 @@
           {
             "type": "tritanium",
             "value": 1674000
-          },
-          {
-            "type": "dilithium",
-            "value": 167400
           }
         ]
       },
@@ -1220,21 +1220,21 @@
       "level": 28,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 28
         }
       ],
       "rewards": [
         {
-          "type": "Armada\u00a0Directives",
+          "type": "armada directives",
           "value": 180
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 58,
-        "bonus2": 4
+        "bonus1": 0.58,
+        "bonus2": 4.0
       },
       "build_costs": {
         "materials": [
@@ -1247,18 +1247,18 @@
         ],
         "others": [
           {
-            "type": "Armada\u00a0Tactical\u00a0Core",
+            "type": "armada tactical core",
             "value": 12103
           }
         ],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 4530500
-          },
-          {
             "type": "tritanium",
             "value": 2665000
+          },
+          {
+            "type": "parsteel",
+            "value": 4530500
           },
           {
             "type": "dilithium",
@@ -1271,21 +1271,21 @@
       "level": 29,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 29
         }
       ],
       "rewards": [
         {
-          "type": "Armada\u00a0Directives",
+          "type": "armada directives",
           "value": 190
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 60,
-        "bonus2": 5
+        "bonus1": 0.6,
+        "bonus2": 5.0
       },
       "build_costs": {
         "materials": [
@@ -1298,22 +1298,22 @@
         ],
         "others": [
           {
-            "type": "Armada\u00a0Tactical\u00a0Core",
+            "type": "armada tactical core",
             "value": 18802
           }
         ],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 6630000
+            "type": "dilithium",
+            "value": 390000
           },
           {
             "type": "tritanium",
             "value": 3900000
           },
           {
-            "type": "dilithium",
-            "value": 390000
+            "type": "parsteel",
+            "value": 6630000
           }
         ]
       },
@@ -1322,21 +1322,21 @@
       "level": 30,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 30
         }
       ],
       "rewards": [
         {
-          "type": "Armada\u00a0Directives",
+          "type": "armada directives",
           "value": 200
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 62,
-        "bonus2": 5
+        "bonus1": 0.62,
+        "bonus2": 5.0
       },
       "build_costs": {
         "materials": [
@@ -1349,7 +1349,7 @@
         ],
         "others": [
           {
-            "type": "Armada\u00a0Tactical\u00a0Core",
+            "type": "armada tactical core",
             "value": 20222
           }
         ],
@@ -1373,21 +1373,21 @@
       "level": 31,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 31
         }
       ],
       "rewards": [
         {
-          "type": "Armada\u00a0Directives",
+          "type": "armada directives",
           "value": 210
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 64,
-        "bonus2": 5
+        "bonus1": 0.64,
+        "bonus2": 5.0
       },
       "build_costs": {
         "materials": [
@@ -1400,18 +1400,18 @@
         ],
         "others": [
           {
-            "type": "Armada\u00a0Tactical\u00a0Core",
+            "type": "armada tactical core",
             "value": 22473
           }
         ],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 15138500
-          },
-          {
             "type": "tritanium",
             "value": 8905000
+          },
+          {
+            "type": "parsteel",
+            "value": 15138500
           },
           {
             "type": "dilithium",
@@ -1424,21 +1424,21 @@
       "level": 32,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 32
         }
       ],
       "rewards": [
         {
-          "type": "Armada\u00a0Directives",
+          "type": "armada directives",
           "value": 220
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 66,
-        "bonus2": 5
+        "bonus1": 0.66,
+        "bonus2": 5.0
       },
       "build_costs": {
         "materials": [
@@ -1451,15 +1451,11 @@
         ],
         "others": [
           {
-            "type": "Armada\u00a0Tactical\u00a0Core",
+            "type": "armada tactical core",
             "value": 26050
           }
         ],
         "resources": [
-          {
-            "type": "parsteel",
-            "value": 23417500
-          },
           {
             "type": "tritanium",
             "value": 13775000
@@ -1467,6 +1463,10 @@
           {
             "type": "dilithium",
             "value": 1377500
+          },
+          {
+            "type": "parsteel",
+            "value": 23417500
           }
         ]
       },
@@ -1475,21 +1475,21 @@
       "level": 33,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 33
         }
       ],
       "rewards": [
         {
-          "type": "Armada\u00a0Directives",
+          "type": "armada directives",
           "value": 230
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 68,
-        "bonus2": 5
+        "bonus1": 0.68,
+        "bonus2": 5.0
       },
       "build_costs": {
         "materials": [
@@ -1502,22 +1502,22 @@
         ],
         "others": [
           {
-            "type": "Armada\u00a0Tactical\u00a0Core",
+            "type": "armada tactical core",
             "value": 31130
           }
         ],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 36975000
+            "type": "dilithium",
+            "value": 2175000
           },
           {
             "type": "tritanium",
             "value": 21750000
           },
           {
-            "type": "dilithium",
-            "value": 2175000
+            "type": "parsteel",
+            "value": 36975000
           }
         ]
       },
@@ -1526,21 +1526,21 @@
       "level": 34,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 34
         }
       ],
       "rewards": [
         {
-          "type": "Armada\u00a0Directives",
+          "type": "armada directives",
           "value": 240
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 70,
-        "bonus2": 5
+        "bonus1": 0.7,
+        "bonus2": 5.0
       },
       "build_costs": {
         "materials": [
@@ -1553,7 +1553,7 @@
         ],
         "others": [
           {
-            "type": "Armada\u00a0Tactical\u00a0Core",
+            "type": "armada tactical core",
             "value": 38316
           }
         ],
@@ -1563,12 +1563,12 @@
             "value": 57222000
           },
           {
-            "type": "tritanium",
-            "value": 33660000
-          },
-          {
             "type": "dilithium",
             "value": 3366000
+          },
+          {
+            "type": "tritanium",
+            "value": 33660000
           }
         ]
       },
@@ -1577,21 +1577,21 @@
       "level": 35,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 35
         }
       ],
       "rewards": [
         {
-          "type": "Armada\u00a0Directives",
+          "type": "armada directives",
           "value": 250
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 72,
-        "bonus2": 5
+        "bonus1": 0.72,
+        "bonus2": 5.0
       },
       "build_costs": {
         "materials": [
@@ -1604,7 +1604,7 @@
         ],
         "others": [
           {
-            "type": "Armada\u00a0Tactical\u00a0Core",
+            "type": "armada tactical core",
             "value": 48993
           }
         ],
@@ -1614,12 +1614,12 @@
             "value": 80631000
           },
           {
-            "type": "tritanium",
-            "value": 47430000
-          },
-          {
             "type": "dilithium",
             "value": 4743000
+          },
+          {
+            "type": "tritanium",
+            "value": 47430000
           }
         ]
       },
@@ -1628,21 +1628,21 @@
       "level": 36,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 36
         }
       ],
       "rewards": [
         {
-          "type": "Armada\u00a0Directives",
+          "type": "armada directives",
           "value": 260
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 74,
-        "bonus2": 5
+        "bonus1": 0.74,
+        "bonus2": 5.0
       },
       "build_costs": {
         "materials": [
@@ -1655,7 +1655,7 @@
         ],
         "others": [
           {
-            "type": "Armada\u00a0Tactical\u00a0Core",
+            "type": "armada tactical core",
             "value": 65572
           }
         ],
@@ -1665,12 +1665,12 @@
             "value": 123930000
           },
           {
-            "type": "tritanium",
-            "value": 72900000
-          },
-          {
             "type": "dilithium",
             "value": 7290000
+          },
+          {
+            "type": "tritanium",
+            "value": 72900000
           }
         ]
       },
@@ -1679,21 +1679,21 @@
       "level": 37,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 37
         }
       ],
       "rewards": [
         {
-          "type": "Armada\u00a0Directives",
+          "type": "armada directives",
           "value": 270
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 76,
-        "bonus2": 5
+        "bonus1": 0.76,
+        "bonus2": 5.0
       },
       "build_costs": {
         "materials": [
@@ -1706,18 +1706,18 @@
         ],
         "others": [
           {
-            "type": "Armada\u00a0Tactical\u00a0Core",
+            "type": "armada tactical core",
             "value": 92463
           }
         ],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 192780000
-          },
-          {
             "type": "tritanium",
             "value": 113400000
+          },
+          {
+            "type": "parsteel",
+            "value": 192780000
           },
           {
             "type": "dilithium",
@@ -1730,38 +1730,38 @@
       "level": 38,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 38
         }
       ],
       "rewards": [
         {
-          "type": "Armada\u00a0Directives",
+          "type": "armada directives",
           "value": 280
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 78,
-        "bonus2": 6
+        "bonus1": 0.78,
+        "bonus2": 6.0
       },
       "build_costs": {
         "materials": [],
         "others": [
           {
-            "type": "Armada\u00a0Tactical\u00a0Core",
+            "type": "armada tactical core",
             "value": 143641
           }
         ],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 328950000
-          },
-          {
             "type": "tritanium",
             "value": 193500000
+          },
+          {
+            "type": "parsteel",
+            "value": 328950000
           },
           {
             "type": "dilithium",
@@ -1774,32 +1774,32 @@
       "level": 39,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 39
         }
       ],
       "rewards": [
         {
-          "type": "Armada\u00a0Directives",
+          "type": "armada directives",
           "value": 290
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 80,
-        "bonus2": 6
+        "bonus1": 0.8,
+        "bonus2": 6.0
       },
       "build_costs": {
         "materials": [],
         "others": [
           {
-            "type": "Rare\u00a0Armada\u00a0Tactical\u00a0Core",
-            "value": 400
+            "type": "armada tactical core",
+            "value": 248895
           },
           {
-            "type": "Armada\u00a0Tactical\u00a0Core",
-            "value": 248895
+            "type": "rare armada tactical core",
+            "value": 400
           }
         ],
         "resources": [
@@ -1822,42 +1822,42 @@
       "level": 40,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 40
         }
       ],
       "rewards": [
         {
-          "type": "Armada\u00a0Directives",
+          "type": "armada directives",
           "value": 300
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 82,
-        "bonus2": 6
+        "bonus1": 0.82,
+        "bonus2": 6.0
       },
       "build_costs": {
         "materials": [],
         "others": [
           {
-            "type": "Rare\u00a0Armada\u00a0Tactical\u00a0Core",
-            "value": 650
+            "type": "armada tactical core",
+            "value": 300000
           },
           {
-            "type": "Armada\u00a0Tactical\u00a0Core",
-            "value": 300000
+            "type": "rare armada tactical core",
+            "value": 650
           }
         ],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 560000000
-          },
-          {
             "type": "tritanium",
             "value": 24200000
+          },
+          {
+            "type": "parsteel",
+            "value": 560000000
           },
           {
             "type": "dilithium",
@@ -1870,31 +1870,31 @@
       "level": 41,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 41
         }
       ],
       "rewards": [
         {
-          "type": "Armada\u00a0Directives",
+          "type": "armada directives",
           "value": 310
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 84,
-        "bonus2": 6
+        "bonus1": 0.84,
+        "bonus2": 6.0
       },
       "build_costs": {
         "materials": [],
         "others": [
           {
-            "type": "Armada\u00a0Tactical\u00a0Core",
+            "type": "armada tactical core",
             "value": 350000
           },
           {
-            "type": "Rare\u00a0Armada\u00a0Tactical\u00a0Core",
+            "type": "rare armada tactical core",
             "value": 1300
           }
         ],
@@ -1918,32 +1918,32 @@
       "level": 42,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 42
         }
       ],
       "rewards": [
         {
-          "type": "Armada\u00a0Directives",
+          "type": "armada directives",
           "value": 320
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 86,
-        "bonus2": 6
+        "bonus1": 0.86,
+        "bonus2": 6.0
       },
       "build_costs": {
         "materials": [],
         "others": [
           {
-            "type": "Rare\u00a0Armada\u00a0Tactical\u00a0Core",
-            "value": 1950
+            "type": "armada tactical core",
+            "value": 400000
           },
           {
-            "type": "Armada\u00a0Tactical\u00a0Core",
-            "value": 400000
+            "type": "rare armada tactical core",
+            "value": 1950
           }
         ],
         "resources": [
@@ -1952,12 +1952,12 @@
             "value": 1190000000
           },
           {
-            "type": "tritanium",
-            "value": 51425000
-          },
-          {
             "type": "dilithium",
             "value": 14500000
+          },
+          {
+            "type": "tritanium",
+            "value": 51425000
           }
         ]
       },
@@ -1966,42 +1966,42 @@
       "level": 43,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 43
         }
       ],
       "rewards": [
         {
-          "type": "Armada\u00a0Directives",
+          "type": "armada directives",
           "value": 330
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 88,
-        "bonus2": 6
+        "bonus1": 0.88,
+        "bonus2": 6.0
       },
       "build_costs": {
         "materials": [],
         "others": [
           {
-            "type": "Armada\u00a0Tactical\u00a0Core",
-            "value": 450000
+            "type": "rare armada tactical core",
+            "value": 2600
           },
           {
-            "type": "Rare\u00a0Armada\u00a0Tactical\u00a0Core",
-            "value": 2600
+            "type": "armada tactical core",
+            "value": 450000
           }
         ],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 1750000000
-          },
-          {
             "type": "tritanium",
             "value": 75625000
+          },
+          {
+            "type": "parsteel",
+            "value": 1750000000
           },
           {
             "type": "dilithium",
@@ -2014,39 +2014,35 @@
       "level": 44,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 44
         }
       ],
       "rewards": [
         {
-          "type": "Armada\u00a0Directives",
+          "type": "armada directives",
           "value": 340
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 90,
-        "bonus2": 6
+        "bonus1": 0.9,
+        "bonus2": 6.0
       },
       "build_costs": {
         "materials": [],
         "others": [
           {
-            "type": "Armada\u00a0Tactical\u00a0Core",
-            "value": 500000
+            "type": "rare armada tactical core",
+            "value": 6500
           },
           {
-            "type": "Rare\u00a0Armada\u00a0Tactical\u00a0Core",
-            "value": 6500
+            "type": "armada tactical core",
+            "value": 500000
           }
         ],
         "resources": [
-          {
-            "type": "parsteel",
-            "value": 2660000000
-          },
           {
             "type": "tritanium",
             "value": 114950000
@@ -2054,6 +2050,10 @@
           {
             "type": "dilithium",
             "value": 18125000
+          },
+          {
+            "type": "parsteel",
+            "value": 2660000000
           }
         ]
       },
@@ -2062,32 +2062,32 @@
       "level": 45,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 45
         }
       ],
       "rewards": [
         {
-          "type": "Armada\u00a0Directives",
+          "type": "armada directives",
           "value": 350
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 92,
-        "bonus2": 6
+        "bonus1": 0.92,
+        "bonus2": 6.0
       },
       "build_costs": {
         "materials": [],
         "others": [
           {
-            "type": "Rare\u00a0Armada\u00a0Tactical\u00a0Core",
-            "value": 9000
+            "type": "armada tactical core",
+            "value": 690000
           },
           {
-            "type": "Armada\u00a0Tactical\u00a0Core",
-            "value": 690000
+            "type": "rare armada tactical core",
+            "value": 9000
           }
         ],
         "resources": [
@@ -2096,12 +2096,12 @@
             "value": 8000000000
           },
           {
-            "type": "tritanium",
-            "value": 185600000
-          },
-          {
             "type": "dilithium",
             "value": 32880000
+          },
+          {
+            "type": "tritanium",
+            "value": 185600000
           }
         ]
       },
@@ -2110,31 +2110,31 @@
       "level": 46,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 46
         }
       ],
       "rewards": [
         {
-          "type": "Armada\u00a0Directives",
+          "type": "armada directives",
           "value": 360
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 94,
-        "bonus2": 6
+        "bonus1": 0.94,
+        "bonus2": 6.0
       },
       "build_costs": {
         "materials": [],
         "others": [
           {
-            "type": "Rare\u00a0Armada\u00a0Tactical\u00a0Core",
+            "type": "rare armada tactical core",
             "value": 18000
           },
           {
-            "type": "Armada\u00a0Tactical\u00a0Core",
+            "type": "armada tactical core",
             "value": 805000
           }
         ],
@@ -2158,31 +2158,31 @@
       "level": 47,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 47
         }
       ],
       "rewards": [
         {
-          "type": "Armada\u00a0Directives",
+          "type": "armada directives",
           "value": 370
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 96,
-        "bonus2": 6
+        "bonus1": 0.96,
+        "bonus2": 6.0
       },
       "build_costs": {
         "materials": [],
         "others": [
           {
-            "type": "Rare\u00a0Armada\u00a0Tactical\u00a0Core",
+            "type": "rare armada tactical core",
             "value": 27000
           },
           {
-            "type": "Armada\u00a0Tactical\u00a0Core",
+            "type": "armada tactical core",
             "value": 920000
           }
         ],
@@ -2206,31 +2206,31 @@
       "level": 48,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 48
         }
       ],
       "rewards": [
         {
-          "type": "Armada\u00a0Directives",
+          "type": "armada directives",
           "value": 380
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 98,
-        "bonus2": 6
+        "bonus1": 0.98,
+        "bonus2": 6.0
       },
       "build_costs": {
         "materials": [],
         "others": [
           {
-            "type": "Armada\u00a0Tactical\u00a0Core",
+            "type": "armada tactical core",
             "value": 1035000
           },
           {
-            "type": "Rare\u00a0Armada\u00a0Tactical\u00a0Core",
+            "type": "rare armada tactical core",
             "value": 36000
           }
         ],
@@ -2254,39 +2254,35 @@
       "level": 49,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 49
         }
       ],
       "rewards": [
         {
-          "type": "Armada\u00a0Directives",
+          "type": "armada directives",
           "value": 390
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 100,
-        "bonus2": 7
+        "bonus1": 1.0,
+        "bonus2": 7.0
       },
       "build_costs": {
         "materials": [],
         "others": [
           {
-            "type": "Armada\u00a0Tactical\u00a0Core",
-            "value": 1150000
+            "type": "rare armada tactical core",
+            "value": 90000
           },
           {
-            "type": "Rare\u00a0Armada\u00a0Tactical\u00a0Core",
-            "value": 90000
+            "type": "armada tactical core",
+            "value": 1150000
           }
         ],
         "resources": [
-          {
-            "type": "parsteel",
-            "value": 38000000000
-          },
           {
             "type": "tritanium",
             "value": 881600000
@@ -2294,6 +2290,10 @@
           {
             "type": "dilithium",
             "value": 156180000
+          },
+          {
+            "type": "parsteel",
+            "value": 38000000000
           }
         ]
       },
@@ -2302,13 +2302,13 @@
       "level": 50,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 50
         }
       ],
       "rewards": [
         {
-          "type": "Armada\u00a0Directives",
+          "type": "armada directives",
           "value": 400
         }
       ]

--- a/buildings/astronautics_studio.json
+++ b/buildings/astronautics_studio.json
@@ -2,7 +2,7 @@
   "description": "New ship hulls are researched and unlocked here before becoming available in the Shipyard.",
   "bonuses": {
     "bonus1": {
-      "name": "Research Cost Efficiency",
+      "name": "research cost efficiency",
       "percentage": true
     }
   },
@@ -10,7 +10,7 @@
   "levels": [
     {
       "bonuses": {
-        "bonus1": 0
+        "bonus1": 0.0
       },
       "build_costs": {
         "materials": [],
@@ -27,15 +27,14 @@
       "level": 1,
       "requirements": [
         {
-          "name": "Unlock Astronautics",
+          "name": "unlock astronautics",
           "level": 1
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 3
+        "bonus1": 0.03
       },
       "build_costs": {
         "materials": [],
@@ -52,19 +51,18 @@
       "level": 2,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 2
         },
         {
-          "name": "R&D Department",
+          "name": "r&d department",
           "level": 2
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 4
+        "bonus1": 0.04
       },
       "build_costs": {
         "materials": [],
@@ -81,19 +79,18 @@
       "level": 3,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 3
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 3
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 5
+        "bonus1": 0.05
       },
       "build_costs": {
         "materials": [],
@@ -110,19 +107,18 @@
       "level": 4,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 4
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 4
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 6
+        "bonus1": 0.06
       },
       "build_costs": {
         "materials": [],
@@ -139,19 +135,18 @@
       "level": 5,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 5
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 5
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 8
+        "bonus1": 0.08
       },
       "build_costs": {
         "materials": [],
@@ -168,19 +163,18 @@
       "level": 6,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 6
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 6
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 9
+        "bonus1": 0.09
       },
       "build_costs": {
         "materials": [],
@@ -201,19 +195,18 @@
       "level": 7,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 7
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 7
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 11
+        "bonus1": 0.11
       },
       "build_costs": {
         "materials": [],
@@ -234,19 +227,18 @@
       "level": 8,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 8
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 8
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 12
+        "bonus1": 0.12
       },
       "build_costs": {
         "materials": [],
@@ -267,19 +259,18 @@
       "level": 9,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 9
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 9
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 14
+        "bonus1": 0.14
       },
       "build_costs": {
         "materials": [],
@@ -300,19 +291,18 @@
       "level": 10,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 10
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 10
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 16
+        "bonus1": 0.16
       },
       "build_costs": {
         "materials": [],
@@ -333,31 +323,30 @@
       "level": 11,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 11
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 11
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 18
+        "bonus1": 0.18
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 13090
-          },
-          {
             "type": "tritanium",
             "value": 550
+          },
+          {
+            "type": "parsteel",
+            "value": 13090
           }
         ]
       },
@@ -366,31 +355,30 @@
       "level": 12,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 12
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 12
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 20
+        "bonus1": 0.2
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 19040
-          },
-          {
             "type": "tritanium",
             "value": 800
+          },
+          {
+            "type": "parsteel",
+            "value": 19040
           }
         ]
       },
@@ -399,19 +387,18 @@
       "level": 13,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 13
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 13
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 22
+        "bonus1": 0.22
       },
       "build_costs": {
         "materials": [],
@@ -432,19 +419,18 @@
       "level": 14,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 14
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 14
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 24
+        "bonus1": 0.24
       },
       "build_costs": {
         "materials": [],
@@ -465,19 +451,18 @@
       "level": 15,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 15
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 15
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 26
+        "bonus1": 0.26
       },
       "build_costs": {
         "materials": [],
@@ -498,19 +483,18 @@
       "level": 16,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 16
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 16
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 29
+        "bonus1": 0.29
       },
       "build_costs": {
         "materials": [
@@ -538,19 +522,18 @@
       "level": 17,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 17
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 17
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 31
+        "bonus1": 0.31
       },
       "build_costs": {
         "materials": [
@@ -564,12 +547,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 95200
-          },
-          {
             "type": "tritanium",
             "value": 4000
+          },
+          {
+            "type": "parsteel",
+            "value": 95200
           }
         ]
       },
@@ -578,19 +561,18 @@
       "level": 18,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 18
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 18
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 34
+        "bonus1": 0.34
       },
       "build_costs": {
         "materials": [
@@ -604,12 +586,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 142800
-          },
-          {
             "type": "tritanium",
             "value": 6000
+          },
+          {
+            "type": "parsteel",
+            "value": 142800
           }
         ]
       },
@@ -618,19 +600,18 @@
       "level": 19,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 19
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 19
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 36
+        "bonus1": 0.36
       },
       "build_costs": {
         "materials": [],
@@ -651,31 +632,30 @@
       "level": 20,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 20
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 20
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 39
+        "bonus1": 0.39
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 340578
-          },
-          {
             "type": "tritanium",
             "value": 14310
+          },
+          {
+            "type": "parsteel",
+            "value": 340578
           }
         ]
       },
@@ -684,31 +664,30 @@
       "level": 21,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 21
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 21
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 42
+        "bonus1": 0.42
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 529788
-          },
-          {
             "type": "tritanium",
             "value": 22260
+          },
+          {
+            "type": "parsteel",
+            "value": 529788
           }
         ]
       },
@@ -717,19 +696,18 @@
       "level": 22,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 22
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 22
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 45
+        "bonus1": 0.45
       },
       "build_costs": {
         "materials": [],
@@ -750,19 +728,18 @@
       "level": 23,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 23
         },
         {
-          "name": "R&D Department",
+          "name": "r&d department",
           "level": 23
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 48
+        "bonus1": 0.48
       },
       "build_costs": {
         "materials": [
@@ -776,12 +753,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 1373736
-          },
-          {
             "type": "tritanium",
             "value": 57720
+          },
+          {
+            "type": "parsteel",
+            "value": 1373736
           }
         ]
       },
@@ -790,19 +767,18 @@
       "level": 24,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 24
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 24
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 51
+        "bonus1": 0.51
       },
       "build_costs": {
         "materials": [
@@ -836,19 +812,18 @@
       "level": 25,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 25
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 25
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 55
+        "bonus1": 0.55
       },
       "build_costs": {
         "materials": [
@@ -876,19 +851,18 @@
       "level": 26,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 26
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 26
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 58
+        "bonus1": 0.58
       },
       "build_costs": {
         "materials": [
@@ -908,12 +882,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 5312160
-          },
-          {
             "type": "tritanium",
             "value": 223200
+          },
+          {
+            "type": "parsteel",
+            "value": 5312160
           }
         ]
       },
@@ -922,44 +896,43 @@
       "level": 27,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 27
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 27
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 62
+        "bonus1": 0.62
       },
       "build_costs": {
         "materials": [
           {
             "type": "crystal",
             "grade": 3,
-            "rarity": "common",
-            "value": 360
+            "rarity": "uncommon",
+            "value": 18
           },
           {
             "type": "crystal",
             "grade": 3,
-            "rarity": "uncommon",
-            "value": 18
+            "rarity": "common",
+            "value": 360
           }
         ],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 7968240
-          },
-          {
             "type": "tritanium",
             "value": 334800
+          },
+          {
+            "type": "parsteel",
+            "value": 7968240
           }
         ]
       },
@@ -968,33 +941,32 @@
       "level": 28,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 28
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 28
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 65
+        "bonus1": 0.65
       },
       "build_costs": {
         "materials": [
           {
             "type": "crystal",
             "grade": 3,
-            "rarity": "common",
-            "value": 450
+            "rarity": "uncommon",
+            "value": 30
           },
           {
             "type": "crystal",
             "grade": 3,
-            "rarity": "uncommon",
-            "value": 30
+            "rarity": "common",
+            "value": 450
           }
         ],
         "others": [],
@@ -1014,19 +986,18 @@
       "level": 29,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 29
         },
         {
-          "name": "R&D Department",
+          "name": "r&d department",
           "level": 29
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 69
+        "bonus1": 0.69
       },
       "build_costs": {
         "materials": [
@@ -1040,12 +1011,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 18564000
-          },
-          {
             "type": "tritanium",
             "value": 780000
+          },
+          {
+            "type": "parsteel",
+            "value": 18564000
           }
         ]
       },
@@ -1054,23 +1025,22 @@
       "level": 30,
       "requirements": [
         {
-          "name": "Engine Technology Lab",
+          "name": "operations",
+          "level": 30
+        },
+        {
+          "name": "r&d department",
+          "level": 30
+        },
+        {
+          "name": "engine technology lab",
           "level": 28
-        },
-        {
-          "name": "R&D Department",
-          "level": 30
-        },
-        {
-          "name": "Operations",
-          "level": 30
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 73
+        "bonus1": 0.73
       },
       "build_costs": {
         "materials": [
@@ -1090,12 +1060,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 29345400
-          },
-          {
             "type": "tritanium",
             "value": 1233000
+          },
+          {
+            "type": "parsteel",
+            "value": 29345400
           }
         ]
       },
@@ -1104,19 +1074,18 @@
       "level": 31,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 31
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 31
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 77
+        "bonus1": 0.77
       },
       "build_costs": {
         "materials": [
@@ -1150,23 +1119,22 @@
       "level": 32,
       "requirements": [
         {
-          "name": "Foundry",
+          "name": "operations",
           "level": 32
         },
         {
-          "name": "R&D Department",
+          "name": "r&d department",
           "level": 32
         },
         {
-          "name": "Operations",
+          "name": "foundry",
           "level": 32
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 81
+        "bonus1": 0.81
       },
       "build_costs": {
         "materials": [
@@ -1194,19 +1162,18 @@
       "level": 33,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 33
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 33
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 85
+        "bonus1": 0.85
       },
       "build_costs": {
         "materials": [
@@ -1226,12 +1193,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 103530000
-          },
-          {
             "type": "tritanium",
             "value": 4350000
+          },
+          {
+            "type": "parsteel",
+            "value": 103530000
           }
         ]
       },
@@ -1240,19 +1207,18 @@
       "level": 34,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 34
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 34
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 89
+        "bonus1": 0.89
       },
       "build_costs": {
         "materials": [
@@ -1280,19 +1246,18 @@
       "level": 35,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 35
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 35
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 93
+        "bonus1": 0.93
       },
       "build_costs": {
         "materials": [
@@ -1306,12 +1271,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 225766800
-          },
-          {
             "type": "tritanium",
             "value": 9486000
+          },
+          {
+            "type": "parsteel",
+            "value": 225766800
           }
         ]
       },
@@ -1320,48 +1285,47 @@
       "level": 36,
       "requirements": [
         {
-          "name": "Engine Technology Lab",
+          "name": "operations",
           "level": 36
         },
         {
-          "name": "R&D Department",
+          "name": "r&d department",
           "level": 36
         },
         {
-          "name": "Operations",
+          "name": "engine technology lab",
           "level": 36
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 98
+        "bonus1": 0.98
       },
       "build_costs": {
         "materials": [
           {
             "type": "crystal",
             "grade": 3,
-            "rarity": "common",
-            "value": 1800
+            "rarity": "uncommon",
+            "value": 260
           },
           {
             "type": "crystal",
             "grade": 3,
-            "rarity": "uncommon",
-            "value": 260
+            "rarity": "common",
+            "value": 1800
           }
         ],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 347004000
-          },
-          {
             "type": "tritanium",
             "value": 14580000
+          },
+          {
+            "type": "parsteel",
+            "value": 347004000
           }
         ]
       },
@@ -1370,19 +1334,18 @@
       "level": 37,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 37
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 37
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 102
+        "bonus1": 1.02
       },
       "build_costs": {
         "materials": [
@@ -1416,44 +1379,43 @@
       "level": 38,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 38
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 38
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 107
+        "bonus1": 1.07
       },
       "build_costs": {
         "materials": [
           {
             "type": "crystal",
             "grade": 3,
-            "rarity": "common",
-            "value": 2500
+            "rarity": "uncommon",
+            "value": 360
           },
           {
             "type": "crystal",
             "grade": 3,
-            "rarity": "uncommon",
-            "value": 360
+            "rarity": "common",
+            "value": 2500
           }
         ],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 921060000
-          },
-          {
             "type": "tritanium",
             "value": 38700000
+          },
+          {
+            "type": "parsteel",
+            "value": 921060000
           }
         ]
       },
@@ -1462,19 +1424,18 @@
       "level": 39,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 39
         },
         {
-          "name": "R&D Department",
+          "name": "r&d department",
           "level": 39
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 111
+        "bonus1": 1.11
       },
       "build_costs": {
         "materials": [
@@ -1494,12 +1455,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 4011728000
-          },
-          {
             "type": "tritanium",
             "value": 60200000
+          },
+          {
+            "type": "parsteel",
+            "value": 4011728000
           }
         ]
       },
@@ -1508,44 +1469,43 @@
       "level": 40,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 40
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 40
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 116
+        "bonus1": 1.16
       },
       "build_costs": {
         "materials": [
           {
             "type": "crystal",
             "grade": 4,
-            "rarity": "common",
-            "value": 20000
+            "rarity": "uncommon",
+            "value": 7000
           },
           {
             "type": "crystal",
             "grade": 4,
-            "rarity": "uncommon",
-            "value": 7000
+            "rarity": "common",
+            "value": 20000
           }
         ],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 4093600000
-          },
-          {
             "type": "tritanium",
             "value": 86000000
+          },
+          {
+            "type": "parsteel",
+            "value": 4093600000
           }
         ]
       },
@@ -1554,19 +1514,18 @@
       "level": 41,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 41
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 41
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 121
+        "bonus1": 1.21
       },
       "build_costs": {
         "materials": [
@@ -1600,48 +1559,47 @@
       "level": 42,
       "requirements": [
         {
-          "name": "Foundry",
+          "name": "operations",
           "level": 42
         },
         {
-          "name": "R&D Department",
+          "name": "r&d department",
           "level": 42
         },
         {
-          "name": "Operations",
+          "name": "foundry",
           "level": 42
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 126
+        "bonus1": 1.26
       },
       "build_costs": {
         "materials": [
           {
             "type": "crystal",
             "grade": 4,
-            "rarity": "common",
-            "value": 40000
+            "rarity": "uncommon",
+            "value": 9000
           },
           {
             "type": "crystal",
             "grade": 4,
-            "rarity": "uncommon",
-            "value": 9000
+            "rarity": "common",
+            "value": 40000
           }
         ],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 8710800000
-          },
-          {
             "type": "tritanium",
             "value": 183000000
+          },
+          {
+            "type": "parsteel",
+            "value": 8710800000
           }
         ]
       },
@@ -1650,44 +1608,43 @@
       "level": 43,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 43
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 43
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 131
+        "bonus1": 1.31
       },
       "build_costs": {
         "materials": [
           {
             "type": "crystal",
             "grade": 4,
-            "rarity": "common",
-            "value": 50000
+            "rarity": "uncommon",
+            "value": 10000
           },
           {
             "type": "crystal",
             "grade": 4,
-            "rarity": "uncommon",
-            "value": 10000
+            "rarity": "common",
+            "value": 50000
           }
         ],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 13066200000
-          },
-          {
             "type": "tritanium",
             "value": 274500000
+          },
+          {
+            "type": "parsteel",
+            "value": 13066200000
           }
         ]
       },
@@ -1696,19 +1653,18 @@
       "level": 44,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 44
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 44
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 137
+        "bonus1": 1.37
       },
       "build_costs": {
         "materials": [
@@ -1736,19 +1692,18 @@
       "level": 45,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 45
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 45
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 143
+        "bonus1": 1.43
       },
       "build_costs": {
         "materials": [
@@ -1762,12 +1717,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 25525500000
-          },
-          {
             "type": "tritanium",
             "value": 536250000
+          },
+          {
+            "type": "parsteel",
+            "value": 25525500000
           }
         ]
       },
@@ -1776,19 +1731,18 @@
       "level": 46,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 46
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 46
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 149
+        "bonus1": 1.49
       },
       "build_costs": {
         "materials": [
@@ -1802,12 +1756,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 37128000000
-          },
-          {
             "type": "tritanium",
             "value": 780000000
+          },
+          {
+            "type": "parsteel",
+            "value": 37128000000
           }
         ]
       },
@@ -1816,23 +1770,22 @@
       "level": 47,
       "requirements": [
         {
-          "name": "Engine Technology Lab",
+          "name": "operations",
           "level": 47
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 47
         },
         {
-          "name": "R&D Department",
+          "name": "engine technology lab",
           "level": 47
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 155
+        "bonus1": 1.55
       },
       "build_costs": {
         "materials": [
@@ -1846,12 +1799,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 59976000000
-          },
-          {
             "type": "tritanium",
             "value": 1260000000
+          },
+          {
+            "type": "parsteel",
+            "value": 59976000000
           }
         ]
       },
@@ -1860,23 +1813,22 @@
       "level": 48,
       "requirements": [
         {
-          "name": "Science Lab",
+          "name": "operations",
           "level": 48
         },
         {
-          "name": "R&D Department",
+          "name": "r&d department",
           "level": 48
         },
         {
-          "name": "Operations",
+          "name": "science lab",
           "level": 48
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 161
+        "bonus1": 1.61
       },
       "build_costs": {
         "materials": [
@@ -1890,12 +1842,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 99960000000
-          },
-          {
             "type": "tritanium",
             "value": 2100000000
+          },
+          {
+            "type": "parsteel",
+            "value": 99960000000
           }
         ]
       },
@@ -1904,23 +1856,22 @@
       "level": 49,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 49
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 49
         },
         {
-          "name": "Foundry",
+          "name": "foundry",
           "level": 49
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 170
+        "bonus1": 1.7
       },
       "build_costs": {
         "materials": [],
@@ -1941,15 +1892,225 @@
       "level": 50,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 50
         },
         {
-          "name": "R&D Department",
+          "name": "r&d department",
           "level": 50
         }
-      ],
-      "rewards": []
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 1.77
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "crystal",
+            "grade": 5,
+            "rarity": "common",
+            "value": 11000
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 7800000000
+          },
+          {
+            "type": "parsteel",
+            "value": 872508000000
+          }
+        ]
+      },
+      "build_time": 59626080,
+      "increased_power": 5000,
+      "level": 51,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 51
+        },
+        {
+          "name": "r&d department",
+          "level": 51
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 1.84
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "crystal",
+            "grade": 5,
+            "rarity": "common",
+            "value": 19000
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 13260000000
+          },
+          {
+            "type": "parsteel",
+            "value": 1577940000000
+          }
+        ]
+      },
+      "build_time": 63204480,
+      "increased_power": 6000,
+      "level": 52,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 52
+        },
+        {
+          "name": "r&d department",
+          "level": 52
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 1.91
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "crystal",
+            "grade": 5,
+            "rarity": "common",
+            "value": 36600
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 23200000000
+          },
+          {
+            "type": "parsteel",
+            "value": 2650368000000
+          }
+        ]
+      },
+      "build_time": 66996000,
+      "increased_power": 5000,
+      "level": 53,
+      "requirements": [
+        {
+          "name": "science lab",
+          "level": 52
+        },
+        {
+          "name": "engine technology lab",
+          "level": 52
+        },
+        {
+          "name": "foundry",
+          "level": 52
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 1.98
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "crystal",
+            "grade": 5,
+            "rarity": "rare",
+            "value": 11200
+          },
+          {
+            "type": "crystal",
+            "grade": 5,
+            "rarity": "common",
+            "value": 48400
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 34800000000
+          },
+          {
+            "type": "parsteel",
+            "value": 3975552000000
+          }
+        ]
+      },
+      "build_time": 71016480,
+      "increased_power": 6000,
+      "level": 54,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 54
+        },
+        {
+          "name": "r&d department",
+          "level": 54
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 2.05
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "crystal",
+            "grade": 5,
+            "rarity": "uncommon",
+            "value": 40000
+          },
+          {
+            "type": "crystal",
+            "grade": 5,
+            "rarity": "rare",
+            "value": 13600
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 54600000000
+          },
+          {
+            "type": "parsteel",
+            "value": 6757296000000
+          }
+        ]
+      },
+      "build_time": 75277440,
+      "increased_power": 6000,
+      "level": 55,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 55
+        },
+        {
+          "name": "r&d department",
+          "level": 55
+        }
+      ]
     }
   ]
 }

--- a/buildings/defense_platform_a.json
+++ b/buildings/defense_platform_a.json
@@ -2,7 +2,7 @@
   "description": "Defense Platforms are the last line of Defense for the Station. Behind defending ships they provide additional fire support. Upgrade to increase the Platform's combat performance.",
   "bonuses": {
     "bonus1": {
-      "name": "Power Level",
+      "name": "power level",
       "percentage": false
     }
   },
@@ -10,7 +10,7 @@
   "levels": [
     {
       "bonuses": {
-        "bonus1": 1
+        "bonus1": 1.0
       },
       "build_costs": {
         "materials": [],
@@ -21,11 +21,62 @@
       "increased_power": 945,
       "level": 1,
       "requirements": [],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 18,
+          "armor_pierce": 18,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 506,
+          "shield_pierce": 18
+        },
+        "defense": {
+          "armor": 9,
+          "dodge": 9,
+          "shield_deflect": 9
+        },
+        "health": {
+          "hull_health": 250,
+          "shield_health": 250
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 18,
+            "armor_pierce": 18,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 253,
+            "max_damage": 240,
+            "min_damage": 200,
+            "shield_pierce": 18
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 2
+        "bonus1": 2.0
       },
       "build_costs": {
         "materials": [],
@@ -46,31 +97,82 @@
       "level": 2,
       "requirements": [
         {
-          "name": "Drydock A",
-          "level": 3
+          "name": "r&d department",
+          "level": 13
         },
         {
-          "name": "R&D Department",
-          "level": 13
+          "name": "drydock a",
+          "level": 3
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 19,
+          "armor_pierce": 19,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 527,
+          "shield_pierce": 19
+        },
+        "defense": {
+          "armor": 9,
+          "dodge": 9,
+          "shield_deflect": 9
+        },
+        "health": {
+          "hull_health": 270,
+          "shield_health": 270
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 19,
+            "armor_pierce": 19,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 263,
+            "max_damage": 250,
+            "min_damage": 208,
+            "shield_pierce": 19
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 3
+        "bonus1": 3.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 6250
-          },
-          {
             "type": "tritanium",
             "value": 240
+          },
+          {
+            "type": "parsteel",
+            "value": 6250
           }
         ]
       },
@@ -79,31 +181,82 @@
       "level": 3,
       "requirements": [
         {
-          "name": "Drydock A",
-          "level": 3
+          "name": "r&d department",
+          "level": 13
         },
         {
-          "name": "R&D Department",
-          "level": 13
+          "name": "drydock a",
+          "level": 3
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 27,
+          "armor_pierce": 27,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 587,
+          "shield_pierce": 27
+        },
+        "defense": {
+          "armor": 14,
+          "dodge": 14,
+          "shield_deflect": 14
+        },
+        "health": {
+          "hull_health": 290,
+          "shield_health": 290
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 27,
+            "armor_pierce": 27,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 293,
+            "max_damage": 278,
+            "min_damage": 232,
+            "shield_pierce": 27
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 4
+        "bonus1": 4.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 7000
-          },
-          {
             "type": "tritanium",
             "value": 300
+          },
+          {
+            "type": "parsteel",
+            "value": 7000
           }
         ]
       },
@@ -112,19 +265,70 @@
       "level": 4,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "r&d department",
           "level": 13
         },
         {
-          "name": "Drydock A",
+          "name": "drydock a",
           "level": 3
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 36,
+          "armor_pierce": 36,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 662,
+          "shield_pierce": 36
+        },
+        "defense": {
+          "armor": 18,
+          "dodge": 18,
+          "shield_deflect": 18
+        },
+        "health": {
+          "hull_health": 360,
+          "shield_health": 360
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 36,
+            "armor_pierce": 36,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 331,
+            "max_damage": 314,
+            "min_damage": 262,
+            "shield_pierce": 36
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 5
+        "bonus1": 5.0
       },
       "build_costs": {
         "materials": [],
@@ -145,31 +349,82 @@
       "level": 5,
       "requirements": [
         {
-          "name": "Drydock A",
-          "level": 3
+          "name": "r&d department",
+          "level": 13
         },
         {
-          "name": "R&D Department",
-          "level": 13
+          "name": "drydock a",
+          "level": 3
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 46,
+          "armor_pierce": 46,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 818,
+          "shield_pierce": 46
+        },
+        "defense": {
+          "armor": 23,
+          "dodge": 23,
+          "shield_deflect": 23
+        },
+        "health": {
+          "hull_health": 500,
+          "shield_health": 500
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 46,
+            "armor_pierce": 46,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 409,
+            "max_damage": 388,
+            "min_damage": 323,
+            "shield_pierce": 46
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 6
+        "bonus1": 6.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 8500
-          },
-          {
             "type": "tritanium",
             "value": 400
+          },
+          {
+            "type": "parsteel",
+            "value": 8500
           }
         ]
       },
@@ -178,19 +433,70 @@
       "level": 6,
       "requirements": [
         {
-          "name": "Drydock A",
-          "level": 5
+          "name": "r&d department",
+          "level": 13
         },
         {
-          "name": "R&D Department",
-          "level": 13
+          "name": "drydock a",
+          "level": 5
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 63,
+          "armor_pierce": 63,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 1045,
+          "shield_pierce": 63
+        },
+        "defense": {
+          "armor": 32,
+          "dodge": 32,
+          "shield_deflect": 32
+        },
+        "health": {
+          "hull_health": 660,
+          "shield_health": 660
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 63,
+            "armor_pierce": 63,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 523,
+            "max_damage": 496,
+            "min_damage": 413,
+            "shield_pierce": 63
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 7
+        "bonus1": 7.0
       },
       "build_costs": {
         "materials": [],
@@ -211,19 +517,70 @@
       "level": 7,
       "requirements": [
         {
-          "name": "Drydock A",
-          "level": 5
+          "name": "r&d department",
+          "level": 13
         },
         {
-          "name": "R&D Department",
-          "level": 13
+          "name": "drydock a",
+          "level": 5
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 94,
+          "armor_pierce": 94,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 1298,
+          "shield_pierce": 94
+        },
+        "defense": {
+          "armor": 47,
+          "dodge": 47,
+          "shield_deflect": 47
+        },
+        "health": {
+          "hull_health": 960,
+          "shield_health": 960
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 94,
+            "armor_pierce": 94,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 649,
+            "max_damage": 616,
+            "min_damage": 513,
+            "shield_pierce": 94
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 8
+        "bonus1": 8.0
       },
       "build_costs": {
         "materials": [],
@@ -244,27 +601,78 @@
       "level": 8,
       "requirements": [
         {
-          "name": "Drydock A",
+          "name": "drydock a",
           "level": 8
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 138,
+          "armor_pierce": 138,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 1948,
+          "shield_pierce": 138
+        },
+        "defense": {
+          "armor": 69,
+          "dodge": 69,
+          "shield_deflect": 69
+        },
+        "health": {
+          "hull_health": 1370,
+          "shield_health": 1370
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 138,
+            "armor_pierce": 138,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 974,
+            "max_damage": 924,
+            "min_damage": 770,
+            "shield_pierce": 138
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 9
+        "bonus1": 9.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 11000
-          },
-          {
             "type": "tritanium",
             "value": 550
+          },
+          {
+            "type": "parsteel",
+            "value": 11000
           }
         ]
       },
@@ -273,15 +681,66 @@
       "level": 9,
       "requirements": [
         {
-          "name": "Drydock A",
+          "name": "drydock a",
           "level": 9
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 200,
+          "armor_pierce": 200,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 2728,
+          "shield_pierce": 200
+        },
+        "defense": {
+          "armor": 100,
+          "dodge": 100,
+          "shield_deflect": 100
+        },
+        "health": {
+          "hull_health": 2020,
+          "shield_health": 2020
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 200,
+            "armor_pierce": 200,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 1364,
+            "max_damage": 1294,
+            "min_damage": 1078,
+            "shield_pierce": 200
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 10
+        "bonus1": 10.0
       },
       "build_costs": {
         "materials": [],
@@ -302,15 +761,97 @@
       "level": 10,
       "requirements": [
         {
-          "name": "Drydock A",
+          "name": "drydock a",
           "level": 10
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 236,
+          "armor_pierce": 236,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 3503,
+          "shield_pierce": 236
+        },
+        "defense": {
+          "armor": 131,
+          "dodge": 131,
+          "shield_deflect": 131
+        },
+        "health": {
+          "hull_health": 2560,
+          "shield_health": 2560
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 236,
+            "armor_pierce": 236,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 1168,
+            "max_damage": 1108,
+            "min_damage": 923,
+            "shield_pierce": 236
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 1,
+          "weapon_stats": {
+            "accuracy": 236,
+            "armor_pierce": 236,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 1168,
+            "max_damage": 1108,
+            "min_damage": 923,
+            "shield_pierce": 236
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 11
+        "bonus1": 11.0
       },
       "build_costs": {
         "materials": [],
@@ -321,12 +862,12 @@
             "value": 13600
           },
           {
-            "type": "tritanium",
-            "value": 400
-          },
-          {
             "type": "dilithium",
             "value": 8
+          },
+          {
+            "type": "tritanium",
+            "value": 400
           }
         ]
       },
@@ -335,19 +876,101 @@
       "level": 11,
       "requirements": [
         {
-          "name": "Drydock B",
-          "level": 10
+          "name": "drydock a",
+          "level": 11
         },
         {
-          "name": "Drydock A",
-          "level": 11
+          "name": "drydock b",
+          "level": 10
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 260,
+          "armor_pierce": 260,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 4782,
+          "shield_pierce": 260
+        },
+        "defense": {
+          "armor": 153,
+          "dodge": 153,
+          "shield_deflect": 153
+        },
+        "health": {
+          "hull_health": 2740,
+          "shield_health": 2740
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 260,
+            "armor_pierce": 260,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 1594,
+            "max_damage": 1512,
+            "min_damage": 1260,
+            "shield_pierce": 260
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 1,
+          "weapon_stats": {
+            "accuracy": 260,
+            "armor_pierce": 260,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 1594,
+            "max_damage": 1512,
+            "min_damage": 1260,
+            "shield_pierce": 260
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 12
+        "bonus1": 12.0
       },
       "build_costs": {
         "materials": [],
@@ -372,15 +995,97 @@
       "level": 12,
       "requirements": [
         {
-          "name": "Drydock A",
+          "name": "drydock a",
           "level": 12
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 340,
+          "armor_pierce": 340,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 5142,
+          "shield_pierce": 340
+        },
+        "defense": {
+          "armor": 213,
+          "dodge": 213,
+          "shield_deflect": 213
+        },
+        "health": {
+          "hull_health": 2880,
+          "shield_health": 2880
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 340,
+            "armor_pierce": 340,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 1714,
+            "max_damage": 1626,
+            "min_damage": 1355,
+            "shield_pierce": 340
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 1,
+          "weapon_stats": {
+            "accuracy": 340,
+            "armor_pierce": 340,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 1714,
+            "max_damage": 1626,
+            "min_damage": 1355,
+            "shield_pierce": 340
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 13
+        "bonus1": 13.0
       },
       "build_costs": {
         "materials": [],
@@ -391,12 +1096,12 @@
             "value": 27200
           },
           {
-            "type": "tritanium",
-            "value": 800
-          },
-          {
             "type": "dilithium",
             "value": 48
+          },
+          {
+            "type": "tritanium",
+            "value": 800
           }
         ]
       },
@@ -405,15 +1110,97 @@
       "level": 13,
       "requirements": [
         {
-          "name": "Drydock A",
+          "name": "drydock a",
           "level": 13
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 438,
+          "armor_pierce": 438,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 5572,
+          "shield_pierce": 438
+        },
+        "defense": {
+          "armor": 274,
+          "dodge": 274,
+          "shield_deflect": 274
+        },
+        "health": {
+          "hull_health": 3350,
+          "shield_health": 3350
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 438,
+            "armor_pierce": 438,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 1857,
+            "max_damage": 1762,
+            "min_damage": 1468,
+            "shield_pierce": 438
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 1,
+          "weapon_stats": {
+            "accuracy": 438,
+            "armor_pierce": 438,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 1857,
+            "max_damage": 1762,
+            "min_damage": 1468,
+            "shield_pierce": 438
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 14
+        "bonus1": 14.0
       },
       "build_costs": {
         "materials": [],
@@ -424,12 +1211,12 @@
             "value": 37400
           },
           {
-            "type": "tritanium",
-            "value": 1100
-          },
-          {
             "type": "dilithium",
             "value": 88
+          },
+          {
+            "type": "tritanium",
+            "value": 1100
           }
         ]
       },
@@ -438,31 +1225,113 @@
       "level": 14,
       "requirements": [
         {
-          "name": "Drydock A",
+          "name": "drydock a",
           "level": 14
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 454,
+          "armor_pierce": 454,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 5730,
+          "shield_pierce": 454
+        },
+        "defense": {
+          "armor": 371,
+          "dodge": 371,
+          "shield_deflect": 371
+        },
+        "health": {
+          "hull_health": 3460,
+          "shield_health": 3460
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 454,
+            "armor_pierce": 454,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 1910,
+            "max_damage": 1812,
+            "min_damage": 1510,
+            "shield_pierce": 454
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 1,
+          "weapon_stats": {
+            "accuracy": 454,
+            "armor_pierce": 454,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 1910,
+            "max_damage": 1812,
+            "min_damage": 1510,
+            "shield_pierce": 454
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 15
+        "bonus1": 15.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 51000
+            "type": "dilithium",
+            "value": 150
           },
           {
             "type": "tritanium",
             "value": 1500
           },
           {
-            "type": "dilithium",
-            "value": 150
+            "type": "parsteel",
+            "value": 51000
           }
         ]
       },
@@ -471,15 +1340,97 @@
       "level": 15,
       "requirements": [
         {
-          "name": "Drydock A",
+          "name": "drydock a",
           "level": 15
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 475,
+          "armor_pierce": 475,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 5863,
+          "shield_pierce": 475
+        },
+        "defense": {
+          "armor": 400,
+          "dodge": 400,
+          "shield_deflect": 400
+        },
+        "health": {
+          "hull_health": 3730,
+          "shield_health": 3730
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 475,
+            "armor_pierce": 475,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 1954,
+            "max_damage": 1854,
+            "min_damage": 1545,
+            "shield_pierce": 475
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 1,
+          "weapon_stats": {
+            "accuracy": 475,
+            "armor_pierce": 475,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 1954,
+            "max_damage": 1854,
+            "min_damage": 1545,
+            "shield_pierce": 475
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 16
+        "bonus1": 16.0
       },
       "build_costs": {
         "materials": [],
@@ -504,15 +1455,97 @@
       "level": 16,
       "requirements": [
         {
-          "name": "Drydock A",
+          "name": "drydock a",
           "level": 16
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 556,
+          "armor_pierce": 556,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 7476,
+          "shield_pierce": 556
+        },
+        "defense": {
+          "armor": 479,
+          "dodge": 479,
+          "shield_deflect": 479
+        },
+        "health": {
+          "hull_health": 4750,
+          "shield_health": 4750
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 556,
+            "armor_pierce": 556,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 2492,
+            "max_damage": 2364,
+            "min_damage": 1970,
+            "shield_pierce": 556
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 1,
+          "weapon_stats": {
+            "accuracy": 556,
+            "armor_pierce": 556,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 2492,
+            "max_damage": 2364,
+            "min_damage": 1970,
+            "shield_pierce": 556
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 17
+        "bonus1": 17.0
       },
       "build_costs": {
         "materials": [
@@ -526,16 +1559,16 @@
         "others": [],
         "resources": [
           {
+            "type": "dilithium",
+            "value": 280
+          },
+          {
             "type": "parsteel",
             "value": 95200
           },
           {
             "type": "tritanium",
             "value": 2800
-          },
-          {
-            "type": "dilithium",
-            "value": 280
           }
         ]
       },
@@ -544,15 +1577,97 @@
       "level": 17,
       "requirements": [
         {
-          "name": "Drydock A",
+          "name": "drydock a",
           "level": 17
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 649,
+          "armor_pierce": 649,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 8779,
+          "shield_pierce": 649
+        },
+        "defense": {
+          "armor": 535,
+          "dodge": 535,
+          "shield_deflect": 535
+        },
+        "health": {
+          "hull_health": 5620,
+          "shield_health": 5620
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 649,
+            "armor_pierce": 649,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 2926,
+            "max_damage": 2776,
+            "min_damage": 2313,
+            "shield_pierce": 649
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 1,
+          "weapon_stats": {
+            "accuracy": 649,
+            "armor_pierce": 649,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 2926,
+            "max_damage": 2776,
+            "min_damage": 2313,
+            "shield_pierce": 649
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 18
+        "bonus1": 18.0
       },
       "build_costs": {
         "materials": [
@@ -584,15 +1699,97 @@
       "level": 18,
       "requirements": [
         {
-          "name": "Drydock A",
+          "name": "drydock a",
           "level": 18
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 672,
+          "armor_pierce": 672,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 10265,
+          "shield_pierce": 672
+        },
+        "defense": {
+          "armor": 560,
+          "dodge": 560,
+          "shield_deflect": 560
+        },
+        "health": {
+          "hull_health": 6120,
+          "shield_health": 6120
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 672,
+            "armor_pierce": 672,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 3422,
+            "max_damage": 3246,
+            "min_damage": 2705,
+            "shield_pierce": 672
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 1,
+          "weapon_stats": {
+            "accuracy": 672,
+            "armor_pierce": 672,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 3422,
+            "max_damage": 3246,
+            "min_damage": 2705,
+            "shield_pierce": 672
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 19
+        "bonus1": 19.0
       },
       "build_costs": {
         "materials": [
@@ -606,16 +1803,16 @@
         "others": [],
         "resources": [
           {
+            "type": "dilithium",
+            "value": 600
+          },
+          {
             "type": "parsteel",
             "value": 204000
           },
           {
             "type": "tritanium",
             "value": 6000
-          },
-          {
-            "type": "dilithium",
-            "value": 600
           }
         ]
       },
@@ -624,35 +1821,117 @@
       "level": 19,
       "requirements": [
         {
-          "name": "Drydock A",
+          "name": "drydock a",
           "level": 19
         },
         {
-          "name": "Defense Platform B",
+          "name": "defense platform b",
           "level": 19
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 2023,
+          "armor_pierce": 2023,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 10823,
+          "shield_pierce": 2023
+        },
+        "defense": {
+          "armor": 674,
+          "dodge": 674,
+          "shield_deflect": 674
+        },
+        "health": {
+          "hull_health": 6500,
+          "shield_health": 6500
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 2023,
+            "armor_pierce": 2023,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 3608,
+            "max_damage": 3422,
+            "min_damage": 2852,
+            "shield_pierce": 2023
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 1,
+          "weapon_stats": {
+            "accuracy": 2023,
+            "armor_pierce": 2023,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 3608,
+            "max_damage": 3422,
+            "min_damage": 2852,
+            "shield_pierce": 2023
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 20
+        "bonus1": 20.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 289000
+            "type": "dilithium",
+            "value": 850
           },
           {
             "type": "tritanium",
             "value": 8500
           },
           {
-            "type": "dilithium",
-            "value": 850
+            "type": "parsteel",
+            "value": 289000
           }
         ]
       },
@@ -661,19 +1940,101 @@
       "level": 20,
       "requirements": [
         {
-          "name": "Defense Technologies",
+          "name": "drydock a",
           "level": 20
         },
         {
-          "name": "Drydock A",
+          "name": "defense technologies",
           "level": 20
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 2755,
+          "armor_pierce": 2755,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 11173,
+          "shield_pierce": 2755
+        },
+        "defense": {
+          "armor": 689,
+          "dodge": 689,
+          "shield_deflect": 689
+        },
+        "health": {
+          "hull_health": 9860,
+          "shield_health": 6570
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 2755,
+            "armor_pierce": 2755,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 2793,
+            "max_damage": 2650,
+            "min_damage": 2208,
+            "shield_pierce": 2755
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 2755,
+            "armor_pierce": 2755,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 2793,
+            "max_damage": 2650,
+            "min_damage": 2208,
+            "shield_pierce": 2755
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 21
+        "bonus1": 21.0
       },
       "build_costs": {
         "materials": [],
@@ -684,12 +2045,12 @@
             "value": 486540
           },
           {
-            "type": "tritanium",
-            "value": 14310
-          },
-          {
             "type": "dilithium",
             "value": 1431
+          },
+          {
+            "type": "tritanium",
+            "value": 14310
           }
         ]
       },
@@ -698,24 +2059,102 @@
       "level": 21,
       "requirements": [
         {
-          "name": "Drydock A",
+          "name": "drydock a",
           "level": 21
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 3494,
+          "armor_pierce": 3494,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 11360,
+          "shield_pierce": 3494
+        },
+        "defense": {
+          "armor": 699,
+          "dodge": 699,
+          "shield_deflect": 699
+        },
+        "health": {
+          "hull_health": 13540,
+          "shield_health": 6770
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 3494,
+            "armor_pierce": 3494,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 2840,
+            "max_damage": 2694,
+            "min_damage": 2245,
+            "shield_pierce": 3494
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 3494,
+            "armor_pierce": 3494,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 2840,
+            "max_damage": 2694,
+            "min_damage": 2245,
+            "shield_pierce": 3494
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 22
+        "bonus1": 22.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
-          {
-            "type": "parsteel",
-            "value": 756840
-          },
           {
             "type": "tritanium",
             "value": 22260
@@ -723,6 +2162,10 @@
           {
             "type": "dilithium",
             "value": 2226
+          },
+          {
+            "type": "parsteel",
+            "value": 756840
           }
         ]
       },
@@ -731,24 +2174,102 @@
       "level": 22,
       "requirements": [
         {
-          "name": "Drydock A",
+          "name": "drydock a",
           "level": 22
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 35000,
+          "armor_pierce": 35000,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 17528,
+          "shield_pierce": 35000
+        },
+        "defense": {
+          "armor": 1701,
+          "dodge": 1701,
+          "shield_deflect": 1701
+        },
+        "health": {
+          "hull_health": 25246,
+          "shield_health": 6840
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 35000,
+            "armor_pierce": 35000,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 4382,
+            "max_damage": 4157,
+            "min_damage": 3464,
+            "shield_pierce": 35000
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 35000,
+            "armor_pierce": 35000,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 4382,
+            "max_damage": 4157,
+            "min_damage": 3464,
+            "shield_pierce": 35000
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 23
+        "bonus1": 23.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
-          {
-            "type": "parsteel",
-            "value": 1245420
-          },
           {
             "type": "tritanium",
             "value": 36630
@@ -756,6 +2277,10 @@
           {
             "type": "dilithium",
             "value": 3663
+          },
+          {
+            "type": "parsteel",
+            "value": 1245420
           }
         ]
       },
@@ -764,15 +2289,97 @@
       "level": 23,
       "requirements": [
         {
-          "name": "Drydock A",
+          "name": "drydock a",
           "level": 23
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 36150,
+          "armor_pierce": 37625,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 21243,
+          "shield_pierce": 37625
+        },
+        "defense": {
+          "armor": 2724,
+          "dodge": 2724,
+          "shield_deflect": 2724
+        },
+        "health": {
+          "hull_health": 25582,
+          "shield_health": 6910
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 36150,
+            "armor_pierce": 37625,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 5311,
+            "max_damage": 5038,
+            "min_damage": 4198,
+            "shield_pierce": 37625
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 36150,
+            "armor_pierce": 37625,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 5311,
+            "max_damage": 5038,
+            "min_damage": 4198,
+            "shield_pierce": 37625
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 24
+        "bonus1": 24.0
       },
       "build_costs": {
         "materials": [
@@ -786,16 +2393,16 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 1962480
-          },
-          {
             "type": "tritanium",
             "value": 57720
           },
           {
             "type": "dilithium",
             "value": 5772
+          },
+          {
+            "type": "parsteel",
+            "value": 1962480
           }
         ]
       },
@@ -804,15 +2411,97 @@
       "level": 24,
       "requirements": [
         {
-          "name": "Drydock A",
+          "name": "drydock a",
           "level": 24
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 36300,
+          "armor_pierce": 43125,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 22211,
+          "shield_pierce": 43125
+        },
+        "defense": {
+          "armor": 3571,
+          "dodge": 3571,
+          "shield_deflect": 3571
+        },
+        "health": {
+          "hull_health": 25671,
+          "shield_health": 7020
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 36300,
+            "armor_pierce": 43125,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 5553,
+            "max_damage": 5267,
+            "min_damage": 4390,
+            "shield_pierce": 43125
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 36300,
+            "armor_pierce": 43125,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 5553,
+            "max_damage": 5267,
+            "min_damage": 4390,
+            "shield_pierce": 43125
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 25
+        "bonus1": 25.0
       },
       "build_costs": {
         "materials": [
@@ -850,41 +2539,119 @@
       "level": 25,
       "requirements": [
         {
-          "name": "Drydock A",
+          "name": "drydock a",
           "level": 25
         },
         {
-          "name": "Defense Technologies",
+          "name": "defense technologies",
           "level": 25
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 36425,
+          "armor_pierce": 43750,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 27400,
+          "shield_pierce": 43750
+        },
+        "defense": {
+          "armor": 4865,
+          "dodge": 4865,
+          "shield_deflect": 4865
+        },
+        "health": {
+          "hull_health": 28013,
+          "shield_health": 7780
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 36425,
+            "armor_pierce": 43750,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 6850,
+            "max_damage": 6498,
+            "min_damage": 5415,
+            "shield_pierce": 43750
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 36425,
+            "armor_pierce": 43750,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 6850,
+            "max_damage": 6498,
+            "min_damage": 5415,
+            "shield_pierce": 43750
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 26
+        "bonus1": 26.0
       },
       "build_costs": {
         "materials": [
           {
             "type": "gas",
             "grade": 3,
-            "rarity": "common",
-            "value": 230
+            "rarity": "uncommon",
+            "value": 4
           },
           {
             "type": "gas",
             "grade": 3,
-            "rarity": "uncommon",
-            "value": 4
+            "rarity": "common",
+            "value": 230
           }
         ],
         "others": [],
         "resources": [
-          {
-            "type": "parsteel",
-            "value": 4972500
-          },
           {
             "type": "tritanium",
             "value": 146250
@@ -892,6 +2659,10 @@
           {
             "type": "dilithium",
             "value": 14625
+          },
+          {
+            "type": "parsteel",
+            "value": 4972500
           }
         ]
       },
@@ -900,15 +2671,97 @@
       "level": 26,
       "requirements": [
         {
-          "name": "Drydock A",
+          "name": "drydock a",
           "level": 26
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 38710,
+          "armor_pierce": 46875,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 28775,
+          "shield_pierce": 46875
+        },
+        "defense": {
+          "armor": 5687,
+          "dodge": 5687,
+          "shield_deflect": 5687
+        },
+        "health": {
+          "hull_health": 32009,
+          "shield_health": 9000
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 38710,
+            "armor_pierce": 46875,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 7194,
+            "max_damage": 6824,
+            "min_damage": 5687,
+            "shield_pierce": 46875
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 38710,
+            "armor_pierce": 46875,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 7194,
+            "max_damage": 6824,
+            "min_damage": 5687,
+            "shield_pierce": 46875
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 27
+        "bonus1": 27.0
       },
       "build_costs": {
         "materials": [
@@ -922,16 +2775,16 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 7588800
+            "type": "dilithium",
+            "value": 22320
           },
           {
             "type": "tritanium",
             "value": 223200
           },
           {
-            "type": "dilithium",
-            "value": 22320
+            "type": "parsteel",
+            "value": 7588800
           }
         ]
       },
@@ -940,33 +2793,119 @@
       "level": 27,
       "requirements": [
         {
-          "name": "Drydock A",
+          "name": "drydock a",
           "level": 27
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 44516,
+          "armor_pierce": 57500,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 30811,
+          "shield_pierce": 57500
+        },
+        "defense": {
+          "armor": 6303,
+          "dodge": 6302,
+          "shield_deflect": 6302
+        },
+        "health": {
+          "hull_health": 40145,
+          "shield_health": 11340
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 44516,
+            "armor_pierce": 57500,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 7703,
+            "max_damage": 7307,
+            "min_damage": 6089,
+            "shield_pierce": 57500
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 44516,
+            "armor_pierce": 57500,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 7703,
+            "max_damage": 7307,
+            "min_damage": 6089,
+            "shield_pierce": 57500
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 28
+        "bonus1": 28.0
       },
       "build_costs": {
         "materials": [
           {
             "type": "gas",
             "grade": 3,
-            "rarity": "common",
-            "value": 360
+            "rarity": "uncommon",
+            "value": 18
           },
           {
             "type": "gas",
             "grade": 3,
-            "rarity": "uncommon",
-            "value": 18
+            "rarity": "common",
+            "value": 360
           }
         ],
         "others": [],
         "resources": [
+          {
+            "type": "dilithium",
+            "value": 33480
+          },
           {
             "type": "parsteel",
             "value": 11383200
@@ -974,10 +2913,6 @@
           {
             "type": "tritanium",
             "value": 334800
-          },
-          {
-            "type": "dilithium",
-            "value": 33480
           }
         ]
       },
@@ -986,15 +2921,97 @@
       "level": 28,
       "requirements": [
         {
-          "name": "Drydock A",
+          "name": "drydock a",
           "level": 28
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 56473,
+          "armor_pierce": 68750,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 32324,
+          "shield_pierce": 68750
+        },
+        "defense": {
+          "armor": 8052,
+          "dodge": 8052,
+          "shield_deflect": 8052
+        },
+        "health": {
+          "hull_health": 50751,
+          "shield_health": 14400
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 56473,
+            "armor_pierce": 68750,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 8081,
+            "max_damage": 7666,
+            "min_damage": 6388,
+            "shield_pierce": 68750
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 56473,
+            "armor_pierce": 68750,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 8081,
+            "max_damage": 7666,
+            "min_damage": 6388,
+            "shield_pierce": 68750
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 29
+        "bonus1": 29.0
       },
       "build_costs": {
         "materials": [
@@ -1008,16 +3025,16 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 18122000
+            "type": "dilithium",
+            "value": 53300
           },
           {
             "type": "tritanium",
             "value": 533000
           },
           {
-            "type": "dilithium",
-            "value": 53300
+            "type": "parsteel",
+            "value": 18122000
           }
         ]
       },
@@ -1026,15 +3043,97 @@
       "level": 29,
       "requirements": [
         {
-          "name": "Drydock A",
+          "name": "drydock a",
           "level": 29
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 62448,
+          "armor_pierce": 74375,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 35841,
+          "shield_pierce": 74375
+        },
+        "defense": {
+          "armor": 8908,
+          "dodge": 8908,
+          "shield_deflect": 8908
+        },
+        "health": {
+          "hull_health": 59028,
+          "shield_health": 16830
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 62448,
+            "armor_pierce": 74375,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 8960,
+            "max_damage": 8500,
+            "min_damage": 7083,
+            "shield_pierce": 74375
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 62448,
+            "armor_pierce": 74375,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 8960,
+            "max_damage": 8500,
+            "min_damage": 7083,
+            "shield_pierce": 74375
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 30
+        "bonus1": 30.0
       },
       "build_costs": {
         "materials": [
@@ -1052,12 +3151,12 @@
             "value": 26520000
           },
           {
-            "type": "tritanium",
-            "value": 780000
-          },
-          {
             "type": "dilithium",
             "value": 78000
+          },
+          {
+            "type": "tritanium",
+            "value": 780000
           }
         ]
       },
@@ -1066,44 +3165,126 @@
       "level": 30,
       "requirements": [
         {
-          "name": "Drydock A",
+          "name": "drydock a",
           "level": 30
         },
         {
-          "name": "Defense Technologies",
+          "name": "defense technologies",
           "level": 30
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 77490,
+          "armor_pierce": 76125,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 37780,
+          "shield_pierce": 76125
+        },
+        "defense": {
+          "armor": 10611,
+          "dodge": 10611,
+          "shield_deflect": 10611
+        },
+        "health": {
+          "hull_health": 67494,
+          "shield_health": 17230
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 77490,
+            "armor_pierce": 76125,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 9445,
+            "max_damage": 8960,
+            "min_damage": 7466,
+            "shield_pierce": 76125
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 77490,
+            "armor_pierce": 76125,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 9445,
+            "max_damage": 8960,
+            "min_damage": 7466,
+            "shield_pierce": 76125
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 31
+        "bonus1": 31.0
       },
       "build_costs": {
         "materials": [
           {
             "type": "gas",
             "grade": 3,
-            "rarity": "common",
-            "value": 700
+            "rarity": "uncommon",
+            "value": 65
           },
           {
             "type": "gas",
             "grade": 3,
-            "rarity": "uncommon",
-            "value": 65
+            "rarity": "common",
+            "value": 700
           }
         ],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 41922000
-          },
-          {
             "type": "tritanium",
             "value": 1233000
+          },
+          {
+            "type": "parsteel",
+            "value": 41922000
           },
           {
             "type": "dilithium",
@@ -1116,15 +3297,97 @@
       "level": 31,
       "requirements": [
         {
-          "name": "Drydock A",
+          "name": "drydock a",
           "level": 31
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 87436,
+          "armor_pierce": 89375,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 40278,
+          "shield_pierce": 89375
+        },
+        "defense": {
+          "armor": 12016,
+          "dodge": 12016,
+          "shield_deflect": 12016
+        },
+        "health": {
+          "hull_health": 77484,
+          "shield_health": 19910
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 87436,
+            "armor_pierce": 89375,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 10069,
+            "max_damage": 9552,
+            "min_damage": 7960,
+            "shield_pierce": 89375
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 87436,
+            "armor_pierce": 89375,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 10069,
+            "max_damage": 9552,
+            "min_damage": 7960,
+            "shield_pierce": 89375
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 32
+        "bonus1": 32.0
       },
       "build_costs": {
         "materials": [
@@ -1156,15 +3419,97 @@
       "level": 32,
       "requirements": [
         {
-          "name": "Drydock A",
+          "name": "drydock a",
           "level": 32
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 91746,
+          "armor_pierce": 123750,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 45600,
+          "shield_pierce": 123750
+        },
+        "defense": {
+          "armor": 13124,
+          "dodge": 13124,
+          "shield_deflect": 13124
+        },
+        "health": {
+          "hull_health": 83090,
+          "shield_health": 20120
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 91746,
+            "armor_pierce": 123750,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 11400,
+            "max_damage": 10814,
+            "min_damage": 9012,
+            "shield_pierce": 123750
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 91746,
+            "armor_pierce": 123750,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 11400,
+            "max_damage": 10814,
+            "min_damage": 9012,
+            "shield_pierce": 123750
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 33
+        "bonus1": 33.0
       },
       "build_costs": {
         "materials": [
@@ -1178,16 +3523,16 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 93670000
-          },
-          {
             "type": "tritanium",
             "value": 2755000
           },
           {
             "type": "dilithium",
             "value": 275500
+          },
+          {
+            "type": "parsteel",
+            "value": 93670000
           }
         ]
       },
@@ -1196,48 +3541,130 @@
       "level": 33,
       "requirements": [
         {
-          "name": "Drydock A",
+          "name": "drydock a",
           "level": 33
         },
         {
-          "name": "Defense Technologies",
+          "name": "defense technologies",
           "level": 33
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 94480,
+          "armor_pierce": 144038,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 47773,
+          "shield_pierce": 144038
+        },
+        "defense": {
+          "armor": 13560,
+          "dodge": 13560,
+          "shield_deflect": 13560
+        },
+        "health": {
+          "hull_health": 92622,
+          "shield_health": 21830
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 94480,
+            "armor_pierce": 144038,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 11943,
+            "max_damage": 11330,
+            "min_damage": 9441,
+            "shield_pierce": 144038
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 94480,
+            "armor_pierce": 144038,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 11943,
+            "max_damage": 11330,
+            "min_damage": 9441,
+            "shield_pierce": 144038
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 34
+        "bonus1": 34.0
       },
       "build_costs": {
         "materials": [
           {
             "type": "gas",
             "grade": 3,
-            "rarity": "common",
-            "value": 1100
+            "rarity": "uncommon",
+            "value": 140
           },
           {
             "type": "gas",
             "grade": 3,
-            "rarity": "uncommon",
-            "value": 140
+            "rarity": "common",
+            "value": 1100
           }
         ],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 147900000
+            "type": "dilithium",
+            "value": 435000
           },
           {
             "type": "tritanium",
             "value": 4350000
           },
           {
-            "type": "dilithium",
-            "value": 435000
+            "type": "parsteel",
+            "value": 147900000
           }
         ]
       },
@@ -1246,15 +3673,97 @@
       "level": 34,
       "requirements": [
         {
-          "name": "Drydock A",
+          "name": "drydock a",
           "level": 34
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 100000,
+          "armor_pierce": 161563,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 50660,
+          "shield_pierce": 161563
+        },
+        "defense": {
+          "armor": 14845,
+          "dodge": 14845,
+          "shield_deflect": 14845
+        },
+        "health": {
+          "hull_health": 102230,
+          "shield_health": 22770
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 100000,
+            "armor_pierce": 161563,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 12665,
+            "max_damage": 12014,
+            "min_damage": 10012,
+            "shield_pierce": 161563
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 100000,
+            "armor_pierce": 161563,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 12665,
+            "max_damage": 12014,
+            "min_damage": 10012,
+            "shield_pierce": 161563
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 35
+        "bonus1": 35.0
       },
       "build_costs": {
         "materials": [
@@ -1268,16 +3777,16 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 228888000
-          },
-          {
             "type": "tritanium",
             "value": 6732000
           },
           {
             "type": "dilithium",
             "value": 673200
+          },
+          {
+            "type": "parsteel",
+            "value": 228888000
           }
         ]
       },
@@ -1286,19 +3795,101 @@
       "level": 35,
       "requirements": [
         {
-          "name": "Drydock A",
+          "name": "drydock a",
           "level": 35
         },
         {
-          "name": "Defense Technologies",
+          "name": "defense technologies",
           "level": 35
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 109796,
+          "armor_pierce": 196875,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 59319,
+          "shield_pierce": 196875
+        },
+        "defense": {
+          "armor": 16480,
+          "dodge": 16480,
+          "shield_deflect": 16480
+        },
+        "health": {
+          "hull_health": 118699,
+          "shield_health": 28350
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 109796,
+            "armor_pierce": 196875,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 14830,
+            "max_damage": 14068,
+            "min_damage": 11723,
+            "shield_pierce": 196875
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 109796,
+            "armor_pierce": 196875,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 14830,
+            "max_damage": 14068,
+            "min_damage": 11723,
+            "shield_pierce": 196875
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 36
+        "bonus1": 36.0
       },
       "build_costs": {
         "materials": [
@@ -1318,16 +3909,16 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 322524000
+            "type": "dilithium",
+            "value": 948600
           },
           {
             "type": "tritanium",
             "value": 9486000
           },
           {
-            "type": "dilithium",
-            "value": 948600
+            "type": "parsteel",
+            "value": 322524000
           }
         ]
       },
@@ -1336,40 +3927,122 @@
       "level": 36,
       "requirements": [
         {
-          "name": "Drydock A",
+          "name": "drydock a",
           "level": 36
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 119489,
+          "armor_pierce": 227807,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 71792,
+          "shield_pierce": 227807
+        },
+        "defense": {
+          "armor": 17855,
+          "dodge": 17855,
+          "shield_deflect": 17855
+        },
+        "health": {
+          "hull_health": 138605,
+          "shield_health": 32610
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 119489,
+            "armor_pierce": 227807,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 17948,
+            "max_damage": 17026,
+            "min_damage": 14188,
+            "shield_pierce": 227807
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 119489,
+            "armor_pierce": 227807,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 17948,
+            "max_damage": 17026,
+            "min_damage": 14188,
+            "shield_pierce": 227807
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 37
+        "bonus1": 37.0
       },
       "build_costs": {
         "materials": [
           {
             "type": "gas",
             "grade": 3,
-            "rarity": "common",
-            "value": 1800
+            "rarity": "uncommon",
+            "value": 260
           },
           {
             "type": "gas",
             "grade": 3,
-            "rarity": "uncommon",
-            "value": 260
+            "rarity": "common",
+            "value": 1800
           }
         ],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 495720000
-          },
-          {
             "type": "tritanium",
             "value": 14580000
+          },
+          {
+            "type": "parsteel",
+            "value": 495720000
           },
           {
             "type": "dilithium",
@@ -1382,15 +4055,97 @@
       "level": 37,
       "requirements": [
         {
-          "name": "Drydock A",
+          "name": "drydock a",
           "level": 37
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 132418,
+          "armor_pierce": 247922,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 77781,
+          "shield_pierce": 247922
+        },
+        "defense": {
+          "armor": 18489,
+          "dodge": 18489,
+          "shield_deflect": 18489
+        },
+        "health": {
+          "hull_health": 163789,
+          "shield_health": 35710
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 132418,
+            "armor_pierce": 247922,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 19445,
+            "max_damage": 18446,
+            "min_damage": 15372,
+            "shield_pierce": 247922
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 132418,
+            "armor_pierce": 247922,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 19445,
+            "max_damage": 18446,
+            "min_damage": 15372,
+            "shield_pierce": 247922
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 38
+        "bonus1": 38.0
       },
       "build_costs": {
         "materials": [
@@ -1410,12 +4165,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 771120000
-          },
-          {
             "type": "tritanium",
             "value": 22680000
+          },
+          {
+            "type": "parsteel",
+            "value": 771120000
           },
           {
             "type": "dilithium",
@@ -1428,15 +4183,97 @@
       "level": 38,
       "requirements": [
         {
-          "name": "Drydock A",
+          "name": "drydock a",
           "level": 38
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 144918,
+          "armor_pierce": 286066,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 89173,
+          "shield_pierce": 286066
+        },
+        "defense": {
+          "armor": 20112,
+          "dodge": 20112,
+          "shield_deflect": 20112
+        },
+        "health": {
+          "hull_health": 188609,
+          "shield_health": 41570
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 144918,
+            "armor_pierce": 286066,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 22293,
+            "max_damage": 21148,
+            "min_damage": 17623,
+            "shield_pierce": 286066
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 144918,
+            "armor_pierce": 286066,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 22293,
+            "max_damage": 21148,
+            "min_damage": 17623,
+            "shield_pierce": 286066
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 39
+        "bonus1": 39.0
       },
       "build_costs": {
         "materials": [],
@@ -1447,12 +4284,12 @@
             "value": 1315800000
           },
           {
-            "type": "tritanium",
-            "value": 38700000
-          },
-          {
             "type": "dilithium",
             "value": 3870000
+          },
+          {
+            "type": "tritanium",
+            "value": 38700000
           }
         ]
       },
@@ -1461,19 +4298,101 @@
       "level": 39,
       "requirements": [
         {
-          "name": "Drydock A",
+          "name": "drydock a",
           "level": 39
         },
         {
-          "name": "Defense Technologies",
+          "name": "defense technologies",
           "level": 39
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 159412,
+          "armor_pierce": 333789,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 103443,
+          "shield_pierce": 333789
+        },
+        "defense": {
+          "armor": 22010,
+          "dodge": 22010,
+          "shield_deflect": 22010
+        },
+        "health": {
+          "hull_health": 221741,
+          "shield_health": 48900
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 159412,
+            "armor_pierce": 333789,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 25861,
+            "max_damage": 24532,
+            "min_damage": 20443,
+            "shield_pierce": 333789
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 159412,
+            "armor_pierce": 333789,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 25861,
+            "max_damage": 24532,
+            "min_damage": 20443,
+            "shield_pierce": 333789
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 40
+        "bonus1": 40.0
       },
       "build_costs": {
         "materials": [
@@ -1493,16 +4412,16 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 5731040000
-          },
-          {
             "type": "tritanium",
             "value": 60200000
           },
           {
             "type": "dilithium",
             "value": 6020000
+          },
+          {
+            "type": "parsteel",
+            "value": 5731040000
           }
         ]
       },
@@ -1511,33 +4430,150 @@
       "level": 40,
       "requirements": [
         {
-          "name": "Drydock A",
+          "name": "drydock a",
           "level": 40
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 362912,
+          "armor_pierce": 362912,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 140585,
+          "shield_pierce": 362912
+        },
+        "defense": {
+          "armor": 23930,
+          "dodge": 23930,
+          "shield_deflect": 23930
+        },
+        "health": {
+          "hull_health": 241088,
+          "shield_health": 53167
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 362912,
+            "armor_pierce": 362912,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 28117,
+            "max_damage": 26672,
+            "min_damage": 22227,
+            "shield_pierce": 362912
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 362912,
+            "armor_pierce": 362912,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 28117,
+            "max_damage": 26672,
+            "min_damage": 22227,
+            "shield_pierce": 362912
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 1,
+          "weapon_stats": {
+            "accuracy": 362912,
+            "armor_pierce": 362912,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 28117,
+            "max_damage": 26672,
+            "min_damage": 22227,
+            "shield_pierce": 362912
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 41
+        "bonus1": 41.0
       },
       "build_costs": {
         "materials": [
           {
             "type": "gas",
             "grade": 4,
-            "rarity": "common",
-            "value": 20000
+            "rarity": "uncommon",
+            "value": 4000
           },
           {
             "type": "gas",
             "grade": 4,
-            "rarity": "uncommon",
-            "value": 4000
+            "rarity": "common",
+            "value": 20000
           }
         ],
         "others": [],
         "resources": [
+          {
+            "type": "dilithium",
+            "value": 8600000
+          },
           {
             "type": "parsteel",
             "value": 5848000000
@@ -1545,10 +4581,6 @@
           {
             "type": "tritanium",
             "value": 86000000
-          },
-          {
-            "type": "dilithium",
-            "value": 8600000
           }
         ]
       },
@@ -1557,15 +4589,128 @@
       "level": 41,
       "requirements": [
         {
-          "name": "Drydock A",
+          "name": "drydock a",
           "level": 41
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 393258,
+          "armor_pierce": 393258,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 152343,
+          "shield_pierce": 393258
+        },
+        "defense": {
+          "armor": 25931,
+          "dodge": 26457,
+          "shield_deflect": 26457
+        },
+        "health": {
+          "hull_health": 261247,
+          "shield_health": 58781
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 393258,
+            "armor_pierce": 393258,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 30469,
+            "max_damage": 28903,
+            "min_damage": 24086,
+            "shield_pierce": 393258
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 393258,
+            "armor_pierce": 393258,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 30469,
+            "max_damage": 28903,
+            "min_damage": 24086,
+            "shield_pierce": 393258
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 1,
+          "weapon_stats": {
+            "accuracy": 393258,
+            "armor_pierce": 393258,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 30469,
+            "max_damage": 28903,
+            "min_damage": 24086,
+            "shield_pierce": 393258
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 42
+        "bonus1": 42.0
       },
       "build_costs": {
         "materials": [
@@ -1585,12 +4730,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 8710800000
-          },
-          {
             "type": "tritanium",
             "value": 128100000
+          },
+          {
+            "type": "parsteel",
+            "value": 8710800000
           },
           {
             "type": "dilithium",
@@ -1603,15 +4748,128 @@
       "level": 42,
       "requirements": [
         {
-          "name": "Drydock A",
+          "name": "drydock a",
           "level": 42
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 426142,
+          "armor_pierce": 426142,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 165083,
+          "shield_pierce": 426142
+        },
+        "defense": {
+          "armor": 28099,
+          "dodge": 29251,
+          "shield_deflect": 29251
+        },
+        "health": {
+          "hull_health": 283092,
+          "shield_health": 64988
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 426142,
+            "armor_pierce": 426142,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 33016,
+            "max_damage": 31320,
+            "min_damage": 26100,
+            "shield_pierce": 426142
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 426142,
+            "armor_pierce": 426142,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 33016,
+            "max_damage": 31320,
+            "min_damage": 26100,
+            "shield_pierce": 426142
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 1,
+          "weapon_stats": {
+            "accuracy": 426142,
+            "armor_pierce": 426142,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 33016,
+            "max_damage": 31320,
+            "min_damage": 26100,
+            "shield_pierce": 426142
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 43
+        "bonus1": 43.0
       },
       "build_costs": {
         "materials": [
@@ -1631,16 +4889,16 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 12444000000
+            "type": "dilithium",
+            "value": 18300000
           },
           {
             "type": "tritanium",
             "value": 183000000
           },
           {
-            "type": "dilithium",
-            "value": 18300000
+            "type": "parsteel",
+            "value": 12444000000
           }
         ]
       },
@@ -1649,15 +4907,128 @@
       "level": 43,
       "requirements": [
         {
-          "name": "Drydock A",
+          "name": "drydock a",
           "level": 43
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 461775,
+          "armor_pierce": 461775,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 178883,
+          "shield_pierce": 461775
+        },
+        "defense": {
+          "armor": 30449,
+          "dodge": 32339,
+          "shield_deflect": 32339
+        },
+        "health": {
+          "hull_health": 306764,
+          "shield_health": 71850
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 461775,
+            "armor_pierce": 461775,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 35776,
+            "max_damage": 33938,
+            "min_damage": 28282,
+            "shield_pierce": 461775
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 461775,
+            "armor_pierce": 461775,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 35776,
+            "max_damage": 33938,
+            "min_damage": 28282,
+            "shield_pierce": 461775
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 1,
+          "weapon_stats": {
+            "accuracy": 461775,
+            "armor_pierce": 461775,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 35776,
+            "max_damage": 33938,
+            "min_damage": 28282,
+            "shield_pierce": 461775
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 44
+        "bonus1": 44.0
       },
       "build_costs": {
         "materials": [
@@ -1675,12 +5046,12 @@
             "value": 18666000000
           },
           {
-            "type": "tritanium",
-            "value": 274500000
-          },
-          {
             "type": "dilithium",
             "value": 27450000
+          },
+          {
+            "type": "tritanium",
+            "value": 274500000
           }
         ]
       },
@@ -1689,44 +5060,157 @@
       "level": 44,
       "requirements": [
         {
-          "name": "Drydock A",
+          "name": "drydock a",
           "level": 44
         },
         {
-          "name": "Defense Technologies",
+          "name": "defense technologies",
           "level": 44
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 500387,
+          "armor_pierce": 500387,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 193841,
+          "shield_pierce": 500387
+        },
+        "defense": {
+          "armor": 32995,
+          "dodge": 35754,
+          "shield_deflect": 35754
+        },
+        "health": {
+          "hull_health": 332415,
+          "shield_health": 79437
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 500387,
+            "armor_pierce": 500387,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 38768,
+            "max_damage": 36776,
+            "min_damage": 30647,
+            "shield_pierce": 500387
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 500387,
+            "armor_pierce": 500387,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 38768,
+            "max_damage": 36776,
+            "min_damage": 30647,
+            "shield_pierce": 500387
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 1,
+          "weapon_stats": {
+            "accuracy": 500387,
+            "armor_pierce": 500387,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 38768,
+            "max_damage": 36776,
+            "min_damage": 30647,
+            "shield_pierce": 500387
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 45
+        "bonus1": 45.0
       },
       "build_costs": {
         "materials": [
           {
             "type": "gas",
             "grade": 4,
-            "rarity": "common",
-            "value": 15000
+            "rarity": "rare",
+            "value": 1000
           },
           {
             "type": "gas",
             "grade": 4,
-            "rarity": "rare",
-            "value": 1000
+            "rarity": "common",
+            "value": 15000
           }
         ],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 26520000000
-          },
-          {
             "type": "tritanium",
             "value": 390000000
+          },
+          {
+            "type": "parsteel",
+            "value": 26520000000
           },
           {
             "type": "dilithium",
@@ -1739,19 +5223,132 @@
       "level": 45,
       "requirements": [
         {
-          "name": "Defense Technologies",
+          "name": "drydock a",
           "level": 45
         },
         {
-          "name": "Drydock A",
+          "name": "defense technologies",
           "level": 45
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 542229,
+          "armor_pierce": 542229,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 210048,
+          "shield_pierce": 542229
+        },
+        "defense": {
+          "armor": 35754,
+          "dodge": 39529,
+          "shield_deflect": 39529
+        },
+        "health": {
+          "hull_health": 360211,
+          "shield_health": 87825
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 542229,
+            "armor_pierce": 542229,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 42010,
+            "max_damage": 39851,
+            "min_damage": 33209,
+            "shield_pierce": 542229
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 542229,
+            "armor_pierce": 542229,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 42010,
+            "max_damage": 39851,
+            "min_damage": 33209,
+            "shield_pierce": 542229
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 1,
+          "weapon_stats": {
+            "accuracy": 542229,
+            "armor_pierce": 542229,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 42010,
+            "max_damage": 39851,
+            "min_damage": 33209,
+            "shield_pierce": 542229
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 46
+        "bonus1": 46.0
       },
       "build_costs": {
         "materials": [
@@ -1771,12 +5368,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 36465000000
-          },
-          {
             "type": "tritanium",
             "value": 536250000
+          },
+          {
+            "type": "parsteel",
+            "value": 36465000000
           },
           {
             "type": "dilithium",
@@ -1789,44 +5386,157 @@
       "level": 46,
       "requirements": [
         {
-          "name": "Drydock A",
+          "name": "drydock a",
           "level": 46
         },
         {
-          "name": "Drydock E",
+          "name": "drydock e",
           "level": 46
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 587569,
+          "armor_pierce": 587569,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 227614,
+          "shield_pierce": 587569
+        },
+        "defense": {
+          "armor": 38744,
+          "dodge": 43703,
+          "shield_deflect": 43703
+        },
+        "health": {
+          "hull_health": 390331,
+          "shield_health": 97099
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 587569,
+            "armor_pierce": 587569,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 45523,
+            "max_damage": 43184,
+            "min_damage": 35986,
+            "shield_pierce": 587569
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 587569,
+            "armor_pierce": 587569,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 45523,
+            "max_damage": 43184,
+            "min_damage": 35986,
+            "shield_pierce": 587569
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 1,
+          "weapon_stats": {
+            "accuracy": 587569,
+            "armor_pierce": 587569,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 45523,
+            "max_damage": 43184,
+            "min_damage": 35986,
+            "shield_pierce": 587569
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 47
+        "bonus1": 47.0
       },
       "build_costs": {
         "materials": [
           {
             "type": "gas",
             "grade": 4,
-            "rarity": "common",
-            "value": 45000
+            "rarity": "uncommon",
+            "value": 2500
           },
           {
             "type": "gas",
             "grade": 4,
-            "rarity": "uncommon",
-            "value": 2500
+            "rarity": "common",
+            "value": 45000
           }
         ],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 53040000000
-          },
-          {
             "type": "tritanium",
             "value": 780000000
+          },
+          {
+            "type": "parsteel",
+            "value": 53040000000
           },
           {
             "type": "dilithium",
@@ -1839,15 +5549,128 @@
       "level": 47,
       "requirements": [
         {
-          "name": "Drydock A",
+          "name": "drydock a",
           "level": 47
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 636700,
+          "armor_pierce": 636700,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 246649,
+          "shield_pierce": 636700
+        },
+        "defense": {
+          "armor": 41983,
+          "dodge": 48318,
+          "shield_deflect": 48318
+        },
+        "health": {
+          "hull_health": 422970,
+          "shield_health": 107352
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 636700,
+            "armor_pierce": 636700,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 49330,
+            "max_damage": 46795,
+            "min_damage": 38996,
+            "shield_pierce": 636700
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 636700,
+            "armor_pierce": 636700,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 49330,
+            "max_damage": 46795,
+            "min_damage": 38996,
+            "shield_pierce": 636700
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 1,
+          "weapon_stats": {
+            "accuracy": 636700,
+            "armor_pierce": 636700,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 49330,
+            "max_damage": 46795,
+            "min_damage": 38996,
+            "shield_pierce": 636700
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 48
+        "bonus1": 48.0
       },
       "build_costs": {
         "materials": [
@@ -1867,16 +5690,16 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 85680000000
+            "type": "dilithium",
+            "value": 126000000
           },
           {
             "type": "tritanium",
             "value": 1260000000
           },
           {
-            "type": "dilithium",
-            "value": 126000000
+            "type": "parsteel",
+            "value": 85680000000
           }
         ]
       },
@@ -1885,29 +5708,142 @@
       "level": 48,
       "requirements": [
         {
-          "name": "Drydock A",
+          "name": "drydock a",
           "level": 48
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 689940,
+          "armor_pierce": 689940,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 267272,
+          "shield_pierce": 689940
+        },
+        "defense": {
+          "armor": 45494,
+          "dodge": 53420,
+          "shield_deflect": 53420
+        },
+        "health": {
+          "hull_health": 458338,
+          "shield_health": 118687
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 689940,
+            "armor_pierce": 689940,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 53454,
+            "max_damage": 50708,
+            "min_damage": 42256,
+            "shield_pierce": 689940
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 689940,
+            "armor_pierce": 689940,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 53454,
+            "max_damage": 50708,
+            "min_damage": 42256,
+            "shield_pierce": 689940
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 1,
+          "weapon_stats": {
+            "accuracy": 689940,
+            "armor_pierce": 689940,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 53454,
+            "max_damage": 50708,
+            "min_damage": 42256,
+            "shield_pierce": 689940
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 49
+        "bonus1": 49.0
       },
       "build_costs": {
         "materials": [
           {
             "type": "gas",
             "grade": 4,
-            "rarity": "uncommon",
-            "value": 12000
+            "rarity": "rare",
+            "value": 4000
           },
           {
             "type": "gas",
             "grade": 4,
-            "rarity": "rare",
-            "value": 4000
+            "rarity": "uncommon",
+            "value": 12000
           }
         ],
         "others": [],
@@ -1931,35 +5867,148 @@
       "level": 49,
       "requirements": [
         {
-          "name": "Drydock E",
+          "name": "drydock a",
           "level": 49
         },
         {
-          "name": "Drydock A",
+          "name": "drydock e",
           "level": 49
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 747632,
+          "armor_pierce": 747632,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 289622,
+          "shield_pierce": 747632
+        },
+        "defense": {
+          "armor": 49298,
+          "dodge": 59061,
+          "shield_deflect": 59061
+        },
+        "health": {
+          "hull_health": 496663,
+          "shield_health": 131220
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 747632,
+            "armor_pierce": 747632,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 57924,
+            "max_damage": 54948,
+            "min_damage": 45790,
+            "shield_pierce": 747632
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 747632,
+            "armor_pierce": 747632,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 57924,
+            "max_damage": 54948,
+            "min_damage": 45790,
+            "shield_pierce": 747632
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 1,
+          "weapon_stats": {
+            "accuracy": 747632,
+            "armor_pierce": 747632,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 57924,
+            "max_damage": 54948,
+            "min_damage": 45790,
+            "shield_pierce": 747632
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 50
+        "bonus1": 50.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 249900000000
+            "type": "dilithium",
+            "value": 367500000
           },
           {
             "type": "tritanium",
             "value": 3675000000
           },
           {
-            "type": "dilithium",
-            "value": 367500000
+            "type": "parsteel",
+            "value": 249900000000
           }
         ]
       },
@@ -1968,11 +6017,923 @@
       "level": 50,
       "requirements": [
         {
-          "name": "Drydock A",
+          "name": "drydock a",
           "level": 50
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 810147,
+          "armor_pierce": 810147,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 313835,
+          "shield_pierce": 810147
+        },
+        "defense": {
+          "armor": 53420,
+          "dodge": 65297,
+          "shield_deflect": 65297
+        },
+        "health": {
+          "hull_health": 538193,
+          "shield_health": 145076
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 810147,
+            "armor_pierce": 810147,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 62767,
+            "max_damage": 59542,
+            "min_damage": 49618,
+            "shield_pierce": 810147
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 810147,
+            "armor_pierce": 810147,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 62767,
+            "max_damage": 59542,
+            "min_damage": 49618,
+            "shield_pierce": 810147
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 1,
+          "weapon_stats": {
+            "accuracy": 810147,
+            "armor_pierce": 810147,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 62767,
+            "max_damage": 59542,
+            "min_damage": 49618,
+            "shield_pierce": 810147
+          },
+          "weapon_type": "energy"
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 51.0
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "gas",
+            "grade": 5,
+            "rarity": "uncommon",
+            "value": 1900
+          },
+          {
+            "type": "gas",
+            "grade": 5,
+            "rarity": "common",
+            "value": 21700
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 7800000000
+          },
+          {
+            "type": "parsteel",
+            "value": 1246440000000
+          },
+          {
+            "type": "dilithium",
+            "value": 780000000
+          }
+        ]
+      },
+      "build_time": 104346720,
+      "increased_power": 1216045,
+      "level": 51,
+      "requirements": [
+        {
+          "name": "drydock a",
+          "level": 51
+        }
+      ],
+      "stats": {
+        "attack": {
+          "accuracy": 931669,
+          "armor_pierce": 931669,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 360910,
+          "shield_pierce": 931669
+        },
+        "defense": {
+          "armor": 75092,
+          "dodge": 75092,
+          "shield_deflect": 75092
+        },
+        "health": {
+          "hull_health": 618922,
+          "shield_health": 166837
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 931669,
+            "armor_pierce": 931669,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 72182,
+            "max_damage": 68473,
+            "min_damage": 57061,
+            "shield_pierce": 931669
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 931669,
+            "armor_pierce": 931669,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 72182,
+            "max_damage": 68473,
+            "min_damage": 57061,
+            "shield_pierce": 931669
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 1,
+          "weapon_stats": {
+            "accuracy": 931669,
+            "armor_pierce": 931669,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 72182,
+            "max_damage": 68473,
+            "min_damage": 57061,
+            "shield_pierce": 931669
+          },
+          "weapon_type": "energy"
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 52.0
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "gas",
+            "grade": 5,
+            "rarity": "common",
+            "value": 37500
+          },
+          {
+            "type": "gas",
+            "grade": 5,
+            "rarity": "uncommon",
+            "value": 4300
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "dilithium",
+            "value": 1326000000
+          },
+          {
+            "type": "parsteel",
+            "value": 2254200000000
+          },
+          {
+            "type": "tritanium",
+            "value": 13260000000
+          }
+        ]
+      },
+      "build_time": 110606400,
+      "increased_power": 2571112,
+      "level": 52,
+      "requirements": [
+        {
+          "name": "drydock a",
+          "level": 52
+        }
+      ],
+      "stats": {
+        "attack": {
+          "accuracy": 1174713,
+          "armor_pierce": 1174713,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 712868,
+          "shield_pierce": 1174713
+        },
+        "defense": {
+          "armor": 94681,
+          "dodge": 94681,
+          "shield_deflect": 94681
+        },
+        "health": {
+          "hull_health": 780380,
+          "shield_health": 210360
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 1174713,
+            "armor_pierce": 1174713,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 142574,
+            "max_damage": 161618,
+            "min_damage": 86336,
+            "shield_pierce": 1174713
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 1174713,
+            "armor_pierce": 1174713,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 142574,
+            "max_damage": 161618,
+            "min_damage": 86336,
+            "shield_pierce": 1174713
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 1,
+          "weapon_stats": {
+            "accuracy": 1174713,
+            "armor_pierce": 1174713,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 142574,
+            "max_damage": 161618,
+            "min_damage": 86336,
+            "shield_pierce": 1174713
+          },
+          "weapon_type": "energy"
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 53.0
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "gas",
+            "grade": 5,
+            "rarity": "common",
+            "value": 88900
+          },
+          {
+            "type": "gas",
+            "grade": 5,
+            "rarity": "uncommon",
+            "value": 15500
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 3786240000000
+          },
+          {
+            "type": "tritanium",
+            "value": 23200000000
+          },
+          {
+            "type": "dilithium",
+            "value": 2320000000
+          }
+        ]
+      },
+      "build_time": 117243360,
+      "increased_power": 9914492,
+      "level": 53,
+      "requirements": [
+        {
+          "name": "drydock a",
+          "level": 53
+        }
+      ],
+      "stats": {
+        "attack": {
+          "accuracy": 2187397,
+          "armor_pierce": 2187397,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 1380871,
+          "shield_pierce": 2187397
+        },
+        "defense": {
+          "armor": 176302,
+          "dodge": 176302,
+          "shield_deflect": 176302
+        },
+        "health": {
+          "hull_health": 1453121,
+          "shield_health": 391705
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 2187397,
+            "armor_pierce": 2187397,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 276174,
+            "max_damage": 319540,
+            "min_damage": 160763,
+            "shield_pierce": 2187397
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 2187397,
+            "armor_pierce": 2187397,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 276174,
+            "max_damage": 319540,
+            "min_damage": 160763,
+            "shield_pierce": 2187397
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 1,
+          "weapon_stats": {
+            "accuracy": 2187397,
+            "armor_pierce": 2187397,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 276174,
+            "max_damage": 319540,
+            "min_damage": 160763,
+            "shield_pierce": 2187397
+          },
+          "weapon_type": "energy"
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 54.0
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "gas",
+            "grade": 5,
+            "rarity": "common",
+            "value": 76500
+          },
+          {
+            "type": "gas",
+            "grade": 5,
+            "rarity": "rare",
+            "value": 7000
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 5679360000000
+          },
+          {
+            "type": "dilithium",
+            "value": 3480000000
+          },
+          {
+            "type": "tritanium",
+            "value": 34800000000
+          }
+        ]
+      },
+      "build_time": 124277760,
+      "increased_power": 2449504,
+      "level": 54,
+      "requirements": [
+        {
+          "name": "drydock a",
+          "level": 54
+        },
+        {
+          "name": "defense technologies",
+          "level": 54
+        }
+      ],
+      "stats": {
+        "attack": {
+          "accuracy": 2430441,
+          "armor_pierce": 2430441,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 1611219,
+          "shield_pierce": 2430441
+        },
+        "defense": {
+          "armor": 195891,
+          "dodge": 195891,
+          "shield_deflect": 195891
+        },
+        "health": {
+          "hull_health": 1614579,
+          "shield_health": 435228
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 2430441,
+            "armor_pierce": 2430441,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 322244,
+            "max_damage": 381798,
+            "min_damage": 178626,
+            "shield_pierce": 2430441
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 2430441,
+            "armor_pierce": 2430441,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 322244,
+            "max_damage": 381798,
+            "min_damage": 178626,
+            "shield_pierce": 2430441
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 1,
+          "weapon_stats": {
+            "accuracy": 2430441,
+            "armor_pierce": 2430441,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 322244,
+            "max_damage": 381798,
+            "min_damage": 178626,
+            "shield_pierce": 2430441
+          },
+          "weapon_type": "energy"
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 55.0
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "gas",
+            "grade": 5,
+            "rarity": "uncommon",
+            "value": 22300
+          },
+          {
+            "type": "gas",
+            "grade": 5,
+            "rarity": "rare",
+            "value": 8100
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 54600000000
+          },
+          {
+            "type": "dilithium",
+            "value": 5460000000
+          },
+          {
+            "type": "parsteel",
+            "value": 9653280000000
+          }
+        ]
+      },
+      "build_time": 131734080,
+      "increased_power": 4869860,
+      "level": 55,
+      "requirements": [
+        {
+          "name": "drydock a",
+          "level": 55
+        }
+      ],
+      "stats": {
+        "attack": {
+          "accuracy": 2916529,
+          "armor_pierce": 2916529,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 2042768,
+          "shield_pierce": 2916529
+        },
+        "defense": {
+          "armor": 235069,
+          "dodge": 235069,
+          "shield_deflect": 235069
+        },
+        "health": {
+          "hull_health": 1937495,
+          "shield_health": 522274
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 2916529,
+            "armor_pierce": 2916529,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 408554,
+            "max_damage": 496177,
+            "min_damage": 214351,
+            "shield_pierce": 2916529
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 2916529,
+            "armor_pierce": 2916529,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 408554,
+            "max_damage": 496177,
+            "min_damage": 214351,
+            "shield_pierce": 2916529
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 1,
+          "weapon_stats": {
+            "accuracy": 2916529,
+            "armor_pierce": 2916529,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 408554,
+            "max_damage": 496177,
+            "min_damage": 214351,
+            "shield_pierce": 2916529
+          },
+          "weapon_type": "energy"
+        }
+      ]
     }
   ]
 }

--- a/buildings/defense_platform_b.json
+++ b/buildings/defense_platform_b.json
@@ -2,7 +2,7 @@
   "description": "Defense Platforms are the last line of Defense for the Station. Behind defending ships they provide additional fire support. Upgrade to increase the Platform's combat performance.",
   "bonuses": {
     "bonus1": {
-      "name": "Power Level",
+      "name": "power level",
       "percentage": false
     }
   },
@@ -10,7 +10,7 @@
   "levels": [
     {
       "bonuses": {
-        "bonus1": 1
+        "bonus1": 1.0
       },
       "build_costs": {
         "materials": [],
@@ -21,12 +21,12 @@
             "value": 136
           },
           {
-            "type": "tritanium",
-            "value": 500
-          },
-          {
             "type": "dilithium",
             "value": 50
+          },
+          {
+            "type": "tritanium",
+            "value": 500
           }
         ]
       },
@@ -35,20 +35,75 @@
       "level": 1,
       "requirements": [
         {
-          "name": "Defense Platforms",
+          "name": "defense platforms",
           "level": 1
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 18,
+          "armor_pierce": 18,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 506,
+          "shield_pierce": 18
+        },
+        "defense": {
+          "armor": 9,
+          "dodge": 9,
+          "shield_deflect": 9
+        },
+        "health": {
+          "hull_health": 250,
+          "shield_health": 250
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 18,
+            "armor_pierce": 18,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 253,
+            "max_damage": 240,
+            "min_damage": 200,
+            "shield_pierce": 18
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 2
+        "bonus1": 2.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
+          {
+            "type": "dilithium",
+            "value": 40
+          },
           {
             "type": "parsteel",
             "value": 5500
@@ -56,10 +111,6 @@
           {
             "type": "tritanium",
             "value": 400
-          },
-          {
-            "type": "dilithium",
-            "value": 40
           }
         ]
       },
@@ -68,31 +119,82 @@
       "level": 2,
       "requirements": [
         {
-          "name": "Drydock B",
+          "name": "drydock b",
           "level": 2
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 19,
+          "armor_pierce": 19,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 527,
+          "shield_pierce": 19
+        },
+        "defense": {
+          "armor": 9,
+          "dodge": 9,
+          "shield_deflect": 9
+        },
+        "health": {
+          "hull_health": 270,
+          "shield_health": 270
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 19,
+            "armor_pierce": 19,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 263,
+            "max_damage": 250,
+            "min_damage": 208,
+            "shield_pierce": 19
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 3
+        "bonus1": 3.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 6250
+            "type": "dilithium",
+            "value": 42
           },
           {
             "type": "tritanium",
             "value": 420
           },
           {
-            "type": "dilithium",
-            "value": 42
+            "type": "parsteel",
+            "value": 6250
           }
         ]
       },
@@ -101,27 +203,78 @@
       "level": 3,
       "requirements": [
         {
-          "name": "Drydock B",
+          "name": "drydock b",
           "level": 3
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 27,
+          "armor_pierce": 27,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 587,
+          "shield_pierce": 27
+        },
+        "defense": {
+          "armor": 14,
+          "dodge": 14,
+          "shield_deflect": 14
+        },
+        "health": {
+          "hull_health": 290,
+          "shield_health": 290
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 27,
+            "armor_pierce": 27,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 293,
+            "max_damage": 278,
+            "min_damage": 232,
+            "shield_pierce": 27
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 4
+        "bonus1": 4.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 7000
-          },
-          {
             "type": "tritanium",
             "value": 440
+          },
+          {
+            "type": "parsteel",
+            "value": 7000
           },
           {
             "type": "dilithium",
@@ -134,31 +287,82 @@
       "level": 4,
       "requirements": [
         {
-          "name": "Drydock B",
+          "name": "drydock b",
           "level": 4
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 36,
+          "armor_pierce": 36,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 662,
+          "shield_pierce": 36
+        },
+        "defense": {
+          "armor": 18,
+          "dodge": 18,
+          "shield_deflect": 18
+        },
+        "health": {
+          "hull_health": 360,
+          "shield_health": 360
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 36,
+            "armor_pierce": 36,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 331,
+            "max_damage": 314,
+            "min_damage": 262,
+            "shield_pierce": 36
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 5
+        "bonus1": 5.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 7750
+            "type": "dilithium",
+            "value": 46
           },
           {
             "type": "tritanium",
             "value": 460
           },
           {
-            "type": "dilithium",
-            "value": 46
+            "type": "parsteel",
+            "value": 7750
           }
         ]
       },
@@ -167,15 +371,66 @@
       "level": 5,
       "requirements": [
         {
-          "name": "Drydock B",
+          "name": "drydock b",
           "level": 5
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 46,
+          "armor_pierce": 46,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 818,
+          "shield_pierce": 46
+        },
+        "defense": {
+          "armor": 23,
+          "dodge": 23,
+          "shield_deflect": 23
+        },
+        "health": {
+          "hull_health": 500,
+          "shield_health": 500
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 46,
+            "armor_pierce": 46,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 409,
+            "max_damage": 388,
+            "min_damage": 323,
+            "shield_pierce": 46
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 6
+        "bonus1": 6.0
       },
       "build_costs": {
         "materials": [],
@@ -186,12 +441,12 @@
             "value": 8500
           },
           {
-            "type": "tritanium",
-            "value": 480
-          },
-          {
             "type": "dilithium",
             "value": 48
+          },
+          {
+            "type": "tritanium",
+            "value": 480
           }
         ]
       },
@@ -200,31 +455,82 @@
       "level": 6,
       "requirements": [
         {
-          "name": "Drydock B",
+          "name": "drydock b",
           "level": 6
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 63,
+          "armor_pierce": 63,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 1045,
+          "shield_pierce": 63
+        },
+        "defense": {
+          "armor": 32,
+          "dodge": 32,
+          "shield_deflect": 32
+        },
+        "health": {
+          "hull_health": 660,
+          "shield_health": 660
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 63,
+            "armor_pierce": 63,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 523,
+            "max_damage": 496,
+            "min_damage": 413,
+            "shield_pierce": 63
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 7
+        "bonus1": 7.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 9250
+            "type": "dilithium",
+            "value": 50
           },
           {
             "type": "tritanium",
             "value": 500
           },
           {
-            "type": "dilithium",
-            "value": 50
+            "type": "parsteel",
+            "value": 9250
           }
         ]
       },
@@ -233,27 +539,78 @@
       "level": 7,
       "requirements": [
         {
-          "name": "Drydock B",
+          "name": "drydock b",
           "level": 7
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 94,
+          "armor_pierce": 94,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 1298,
+          "shield_pierce": 94
+        },
+        "defense": {
+          "armor": 47,
+          "dodge": 47,
+          "shield_deflect": 47
+        },
+        "health": {
+          "hull_health": 960,
+          "shield_health": 960
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 94,
+            "armor_pierce": 94,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 649,
+            "max_damage": 616,
+            "min_damage": 513,
+            "shield_pierce": 94
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 8
+        "bonus1": 8.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 10000
-          },
-          {
             "type": "tritanium",
             "value": 520
+          },
+          {
+            "type": "parsteel",
+            "value": 10000
           },
           {
             "type": "dilithium",
@@ -266,20 +623,75 @@
       "level": 8,
       "requirements": [
         {
-          "name": "Drydock B",
+          "name": "drydock b",
           "level": 8
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 138,
+          "armor_pierce": 138,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 1948,
+          "shield_pierce": 138
+        },
+        "defense": {
+          "armor": 69,
+          "dodge": 69,
+          "shield_deflect": 69
+        },
+        "health": {
+          "hull_health": 1370,
+          "shield_health": 1370
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 138,
+            "armor_pierce": 138,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 974,
+            "max_damage": 924,
+            "min_damage": 770,
+            "shield_pierce": 138
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 9
+        "bonus1": 9.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
+          {
+            "type": "dilithium",
+            "value": 54
+          },
           {
             "type": "parsteel",
             "value": 11000
@@ -287,10 +699,6 @@
           {
             "type": "tritanium",
             "value": 540
-          },
-          {
-            "type": "dilithium",
-            "value": 54
           }
         ]
       },
@@ -299,31 +707,82 @@
       "level": 9,
       "requirements": [
         {
-          "name": "Drydock B",
+          "name": "drydock b",
           "level": 9
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 200,
+          "armor_pierce": 200,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 2728,
+          "shield_pierce": 200
+        },
+        "defense": {
+          "armor": 100,
+          "dodge": 100,
+          "shield_deflect": 100
+        },
+        "health": {
+          "hull_health": 2020,
+          "shield_health": 2020
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 200,
+            "armor_pierce": 200,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 1364,
+            "max_damage": 1294,
+            "min_damage": 1078,
+            "shield_pierce": 200
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 10
+        "bonus1": 10.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 12500
+            "type": "dilithium",
+            "value": 60
           },
           {
             "type": "tritanium",
             "value": 600
           },
           {
-            "type": "dilithium",
-            "value": 60
+            "type": "parsteel",
+            "value": 12500
           }
         ]
       },
@@ -332,27 +791,109 @@
       "level": 10,
       "requirements": [
         {
-          "name": "Drydock B",
+          "name": "drydock b",
           "level": 10
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 236,
+          "armor_pierce": 236,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 3503,
+          "shield_pierce": 236
+        },
+        "defense": {
+          "armor": 131,
+          "dodge": 131,
+          "shield_deflect": 131
+        },
+        "health": {
+          "hull_health": 2560,
+          "shield_health": 2560
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 236,
+            "armor_pierce": 236,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 1168,
+            "max_damage": 1108,
+            "min_damage": 923,
+            "shield_pierce": 236
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 1,
+          "weapon_stats": {
+            "accuracy": 236,
+            "armor_pierce": 236,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 1168,
+            "max_damage": 1108,
+            "min_damage": 923,
+            "shield_pierce": 236
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 11
+        "bonus1": 11.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 13600
-          },
-          {
             "type": "tritanium",
             "value": 400
+          },
+          {
+            "type": "parsteel",
+            "value": 13600
           },
           {
             "type": "dilithium",
@@ -365,20 +906,106 @@
       "level": 11,
       "requirements": [
         {
-          "name": "Drydock B",
+          "name": "drydock b",
           "level": 11
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 260,
+          "armor_pierce": 260,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 4782,
+          "shield_pierce": 260
+        },
+        "defense": {
+          "armor": 153,
+          "dodge": 153,
+          "shield_deflect": 153
+        },
+        "health": {
+          "hull_health": 2740,
+          "shield_health": 2740
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 260,
+            "armor_pierce": 260,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 1594,
+            "max_damage": 1512,
+            "min_damage": 1260,
+            "shield_pierce": 260
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 1,
+          "weapon_stats": {
+            "accuracy": 260,
+            "armor_pierce": 260,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 1594,
+            "max_damage": 1512,
+            "min_damage": 1260,
+            "shield_pierce": 260
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 12
+        "bonus1": 12.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
+          {
+            "type": "dilithium",
+            "value": 22
+          },
           {
             "type": "parsteel",
             "value": 18700
@@ -386,10 +1013,6 @@
           {
             "type": "tritanium",
             "value": 550
-          },
-          {
-            "type": "dilithium",
-            "value": 22
           }
         ]
       },
@@ -398,35 +1021,117 @@
       "level": 12,
       "requirements": [
         {
-          "name": "Defense Platform A",
+          "name": "drydock b",
           "level": 12
         },
         {
-          "name": "Drydock B",
+          "name": "defense platform a",
           "level": 12
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 340,
+          "armor_pierce": 340,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 5142,
+          "shield_pierce": 340
+        },
+        "defense": {
+          "armor": 213,
+          "dodge": 213,
+          "shield_deflect": 213
+        },
+        "health": {
+          "hull_health": 2880,
+          "shield_health": 2880
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 340,
+            "armor_pierce": 340,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 1714,
+            "max_damage": 1626,
+            "min_damage": 1355,
+            "shield_pierce": 340
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 1,
+          "weapon_stats": {
+            "accuracy": 340,
+            "armor_pierce": 340,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 1714,
+            "max_damage": 1626,
+            "min_damage": 1355,
+            "shield_pierce": 340
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 13
+        "bonus1": 13.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 27200
+            "type": "dilithium",
+            "value": 48
           },
           {
             "type": "tritanium",
             "value": 800
           },
           {
-            "type": "dilithium",
-            "value": 48
+            "type": "parsteel",
+            "value": 27200
           }
         ]
       },
@@ -435,27 +1140,109 @@
       "level": 13,
       "requirements": [
         {
-          "name": "Drydock B",
+          "name": "drydock b",
           "level": 13
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 438,
+          "armor_pierce": 438,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 5572,
+          "shield_pierce": 438
+        },
+        "defense": {
+          "armor": 274,
+          "dodge": 274,
+          "shield_deflect": 274
+        },
+        "health": {
+          "hull_health": 3350,
+          "shield_health": 3350
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 438,
+            "armor_pierce": 438,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 1857,
+            "max_damage": 1762,
+            "min_damage": 1468,
+            "shield_pierce": 438
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 1,
+          "weapon_stats": {
+            "accuracy": 438,
+            "armor_pierce": 438,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 1857,
+            "max_damage": 1762,
+            "min_damage": 1468,
+            "shield_pierce": 438
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 14
+        "bonus1": 14.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 37400
-          },
-          {
             "type": "tritanium",
             "value": 1100
+          },
+          {
+            "type": "parsteel",
+            "value": 37400
           },
           {
             "type": "dilithium",
@@ -468,20 +1255,106 @@
       "level": 14,
       "requirements": [
         {
-          "name": "Drydock B",
+          "name": "drydock b",
           "level": 14
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 454,
+          "armor_pierce": 454,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 5730,
+          "shield_pierce": 454
+        },
+        "defense": {
+          "armor": 371,
+          "dodge": 371,
+          "shield_deflect": 371
+        },
+        "health": {
+          "hull_health": 3460,
+          "shield_health": 3460
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 454,
+            "armor_pierce": 454,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 1910,
+            "max_damage": 1812,
+            "min_damage": 1510,
+            "shield_pierce": 454
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 1,
+          "weapon_stats": {
+            "accuracy": 454,
+            "armor_pierce": 454,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 1910,
+            "max_damage": 1812,
+            "min_damage": 1510,
+            "shield_pierce": 454
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 15
+        "bonus1": 15.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
+          {
+            "type": "dilithium",
+            "value": 150
+          },
           {
             "type": "parsteel",
             "value": 51000
@@ -489,10 +1362,6 @@
           {
             "type": "tritanium",
             "value": 1500
-          },
-          {
-            "type": "dilithium",
-            "value": 150
           }
         ]
       },
@@ -501,20 +1370,106 @@
       "level": 15,
       "requirements": [
         {
-          "name": "Drydock B",
+          "name": "drydock b",
           "level": 15
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 475,
+          "armor_pierce": 475,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 5863,
+          "shield_pierce": 475
+        },
+        "defense": {
+          "armor": 400,
+          "dodge": 400,
+          "shield_deflect": 400
+        },
+        "health": {
+          "hull_health": 3730,
+          "shield_health": 3730
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 475,
+            "armor_pierce": 475,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 1954,
+            "max_damage": 1854,
+            "min_damage": 1545,
+            "shield_pierce": 475
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 1,
+          "weapon_stats": {
+            "accuracy": 475,
+            "armor_pierce": 475,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 1954,
+            "max_damage": 1854,
+            "min_damage": 1545,
+            "shield_pierce": 475
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 16
+        "bonus1": 16.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
+          {
+            "type": "dilithium",
+            "value": 200
+          },
           {
             "type": "parsteel",
             "value": 68000
@@ -522,10 +1477,6 @@
           {
             "type": "tritanium",
             "value": 2000
-          },
-          {
-            "type": "dilithium",
-            "value": 200
           }
         ]
       },
@@ -534,15 +1485,97 @@
       "level": 16,
       "requirements": [
         {
-          "name": "Drydock B",
+          "name": "drydock b",
           "level": 16
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 556,
+          "armor_pierce": 556,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 7476,
+          "shield_pierce": 556
+        },
+        "defense": {
+          "armor": 479,
+          "dodge": 479,
+          "shield_deflect": 479
+        },
+        "health": {
+          "hull_health": 4750,
+          "shield_health": 4750
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 556,
+            "armor_pierce": 556,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 2492,
+            "max_damage": 2364,
+            "min_damage": 1970,
+            "shield_pierce": 556
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 1,
+          "weapon_stats": {
+            "accuracy": 556,
+            "armor_pierce": 556,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 2492,
+            "max_damage": 2364,
+            "min_damage": 1970,
+            "shield_pierce": 556
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 17
+        "bonus1": 17.0
       },
       "build_costs": {
         "materials": [
@@ -556,12 +1589,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 95200
-          },
-          {
             "type": "tritanium",
             "value": 2800
+          },
+          {
+            "type": "parsteel",
+            "value": 95200
           },
           {
             "type": "dilithium",
@@ -574,15 +1607,97 @@
       "level": 17,
       "requirements": [
         {
-          "name": "Drydock B",
+          "name": "drydock b",
           "level": 17
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 649,
+          "armor_pierce": 649,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 8779,
+          "shield_pierce": 649
+        },
+        "defense": {
+          "armor": 535,
+          "dodge": 535,
+          "shield_deflect": 535
+        },
+        "health": {
+          "hull_health": 5620,
+          "shield_health": 5620
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 649,
+            "armor_pierce": 649,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 2926,
+            "max_damage": 2776,
+            "min_damage": 2313,
+            "shield_pierce": 649
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 1,
+          "weapon_stats": {
+            "accuracy": 649,
+            "armor_pierce": 649,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 2926,
+            "max_damage": 2776,
+            "min_damage": 2313,
+            "shield_pierce": 649
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 18
+        "bonus1": 18.0
       },
       "build_costs": {
         "materials": [
@@ -600,12 +1715,12 @@
             "value": 136000
           },
           {
-            "type": "tritanium",
-            "value": 4000
-          },
-          {
             "type": "dilithium",
             "value": 400
+          },
+          {
+            "type": "tritanium",
+            "value": 4000
           }
         ]
       },
@@ -614,15 +1729,97 @@
       "level": 18,
       "requirements": [
         {
-          "name": "Drydock B",
+          "name": "drydock b",
           "level": 18
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 672,
+          "armor_pierce": 672,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 10265,
+          "shield_pierce": 672
+        },
+        "defense": {
+          "armor": 560,
+          "dodge": 560,
+          "shield_deflect": 560
+        },
+        "health": {
+          "hull_health": 6120,
+          "shield_health": 6120
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 672,
+            "armor_pierce": 672,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 3422,
+            "max_damage": 3246,
+            "min_damage": 2705,
+            "shield_pierce": 672
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 1,
+          "weapon_stats": {
+            "accuracy": 672,
+            "armor_pierce": 672,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 3422,
+            "max_damage": 3246,
+            "min_damage": 2705,
+            "shield_pierce": 672
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 19
+        "bonus1": 19.0
       },
       "build_costs": {
         "materials": [
@@ -636,16 +1833,16 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 204000
+            "type": "dilithium",
+            "value": 600
           },
           {
             "type": "tritanium",
             "value": 6000
           },
           {
-            "type": "dilithium",
-            "value": 600
+            "type": "parsteel",
+            "value": 204000
           }
         ]
       },
@@ -654,24 +1851,102 @@
       "level": 19,
       "requirements": [
         {
-          "name": "Drydock B",
+          "name": "drydock b",
           "level": 19
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 2023,
+          "armor_pierce": 2023,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 10823,
+          "shield_pierce": 2023
+        },
+        "defense": {
+          "armor": 674,
+          "dodge": 674,
+          "shield_deflect": 674
+        },
+        "health": {
+          "hull_health": 6500,
+          "shield_health": 6500
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 2023,
+            "armor_pierce": 2023,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 3608,
+            "max_damage": 3422,
+            "min_damage": 2852,
+            "shield_pierce": 2023
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 1,
+          "weapon_stats": {
+            "accuracy": 2023,
+            "armor_pierce": 2023,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 3608,
+            "max_damage": 3422,
+            "min_damage": 2852,
+            "shield_pierce": 2023
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 20
+        "bonus1": 20.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
-          {
-            "type": "parsteel",
-            "value": 289000
-          },
           {
             "type": "tritanium",
             "value": 8500
@@ -679,6 +1954,10 @@
           {
             "type": "dilithium",
             "value": 850
+          },
+          {
+            "type": "parsteel",
+            "value": 289000
           }
         ]
       },
@@ -687,19 +1966,101 @@
       "level": 20,
       "requirements": [
         {
-          "name": "Defense Technologies",
+          "name": "drydock b",
           "level": 20
         },
         {
-          "name": "Drydock B",
+          "name": "defense technologies",
           "level": 20
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 2755,
+          "armor_pierce": 2755,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 11173,
+          "shield_pierce": 2755
+        },
+        "defense": {
+          "armor": 689,
+          "dodge": 689,
+          "shield_deflect": 689
+        },
+        "health": {
+          "hull_health": 9860,
+          "shield_health": 6570
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 2755,
+            "armor_pierce": 2755,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 2793,
+            "max_damage": 2650,
+            "min_damage": 2208,
+            "shield_pierce": 2755
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 2755,
+            "armor_pierce": 2755,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 2793,
+            "max_damage": 2650,
+            "min_damage": 2208,
+            "shield_pierce": 2755
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 21
+        "bonus1": 21.0
       },
       "build_costs": {
         "materials": [],
@@ -724,15 +2085,97 @@
       "level": 21,
       "requirements": [
         {
-          "name": "Drydock B",
+          "name": "drydock b",
           "level": 21
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 3494,
+          "armor_pierce": 3494,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 11360,
+          "shield_pierce": 3494
+        },
+        "defense": {
+          "armor": 699,
+          "dodge": 699,
+          "shield_deflect": 699
+        },
+        "health": {
+          "hull_health": 13540,
+          "shield_health": 6770
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 3494,
+            "armor_pierce": 3494,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 2840,
+            "max_damage": 2694,
+            "min_damage": 2245,
+            "shield_pierce": 3494
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 3494,
+            "armor_pierce": 3494,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 2840,
+            "max_damage": 2694,
+            "min_damage": 2245,
+            "shield_pierce": 3494
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 22
+        "bonus1": 22.0
       },
       "build_costs": {
         "materials": [],
@@ -743,12 +2186,12 @@
             "value": 756840
           },
           {
-            "type": "tritanium",
-            "value": 22260
-          },
-          {
             "type": "dilithium",
             "value": 2226
+          },
+          {
+            "type": "tritanium",
+            "value": 22260
           }
         ]
       },
@@ -757,24 +2200,102 @@
       "level": 22,
       "requirements": [
         {
-          "name": "Drydock B",
+          "name": "drydock b",
           "level": 22
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 35000,
+          "armor_pierce": 35000,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 17528,
+          "shield_pierce": 35000
+        },
+        "defense": {
+          "armor": 1701,
+          "dodge": 1701,
+          "shield_deflect": 1701
+        },
+        "health": {
+          "hull_health": 25246,
+          "shield_health": 6840
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 35000,
+            "armor_pierce": 35000,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 4382,
+            "max_damage": 4157,
+            "min_damage": 3464,
+            "shield_pierce": 35000
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 35000,
+            "armor_pierce": 35000,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 4382,
+            "max_damage": 4157,
+            "min_damage": 3464,
+            "shield_pierce": 35000
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 23
+        "bonus1": 23.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
-          {
-            "type": "parsteel",
-            "value": 1245420
-          },
           {
             "type": "tritanium",
             "value": 36630
@@ -782,6 +2303,10 @@
           {
             "type": "dilithium",
             "value": 3663
+          },
+          {
+            "type": "parsteel",
+            "value": 1245420
           }
         ]
       },
@@ -790,15 +2315,97 @@
       "level": 23,
       "requirements": [
         {
-          "name": "Drydock B",
+          "name": "drydock b",
           "level": 23
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 36150,
+          "armor_pierce": 37625,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 21243,
+          "shield_pierce": 37625
+        },
+        "defense": {
+          "armor": 2724,
+          "dodge": 2724,
+          "shield_deflect": 2724
+        },
+        "health": {
+          "hull_health": 25582,
+          "shield_health": 6910
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 36150,
+            "armor_pierce": 37625,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 5311,
+            "max_damage": 5038,
+            "min_damage": 4198,
+            "shield_pierce": 37625
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 36150,
+            "armor_pierce": 37625,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 5311,
+            "max_damage": 5038,
+            "min_damage": 4198,
+            "shield_pierce": 37625
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 24
+        "bonus1": 24.0
       },
       "build_costs": {
         "materials": [
@@ -830,15 +2437,97 @@
       "level": 24,
       "requirements": [
         {
-          "name": "Drydock B",
+          "name": "drydock b",
           "level": 24
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 36300,
+          "armor_pierce": 43125,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 22211,
+          "shield_pierce": 43125
+        },
+        "defense": {
+          "armor": 3571,
+          "dodge": 3571,
+          "shield_deflect": 3571
+        },
+        "health": {
+          "hull_health": 25671,
+          "shield_health": 7020
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 36300,
+            "armor_pierce": 43125,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 5553,
+            "max_damage": 5267,
+            "min_damage": 4390,
+            "shield_pierce": 43125
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 36300,
+            "armor_pierce": 43125,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 5553,
+            "max_damage": 5267,
+            "min_damage": 4390,
+            "shield_pierce": 43125
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 25
+        "bonus1": 25.0
       },
       "build_costs": {
         "materials": [
@@ -858,16 +2547,16 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 3182400
-          },
-          {
             "type": "tritanium",
             "value": 93600
           },
           {
             "type": "dilithium",
             "value": 9360
+          },
+          {
+            "type": "parsteel",
+            "value": 3182400
           }
         ]
       },
@@ -876,19 +2565,101 @@
       "level": 25,
       "requirements": [
         {
-          "name": "Defense Technologies",
+          "name": "drydock b",
           "level": 25
         },
         {
-          "name": "Drydock B",
+          "name": "defense technologies",
           "level": 25
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 36425,
+          "armor_pierce": 43750,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 27400,
+          "shield_pierce": 43750
+        },
+        "defense": {
+          "armor": 4865,
+          "dodge": 4865,
+          "shield_deflect": 4865
+        },
+        "health": {
+          "hull_health": 28013,
+          "shield_health": 7780
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 36425,
+            "armor_pierce": 43750,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 6850,
+            "max_damage": 6498,
+            "min_damage": 5415,
+            "shield_pierce": 43750
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 36425,
+            "armor_pierce": 43750,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 6850,
+            "max_damage": 6498,
+            "min_damage": 5415,
+            "shield_pierce": 43750
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 26
+        "bonus1": 26.0
       },
       "build_costs": {
         "materials": [
@@ -908,16 +2679,16 @@
         "others": [],
         "resources": [
           {
+            "type": "dilithium",
+            "value": 14625
+          },
+          {
             "type": "parsteel",
             "value": 4972500
           },
           {
             "type": "tritanium",
             "value": 146250
-          },
-          {
-            "type": "dilithium",
-            "value": 14625
           }
         ]
       },
@@ -926,15 +2697,97 @@
       "level": 26,
       "requirements": [
         {
-          "name": "Drydock B",
+          "name": "drydock b",
           "level": 26
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 38710,
+          "armor_pierce": 46875,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 28775,
+          "shield_pierce": 46875
+        },
+        "defense": {
+          "armor": 5687,
+          "dodge": 5687,
+          "shield_deflect": 5687
+        },
+        "health": {
+          "hull_health": 32009,
+          "shield_health": 9000
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 38710,
+            "armor_pierce": 46875,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 7194,
+            "max_damage": 6824,
+            "min_damage": 5687,
+            "shield_pierce": 46875
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 38710,
+            "armor_pierce": 46875,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 7194,
+            "max_damage": 6824,
+            "min_damage": 5687,
+            "shield_pierce": 46875
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 27
+        "bonus1": 27.0
       },
       "build_costs": {
         "materials": [
@@ -948,12 +2801,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 7588800
-          },
-          {
             "type": "tritanium",
             "value": 223200
+          },
+          {
+            "type": "parsteel",
+            "value": 7588800
           },
           {
             "type": "dilithium",
@@ -966,15 +2819,97 @@
       "level": 27,
       "requirements": [
         {
-          "name": "Drydock B",
+          "name": "drydock b",
           "level": 27
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 44516,
+          "armor_pierce": 57500,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 30811,
+          "shield_pierce": 57500
+        },
+        "defense": {
+          "armor": 6303,
+          "dodge": 6302,
+          "shield_deflect": 6302
+        },
+        "health": {
+          "hull_health": 40145,
+          "shield_health": 11340
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 44516,
+            "armor_pierce": 57500,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 7703,
+            "max_damage": 7307,
+            "min_damage": 6089,
+            "shield_pierce": 57500
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 44516,
+            "armor_pierce": 57500,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 7703,
+            "max_damage": 7307,
+            "min_damage": 6089,
+            "shield_pierce": 57500
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 28
+        "bonus1": 28.0
       },
       "build_costs": {
         "materials": [
@@ -988,16 +2923,16 @@
         "others": [],
         "resources": [
           {
+            "type": "dilithium",
+            "value": 33480
+          },
+          {
             "type": "parsteel",
             "value": 11383200
           },
           {
             "type": "tritanium",
             "value": 334800
-          },
-          {
-            "type": "dilithium",
-            "value": 33480
           }
         ]
       },
@@ -1006,40 +2941,122 @@
       "level": 28,
       "requirements": [
         {
-          "name": "Drydock B",
+          "name": "drydock b",
           "level": 28
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 56473,
+          "armor_pierce": 68750,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 32324,
+          "shield_pierce": 68750
+        },
+        "defense": {
+          "armor": 8052,
+          "dodge": 8052,
+          "shield_deflect": 8052
+        },
+        "health": {
+          "hull_health": 50751,
+          "shield_health": 14400
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 56473,
+            "armor_pierce": 68750,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 8081,
+            "max_damage": 7666,
+            "min_damage": 6388,
+            "shield_pierce": 68750
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 56473,
+            "armor_pierce": 68750,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 8081,
+            "max_damage": 7666,
+            "min_damage": 6388,
+            "shield_pierce": 68750
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 29
+        "bonus1": 29.0
       },
       "build_costs": {
         "materials": [
           {
             "type": "gas",
             "grade": 3,
-            "rarity": "common",
-            "value": 450
+            "rarity": "uncommon",
+            "value": 30
           },
           {
             "type": "gas",
             "grade": 3,
-            "rarity": "uncommon",
-            "value": 30
+            "rarity": "common",
+            "value": 450
           }
         ],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 18122000
-          },
-          {
             "type": "tritanium",
             "value": 533000
+          },
+          {
+            "type": "parsteel",
+            "value": 18122000
           },
           {
             "type": "dilithium",
@@ -1052,15 +3069,97 @@
       "level": 29,
       "requirements": [
         {
-          "name": "Drydock B",
+          "name": "drydock b",
           "level": 29
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 62448,
+          "armor_pierce": 74375,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 35841,
+          "shield_pierce": 74375
+        },
+        "defense": {
+          "armor": 8908,
+          "dodge": 8908,
+          "shield_deflect": 8908
+        },
+        "health": {
+          "hull_health": 59028,
+          "shield_health": 16830
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 62448,
+            "armor_pierce": 74375,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 8960,
+            "max_damage": 8500,
+            "min_damage": 7083,
+            "shield_pierce": 74375
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 62448,
+            "armor_pierce": 74375,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 8960,
+            "max_damage": 8500,
+            "min_damage": 7083,
+            "shield_pierce": 74375
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 30
+        "bonus1": 30.0
       },
       "build_costs": {
         "materials": [
@@ -1078,12 +3177,12 @@
             "value": 26520000
           },
           {
-            "type": "tritanium",
-            "value": 780000
-          },
-          {
             "type": "dilithium",
             "value": 78000
+          },
+          {
+            "type": "tritanium",
+            "value": 780000
           }
         ]
       },
@@ -1092,41 +3191,119 @@
       "level": 30,
       "requirements": [
         {
-          "name": "Defense Technologies",
+          "name": "drydock b",
           "level": 30
         },
         {
-          "name": "Drydock B",
+          "name": "defense technologies",
           "level": 30
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 77490,
+          "armor_pierce": 76125,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 37780,
+          "shield_pierce": 76125
+        },
+        "defense": {
+          "armor": 10611,
+          "dodge": 10611,
+          "shield_deflect": 10611
+        },
+        "health": {
+          "hull_health": 67494,
+          "shield_health": 17230
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 77490,
+            "armor_pierce": 76125,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 9445,
+            "max_damage": 8960,
+            "min_damage": 7466,
+            "shield_pierce": 76125
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 77490,
+            "armor_pierce": 76125,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 9445,
+            "max_damage": 8960,
+            "min_damage": 7466,
+            "shield_pierce": 76125
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 31
+        "bonus1": 31.0
       },
       "build_costs": {
         "materials": [
           {
             "type": "gas",
             "grade": 3,
-            "rarity": "common",
-            "value": 700
+            "rarity": "uncommon",
+            "value": 65
           },
           {
             "type": "gas",
             "grade": 3,
-            "rarity": "uncommon",
-            "value": 65
+            "rarity": "common",
+            "value": 700
           }
         ],
         "others": [],
         "resources": [
-          {
-            "type": "parsteel",
-            "value": 41922000
-          },
           {
             "type": "tritanium",
             "value": 1233000
@@ -1134,6 +3311,10 @@
           {
             "type": "dilithium",
             "value": 123300
+          },
+          {
+            "type": "parsteel",
+            "value": 41922000
           }
         ]
       },
@@ -1142,15 +3323,97 @@
       "level": 31,
       "requirements": [
         {
-          "name": "Drydock B",
+          "name": "drydock b",
           "level": 31
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 87436,
+          "armor_pierce": 89375,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 40278,
+          "shield_pierce": 89375
+        },
+        "defense": {
+          "armor": 12016,
+          "dodge": 12016,
+          "shield_deflect": 12016
+        },
+        "health": {
+          "hull_health": 77484,
+          "shield_health": 19910
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 87436,
+            "armor_pierce": 89375,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 10069,
+            "max_damage": 9552,
+            "min_damage": 7960,
+            "shield_pierce": 89375
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 87436,
+            "armor_pierce": 89375,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 10069,
+            "max_damage": 9552,
+            "min_damage": 7960,
+            "shield_pierce": 89375
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 32
+        "bonus1": 32.0
       },
       "build_costs": {
         "materials": [
@@ -1164,16 +3427,16 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 60554000
+            "type": "dilithium",
+            "value": 178100
           },
           {
             "type": "tritanium",
             "value": 1781000
           },
           {
-            "type": "dilithium",
-            "value": 178100
+            "type": "parsteel",
+            "value": 60554000
           }
         ]
       },
@@ -1182,15 +3445,97 @@
       "level": 32,
       "requirements": [
         {
-          "name": "Drydock B",
+          "name": "drydock b",
           "level": 32
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 91746,
+          "armor_pierce": 123750,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 45600,
+          "shield_pierce": 123750
+        },
+        "defense": {
+          "armor": 13124,
+          "dodge": 13124,
+          "shield_deflect": 13124
+        },
+        "health": {
+          "hull_health": 83090,
+          "shield_health": 20120
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 91746,
+            "armor_pierce": 123750,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 11400,
+            "max_damage": 10814,
+            "min_damage": 9012,
+            "shield_pierce": 123750
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 91746,
+            "armor_pierce": 123750,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 11400,
+            "max_damage": 10814,
+            "min_damage": 9012,
+            "shield_pierce": 123750
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 33
+        "bonus1": 33.0
       },
       "build_costs": {
         "materials": [
@@ -1204,16 +3549,16 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 93670000
+            "type": "dilithium",
+            "value": 275500
           },
           {
             "type": "tritanium",
             "value": 2755000
           },
           {
-            "type": "dilithium",
-            "value": 275500
+            "type": "parsteel",
+            "value": 93670000
           }
         ]
       },
@@ -1222,19 +3567,101 @@
       "level": 33,
       "requirements": [
         {
-          "name": "Drydock B",
+          "name": "drydock b",
           "level": 33
         },
         {
-          "name": "Defense Platform A",
+          "name": "defense platform a",
           "level": 33
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 94480,
+          "armor_pierce": 144038,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 47773,
+          "shield_pierce": 144038
+        },
+        "defense": {
+          "armor": 13560,
+          "dodge": 13560,
+          "shield_deflect": 13560
+        },
+        "health": {
+          "hull_health": 92622,
+          "shield_health": 21830
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 94480,
+            "armor_pierce": 144038,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 11943,
+            "max_damage": 11330,
+            "min_damage": 9441,
+            "shield_pierce": 144038
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 94480,
+            "armor_pierce": 144038,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 11943,
+            "max_damage": 11330,
+            "min_damage": 9441,
+            "shield_pierce": 144038
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 34
+        "bonus1": 34.0
       },
       "build_costs": {
         "materials": [
@@ -1258,12 +3685,12 @@
             "value": 147900000
           },
           {
-            "type": "tritanium",
-            "value": 4350000
-          },
-          {
             "type": "dilithium",
             "value": 435000
+          },
+          {
+            "type": "tritanium",
+            "value": 4350000
           }
         ]
       },
@@ -1272,15 +3699,97 @@
       "level": 34,
       "requirements": [
         {
-          "name": "Drydock B",
+          "name": "drydock b",
           "level": 34
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 100000,
+          "armor_pierce": 161563,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 50660,
+          "shield_pierce": 161563
+        },
+        "defense": {
+          "armor": 14845,
+          "dodge": 14845,
+          "shield_deflect": 14845
+        },
+        "health": {
+          "hull_health": 102230,
+          "shield_health": 22770
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 100000,
+            "armor_pierce": 161563,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 12665,
+            "max_damage": 12014,
+            "min_damage": 10012,
+            "shield_pierce": 161563
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 100000,
+            "armor_pierce": 161563,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 12665,
+            "max_damage": 12014,
+            "min_damage": 10012,
+            "shield_pierce": 161563
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 35
+        "bonus1": 35.0
       },
       "build_costs": {
         "materials": [
@@ -1300,12 +3809,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 228888000
-          },
-          {
             "type": "tritanium",
             "value": 6732000
+          },
+          {
+            "type": "parsteel",
+            "value": 228888000
           },
           {
             "type": "dilithium",
@@ -1318,19 +3827,101 @@
       "level": 35,
       "requirements": [
         {
-          "name": "Defense Technologies",
+          "name": "drydock b",
           "level": 35
         },
         {
-          "name": "Drydock B",
+          "name": "defense technologies",
           "level": 35
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 109796,
+          "armor_pierce": 196875,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 59319,
+          "shield_pierce": 196875
+        },
+        "defense": {
+          "armor": 16480,
+          "dodge": 16480,
+          "shield_deflect": 16480
+        },
+        "health": {
+          "hull_health": 118699,
+          "shield_health": 28350
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 109796,
+            "armor_pierce": 196875,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 14830,
+            "max_damage": 14068,
+            "min_damage": 11723,
+            "shield_pierce": 196875
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 109796,
+            "armor_pierce": 196875,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 14830,
+            "max_damage": 14068,
+            "min_damage": 11723,
+            "shield_pierce": 196875
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 36
+        "bonus1": 36.0
       },
       "build_costs": {
         "materials": [
@@ -1348,12 +3939,12 @@
             "value": 322524000
           },
           {
-            "type": "tritanium",
-            "value": 9486000
-          },
-          {
             "type": "dilithium",
             "value": 948600
+          },
+          {
+            "type": "tritanium",
+            "value": 9486000
           }
         ]
       },
@@ -1362,15 +3953,97 @@
       "level": 36,
       "requirements": [
         {
-          "name": "Drydock B",
+          "name": "drydock b",
           "level": 36
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 119489,
+          "armor_pierce": 227807,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 71792,
+          "shield_pierce": 227807
+        },
+        "defense": {
+          "armor": 17855,
+          "dodge": 17855,
+          "shield_deflect": 17855
+        },
+        "health": {
+          "hull_health": 138605,
+          "shield_health": 32610
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 119489,
+            "armor_pierce": 227807,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 17948,
+            "max_damage": 17026,
+            "min_damage": 14188,
+            "shield_pierce": 227807
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 119489,
+            "armor_pierce": 227807,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 17948,
+            "max_damage": 17026,
+            "min_damage": 14188,
+            "shield_pierce": 227807
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 37
+        "bonus1": 37.0
       },
       "build_costs": {
         "materials": [
@@ -1390,16 +4063,16 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 495720000
-          },
-          {
             "type": "tritanium",
             "value": 14580000
           },
           {
             "type": "dilithium",
             "value": 1458000
+          },
+          {
+            "type": "parsteel",
+            "value": 495720000
           }
         ]
       },
@@ -1408,15 +4081,97 @@
       "level": 37,
       "requirements": [
         {
-          "name": "Drydock B",
+          "name": "drydock b",
           "level": 37
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 132418,
+          "armor_pierce": 247922,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 77781,
+          "shield_pierce": 247922
+        },
+        "defense": {
+          "armor": 18489,
+          "dodge": 18489,
+          "shield_deflect": 18489
+        },
+        "health": {
+          "hull_health": 163789,
+          "shield_health": 35710
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 132418,
+            "armor_pierce": 247922,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 19445,
+            "max_damage": 18446,
+            "min_damage": 15372,
+            "shield_pierce": 247922
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 132418,
+            "armor_pierce": 247922,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 19445,
+            "max_damage": 18446,
+            "min_damage": 15372,
+            "shield_pierce": 247922
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 38
+        "bonus1": 38.0
       },
       "build_costs": {
         "materials": [
@@ -1436,16 +4191,16 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 771120000
-          },
-          {
             "type": "tritanium",
             "value": 22680000
           },
           {
             "type": "dilithium",
             "value": 2268000
+          },
+          {
+            "type": "parsteel",
+            "value": 771120000
           }
         ]
       },
@@ -1454,31 +4209,113 @@
       "level": 38,
       "requirements": [
         {
-          "name": "Drydock B",
+          "name": "drydock b",
           "level": 38
         },
         {
-          "name": "Defense Platform A",
+          "name": "defense platform a",
           "level": 38
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 144918,
+          "armor_pierce": 286066,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 89173,
+          "shield_pierce": 286066
+        },
+        "defense": {
+          "armor": 20112,
+          "dodge": 20112,
+          "shield_deflect": 20112
+        },
+        "health": {
+          "hull_health": 188609,
+          "shield_health": 41570
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 144918,
+            "armor_pierce": 286066,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 22293,
+            "max_damage": 21148,
+            "min_damage": 17623,
+            "shield_pierce": 286066
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 144918,
+            "armor_pierce": 286066,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 22293,
+            "max_damage": 21148,
+            "min_damage": 17623,
+            "shield_pierce": 286066
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 39
+        "bonus1": 39.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 1315800000
-          },
-          {
             "type": "tritanium",
             "value": 38700000
+          },
+          {
+            "type": "parsteel",
+            "value": 1315800000
           },
           {
             "type": "dilithium",
@@ -1491,37 +4328,123 @@
       "level": 39,
       "requirements": [
         {
-          "name": "Drydock B",
+          "name": "drydock b",
           "level": 39
         },
         {
-          "name": "Defense Platform A",
+          "name": "defense platform a",
           "level": 39
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 159412,
+          "armor_pierce": 333789,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 103443,
+          "shield_pierce": 333789
+        },
+        "defense": {
+          "armor": 22010,
+          "dodge": 22010,
+          "shield_deflect": 22010
+        },
+        "health": {
+          "hull_health": 221741,
+          "shield_health": 48900
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 159412,
+            "armor_pierce": 333789,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 25861,
+            "max_damage": 24532,
+            "min_damage": 20443,
+            "shield_pierce": 333789
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 159412,
+            "armor_pierce": 333789,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 25861,
+            "max_damage": 24532,
+            "min_damage": 20443,
+            "shield_pierce": 333789
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 40
+        "bonus1": 40.0
       },
       "build_costs": {
         "materials": [
           {
             "type": "gas",
             "grade": 4,
-            "rarity": "common",
-            "value": 10000
+            "rarity": "uncommon",
+            "value": 1400
           },
           {
             "type": "gas",
             "grade": 4,
-            "rarity": "uncommon",
-            "value": 1400
+            "rarity": "common",
+            "value": 10000
           }
         ],
         "others": [],
         "resources": [
+          {
+            "type": "dilithium",
+            "value": 6020000
+          },
           {
             "type": "parsteel",
             "value": 5731040000
@@ -1529,10 +4452,6 @@
           {
             "type": "tritanium",
             "value": 60200000
-          },
-          {
-            "type": "dilithium",
-            "value": 6020000
           }
         ]
       },
@@ -1541,29 +4460,142 @@
       "level": 40,
       "requirements": [
         {
-          "name": "Drydock B",
+          "name": "drydock b",
           "level": 40
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 362912,
+          "armor_pierce": 362912,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 140585,
+          "shield_pierce": 362912
+        },
+        "defense": {
+          "armor": 23930,
+          "dodge": 23930,
+          "shield_deflect": 23930
+        },
+        "health": {
+          "hull_health": 241088,
+          "shield_health": 53167
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 362912,
+            "armor_pierce": 362912,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 28117,
+            "max_damage": 26672,
+            "min_damage": 22227,
+            "shield_pierce": 362912
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 362912,
+            "armor_pierce": 362912,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 28117,
+            "max_damage": 26672,
+            "min_damage": 22227,
+            "shield_pierce": 362912
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 1,
+          "weapon_stats": {
+            "accuracy": 362912,
+            "armor_pierce": 362912,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 28117,
+            "max_damage": 26672,
+            "min_damage": 22227,
+            "shield_pierce": 362912
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 41
+        "bonus1": 41.0
       },
       "build_costs": {
         "materials": [
           {
             "type": "gas",
             "grade": 4,
-            "rarity": "common",
-            "value": 14000
+            "rarity": "uncommon",
+            "value": 4000
           },
           {
             "type": "gas",
             "grade": 4,
-            "rarity": "uncommon",
-            "value": 4000
+            "rarity": "common",
+            "value": 14000
           }
         ],
         "others": [],
@@ -1573,12 +4605,12 @@
             "value": 5848000000
           },
           {
-            "type": "tritanium",
-            "value": 86000000
-          },
-          {
             "type": "dilithium",
             "value": 8600000
+          },
+          {
+            "type": "tritanium",
+            "value": 86000000
           }
         ]
       },
@@ -1587,19 +4619,132 @@
       "level": 41,
       "requirements": [
         {
-          "name": "Defense Platform A",
+          "name": "drydock b",
           "level": 41
         },
         {
-          "name": "Drydock B",
+          "name": "defense platform a",
           "level": 41
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 393258,
+          "armor_pierce": 393258,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 152343,
+          "shield_pierce": 393258
+        },
+        "defense": {
+          "armor": 25931,
+          "dodge": 26457,
+          "shield_deflect": 26457
+        },
+        "health": {
+          "hull_health": 261247,
+          "shield_health": 58781
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 393258,
+            "armor_pierce": 393258,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 30469,
+            "max_damage": 28903,
+            "min_damage": 24086,
+            "shield_pierce": 393258
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 393258,
+            "armor_pierce": 393258,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 30469,
+            "max_damage": 28903,
+            "min_damage": 24086,
+            "shield_pierce": 393258
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 1,
+          "weapon_stats": {
+            "accuracy": 393258,
+            "armor_pierce": 393258,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 30469,
+            "max_damage": 28903,
+            "min_damage": 24086,
+            "shield_pierce": 393258
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 42
+        "bonus1": 42.0
       },
       "build_costs": {
         "materials": [
@@ -1623,12 +4768,12 @@
             "value": 8710800000
           },
           {
-            "type": "tritanium",
-            "value": 128100000
-          },
-          {
             "type": "dilithium",
             "value": 12810000
+          },
+          {
+            "type": "tritanium",
+            "value": 128100000
           }
         ]
       },
@@ -1637,33 +4782,150 @@
       "level": 42,
       "requirements": [
         {
-          "name": "Drydock B",
+          "name": "drydock b",
           "level": 42
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 426142,
+          "armor_pierce": 426142,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 165083,
+          "shield_pierce": 426142
+        },
+        "defense": {
+          "armor": 28099,
+          "dodge": 29251,
+          "shield_deflect": 29251
+        },
+        "health": {
+          "hull_health": 283092,
+          "shield_health": 64988
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 426142,
+            "armor_pierce": 426142,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 33016,
+            "max_damage": 31320,
+            "min_damage": 26100,
+            "shield_pierce": 426142
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 426142,
+            "armor_pierce": 426142,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 33016,
+            "max_damage": 31320,
+            "min_damage": 26100,
+            "shield_pierce": 426142
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 1,
+          "weapon_stats": {
+            "accuracy": 426142,
+            "armor_pierce": 426142,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 33016,
+            "max_damage": 31320,
+            "min_damage": 26100,
+            "shield_pierce": 426142
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 43
+        "bonus1": 43.0
       },
       "build_costs": {
         "materials": [
           {
             "type": "gas",
             "grade": 4,
-            "rarity": "uncommon",
-            "value": 6000
+            "rarity": "rare",
+            "value": 750
           },
           {
             "type": "gas",
             "grade": 4,
-            "rarity": "rare",
-            "value": 750
+            "rarity": "uncommon",
+            "value": 6000
           }
         ],
         "others": [],
         "resources": [
+          {
+            "type": "dilithium",
+            "value": 18300000
+          },
           {
             "type": "parsteel",
             "value": 12444000000
@@ -1671,10 +4933,6 @@
           {
             "type": "tritanium",
             "value": 183000000
-          },
-          {
-            "type": "dilithium",
-            "value": 18300000
           }
         ]
       },
@@ -1683,15 +4941,128 @@
       "level": 43,
       "requirements": [
         {
-          "name": "Drydock B",
+          "name": "drydock b",
           "level": 43
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 461775,
+          "armor_pierce": 461775,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 178883,
+          "shield_pierce": 461775
+        },
+        "defense": {
+          "armor": 30449,
+          "dodge": 32339,
+          "shield_deflect": 32339
+        },
+        "health": {
+          "hull_health": 306764,
+          "shield_health": 71850
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 461775,
+            "armor_pierce": 461775,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 35776,
+            "max_damage": 33938,
+            "min_damage": 28282,
+            "shield_pierce": 461775
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 461775,
+            "armor_pierce": 461775,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 35776,
+            "max_damage": 33938,
+            "min_damage": 28282,
+            "shield_pierce": 461775
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 1,
+          "weapon_stats": {
+            "accuracy": 461775,
+            "armor_pierce": 461775,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 35776,
+            "max_damage": 33938,
+            "min_damage": 28282,
+            "shield_pierce": 461775
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 44
+        "bonus1": 44.0
       },
       "build_costs": {
         "materials": [
@@ -1705,12 +5076,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 18666000000
-          },
-          {
             "type": "tritanium",
             "value": 274500000
+          },
+          {
+            "type": "parsteel",
+            "value": 18666000000
           },
           {
             "type": "dilithium",
@@ -1723,19 +5094,132 @@
       "level": 44,
       "requirements": [
         {
-          "name": "Defense Platform A",
+          "name": "drydock b",
           "level": 44
         },
         {
-          "name": "Drydock B",
+          "name": "defense platform a",
           "level": 44
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 500387,
+          "armor_pierce": 500387,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 193841,
+          "shield_pierce": 500387
+        },
+        "defense": {
+          "armor": 32995,
+          "dodge": 35754,
+          "shield_deflect": 35754
+        },
+        "health": {
+          "hull_health": 332415,
+          "shield_health": 79437
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 500387,
+            "armor_pierce": 500387,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 38768,
+            "max_damage": 36776,
+            "min_damage": 30647,
+            "shield_pierce": 500387
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 500387,
+            "armor_pierce": 500387,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 38768,
+            "max_damage": 36776,
+            "min_damage": 30647,
+            "shield_pierce": 500387
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 1,
+          "weapon_stats": {
+            "accuracy": 500387,
+            "armor_pierce": 500387,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 38768,
+            "max_damage": 36776,
+            "min_damage": 30647,
+            "shield_pierce": 500387
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 45
+        "bonus1": 45.0
       },
       "build_costs": {
         "materials": [
@@ -1773,48 +5257,161 @@
       "level": 45,
       "requirements": [
         {
-          "name": "Defense Technologies",
+          "name": "drydock b",
           "level": 45
         },
         {
-          "name": "Drydock B",
+          "name": "defense technologies",
           "level": 45
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 542229,
+          "armor_pierce": 542229,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 210048,
+          "shield_pierce": 542229
+        },
+        "defense": {
+          "armor": 35754,
+          "dodge": 39529,
+          "shield_deflect": 39529
+        },
+        "health": {
+          "hull_health": 360211,
+          "shield_health": 87825
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 542229,
+            "armor_pierce": 542229,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 42010,
+            "max_damage": 39851,
+            "min_damage": 33209,
+            "shield_pierce": 542229
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 542229,
+            "armor_pierce": 542229,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 42010,
+            "max_damage": 39851,
+            "min_damage": 33209,
+            "shield_pierce": 542229
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 1,
+          "weapon_stats": {
+            "accuracy": 542229,
+            "armor_pierce": 542229,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 42010,
+            "max_damage": 39851,
+            "min_damage": 33209,
+            "shield_pierce": 542229
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 46
+        "bonus1": 46.0
       },
       "build_costs": {
         "materials": [
           {
             "type": "gas",
             "grade": 4,
-            "rarity": "common",
-            "value": 30000
+            "rarity": "rare",
+            "value": 1800
           },
           {
             "type": "gas",
             "grade": 4,
-            "rarity": "rare",
-            "value": 1800
+            "rarity": "common",
+            "value": 30000
           }
         ],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 36465000000
+            "type": "dilithium",
+            "value": 53625000
           },
           {
             "type": "tritanium",
             "value": 536250000
           },
           {
-            "type": "dilithium",
-            "value": 53625000
+            "type": "parsteel",
+            "value": 36465000000
           }
         ]
       },
@@ -1823,41 +5420,150 @@
       "level": 46,
       "requirements": [
         {
-          "name": "Defense Platform A",
+          "name": "drydock b",
           "level": 46
         },
         {
-          "name": "Drydock B",
+          "name": "defense platform a",
           "level": 46
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 587569,
+          "armor_pierce": 587569,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 227614,
+          "shield_pierce": 587569
+        },
+        "defense": {
+          "armor": 38744,
+          "dodge": 43703,
+          "shield_deflect": 43703
+        },
+        "health": {
+          "hull_health": 390331,
+          "shield_health": 97099
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 587569,
+            "armor_pierce": 587569,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 45523,
+            "max_damage": 43184,
+            "min_damage": 35986,
+            "shield_pierce": 587569
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 587569,
+            "armor_pierce": 587569,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 45523,
+            "max_damage": 43184,
+            "min_damage": 35986,
+            "shield_pierce": 587569
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 1,
+          "weapon_stats": {
+            "accuracy": 587569,
+            "armor_pierce": 587569,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 45523,
+            "max_damage": 43184,
+            "min_damage": 35986,
+            "shield_pierce": 587569
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 47
+        "bonus1": 47.0
       },
       "build_costs": {
         "materials": [
           {
             "type": "gas",
             "grade": 4,
-            "rarity": "common",
-            "value": 45000
+            "rarity": "uncommon",
+            "value": 2500
           },
           {
             "type": "gas",
             "grade": 4,
-            "rarity": "uncommon",
-            "value": 2500
+            "rarity": "common",
+            "value": 45000
           }
         ],
         "others": [],
         "resources": [
-          {
-            "type": "parsteel",
-            "value": 53040000000
-          },
           {
             "type": "tritanium",
             "value": 780000000
@@ -1865,6 +5571,10 @@
           {
             "type": "dilithium",
             "value": 78000000
+          },
+          {
+            "type": "parsteel",
+            "value": 53040000000
           }
         ]
       },
@@ -1873,15 +5583,128 @@
       "level": 47,
       "requirements": [
         {
-          "name": "Drydock B",
+          "name": "drydock b",
           "level": 47
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 636700,
+          "armor_pierce": 636700,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 246649,
+          "shield_pierce": 636700
+        },
+        "defense": {
+          "armor": 41983,
+          "dodge": 48318,
+          "shield_deflect": 48318
+        },
+        "health": {
+          "hull_health": 422970,
+          "shield_health": 107352
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 636700,
+            "armor_pierce": 636700,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 49330,
+            "max_damage": 46795,
+            "min_damage": 38996,
+            "shield_pierce": 636700
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 636700,
+            "armor_pierce": 636700,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 49330,
+            "max_damage": 46795,
+            "min_damage": 38996,
+            "shield_pierce": 636700
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 1,
+          "weapon_stats": {
+            "accuracy": 636700,
+            "armor_pierce": 636700,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 49330,
+            "max_damage": 46795,
+            "min_damage": 38996,
+            "shield_pierce": 636700
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 48
+        "bonus1": 48.0
       },
       "build_costs": {
         "materials": [
@@ -1905,12 +5728,12 @@
             "value": 85680000000
           },
           {
-            "type": "tritanium",
-            "value": 1260000000
-          },
-          {
             "type": "dilithium",
             "value": 126000000
+          },
+          {
+            "type": "tritanium",
+            "value": 1260000000
           }
         ]
       },
@@ -1919,29 +5742,142 @@
       "level": 48,
       "requirements": [
         {
-          "name": "Drydock B",
+          "name": "drydock b",
           "level": 48
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 689940,
+          "armor_pierce": 689940,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 267272,
+          "shield_pierce": 689940
+        },
+        "defense": {
+          "armor": 45494,
+          "dodge": 53420,
+          "shield_deflect": 53420
+        },
+        "health": {
+          "hull_health": 458338,
+          "shield_health": 118687
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 689940,
+            "armor_pierce": 689940,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 53454,
+            "max_damage": 50708,
+            "min_damage": 42256,
+            "shield_pierce": 689940
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 689940,
+            "armor_pierce": 689940,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 53454,
+            "max_damage": 50708,
+            "min_damage": 42256,
+            "shield_pierce": 689940
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 1,
+          "weapon_stats": {
+            "accuracy": 689940,
+            "armor_pierce": 689940,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 53454,
+            "max_damage": 50708,
+            "min_damage": 42256,
+            "shield_pierce": 689940
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 49
+        "bonus1": 49.0
       },
       "build_costs": {
         "materials": [
           {
             "type": "gas",
             "grade": 4,
-            "rarity": "uncommon",
-            "value": 14000
+            "rarity": "rare",
+            "value": 4500
           },
           {
             "type": "gas",
             "grade": 4,
-            "rarity": "rare",
-            "value": 4500
+            "rarity": "uncommon",
+            "value": 14000
           }
         ],
         "others": [],
@@ -1951,12 +5887,12 @@
             "value": 142800000000
           },
           {
-            "type": "tritanium",
-            "value": 2100000000
-          },
-          {
             "type": "dilithium",
             "value": 210000000
+          },
+          {
+            "type": "tritanium",
+            "value": 2100000000
           }
         ]
       },
@@ -1965,24 +5901,141 @@
       "level": 49,
       "requirements": [
         {
-          "name": "Defense Platform A",
+          "name": "drydock b",
           "level": 49
         },
         {
-          "name": "Drydock B",
+          "name": "defense platform a",
           "level": 49
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 747632,
+          "armor_pierce": 747632,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 289622,
+          "shield_pierce": 747632
+        },
+        "defense": {
+          "armor": 49298,
+          "dodge": 59061,
+          "shield_deflect": 59061
+        },
+        "health": {
+          "hull_health": 496663,
+          "shield_health": 131220
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 747632,
+            "armor_pierce": 747632,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 57924,
+            "max_damage": 54948,
+            "min_damage": 45790,
+            "shield_pierce": 747632
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 747632,
+            "armor_pierce": 747632,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 57924,
+            "max_damage": 54948,
+            "min_damage": 45790,
+            "shield_pierce": 747632
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 1,
+          "weapon_stats": {
+            "accuracy": 747632,
+            "armor_pierce": 747632,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 57924,
+            "max_damage": 54948,
+            "min_damage": 45790,
+            "shield_pierce": 747632
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 50
+        "bonus1": 50.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
+          {
+            "type": "dilithium",
+            "value": 367500000
+          },
           {
             "type": "parsteel",
             "value": 249900000000
@@ -1990,10 +6043,6 @@
           {
             "type": "tritanium",
             "value": 3675000000
-          },
-          {
-            "type": "dilithium",
-            "value": 367500000
           }
         ]
       },
@@ -2002,11 +6051,931 @@
       "level": 50,
       "requirements": [
         {
-          "name": "Drydock B",
+          "name": "drydock b",
           "level": 50
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 810147,
+          "armor_pierce": 810147,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 313835,
+          "shield_pierce": 810147
+        },
+        "defense": {
+          "armor": 53420,
+          "dodge": 65297,
+          "shield_deflect": 65297
+        },
+        "health": {
+          "hull_health": 538193,
+          "shield_health": 145076
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 810147,
+            "armor_pierce": 810147,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 62767,
+            "max_damage": 59542,
+            "min_damage": 49618,
+            "shield_pierce": 810147
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 810147,
+            "armor_pierce": 810147,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 62767,
+            "max_damage": 59542,
+            "min_damage": 49618,
+            "shield_pierce": 810147
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 1,
+          "weapon_stats": {
+            "accuracy": 810147,
+            "armor_pierce": 810147,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 62767,
+            "max_damage": 59542,
+            "min_damage": 49618,
+            "shield_pierce": 810147
+          },
+          "weapon_type": "energy"
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 51.0
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "gas",
+            "grade": 5,
+            "rarity": "common",
+            "value": 21700
+          },
+          {
+            "type": "gas",
+            "grade": 5,
+            "rarity": "uncommon",
+            "value": 1900
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 7800000000
+          },
+          {
+            "type": "dilithium",
+            "value": 780000000
+          },
+          {
+            "type": "parsteel",
+            "value": 1246440000000
+          }
+        ]
+      },
+      "build_time": 104346720,
+      "increased_power": 1216045,
+      "level": 51,
+      "requirements": [
+        {
+          "name": "drydock b",
+          "level": 51
+        }
+      ],
+      "stats": {
+        "attack": {
+          "accuracy": 931669,
+          "armor_pierce": 931669,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 360910,
+          "shield_pierce": 931669
+        },
+        "defense": {
+          "armor": 75092,
+          "dodge": 75092,
+          "shield_deflect": 75092
+        },
+        "health": {
+          "hull_health": 618922,
+          "shield_health": 166837
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 931669,
+            "armor_pierce": 931669,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 72182,
+            "max_damage": 68473,
+            "min_damage": 57061,
+            "shield_pierce": 931669
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 931669,
+            "armor_pierce": 931669,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 72182,
+            "max_damage": 68473,
+            "min_damage": 57061,
+            "shield_pierce": 931669
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 1,
+          "weapon_stats": {
+            "accuracy": 931669,
+            "armor_pierce": 931669,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 72182,
+            "max_damage": 68473,
+            "min_damage": 57061,
+            "shield_pierce": 931669
+          },
+          "weapon_type": "energy"
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 52.0
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "gas",
+            "grade": 5,
+            "rarity": "common",
+            "value": 37500
+          },
+          {
+            "type": "gas",
+            "grade": 5,
+            "rarity": "uncommon",
+            "value": 4300
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "dilithium",
+            "value": 1326000000
+          },
+          {
+            "type": "tritanium",
+            "value": 13260000000
+          },
+          {
+            "type": "parsteel",
+            "value": 2254200000000
+          }
+        ]
+      },
+      "build_time": 110606400,
+      "increased_power": 2571112,
+      "level": 52,
+      "requirements": [
+        {
+          "name": "drydock b",
+          "level": 52
+        },
+        {
+          "name": "defense platform a",
+          "level": 52
+        }
+      ],
+      "stats": {
+        "attack": {
+          "accuracy": 1174713,
+          "armor_pierce": 1174713,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 712868,
+          "shield_pierce": 1174713
+        },
+        "defense": {
+          "armor": 94681,
+          "dodge": 94681,
+          "shield_deflect": 94681
+        },
+        "health": {
+          "hull_health": 780380,
+          "shield_health": 210360
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 1174713,
+            "armor_pierce": 1174713,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 142574,
+            "max_damage": 161618,
+            "min_damage": 86336,
+            "shield_pierce": 1174713
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 1174713,
+            "armor_pierce": 1174713,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 142574,
+            "max_damage": 161618,
+            "min_damage": 86336,
+            "shield_pierce": 1174713
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 1,
+          "weapon_stats": {
+            "accuracy": 1174713,
+            "armor_pierce": 1174713,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 142574,
+            "max_damage": 161618,
+            "min_damage": 86336,
+            "shield_pierce": 1174713
+          },
+          "weapon_type": "energy"
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 53.0
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "gas",
+            "grade": 5,
+            "rarity": "common",
+            "value": 88900
+          },
+          {
+            "type": "gas",
+            "grade": 5,
+            "rarity": "uncommon",
+            "value": 15500
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "dilithium",
+            "value": 2320000000
+          },
+          {
+            "type": "parsteel",
+            "value": 3786240000000
+          },
+          {
+            "type": "tritanium",
+            "value": 23200000000
+          }
+        ]
+      },
+      "build_time": 117243360,
+      "increased_power": 9914492,
+      "level": 53,
+      "requirements": [
+        {
+          "name": "drydock b",
+          "level": 53
+        },
+        {
+          "name": "defense platform a",
+          "level": 53
+        }
+      ],
+      "stats": {
+        "attack": {
+          "accuracy": 2187397,
+          "armor_pierce": 2187397,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 1380871,
+          "shield_pierce": 2187397
+        },
+        "defense": {
+          "armor": 176302,
+          "dodge": 176302,
+          "shield_deflect": 176302
+        },
+        "health": {
+          "hull_health": 1453121,
+          "shield_health": 391705
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 2187397,
+            "armor_pierce": 2187397,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 276174,
+            "max_damage": 319540,
+            "min_damage": 160763,
+            "shield_pierce": 2187397
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 2187397,
+            "armor_pierce": 2187397,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 276174,
+            "max_damage": 319540,
+            "min_damage": 160763,
+            "shield_pierce": 2187397
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 1,
+          "weapon_stats": {
+            "accuracy": 2187397,
+            "armor_pierce": 2187397,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 276174,
+            "max_damage": 319540,
+            "min_damage": 160763,
+            "shield_pierce": 2187397
+          },
+          "weapon_type": "energy"
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 54.0
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "gas",
+            "grade": 5,
+            "rarity": "common",
+            "value": 76500
+          },
+          {
+            "type": "gas",
+            "grade": 5,
+            "rarity": "rare",
+            "value": 7000
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "dilithium",
+            "value": 3480000000
+          },
+          {
+            "type": "tritanium",
+            "value": 34800000000
+          },
+          {
+            "type": "parsteel",
+            "value": 5679360000000
+          }
+        ]
+      },
+      "build_time": 124277760,
+      "increased_power": 2449504,
+      "level": 54,
+      "requirements": [
+        {
+          "name": "drydock b",
+          "level": 54
+        },
+        {
+          "name": "defense platform a",
+          "level": 54
+        }
+      ],
+      "stats": {
+        "attack": {
+          "accuracy": 2430441,
+          "armor_pierce": 2430441,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 1611219,
+          "shield_pierce": 2430441
+        },
+        "defense": {
+          "armor": 195891,
+          "dodge": 195891,
+          "shield_deflect": 195891
+        },
+        "health": {
+          "hull_health": 1614579,
+          "shield_health": 435228
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 2430441,
+            "armor_pierce": 2430441,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 322244,
+            "max_damage": 381798,
+            "min_damage": 178626,
+            "shield_pierce": 2430441
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 2430441,
+            "armor_pierce": 2430441,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 322244,
+            "max_damage": 381798,
+            "min_damage": 178626,
+            "shield_pierce": 2430441
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 1,
+          "weapon_stats": {
+            "accuracy": 2430441,
+            "armor_pierce": 2430441,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 322244,
+            "max_damage": 381798,
+            "min_damage": 178626,
+            "shield_pierce": 2430441
+          },
+          "weapon_type": "energy"
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 55.0
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "gas",
+            "grade": 5,
+            "rarity": "uncommon",
+            "value": 22300
+          },
+          {
+            "type": "gas",
+            "grade": 5,
+            "rarity": "rare",
+            "value": 8100
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 9653280000000
+          },
+          {
+            "type": "tritanium",
+            "value": 54600000000
+          },
+          {
+            "type": "dilithium",
+            "value": 5460000000
+          }
+        ]
+      },
+      "build_time": 131734080,
+      "increased_power": 4869860,
+      "level": 55,
+      "requirements": [
+        {
+          "name": "drydock b",
+          "level": 55
+        }
+      ],
+      "stats": {
+        "attack": {
+          "accuracy": 2916529,
+          "armor_pierce": 2916529,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 2042768,
+          "shield_pierce": 2916529
+        },
+        "defense": {
+          "armor": 235069,
+          "dodge": 235069,
+          "shield_deflect": 235069
+        },
+        "health": {
+          "hull_health": 1937495,
+          "shield_health": 522274
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 2916529,
+            "armor_pierce": 2916529,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 408554,
+            "max_damage": 496177,
+            "min_damage": 214351,
+            "shield_pierce": 2916529
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 2916529,
+            "armor_pierce": 2916529,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 408554,
+            "max_damage": 496177,
+            "min_damage": 214351,
+            "shield_pierce": 2916529
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 1,
+          "weapon_stats": {
+            "accuracy": 2916529,
+            "armor_pierce": 2916529,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 408554,
+            "max_damage": 496177,
+            "min_damage": 214351,
+            "shield_pierce": 2916529
+          },
+          "weapon_type": "energy"
+        }
+      ]
     }
   ]
 }

--- a/buildings/defense_platform_c.json
+++ b/buildings/defense_platform_c.json
@@ -2,7 +2,7 @@
   "description": "Defense Platforms are the last line of Defense for the Station. Behind defending ships they provide additional fire support. Upgrade to increase the Platform's combat performance.",
   "bonuses": {
     "bonus1": {
-      "name": "Power Level",
+      "name": "power level",
       "percentage": false
     }
   },
@@ -10,7 +10,7 @@
   "levels": [
     {
       "bonuses": {
-        "bonus1": 1
+        "bonus1": 1.0
       },
       "build_costs": {
         "materials": [],
@@ -21,12 +21,12 @@
             "value": 136
           },
           {
-            "type": "tritanium",
-            "value": 500
-          },
-          {
             "type": "dilithium",
             "value": 50
+          },
+          {
+            "type": "tritanium",
+            "value": 500
           }
         ]
       },
@@ -35,15 +35,66 @@
       "level": 1,
       "requirements": [
         {
-          "name": "Defense Platforms",
+          "name": "defense platforms",
           "level": 2
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 18,
+          "armor_pierce": 18,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 506,
+          "shield_pierce": 18
+        },
+        "defense": {
+          "armor": 9,
+          "dodge": 9,
+          "shield_deflect": 9
+        },
+        "health": {
+          "hull_health": 250,
+          "shield_health": 250
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 18,
+            "armor_pierce": 18,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 253,
+            "max_damage": 240,
+            "min_damage": 200,
+            "shield_pierce": 18
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 2
+        "bonus1": 2.0
       },
       "build_costs": {
         "materials": [],
@@ -68,24 +119,71 @@
       "level": 2,
       "requirements": [
         {
-          "name": "Drydock C",
+          "name": "drydock c",
           "level": 2
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 19,
+          "armor_pierce": 19,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 527,
+          "shield_pierce": 19
+        },
+        "defense": {
+          "armor": 9,
+          "dodge": 9,
+          "shield_deflect": 9
+        },
+        "health": {
+          "hull_health": 270,
+          "shield_health": 270
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 19,
+            "armor_pierce": 19,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 263,
+            "max_damage": 250,
+            "min_damage": 208,
+            "shield_pierce": 19
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 3
+        "bonus1": 3.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
-          {
-            "type": "parsteel",
-            "value": 6250
-          },
           {
             "type": "tritanium",
             "value": 420
@@ -93,6 +191,10 @@
           {
             "type": "dilithium",
             "value": 42
+          },
+          {
+            "type": "parsteel",
+            "value": 6250
           }
         ]
       },
@@ -101,31 +203,82 @@
       "level": 3,
       "requirements": [
         {
-          "name": "Drydock C",
+          "name": "drydock c",
           "level": 3
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 27,
+          "armor_pierce": 27,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 587,
+          "shield_pierce": 27
+        },
+        "defense": {
+          "armor": 14,
+          "dodge": 14,
+          "shield_deflect": 14
+        },
+        "health": {
+          "hull_health": 290,
+          "shield_health": 290
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 27,
+            "armor_pierce": 27,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 293,
+            "max_damage": 278,
+            "min_damage": 232,
+            "shield_pierce": 27
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 4
+        "bonus1": 4.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 7000
+            "type": "dilithium",
+            "value": 44
           },
           {
             "type": "tritanium",
             "value": 440
           },
           {
-            "type": "dilithium",
-            "value": 44
+            "type": "parsteel",
+            "value": 7000
           }
         ]
       },
@@ -134,20 +287,75 @@
       "level": 4,
       "requirements": [
         {
-          "name": "Drydock C",
+          "name": "drydock c",
           "level": 4
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 36,
+          "armor_pierce": 36,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 662,
+          "shield_pierce": 36
+        },
+        "defense": {
+          "armor": 18,
+          "dodge": 18,
+          "shield_deflect": 18
+        },
+        "health": {
+          "hull_health": 360,
+          "shield_health": 360
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 36,
+            "armor_pierce": 36,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 331,
+            "max_damage": 314,
+            "min_damage": 262,
+            "shield_pierce": 36
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 5
+        "bonus1": 5.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
+          {
+            "type": "dilithium",
+            "value": 46
+          },
           {
             "type": "parsteel",
             "value": 7750
@@ -155,10 +363,6 @@
           {
             "type": "tritanium",
             "value": 460
-          },
-          {
-            "type": "dilithium",
-            "value": 46
           }
         ]
       },
@@ -167,15 +371,66 @@
       "level": 5,
       "requirements": [
         {
-          "name": "Drydock C",
+          "name": "drydock c",
           "level": 5
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 46,
+          "armor_pierce": 46,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 818,
+          "shield_pierce": 46
+        },
+        "defense": {
+          "armor": 23,
+          "dodge": 23,
+          "shield_deflect": 23
+        },
+        "health": {
+          "hull_health": 500,
+          "shield_health": 500
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 46,
+            "armor_pierce": 46,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 409,
+            "max_damage": 388,
+            "min_damage": 323,
+            "shield_pierce": 46
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 6
+        "bonus1": 6.0
       },
       "build_costs": {
         "materials": [],
@@ -186,12 +441,12 @@
             "value": 8500
           },
           {
-            "type": "tritanium",
-            "value": 480
-          },
-          {
             "type": "dilithium",
             "value": 48
+          },
+          {
+            "type": "tritanium",
+            "value": 480
           }
         ]
       },
@@ -200,27 +455,78 @@
       "level": 6,
       "requirements": [
         {
-          "name": "Drydock C",
+          "name": "drydock c",
           "level": 6
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 63,
+          "armor_pierce": 63,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 1045,
+          "shield_pierce": 63
+        },
+        "defense": {
+          "armor": 32,
+          "dodge": 32,
+          "shield_deflect": 32
+        },
+        "health": {
+          "hull_health": 660,
+          "shield_health": 660
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 63,
+            "armor_pierce": 63,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 523,
+            "max_damage": 496,
+            "min_damage": 413,
+            "shield_pierce": 63
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 7
+        "bonus1": 7.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 9250
-          },
-          {
             "type": "tritanium",
             "value": 500
+          },
+          {
+            "type": "parsteel",
+            "value": 9250
           },
           {
             "type": "dilithium",
@@ -233,15 +539,66 @@
       "level": 7,
       "requirements": [
         {
-          "name": "Drydock C",
+          "name": "drydock c",
           "level": 7
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 94,
+          "armor_pierce": 94,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 1298,
+          "shield_pierce": 94
+        },
+        "defense": {
+          "armor": 47,
+          "dodge": 47,
+          "shield_deflect": 47
+        },
+        "health": {
+          "hull_health": 960,
+          "shield_health": 960
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 94,
+            "armor_pierce": 94,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 649,
+            "max_damage": 616,
+            "min_damage": 513,
+            "shield_pierce": 94
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 8
+        "bonus1": 8.0
       },
       "build_costs": {
         "materials": [],
@@ -266,27 +623,78 @@
       "level": 8,
       "requirements": [
         {
-          "name": "Drydock C",
+          "name": "drydock c",
           "level": 8
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 138,
+          "armor_pierce": 138,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 1948,
+          "shield_pierce": 138
+        },
+        "defense": {
+          "armor": 69,
+          "dodge": 69,
+          "shield_deflect": 69
+        },
+        "health": {
+          "hull_health": 1370,
+          "shield_health": 1370
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 138,
+            "armor_pierce": 138,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 974,
+            "max_damage": 924,
+            "min_damage": 770,
+            "shield_pierce": 138
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 9
+        "bonus1": 9.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 11000
-          },
-          {
             "type": "tritanium",
             "value": 540
+          },
+          {
+            "type": "parsteel",
+            "value": 11000
           },
           {
             "type": "dilithium",
@@ -299,31 +707,82 @@
       "level": 9,
       "requirements": [
         {
-          "name": "Drydock C",
+          "name": "drydock c",
           "level": 9
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 200,
+          "armor_pierce": 200,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 2728,
+          "shield_pierce": 200
+        },
+        "defense": {
+          "armor": 100,
+          "dodge": 100,
+          "shield_deflect": 100
+        },
+        "health": {
+          "hull_health": 2020,
+          "shield_health": 2020
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 200,
+            "armor_pierce": 200,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 1364,
+            "max_damage": 1294,
+            "min_damage": 1078,
+            "shield_pierce": 200
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 10
+        "bonus1": 10.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 12500
+            "type": "dilithium",
+            "value": 60
           },
           {
             "type": "tritanium",
             "value": 600
           },
           {
-            "type": "dilithium",
-            "value": 60
+            "type": "parsteel",
+            "value": 12500
           }
         ]
       },
@@ -332,27 +791,109 @@
       "level": 10,
       "requirements": [
         {
-          "name": "Drydock C",
+          "name": "drydock c",
           "level": 10
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 236,
+          "armor_pierce": 236,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 3503,
+          "shield_pierce": 236
+        },
+        "defense": {
+          "armor": 131,
+          "dodge": 131,
+          "shield_deflect": 131
+        },
+        "health": {
+          "hull_health": 2560,
+          "shield_health": 2560
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 236,
+            "armor_pierce": 236,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 1168,
+            "max_damage": 1108,
+            "min_damage": 923,
+            "shield_pierce": 236
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 1,
+          "weapon_stats": {
+            "accuracy": 236,
+            "armor_pierce": 236,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 1168,
+            "max_damage": 1108,
+            "min_damage": 923,
+            "shield_pierce": 236
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 11
+        "bonus1": 11.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 13600
-          },
-          {
             "type": "tritanium",
             "value": 400
+          },
+          {
+            "type": "parsteel",
+            "value": 13600
           },
           {
             "type": "dilithium",
@@ -365,24 +906,102 @@
       "level": 11,
       "requirements": [
         {
-          "name": "Drydock C",
+          "name": "drydock c",
           "level": 11
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 260,
+          "armor_pierce": 260,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 4782,
+          "shield_pierce": 260
+        },
+        "defense": {
+          "armor": 153,
+          "dodge": 153,
+          "shield_deflect": 153
+        },
+        "health": {
+          "hull_health": 2740,
+          "shield_health": 2740
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 260,
+            "armor_pierce": 260,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 1594,
+            "max_damage": 1512,
+            "min_damage": 1260,
+            "shield_pierce": 260
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 1,
+          "weapon_stats": {
+            "accuracy": 260,
+            "armor_pierce": 260,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 1594,
+            "max_damage": 1512,
+            "min_damage": 1260,
+            "shield_pierce": 260
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 12
+        "bonus1": 12.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
-          {
-            "type": "parsteel",
-            "value": 18700
-          },
           {
             "type": "tritanium",
             "value": 550
@@ -390,6 +1009,10 @@
           {
             "type": "dilithium",
             "value": 22
+          },
+          {
+            "type": "parsteel",
+            "value": 18700
           }
         ]
       },
@@ -398,27 +1021,109 @@
       "level": 12,
       "requirements": [
         {
-          "name": "Drydock C",
+          "name": "drydock c",
           "level": 12
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 340,
+          "armor_pierce": 340,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 5142,
+          "shield_pierce": 340
+        },
+        "defense": {
+          "armor": 213,
+          "dodge": 213,
+          "shield_deflect": 213
+        },
+        "health": {
+          "hull_health": 2880,
+          "shield_health": 2880
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 340,
+            "armor_pierce": 340,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 1714,
+            "max_damage": 1626,
+            "min_damage": 1355,
+            "shield_pierce": 340
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 1,
+          "weapon_stats": {
+            "accuracy": 340,
+            "armor_pierce": 340,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 1714,
+            "max_damage": 1626,
+            "min_damage": 1355,
+            "shield_pierce": 340
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 13
+        "bonus1": 13.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 27200
-          },
-          {
             "type": "tritanium",
             "value": 800
+          },
+          {
+            "type": "parsteel",
+            "value": 27200
           },
           {
             "type": "dilithium",
@@ -431,15 +1136,97 @@
       "level": 13,
       "requirements": [
         {
-          "name": "Drydock C",
+          "name": "drydock c",
           "level": 13
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 438,
+          "armor_pierce": 438,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 5572,
+          "shield_pierce": 438
+        },
+        "defense": {
+          "armor": 274,
+          "dodge": 274,
+          "shield_deflect": 274
+        },
+        "health": {
+          "hull_health": 3350,
+          "shield_health": 3350
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 438,
+            "armor_pierce": 438,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 1857,
+            "max_damage": 1762,
+            "min_damage": 1468,
+            "shield_pierce": 438
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 1,
+          "weapon_stats": {
+            "accuracy": 438,
+            "armor_pierce": 438,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 1857,
+            "max_damage": 1762,
+            "min_damage": 1468,
+            "shield_pierce": 438
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 14
+        "bonus1": 14.0
       },
       "build_costs": {
         "materials": [],
@@ -450,12 +1237,12 @@
             "value": 37400
           },
           {
-            "type": "tritanium",
-            "value": 1100
-          },
-          {
             "type": "dilithium",
             "value": 88
+          },
+          {
+            "type": "tritanium",
+            "value": 1100
           }
         ]
       },
@@ -464,24 +1251,102 @@
       "level": 14,
       "requirements": [
         {
-          "name": "Drydock C",
+          "name": "drydock c",
           "level": 14
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 454,
+          "armor_pierce": 454,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 5730,
+          "shield_pierce": 454
+        },
+        "defense": {
+          "armor": 371,
+          "dodge": 371,
+          "shield_deflect": 371
+        },
+        "health": {
+          "hull_health": 3460,
+          "shield_health": 3460
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 454,
+            "armor_pierce": 454,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 1910,
+            "max_damage": 1812,
+            "min_damage": 1510,
+            "shield_pierce": 454
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 1,
+          "weapon_stats": {
+            "accuracy": 454,
+            "armor_pierce": 454,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 1910,
+            "max_damage": 1812,
+            "min_damage": 1510,
+            "shield_pierce": 454
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 15
+        "bonus1": 15.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
-          {
-            "type": "parsteel",
-            "value": 51000
-          },
           {
             "type": "tritanium",
             "value": 1500
@@ -489,6 +1354,10 @@
           {
             "type": "dilithium",
             "value": 150
+          },
+          {
+            "type": "parsteel",
+            "value": 51000
           }
         ]
       },
@@ -497,15 +1366,97 @@
       "level": 15,
       "requirements": [
         {
-          "name": "Drydock C",
+          "name": "drydock c",
           "level": 15
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 475,
+          "armor_pierce": 475,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 5863,
+          "shield_pierce": 475
+        },
+        "defense": {
+          "armor": 400,
+          "dodge": 400,
+          "shield_deflect": 400
+        },
+        "health": {
+          "hull_health": 3730,
+          "shield_health": 3730
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 475,
+            "armor_pierce": 475,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 1954,
+            "max_damage": 1854,
+            "min_damage": 1545,
+            "shield_pierce": 475
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 1,
+          "weapon_stats": {
+            "accuracy": 475,
+            "armor_pierce": 475,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 1954,
+            "max_damage": 1854,
+            "min_damage": 1545,
+            "shield_pierce": 475
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 16
+        "bonus1": 16.0
       },
       "build_costs": {
         "materials": [],
@@ -530,27 +1481,109 @@
       "level": 16,
       "requirements": [
         {
-          "name": "Drydock C",
+          "name": "drydock c",
           "level": 16
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 556,
+          "armor_pierce": 556,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 7476,
+          "shield_pierce": 556
+        },
+        "defense": {
+          "armor": 479,
+          "dodge": 479,
+          "shield_deflect": 479
+        },
+        "health": {
+          "hull_health": 4750,
+          "shield_health": 4750
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 556,
+            "armor_pierce": 556,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 2492,
+            "max_damage": 2364,
+            "min_damage": 1970,
+            "shield_pierce": 556
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 1,
+          "weapon_stats": {
+            "accuracy": 556,
+            "armor_pierce": 556,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 2492,
+            "max_damage": 2364,
+            "min_damage": 1970,
+            "shield_pierce": 556
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 17
+        "bonus1": 17.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 95200
-          },
-          {
             "type": "tritanium",
             "value": 2800
+          },
+          {
+            "type": "parsteel",
+            "value": 95200
           },
           {
             "type": "dilithium",
@@ -563,27 +1596,109 @@
       "level": 17,
       "requirements": [
         {
-          "name": "Drydock C",
+          "name": "drydock c",
           "level": 17
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 649,
+          "armor_pierce": 649,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 8779,
+          "shield_pierce": 649
+        },
+        "defense": {
+          "armor": 535,
+          "dodge": 535,
+          "shield_deflect": 535
+        },
+        "health": {
+          "hull_health": 5620,
+          "shield_health": 5620
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 649,
+            "armor_pierce": 649,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 2926,
+            "max_damage": 2776,
+            "min_damage": 2313,
+            "shield_pierce": 649
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 1,
+          "weapon_stats": {
+            "accuracy": 649,
+            "armor_pierce": 649,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 2926,
+            "max_damage": 2776,
+            "min_damage": 2313,
+            "shield_pierce": 649
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 18
+        "bonus1": 18.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 136000
-          },
-          {
             "type": "tritanium",
             "value": 4000
+          },
+          {
+            "type": "parsteel",
+            "value": 136000
           },
           {
             "type": "dilithium",
@@ -596,31 +1711,113 @@
       "level": 18,
       "requirements": [
         {
-          "name": "Drydock C",
+          "name": "drydock c",
           "level": 18
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 672,
+          "armor_pierce": 672,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 10265,
+          "shield_pierce": 672
+        },
+        "defense": {
+          "armor": 560,
+          "dodge": 560,
+          "shield_deflect": 560
+        },
+        "health": {
+          "hull_health": 6120,
+          "shield_health": 6120
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 672,
+            "armor_pierce": 672,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 3422,
+            "max_damage": 3246,
+            "min_damage": 2705,
+            "shield_pierce": 672
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 1,
+          "weapon_stats": {
+            "accuracy": 672,
+            "armor_pierce": 672,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 3422,
+            "max_damage": 3246,
+            "min_damage": 2705,
+            "shield_pierce": 672
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 19
+        "bonus1": 19.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 204000
+            "type": "dilithium",
+            "value": 600
           },
           {
             "type": "tritanium",
             "value": 6000
           },
           {
-            "type": "dilithium",
-            "value": 600
+            "type": "parsteel",
+            "value": 204000
           }
         ]
       },
@@ -629,15 +1826,97 @@
       "level": 19,
       "requirements": [
         {
-          "name": "Drydock C",
+          "name": "drydock c",
           "level": 19
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 2023,
+          "armor_pierce": 2023,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 10823,
+          "shield_pierce": 2023
+        },
+        "defense": {
+          "armor": 674,
+          "dodge": 674,
+          "shield_deflect": 674
+        },
+        "health": {
+          "hull_health": 6500,
+          "shield_health": 6500
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 2023,
+            "armor_pierce": 2023,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 3608,
+            "max_damage": 3422,
+            "min_damage": 2852,
+            "shield_pierce": 2023
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 1,
+          "weapon_stats": {
+            "accuracy": 2023,
+            "armor_pierce": 2023,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 3608,
+            "max_damage": 3422,
+            "min_damage": 2852,
+            "shield_pierce": 2023
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 20
+        "bonus1": 20.0
       },
       "build_costs": {
         "materials": [],
@@ -648,12 +1927,12 @@
             "value": 289000
           },
           {
-            "type": "tritanium",
-            "value": 8500
-          },
-          {
             "type": "dilithium",
             "value": 850
+          },
+          {
+            "type": "tritanium",
+            "value": 8500
           }
         ]
       },
@@ -662,31 +1941,113 @@
       "level": 20,
       "requirements": [
         {
-          "name": "Defense Technologies",
+          "name": "drydock c",
           "level": 20
         },
         {
-          "name": "Drydock C",
+          "name": "defense technologies",
           "level": 20
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 2755,
+          "armor_pierce": 2755,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 11173,
+          "shield_pierce": 2755
+        },
+        "defense": {
+          "armor": 689,
+          "dodge": 689,
+          "shield_deflect": 689
+        },
+        "health": {
+          "hull_health": 9860,
+          "shield_health": 6570
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 2755,
+            "armor_pierce": 2755,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 2793,
+            "max_damage": 2650,
+            "min_damage": 2208,
+            "shield_pierce": 2755
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 2755,
+            "armor_pierce": 2755,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 2793,
+            "max_damage": 2650,
+            "min_damage": 2208,
+            "shield_pierce": 2755
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 21
+        "bonus1": 21.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 486540
-          },
-          {
             "type": "tritanium",
             "value": 14310
+          },
+          {
+            "type": "parsteel",
+            "value": 486540
           },
           {
             "type": "dilithium",
@@ -699,15 +2060,97 @@
       "level": 21,
       "requirements": [
         {
-          "name": "Drydock C",
+          "name": "drydock c",
           "level": 21
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 3494,
+          "armor_pierce": 3494,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 11360,
+          "shield_pierce": 3494
+        },
+        "defense": {
+          "armor": 699,
+          "dodge": 699,
+          "shield_deflect": 699
+        },
+        "health": {
+          "hull_health": 13540,
+          "shield_health": 6770
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 3494,
+            "armor_pierce": 3494,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 2840,
+            "max_damage": 2694,
+            "min_damage": 2245,
+            "shield_pierce": 3494
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 3494,
+            "armor_pierce": 3494,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 2840,
+            "max_damage": 2694,
+            "min_damage": 2245,
+            "shield_pierce": 3494
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 22
+        "bonus1": 22.0
       },
       "build_costs": {
         "materials": [],
@@ -718,12 +2161,12 @@
             "value": 756840
           },
           {
-            "type": "tritanium",
-            "value": 22260
-          },
-          {
             "type": "dilithium",
             "value": 2226
+          },
+          {
+            "type": "tritanium",
+            "value": 22260
           }
         ]
       },
@@ -732,27 +2175,109 @@
       "level": 22,
       "requirements": [
         {
-          "name": "Drydock C",
+          "name": "drydock c",
           "level": 22
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 35000,
+          "armor_pierce": 35000,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 17528,
+          "shield_pierce": 35000
+        },
+        "defense": {
+          "armor": 1701,
+          "dodge": 1701,
+          "shield_deflect": 1701
+        },
+        "health": {
+          "hull_health": 25246,
+          "shield_health": 6840
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 35000,
+            "armor_pierce": 35000,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 4382,
+            "max_damage": 4157,
+            "min_damage": 3464,
+            "shield_pierce": 35000
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 35000,
+            "armor_pierce": 35000,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 4382,
+            "max_damage": 4157,
+            "min_damage": 3464,
+            "shield_pierce": 35000
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 23
+        "bonus1": 23.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 1245420
-          },
-          {
             "type": "tritanium",
             "value": 36630
+          },
+          {
+            "type": "parsteel",
+            "value": 1245420
           },
           {
             "type": "dilithium",
@@ -765,27 +2290,109 @@
       "level": 23,
       "requirements": [
         {
-          "name": "Drydock C",
+          "name": "drydock c",
           "level": 23
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 36150,
+          "armor_pierce": 37625,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 21243,
+          "shield_pierce": 37625
+        },
+        "defense": {
+          "armor": 2724,
+          "dodge": 2724,
+          "shield_deflect": 2724
+        },
+        "health": {
+          "hull_health": 25582,
+          "shield_health": 6910
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 36150,
+            "armor_pierce": 37625,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 5311,
+            "max_damage": 5038,
+            "min_damage": 4198,
+            "shield_pierce": 37625
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 36150,
+            "armor_pierce": 37625,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 5311,
+            "max_damage": 5038,
+            "min_damage": 4198,
+            "shield_pierce": 37625
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 24
+        "bonus1": 24.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 1962480
-          },
-          {
             "type": "tritanium",
             "value": 57720
+          },
+          {
+            "type": "parsteel",
+            "value": 1962480
           },
           {
             "type": "dilithium",
@@ -798,29 +2405,111 @@
       "level": 24,
       "requirements": [
         {
-          "name": "Drydock C",
+          "name": "drydock c",
           "level": 24
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 36300,
+          "armor_pierce": 43125,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 22211,
+          "shield_pierce": 43125
+        },
+        "defense": {
+          "armor": 3571,
+          "dodge": 3571,
+          "shield_deflect": 3571
+        },
+        "health": {
+          "hull_health": 25671,
+          "shield_health": 7020
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 36300,
+            "armor_pierce": 43125,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 5553,
+            "max_damage": 5267,
+            "min_damage": 4390,
+            "shield_pierce": 43125
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 36300,
+            "armor_pierce": 43125,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 5553,
+            "max_damage": 5267,
+            "min_damage": 4390,
+            "shield_pierce": 43125
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 25
+        "bonus1": 25.0
       },
       "build_costs": {
         "materials": [
           {
             "type": "gas",
             "grade": 3,
-            "rarity": "common",
-            "value": 190
+            "rarity": "uncommon",
+            "value": 1
           },
           {
             "type": "gas",
             "grade": 3,
-            "rarity": "uncommon",
-            "value": 1
+            "rarity": "common",
+            "value": 190
           }
         ],
         "others": [],
@@ -830,12 +2519,12 @@
             "value": 3182400
           },
           {
-            "type": "tritanium",
-            "value": 93600
-          },
-          {
             "type": "dilithium",
             "value": 9360
+          },
+          {
+            "type": "tritanium",
+            "value": 93600
           }
         ]
       },
@@ -844,19 +2533,101 @@
       "level": 25,
       "requirements": [
         {
-          "name": "Drydock C",
+          "name": "drydock c",
           "level": 25
         },
         {
-          "name": "Defense Technologies",
+          "name": "defense technologies",
           "level": 25
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 36425,
+          "armor_pierce": 43750,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 27400,
+          "shield_pierce": 43750
+        },
+        "defense": {
+          "armor": 4865,
+          "dodge": 4865,
+          "shield_deflect": 4865
+        },
+        "health": {
+          "hull_health": 28013,
+          "shield_health": 7780
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 36425,
+            "armor_pierce": 43750,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 6850,
+            "max_damage": 6498,
+            "min_damage": 5415,
+            "shield_pierce": 43750
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 36425,
+            "armor_pierce": 43750,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 6850,
+            "max_damage": 6498,
+            "min_damage": 5415,
+            "shield_pierce": 43750
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 26
+        "bonus1": 26.0
       },
       "build_costs": {
         "materials": [
@@ -876,16 +2647,16 @@
         "others": [],
         "resources": [
           {
+            "type": "dilithium",
+            "value": 14625
+          },
+          {
             "type": "parsteel",
             "value": 4972500
           },
           {
             "type": "tritanium",
             "value": 146250
-          },
-          {
-            "type": "dilithium",
-            "value": 14625
           }
         ]
       },
@@ -894,15 +2665,97 @@
       "level": 26,
       "requirements": [
         {
-          "name": "Drydock C",
+          "name": "drydock c",
           "level": 26
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 38710,
+          "armor_pierce": 46875,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 28775,
+          "shield_pierce": 46875
+        },
+        "defense": {
+          "armor": 5687,
+          "dodge": 5687,
+          "shield_deflect": 5687
+        },
+        "health": {
+          "hull_health": 32009,
+          "shield_health": 9000
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 38710,
+            "armor_pierce": 46875,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 7194,
+            "max_damage": 6824,
+            "min_damage": 5687,
+            "shield_pierce": 46875
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 38710,
+            "armor_pierce": 46875,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 7194,
+            "max_damage": 6824,
+            "min_damage": 5687,
+            "shield_pierce": 46875
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 27
+        "bonus1": 27.0
       },
       "build_costs": {
         "materials": [
@@ -920,12 +2773,12 @@
             "value": 7588800
           },
           {
-            "type": "tritanium",
-            "value": 223200
-          },
-          {
             "type": "dilithium",
             "value": 22320
+          },
+          {
+            "type": "tritanium",
+            "value": 223200
           }
         ]
       },
@@ -934,15 +2787,97 @@
       "level": 27,
       "requirements": [
         {
-          "name": "Drydock C",
+          "name": "drydock c",
           "level": 27
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 44516,
+          "armor_pierce": 57500,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 30811,
+          "shield_pierce": 57500
+        },
+        "defense": {
+          "armor": 6303,
+          "dodge": 6302,
+          "shield_deflect": 6302
+        },
+        "health": {
+          "hull_health": 40145,
+          "shield_health": 11340
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 44516,
+            "armor_pierce": 57500,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 7703,
+            "max_damage": 7307,
+            "min_damage": 6089,
+            "shield_pierce": 57500
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 44516,
+            "armor_pierce": 57500,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 7703,
+            "max_damage": 7307,
+            "min_damage": 6089,
+            "shield_pierce": 57500
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 28
+        "bonus1": 28.0
       },
       "build_costs": {
         "materials": [
@@ -956,16 +2891,16 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 11383200
+            "type": "dilithium",
+            "value": 33480
           },
           {
             "type": "tritanium",
             "value": 334800
           },
           {
-            "type": "dilithium",
-            "value": 33480
+            "type": "parsteel",
+            "value": 11383200
           }
         ]
       },
@@ -974,37 +2909,115 @@
       "level": 28,
       "requirements": [
         {
-          "name": "Drydock C",
+          "name": "drydock c",
           "level": 28
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 56473,
+          "armor_pierce": 68750,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 32324,
+          "shield_pierce": 68750
+        },
+        "defense": {
+          "armor": 8052,
+          "dodge": 8052,
+          "shield_deflect": 8052
+        },
+        "health": {
+          "hull_health": 50751,
+          "shield_health": 14400
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 56473,
+            "armor_pierce": 68750,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 8081,
+            "max_damage": 7666,
+            "min_damage": 6388,
+            "shield_pierce": 68750
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 56473,
+            "armor_pierce": 68750,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 8081,
+            "max_damage": 7666,
+            "min_damage": 6388,
+            "shield_pierce": 68750
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 29
+        "bonus1": 29.0
       },
       "build_costs": {
         "materials": [
           {
             "type": "gas",
             "grade": 3,
-            "rarity": "common",
-            "value": 450
+            "rarity": "uncommon",
+            "value": 30
           },
           {
             "type": "gas",
             "grade": 3,
-            "rarity": "uncommon",
-            "value": 30
+            "rarity": "common",
+            "value": 450
           }
         ],
         "others": [],
         "resources": [
-          {
-            "type": "parsteel",
-            "value": 18122000
-          },
           {
             "type": "tritanium",
             "value": 533000
@@ -1012,6 +3025,10 @@
           {
             "type": "dilithium",
             "value": 53300
+          },
+          {
+            "type": "parsteel",
+            "value": 18122000
           }
         ]
       },
@@ -1020,15 +3037,97 @@
       "level": 29,
       "requirements": [
         {
-          "name": "Drydock C",
+          "name": "drydock c",
           "level": 29
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 62448,
+          "armor_pierce": 74375,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 35841,
+          "shield_pierce": 74375
+        },
+        "defense": {
+          "armor": 8908,
+          "dodge": 8908,
+          "shield_deflect": 8908
+        },
+        "health": {
+          "hull_health": 59028,
+          "shield_health": 16830
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 62448,
+            "armor_pierce": 74375,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 8960,
+            "max_damage": 8500,
+            "min_damage": 7083,
+            "shield_pierce": 74375
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 62448,
+            "armor_pierce": 74375,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 8960,
+            "max_damage": 8500,
+            "min_damage": 7083,
+            "shield_pierce": 74375
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 30
+        "bonus1": 30.0
       },
       "build_costs": {
         "materials": [
@@ -1048,16 +3147,16 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 26520000
+            "type": "dilithium",
+            "value": 78000
           },
           {
             "type": "tritanium",
             "value": 780000
           },
           {
-            "type": "dilithium",
-            "value": 78000
+            "type": "parsteel",
+            "value": 26520000
           }
         ]
       },
@@ -1066,19 +3165,101 @@
       "level": 30,
       "requirements": [
         {
-          "name": "Drydock C",
+          "name": "drydock c",
           "level": 30
         },
         {
-          "name": "Defense Technologies",
+          "name": "defense technologies",
           "level": 30
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 77490,
+          "armor_pierce": 76125,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 37780,
+          "shield_pierce": 76125
+        },
+        "defense": {
+          "armor": 10611,
+          "dodge": 10611,
+          "shield_deflect": 10611
+        },
+        "health": {
+          "hull_health": 67494,
+          "shield_health": 17230
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 77490,
+            "armor_pierce": 76125,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 9445,
+            "max_damage": 8960,
+            "min_damage": 7466,
+            "shield_pierce": 76125
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 77490,
+            "armor_pierce": 76125,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 9445,
+            "max_damage": 8960,
+            "min_damage": 7466,
+            "shield_pierce": 76125
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 31
+        "bonus1": 31.0
       },
       "build_costs": {
         "materials": [
@@ -1092,16 +3273,16 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 41922000
-          },
-          {
             "type": "tritanium",
             "value": 1233000
           },
           {
             "type": "dilithium",
             "value": 123300
+          },
+          {
+            "type": "parsteel",
+            "value": 41922000
           }
         ]
       },
@@ -1110,15 +3291,97 @@
       "level": 31,
       "requirements": [
         {
-          "name": "Drydock C",
+          "name": "drydock c",
           "level": 31
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 87436,
+          "armor_pierce": 89375,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 40278,
+          "shield_pierce": 89375
+        },
+        "defense": {
+          "armor": 12016,
+          "dodge": 12016,
+          "shield_deflect": 12016
+        },
+        "health": {
+          "hull_health": 77484,
+          "shield_health": 19910
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 87436,
+            "armor_pierce": 89375,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 10069,
+            "max_damage": 9552,
+            "min_damage": 7960,
+            "shield_pierce": 89375
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 87436,
+            "armor_pierce": 89375,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 10069,
+            "max_damage": 9552,
+            "min_damage": 7960,
+            "shield_pierce": 89375
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 32
+        "bonus1": 32.0
       },
       "build_costs": {
         "materials": [
@@ -1138,16 +3401,16 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 60554000
-          },
-          {
             "type": "tritanium",
             "value": 1781000
           },
           {
             "type": "dilithium",
             "value": 178100
+          },
+          {
+            "type": "parsteel",
+            "value": 60554000
           }
         ]
       },
@@ -1156,15 +3419,97 @@
       "level": 32,
       "requirements": [
         {
-          "name": "Drydock C",
+          "name": "drydock c",
           "level": 32
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 91746,
+          "armor_pierce": 123750,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 45600,
+          "shield_pierce": 123750
+        },
+        "defense": {
+          "armor": 13124,
+          "dodge": 13124,
+          "shield_deflect": 13124
+        },
+        "health": {
+          "hull_health": 83090,
+          "shield_health": 20120
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 91746,
+            "armor_pierce": 123750,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 11400,
+            "max_damage": 10814,
+            "min_damage": 9012,
+            "shield_pierce": 123750
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 91746,
+            "armor_pierce": 123750,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 11400,
+            "max_damage": 10814,
+            "min_damage": 9012,
+            "shield_pierce": 123750
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 33
+        "bonus1": 33.0
       },
       "build_costs": {
         "materials": [
@@ -1178,16 +3523,16 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 93670000
-          },
-          {
             "type": "tritanium",
             "value": 2755000
           },
           {
             "type": "dilithium",
             "value": 275500
+          },
+          {
+            "type": "parsteel",
+            "value": 93670000
           }
         ]
       },
@@ -1196,19 +3541,101 @@
       "level": 33,
       "requirements": [
         {
-          "name": "Defense Platform B",
+          "name": "drydock c",
           "level": 33
         },
         {
-          "name": "Drydock C",
+          "name": "defense platform b",
           "level": 33
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 94480,
+          "armor_pierce": 144038,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 47773,
+          "shield_pierce": 144038
+        },
+        "defense": {
+          "armor": 13560,
+          "dodge": 13560,
+          "shield_deflect": 13560
+        },
+        "health": {
+          "hull_health": 92622,
+          "shield_health": 21830
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 94480,
+            "armor_pierce": 144038,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 11943,
+            "max_damage": 11330,
+            "min_damage": 9441,
+            "shield_pierce": 144038
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 94480,
+            "armor_pierce": 144038,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 11943,
+            "max_damage": 11330,
+            "min_damage": 9441,
+            "shield_pierce": 144038
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 34
+        "bonus1": 34.0
       },
       "build_costs": {
         "materials": [
@@ -1240,29 +3667,111 @@
       "level": 34,
       "requirements": [
         {
-          "name": "Drydock C",
+          "name": "drydock c",
           "level": 34
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 100000,
+          "armor_pierce": 161563,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 50660,
+          "shield_pierce": 161563
+        },
+        "defense": {
+          "armor": 14845,
+          "dodge": 14845,
+          "shield_deflect": 14845
+        },
+        "health": {
+          "hull_health": 102230,
+          "shield_health": 22770
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 100000,
+            "armor_pierce": 161563,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 12665,
+            "max_damage": 12014,
+            "min_damage": 10012,
+            "shield_pierce": 161563
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 100000,
+            "armor_pierce": 161563,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 12665,
+            "max_damage": 12014,
+            "min_damage": 10012,
+            "shield_pierce": 161563
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 35
+        "bonus1": 35.0
       },
       "build_costs": {
         "materials": [
           {
             "type": "gas",
             "grade": 3,
-            "rarity": "common",
-            "value": 1300
+            "rarity": "uncommon",
+            "value": 180
           },
           {
             "type": "gas",
             "grade": 3,
-            "rarity": "uncommon",
-            "value": 180
+            "rarity": "common",
+            "value": 1300
           }
         ],
         "others": [],
@@ -1272,12 +3781,12 @@
             "value": 228888000
           },
           {
-            "type": "tritanium",
-            "value": 6732000
-          },
-          {
             "type": "dilithium",
             "value": 673200
+          },
+          {
+            "type": "tritanium",
+            "value": 6732000
           }
         ]
       },
@@ -1286,19 +3795,101 @@
       "level": 35,
       "requirements": [
         {
-          "name": "Defense Technologies",
+          "name": "drydock c",
           "level": 35
         },
         {
-          "name": "Drydock C",
+          "name": "defense technologies",
           "level": 35
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 109796,
+          "armor_pierce": 196875,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 59319,
+          "shield_pierce": 196875
+        },
+        "defense": {
+          "armor": 16480,
+          "dodge": 16480,
+          "shield_deflect": 16480
+        },
+        "health": {
+          "hull_health": 118699,
+          "shield_health": 28350
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 109796,
+            "armor_pierce": 196875,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 14830,
+            "max_damage": 14068,
+            "min_damage": 11723,
+            "shield_pierce": 196875
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 109796,
+            "armor_pierce": 196875,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 14830,
+            "max_damage": 14068,
+            "min_damage": 11723,
+            "shield_pierce": 196875
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 36
+        "bonus1": 36.0
       },
       "build_costs": {
         "materials": [
@@ -1312,12 +3903,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 322524000
-          },
-          {
             "type": "tritanium",
             "value": 9486000
+          },
+          {
+            "type": "parsteel",
+            "value": 322524000
           },
           {
             "type": "dilithium",
@@ -1330,15 +3921,97 @@
       "level": 36,
       "requirements": [
         {
-          "name": "Drydock C",
+          "name": "drydock c",
           "level": 36
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 119489,
+          "armor_pierce": 227807,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 71792,
+          "shield_pierce": 227807
+        },
+        "defense": {
+          "armor": 17855,
+          "dodge": 17855,
+          "shield_deflect": 17855
+        },
+        "health": {
+          "hull_health": 138605,
+          "shield_health": 32610
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 119489,
+            "armor_pierce": 227807,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 17948,
+            "max_damage": 17026,
+            "min_damage": 14188,
+            "shield_pierce": 227807
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 119489,
+            "armor_pierce": 227807,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 17948,
+            "max_damage": 17026,
+            "min_damage": 14188,
+            "shield_pierce": 227807
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 37
+        "bonus1": 37.0
       },
       "build_costs": {
         "materials": [
@@ -1362,12 +4035,12 @@
             "value": 495720000
           },
           {
-            "type": "tritanium",
-            "value": 14580000
-          },
-          {
             "type": "dilithium",
             "value": 1458000
+          },
+          {
+            "type": "tritanium",
+            "value": 14580000
           }
         ]
       },
@@ -1376,40 +4049,122 @@
       "level": 37,
       "requirements": [
         {
-          "name": "Drydock C",
+          "name": "drydock c",
           "level": 37
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 132418,
+          "armor_pierce": 247922,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 77781,
+          "shield_pierce": 247922
+        },
+        "defense": {
+          "armor": 18489,
+          "dodge": 18489,
+          "shield_deflect": 18489
+        },
+        "health": {
+          "hull_health": 163789,
+          "shield_health": 35710
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 132418,
+            "armor_pierce": 247922,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 19445,
+            "max_damage": 18446,
+            "min_damage": 15372,
+            "shield_pierce": 247922
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 132418,
+            "armor_pierce": 247922,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 19445,
+            "max_damage": 18446,
+            "min_damage": 15372,
+            "shield_pierce": 247922
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 38
+        "bonus1": 38.0
       },
       "build_costs": {
         "materials": [
           {
             "type": "gas",
             "grade": 3,
-            "rarity": "common",
-            "value": 2100
+            "rarity": "uncommon",
+            "value": 310
           },
           {
             "type": "gas",
             "grade": 3,
-            "rarity": "uncommon",
-            "value": 310
+            "rarity": "common",
+            "value": 2100
           }
         ],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 771120000
-          },
-          {
             "type": "tritanium",
             "value": 22680000
+          },
+          {
+            "type": "parsteel",
+            "value": 771120000
           },
           {
             "type": "dilithium",
@@ -1422,31 +4177,113 @@
       "level": 38,
       "requirements": [
         {
-          "name": "Defense Platform B",
+          "name": "drydock c",
           "level": 38
         },
         {
-          "name": "Drydock C",
+          "name": "defense platform b",
           "level": 38
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 144918,
+          "armor_pierce": 286066,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 89173,
+          "shield_pierce": 286066
+        },
+        "defense": {
+          "armor": 20112,
+          "dodge": 20112,
+          "shield_deflect": 20112
+        },
+        "health": {
+          "hull_health": 188609,
+          "shield_health": 41570
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 144918,
+            "armor_pierce": 286066,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 22293,
+            "max_damage": 21148,
+            "min_damage": 17623,
+            "shield_pierce": 286066
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 144918,
+            "armor_pierce": 286066,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 22293,
+            "max_damage": 21148,
+            "min_damage": 17623,
+            "shield_pierce": 286066
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 39
+        "bonus1": 39.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 1315800000
-          },
-          {
             "type": "tritanium",
             "value": 38700000
+          },
+          {
+            "type": "parsteel",
+            "value": 1315800000
           },
           {
             "type": "dilithium",
@@ -1459,41 +4296,119 @@
       "level": 39,
       "requirements": [
         {
-          "name": "Defense Platform B",
+          "name": "drydock c",
           "level": 39
         },
         {
-          "name": "Drydock C",
+          "name": "defense platform b",
           "level": 39
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 159412,
+          "armor_pierce": 333789,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 103443,
+          "shield_pierce": 333789
+        },
+        "defense": {
+          "armor": 22010,
+          "dodge": 22010,
+          "shield_deflect": 22010
+        },
+        "health": {
+          "hull_health": 221741,
+          "shield_health": 48900
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 159412,
+            "armor_pierce": 333789,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 25861,
+            "max_damage": 24532,
+            "min_damage": 20443,
+            "shield_pierce": 333789
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 159412,
+            "armor_pierce": 333789,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 25861,
+            "max_damage": 24532,
+            "min_damage": 20443,
+            "shield_pierce": 333789
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 40
+        "bonus1": 40.0
       },
       "build_costs": {
         "materials": [
           {
             "type": "gas",
             "grade": 4,
-            "rarity": "common",
-            "value": 8000
+            "rarity": "uncommon",
+            "value": 1400
           },
           {
             "type": "gas",
             "grade": 4,
-            "rarity": "uncommon",
-            "value": 1400
+            "rarity": "common",
+            "value": 8000
           }
         ],
         "others": [],
         "resources": [
-          {
-            "type": "parsteel",
-            "value": 5731040000
-          },
           {
             "type": "tritanium",
             "value": 60200000
@@ -1501,6 +4416,10 @@
           {
             "type": "dilithium",
             "value": 6020000
+          },
+          {
+            "type": "parsteel",
+            "value": 5731040000
           }
         ]
       },
@@ -1509,15 +4428,128 @@
       "level": 40,
       "requirements": [
         {
-          "name": "Drydock C",
+          "name": "drydock c",
           "level": 40
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 362912,
+          "armor_pierce": 362912,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 140585,
+          "shield_pierce": 362912
+        },
+        "defense": {
+          "armor": 23930,
+          "dodge": 23930,
+          "shield_deflect": 23930
+        },
+        "health": {
+          "hull_health": 241088,
+          "shield_health": 53167
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 362912,
+            "armor_pierce": 362912,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 28117,
+            "max_damage": 26672,
+            "min_damage": 22227,
+            "shield_pierce": 362912
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 362912,
+            "armor_pierce": 362912,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 28117,
+            "max_damage": 26672,
+            "min_damage": 22227,
+            "shield_pierce": 362912
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 1,
+          "weapon_stats": {
+            "accuracy": 362912,
+            "armor_pierce": 362912,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 28117,
+            "max_damage": 26672,
+            "min_damage": 22227,
+            "shield_pierce": 362912
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 41
+        "bonus1": 41.0
       },
       "build_costs": {
         "materials": [
@@ -1537,16 +4569,16 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 5848000000
-          },
-          {
             "type": "tritanium",
             "value": 86000000
           },
           {
             "type": "dilithium",
             "value": 8600000
+          },
+          {
+            "type": "parsteel",
+            "value": 5848000000
           }
         ]
       },
@@ -1555,44 +4587,157 @@
       "level": 41,
       "requirements": [
         {
-          "name": "Defense Platform B",
+          "name": "drydock c",
           "level": 41
         },
         {
-          "name": "Drydock C",
+          "name": "defense platform b",
           "level": 41
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 393258,
+          "armor_pierce": 393258,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 152343,
+          "shield_pierce": 393258
+        },
+        "defense": {
+          "armor": 25931,
+          "dodge": 26457,
+          "shield_deflect": 26457
+        },
+        "health": {
+          "hull_health": 261247,
+          "shield_health": 58781
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 393258,
+            "armor_pierce": 393258,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 30469,
+            "max_damage": 28903,
+            "min_damage": 24086,
+            "shield_pierce": 393258
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 393258,
+            "armor_pierce": 393258,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 30469,
+            "max_damage": 28903,
+            "min_damage": 24086,
+            "shield_pierce": 393258
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 1,
+          "weapon_stats": {
+            "accuracy": 393258,
+            "armor_pierce": 393258,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 30469,
+            "max_damage": 28903,
+            "min_damage": 24086,
+            "shield_pierce": 393258
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 42
+        "bonus1": 42.0
       },
       "build_costs": {
         "materials": [
           {
             "type": "gas",
             "grade": 4,
-            "rarity": "common",
-            "value": 25000
+            "rarity": "uncommon",
+            "value": 6000
           },
           {
             "type": "gas",
             "grade": 4,
-            "rarity": "uncommon",
-            "value": 6000
+            "rarity": "common",
+            "value": 25000
           }
         ],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 8710800000
-          },
-          {
             "type": "tritanium",
             "value": 128100000
+          },
+          {
+            "type": "parsteel",
+            "value": 8710800000
           },
           {
             "type": "dilithium",
@@ -1605,29 +4750,142 @@
       "level": 42,
       "requirements": [
         {
-          "name": "Drydock C",
+          "name": "drydock c",
           "level": 42
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 426142,
+          "armor_pierce": 426142,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 165083,
+          "shield_pierce": 426142
+        },
+        "defense": {
+          "armor": 28099,
+          "dodge": 29251,
+          "shield_deflect": 29251
+        },
+        "health": {
+          "hull_health": 283092,
+          "shield_health": 64988
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 426142,
+            "armor_pierce": 426142,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 33016,
+            "max_damage": 31320,
+            "min_damage": 26100,
+            "shield_pierce": 426142
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 426142,
+            "armor_pierce": 426142,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 33016,
+            "max_damage": 31320,
+            "min_damage": 26100,
+            "shield_pierce": 426142
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 1,
+          "weapon_stats": {
+            "accuracy": 426142,
+            "armor_pierce": 426142,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 33016,
+            "max_damage": 31320,
+            "min_damage": 26100,
+            "shield_pierce": 426142
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 43
+        "bonus1": 43.0
       },
       "build_costs": {
         "materials": [
           {
             "type": "gas",
             "grade": 4,
-            "rarity": "uncommon",
-            "value": 6000
+            "rarity": "rare",
+            "value": 750
           },
           {
             "type": "gas",
             "grade": 4,
-            "rarity": "rare",
-            "value": 750
+            "rarity": "uncommon",
+            "value": 6000
           }
         ],
         "others": [],
@@ -1637,12 +4895,12 @@
             "value": 12444000000
           },
           {
-            "type": "tritanium",
-            "value": 183000000
-          },
-          {
             "type": "dilithium",
             "value": 18300000
+          },
+          {
+            "type": "tritanium",
+            "value": 183000000
           }
         ]
       },
@@ -1651,15 +4909,128 @@
       "level": 43,
       "requirements": [
         {
-          "name": "Drydock C",
+          "name": "drydock c",
           "level": 43
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 461775,
+          "armor_pierce": 461775,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 178883,
+          "shield_pierce": 461775
+        },
+        "defense": {
+          "armor": 30449,
+          "dodge": 32339,
+          "shield_deflect": 32339
+        },
+        "health": {
+          "hull_health": 306764,
+          "shield_health": 71850
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 461775,
+            "armor_pierce": 461775,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 35776,
+            "max_damage": 33938,
+            "min_damage": 28282,
+            "shield_pierce": 461775
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 461775,
+            "armor_pierce": 461775,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 35776,
+            "max_damage": 33938,
+            "min_damage": 28282,
+            "shield_pierce": 461775
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 1,
+          "weapon_stats": {
+            "accuracy": 461775,
+            "armor_pierce": 461775,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 35776,
+            "max_damage": 33938,
+            "min_damage": 28282,
+            "shield_pierce": 461775
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 44
+        "bonus1": 44.0
       },
       "build_costs": {
         "materials": [
@@ -1677,12 +5048,12 @@
             "value": 18666000000
           },
           {
-            "type": "tritanium",
-            "value": 274500000
-          },
-          {
             "type": "dilithium",
             "value": 27450000
+          },
+          {
+            "type": "tritanium",
+            "value": 274500000
           }
         ]
       },
@@ -1691,19 +5062,132 @@
       "level": 44,
       "requirements": [
         {
-          "name": "Defense Platform B",
+          "name": "drydock c",
           "level": 44
         },
         {
-          "name": "Drydock C",
+          "name": "defense platform b",
           "level": 44
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 500387,
+          "armor_pierce": 500387,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 193841,
+          "shield_pierce": 500387
+        },
+        "defense": {
+          "armor": 32995,
+          "dodge": 35754,
+          "shield_deflect": 35754
+        },
+        "health": {
+          "hull_health": 332415,
+          "shield_health": 79437
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 500387,
+            "armor_pierce": 500387,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 38768,
+            "max_damage": 36776,
+            "min_damage": 30647,
+            "shield_pierce": 500387
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 500387,
+            "armor_pierce": 500387,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 38768,
+            "max_damage": 36776,
+            "min_damage": 30647,
+            "shield_pierce": 500387
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 1,
+          "weapon_stats": {
+            "accuracy": 500387,
+            "armor_pierce": 500387,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 38768,
+            "max_damage": 36776,
+            "min_damage": 30647,
+            "shield_pierce": 500387
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 45
+        "bonus1": 45.0
       },
       "build_costs": {
         "materials": [
@@ -1723,16 +5207,16 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 26520000000
+            "type": "dilithium",
+            "value": 39000000
           },
           {
             "type": "tritanium",
             "value": 390000000
           },
           {
-            "type": "dilithium",
-            "value": 39000000
+            "type": "parsteel",
+            "value": 26520000000
           }
         ]
       },
@@ -1741,19 +5225,132 @@
       "level": 45,
       "requirements": [
         {
-          "name": "Drydock C",
+          "name": "drydock c",
           "level": 45
         },
         {
-          "name": "Defense Technologies",
+          "name": "defense technologies",
           "level": 45
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 542229,
+          "armor_pierce": 542229,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 210048,
+          "shield_pierce": 542229
+        },
+        "defense": {
+          "armor": 35754,
+          "dodge": 39529,
+          "shield_deflect": 39529
+        },
+        "health": {
+          "hull_health": 360211,
+          "shield_health": 87825
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 542229,
+            "armor_pierce": 542229,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 42010,
+            "max_damage": 39851,
+            "min_damage": 33209,
+            "shield_pierce": 542229
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 542229,
+            "armor_pierce": 542229,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 42010,
+            "max_damage": 39851,
+            "min_damage": 33209,
+            "shield_pierce": 542229
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 1,
+          "weapon_stats": {
+            "accuracy": 542229,
+            "armor_pierce": 542229,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 42010,
+            "max_damage": 39851,
+            "min_damage": 33209,
+            "shield_pierce": 542229
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 46
+        "bonus1": 46.0
       },
       "build_costs": {
         "materials": [
@@ -1791,19 +5388,132 @@
       "level": 46,
       "requirements": [
         {
-          "name": "Defense Platform B",
+          "name": "drydock c",
           "level": 46
         },
         {
-          "name": "Drydock C",
+          "name": "defense platform b",
           "level": 46
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 587569,
+          "armor_pierce": 587569,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 227614,
+          "shield_pierce": 587569
+        },
+        "defense": {
+          "armor": 38744,
+          "dodge": 43703,
+          "shield_deflect": 43703
+        },
+        "health": {
+          "hull_health": 390331,
+          "shield_health": 97099
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 587569,
+            "armor_pierce": 587569,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 45523,
+            "max_damage": 43184,
+            "min_damage": 35986,
+            "shield_pierce": 587569
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 587569,
+            "armor_pierce": 587569,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 45523,
+            "max_damage": 43184,
+            "min_damage": 35986,
+            "shield_pierce": 587569
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 1,
+          "weapon_stats": {
+            "accuracy": 587569,
+            "armor_pierce": 587569,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 45523,
+            "max_damage": 43184,
+            "min_damage": 35986,
+            "shield_pierce": 587569
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 47
+        "bonus1": 47.0
       },
       "build_costs": {
         "materials": [
@@ -1823,12 +5533,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 53040000000
-          },
-          {
             "type": "tritanium",
             "value": 780000000
+          },
+          {
+            "type": "parsteel",
+            "value": 53040000000
           },
           {
             "type": "dilithium",
@@ -1841,15 +5551,128 @@
       "level": 47,
       "requirements": [
         {
-          "name": "Drydock C",
+          "name": "drydock c",
           "level": 47
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 636700,
+          "armor_pierce": 636700,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 246649,
+          "shield_pierce": 636700
+        },
+        "defense": {
+          "armor": 41983,
+          "dodge": 48318,
+          "shield_deflect": 48318
+        },
+        "health": {
+          "hull_health": 422970,
+          "shield_health": 107352
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 636700,
+            "armor_pierce": 636700,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 49330,
+            "max_damage": 46795,
+            "min_damage": 38996,
+            "shield_pierce": 636700
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 636700,
+            "armor_pierce": 636700,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 49330,
+            "max_damage": 46795,
+            "min_damage": 38996,
+            "shield_pierce": 636700
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 1,
+          "weapon_stats": {
+            "accuracy": 636700,
+            "armor_pierce": 636700,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 49330,
+            "max_damage": 46795,
+            "min_damage": 38996,
+            "shield_pierce": 636700
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 48
+        "bonus1": 48.0
       },
       "build_costs": {
         "materials": [
@@ -1869,12 +5692,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 85680000000
-          },
-          {
             "type": "tritanium",
             "value": 1260000000
+          },
+          {
+            "type": "parsteel",
+            "value": 85680000000
           },
           {
             "type": "dilithium",
@@ -1887,15 +5710,128 @@
       "level": 48,
       "requirements": [
         {
-          "name": "Drydock C",
+          "name": "drydock c",
           "level": 48
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 689940,
+          "armor_pierce": 689940,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 267272,
+          "shield_pierce": 689940
+        },
+        "defense": {
+          "armor": 45494,
+          "dodge": 53420,
+          "shield_deflect": 53420
+        },
+        "health": {
+          "hull_health": 458338,
+          "shield_health": 118687
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 689940,
+            "armor_pierce": 689940,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 53454,
+            "max_damage": 50708,
+            "min_damage": 42256,
+            "shield_pierce": 689940
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 689940,
+            "armor_pierce": 689940,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 53454,
+            "max_damage": 50708,
+            "min_damage": 42256,
+            "shield_pierce": 689940
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 1,
+          "weapon_stats": {
+            "accuracy": 689940,
+            "armor_pierce": 689940,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 53454,
+            "max_damage": 50708,
+            "min_damage": 42256,
+            "shield_pierce": 689940
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 49
+        "bonus1": 49.0
       },
       "build_costs": {
         "materials": [
@@ -1915,16 +5851,16 @@
         "others": [],
         "resources": [
           {
+            "type": "dilithium",
+            "value": 210000000
+          },
+          {
             "type": "parsteel",
             "value": 142800000000
           },
           {
             "type": "tritanium",
             "value": 2100000000
-          },
-          {
-            "type": "dilithium",
-            "value": 210000000
           }
         ]
       },
@@ -1933,35 +5869,148 @@
       "level": 49,
       "requirements": [
         {
-          "name": "Drydock C",
+          "name": "drydock c",
           "level": 49
         },
         {
-          "name": "Defense Platform B",
+          "name": "defense platform b",
           "level": 49
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 747632,
+          "armor_pierce": 747632,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 289622,
+          "shield_pierce": 747632
+        },
+        "defense": {
+          "armor": 49298,
+          "dodge": 59061,
+          "shield_deflect": 59061
+        },
+        "health": {
+          "hull_health": 496663,
+          "shield_health": 131220
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 747632,
+            "armor_pierce": 747632,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 57924,
+            "max_damage": 54948,
+            "min_damage": 45790,
+            "shield_pierce": 747632
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 747632,
+            "armor_pierce": 747632,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 57924,
+            "max_damage": 54948,
+            "min_damage": 45790,
+            "shield_pierce": 747632
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 1,
+          "weapon_stats": {
+            "accuracy": 747632,
+            "armor_pierce": 747632,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 57924,
+            "max_damage": 54948,
+            "min_damage": 45790,
+            "shield_pierce": 747632
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 50
+        "bonus1": 50.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 249900000000
+            "type": "dilithium",
+            "value": 367500000
           },
           {
             "type": "tritanium",
             "value": 3675000000
           },
           {
-            "type": "dilithium",
-            "value": 367500000
+            "type": "parsteel",
+            "value": 249900000000
           }
         ]
       },
@@ -1970,11 +6019,931 @@
       "level": 50,
       "requirements": [
         {
-          "name": "Drydock C",
+          "name": "drydock c",
           "level": 50
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 810147,
+          "armor_pierce": 810147,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 313835,
+          "shield_pierce": 810147
+        },
+        "defense": {
+          "armor": 53420,
+          "dodge": 65297,
+          "shield_deflect": 65297
+        },
+        "health": {
+          "hull_health": 538193,
+          "shield_health": 145076
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 810147,
+            "armor_pierce": 810147,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 62767,
+            "max_damage": 59542,
+            "min_damage": 49618,
+            "shield_pierce": 810147
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 810147,
+            "armor_pierce": 810147,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 62767,
+            "max_damage": 59542,
+            "min_damage": 49618,
+            "shield_pierce": 810147
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 1,
+          "weapon_stats": {
+            "accuracy": 810147,
+            "armor_pierce": 810147,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 62767,
+            "max_damage": 59542,
+            "min_damage": 49618,
+            "shield_pierce": 810147
+          },
+          "weapon_type": "energy"
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 51.0
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "gas",
+            "grade": 5,
+            "rarity": "common",
+            "value": 21700
+          },
+          {
+            "type": "gas",
+            "grade": 5,
+            "rarity": "uncommon",
+            "value": 1900
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 1246440000000
+          },
+          {
+            "type": "dilithium",
+            "value": 780000000
+          },
+          {
+            "type": "tritanium",
+            "value": 7800000000
+          }
+        ]
+      },
+      "build_time": 104346720,
+      "increased_power": 1216045,
+      "level": 51,
+      "requirements": [
+        {
+          "name": "drydock c",
+          "level": 51
+        }
+      ],
+      "stats": {
+        "attack": {
+          "accuracy": 931669,
+          "armor_pierce": 931669,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 360910,
+          "shield_pierce": 931669
+        },
+        "defense": {
+          "armor": 75092,
+          "dodge": 75092,
+          "shield_deflect": 75092
+        },
+        "health": {
+          "hull_health": 618922,
+          "shield_health": 166837
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 931669,
+            "armor_pierce": 931669,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 72182,
+            "max_damage": 68473,
+            "min_damage": 57061,
+            "shield_pierce": 931669
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 931669,
+            "armor_pierce": 931669,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 72182,
+            "max_damage": 68473,
+            "min_damage": 57061,
+            "shield_pierce": 931669
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 1,
+          "weapon_stats": {
+            "accuracy": 931669,
+            "armor_pierce": 931669,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 72182,
+            "max_damage": 68473,
+            "min_damage": 57061,
+            "shield_pierce": 931669
+          },
+          "weapon_type": "energy"
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 52.0
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "gas",
+            "grade": 5,
+            "rarity": "uncommon",
+            "value": 4300
+          },
+          {
+            "type": "gas",
+            "grade": 5,
+            "rarity": "common",
+            "value": 37500
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 2254200000000
+          },
+          {
+            "type": "tritanium",
+            "value": 13260000000
+          },
+          {
+            "type": "dilithium",
+            "value": 1326000000
+          }
+        ]
+      },
+      "build_time": 110606400,
+      "increased_power": 2571112,
+      "level": 52,
+      "requirements": [
+        {
+          "name": "drydock c",
+          "level": 52
+        },
+        {
+          "name": "defense platform b",
+          "level": 52
+        }
+      ],
+      "stats": {
+        "attack": {
+          "accuracy": 1174713,
+          "armor_pierce": 1174713,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 712868,
+          "shield_pierce": 1174713
+        },
+        "defense": {
+          "armor": 94681,
+          "dodge": 94681,
+          "shield_deflect": 94681
+        },
+        "health": {
+          "hull_health": 780380,
+          "shield_health": 210360
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 1174713,
+            "armor_pierce": 1174713,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 142574,
+            "max_damage": 161618,
+            "min_damage": 86336,
+            "shield_pierce": 1174713
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 1174713,
+            "armor_pierce": 1174713,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 142574,
+            "max_damage": 161618,
+            "min_damage": 86336,
+            "shield_pierce": 1174713
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 1,
+          "weapon_stats": {
+            "accuracy": 1174713,
+            "armor_pierce": 1174713,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 142574,
+            "max_damage": 161618,
+            "min_damage": 86336,
+            "shield_pierce": 1174713
+          },
+          "weapon_type": "energy"
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 53.0
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "gas",
+            "grade": 5,
+            "rarity": "common",
+            "value": 88900
+          },
+          {
+            "type": "gas",
+            "grade": 5,
+            "rarity": "uncommon",
+            "value": 15500
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 23200000000
+          },
+          {
+            "type": "parsteel",
+            "value": 3786240000000
+          },
+          {
+            "type": "dilithium",
+            "value": 2320000000
+          }
+        ]
+      },
+      "build_time": 117243360,
+      "increased_power": 9914492,
+      "level": 53,
+      "requirements": [
+        {
+          "name": "drydock c",
+          "level": 53
+        },
+        {
+          "name": "defense platform b",
+          "level": 53
+        }
+      ],
+      "stats": {
+        "attack": {
+          "accuracy": 2187397,
+          "armor_pierce": 2187397,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 1380871,
+          "shield_pierce": 2187397
+        },
+        "defense": {
+          "armor": 176302,
+          "dodge": 176302,
+          "shield_deflect": 176302
+        },
+        "health": {
+          "hull_health": 1453121,
+          "shield_health": 391705
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 2187397,
+            "armor_pierce": 2187397,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 276174,
+            "max_damage": 319540,
+            "min_damage": 160763,
+            "shield_pierce": 2187397
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 2187397,
+            "armor_pierce": 2187397,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 276174,
+            "max_damage": 319540,
+            "min_damage": 160763,
+            "shield_pierce": 2187397
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 1,
+          "weapon_stats": {
+            "accuracy": 2187397,
+            "armor_pierce": 2187397,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 276174,
+            "max_damage": 319540,
+            "min_damage": 160763,
+            "shield_pierce": 2187397
+          },
+          "weapon_type": "energy"
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 54.0
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "gas",
+            "grade": 5,
+            "rarity": "common",
+            "value": 76500
+          },
+          {
+            "type": "gas",
+            "grade": 5,
+            "rarity": "rare",
+            "value": 7000
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 34800000000
+          },
+          {
+            "type": "dilithium",
+            "value": 3480000000
+          },
+          {
+            "type": "parsteel",
+            "value": 5679360000000
+          }
+        ]
+      },
+      "build_time": 124277760,
+      "increased_power": 2449504,
+      "level": 54,
+      "requirements": [
+        {
+          "name": "drydock c",
+          "level": 54
+        },
+        {
+          "name": "defense platform b",
+          "level": 54
+        }
+      ],
+      "stats": {
+        "attack": {
+          "accuracy": 2430441,
+          "armor_pierce": 2430441,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 1611219,
+          "shield_pierce": 2430441
+        },
+        "defense": {
+          "armor": 195891,
+          "dodge": 195891,
+          "shield_deflect": 195891
+        },
+        "health": {
+          "hull_health": 1614579,
+          "shield_health": 435228
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 2430441,
+            "armor_pierce": 2430441,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 322244,
+            "max_damage": 381798,
+            "min_damage": 178626,
+            "shield_pierce": 2430441
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 2430441,
+            "armor_pierce": 2430441,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 322244,
+            "max_damage": 381798,
+            "min_damage": 178626,
+            "shield_pierce": 2430441
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 1,
+          "weapon_stats": {
+            "accuracy": 2430441,
+            "armor_pierce": 2430441,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 322244,
+            "max_damage": 381798,
+            "min_damage": 178626,
+            "shield_pierce": 2430441
+          },
+          "weapon_type": "energy"
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 55.0
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "gas",
+            "grade": 5,
+            "rarity": "rare",
+            "value": 8100
+          },
+          {
+            "type": "gas",
+            "grade": 5,
+            "rarity": "uncommon",
+            "value": 22300
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 9653280000000
+          },
+          {
+            "type": "tritanium",
+            "value": 54600000000
+          },
+          {
+            "type": "dilithium",
+            "value": 5460000000
+          }
+        ]
+      },
+      "build_time": 131734080,
+      "increased_power": 4869860,
+      "level": 55,
+      "requirements": [
+        {
+          "name": "drydock c",
+          "level": 55
+        }
+      ],
+      "stats": {
+        "attack": {
+          "accuracy": 2916529,
+          "armor_pierce": 2916529,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 2042768,
+          "shield_pierce": 2916529
+        },
+        "defense": {
+          "armor": 235069,
+          "dodge": 235069,
+          "shield_deflect": 235069
+        },
+        "health": {
+          "hull_health": 1937495,
+          "shield_health": 522274
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 2916529,
+            "armor_pierce": 2916529,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 408554,
+            "max_damage": 496177,
+            "min_damage": 214351,
+            "shield_pierce": 2916529
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 2916529,
+            "armor_pierce": 2916529,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 408554,
+            "max_damage": 496177,
+            "min_damage": 214351,
+            "shield_pierce": 2916529
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 1,
+          "weapon_stats": {
+            "accuracy": 2916529,
+            "armor_pierce": 2916529,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 408554,
+            "max_damage": 496177,
+            "min_damage": 214351,
+            "shield_pierce": 2916529
+          },
+          "weapon_type": "energy"
+        }
+      ]
     }
   ]
 }

--- a/buildings/defense_platform_d.json
+++ b/buildings/defense_platform_d.json
@@ -2,7 +2,7 @@
   "description": "Defense Platforms are the last line of Defense for the Station. Behind defending ships they provide additional fire support. Upgrade to increase the Platform's combat performance.",
   "bonuses": {
     "bonus1": {
-      "name": "Power Level",
+      "name": "power level",
       "percentage": false
     }
   },
@@ -10,19 +10,19 @@
   "levels": [
     {
       "bonuses": {
-        "bonus1": 1
+        "bonus1": 1.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 136
-          },
-          {
             "type": "tritanium",
             "value": 500
+          },
+          {
+            "type": "parsteel",
+            "value": 136
           },
           {
             "type": "dilithium",
@@ -35,15 +35,66 @@
       "level": 1,
       "requirements": [
         {
-          "name": "Defense Platforms",
+          "name": "defense platforms",
           "level": 3
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 18,
+          "armor_pierce": 18,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 506,
+          "shield_pierce": 18
+        },
+        "defense": {
+          "armor": 9,
+          "dodge": 9,
+          "shield_deflect": 9
+        },
+        "health": {
+          "hull_health": 250,
+          "shield_health": 250
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 18,
+            "armor_pierce": 18,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 253,
+            "max_damage": 240,
+            "min_damage": 200,
+            "shield_pierce": 18
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 2
+        "bonus1": 2.0
       },
       "build_costs": {
         "materials": [],
@@ -68,15 +119,66 @@
       "level": 2,
       "requirements": [
         {
-          "name": "Drydock D",
+          "name": "drydock d",
           "level": 2
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 19,
+          "armor_pierce": 19,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 527,
+          "shield_pierce": 19
+        },
+        "defense": {
+          "armor": 9,
+          "dodge": 9,
+          "shield_deflect": 9
+        },
+        "health": {
+          "hull_health": 270,
+          "shield_health": 270
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 19,
+            "armor_pierce": 19,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 263,
+            "max_damage": 250,
+            "min_damage": 208,
+            "shield_pierce": 19
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 3
+        "bonus1": 3.0
       },
       "build_costs": {
         "materials": [],
@@ -101,31 +203,82 @@
       "level": 3,
       "requirements": [
         {
-          "name": "Drydock D",
+          "name": "drydock d",
           "level": 3
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 27,
+          "armor_pierce": 27,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 587,
+          "shield_pierce": 27
+        },
+        "defense": {
+          "armor": 14,
+          "dodge": 14,
+          "shield_deflect": 14
+        },
+        "health": {
+          "hull_health": 290,
+          "shield_health": 290
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 27,
+            "armor_pierce": 27,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 293,
+            "max_damage": 278,
+            "min_damage": 232,
+            "shield_pierce": 27
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 4
+        "bonus1": 4.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 7000
+            "type": "dilithium",
+            "value": 44
           },
           {
             "type": "tritanium",
             "value": 440
           },
           {
-            "type": "dilithium",
-            "value": 44
+            "type": "parsteel",
+            "value": 7000
           }
         ]
       },
@@ -134,24 +287,71 @@
       "level": 4,
       "requirements": [
         {
-          "name": "Drydock D",
+          "name": "drydock d",
           "level": 4
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 36,
+          "armor_pierce": 36,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 662,
+          "shield_pierce": 36
+        },
+        "defense": {
+          "armor": 18,
+          "dodge": 18,
+          "shield_deflect": 18
+        },
+        "health": {
+          "hull_health": 360,
+          "shield_health": 360
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 36,
+            "armor_pierce": 36,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 331,
+            "max_damage": 314,
+            "min_damage": 262,
+            "shield_pierce": 36
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 5
+        "bonus1": 5.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
-          {
-            "type": "parsteel",
-            "value": 7750
-          },
           {
             "type": "tritanium",
             "value": 460
@@ -159,6 +359,10 @@
           {
             "type": "dilithium",
             "value": 46
+          },
+          {
+            "type": "parsteel",
+            "value": 7750
           }
         ]
       },
@@ -167,27 +371,78 @@
       "level": 5,
       "requirements": [
         {
-          "name": "Drydock D",
+          "name": "drydock d",
           "level": 5
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 46,
+          "armor_pierce": 46,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 818,
+          "shield_pierce": 46
+        },
+        "defense": {
+          "armor": 23,
+          "dodge": 23,
+          "shield_deflect": 23
+        },
+        "health": {
+          "hull_health": 500,
+          "shield_health": 500
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 46,
+            "armor_pierce": 46,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 409,
+            "max_damage": 388,
+            "min_damage": 323,
+            "shield_pierce": 46
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 6
+        "bonus1": 6.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 8500
-          },
-          {
             "type": "tritanium",
             "value": 480
+          },
+          {
+            "type": "parsteel",
+            "value": 8500
           },
           {
             "type": "dilithium",
@@ -200,31 +455,82 @@
       "level": 6,
       "requirements": [
         {
-          "name": "Drydock D",
+          "name": "drydock d",
           "level": 6
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 63,
+          "armor_pierce": 63,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 1045,
+          "shield_pierce": 63
+        },
+        "defense": {
+          "armor": 32,
+          "dodge": 32,
+          "shield_deflect": 32
+        },
+        "health": {
+          "hull_health": 660,
+          "shield_health": 660
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 63,
+            "armor_pierce": 63,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 523,
+            "max_damage": 496,
+            "min_damage": 413,
+            "shield_pierce": 63
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 7
+        "bonus1": 7.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 9250
+            "type": "dilithium",
+            "value": 50
           },
           {
             "type": "tritanium",
             "value": 500
           },
           {
-            "type": "dilithium",
-            "value": 50
+            "type": "parsteel",
+            "value": 9250
           }
         ]
       },
@@ -233,20 +539,75 @@
       "level": 7,
       "requirements": [
         {
-          "name": "Drydock D",
+          "name": "drydock d",
           "level": 7
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 94,
+          "armor_pierce": 94,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 1298,
+          "shield_pierce": 94
+        },
+        "defense": {
+          "armor": 47,
+          "dodge": 47,
+          "shield_deflect": 47
+        },
+        "health": {
+          "hull_health": 960,
+          "shield_health": 960
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 94,
+            "armor_pierce": 94,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 649,
+            "max_damage": 616,
+            "min_damage": 513,
+            "shield_pierce": 94
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 8
+        "bonus1": 8.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
+          {
+            "type": "dilithium",
+            "value": 52
+          },
           {
             "type": "parsteel",
             "value": 10000
@@ -254,10 +615,6 @@
           {
             "type": "tritanium",
             "value": 520
-          },
-          {
-            "type": "dilithium",
-            "value": 52
           }
         ]
       },
@@ -266,31 +623,82 @@
       "level": 8,
       "requirements": [
         {
-          "name": "Drydock D",
+          "name": "drydock d",
           "level": 8
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 138,
+          "armor_pierce": 138,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 1948,
+          "shield_pierce": 138
+        },
+        "defense": {
+          "armor": 69,
+          "dodge": 69,
+          "shield_deflect": 69
+        },
+        "health": {
+          "hull_health": 1370,
+          "shield_health": 1370
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 138,
+            "armor_pierce": 138,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 974,
+            "max_damage": 924,
+            "min_damage": 770,
+            "shield_pierce": 138
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 9
+        "bonus1": 9.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 11000
+            "type": "dilithium",
+            "value": 54
           },
           {
             "type": "tritanium",
             "value": 540
           },
           {
-            "type": "dilithium",
-            "value": 54
+            "type": "parsteel",
+            "value": 11000
           }
         ]
       },
@@ -299,27 +707,78 @@
       "level": 9,
       "requirements": [
         {
-          "name": "Drydock D",
+          "name": "drydock d",
           "level": 9
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 200,
+          "armor_pierce": 200,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 2728,
+          "shield_pierce": 200
+        },
+        "defense": {
+          "armor": 100,
+          "dodge": 100,
+          "shield_deflect": 100
+        },
+        "health": {
+          "hull_health": 2020,
+          "shield_health": 2020
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 200,
+            "armor_pierce": 200,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 1364,
+            "max_damage": 1294,
+            "min_damage": 1078,
+            "shield_pierce": 200
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 10
+        "bonus1": 10.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 12500
-          },
-          {
             "type": "tritanium",
             "value": 600
+          },
+          {
+            "type": "parsteel",
+            "value": 12500
           },
           {
             "type": "dilithium",
@@ -332,31 +791,113 @@
       "level": 10,
       "requirements": [
         {
-          "name": "Drydock D",
+          "name": "drydock d",
           "level": 10
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 236,
+          "armor_pierce": 236,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 3503,
+          "shield_pierce": 236
+        },
+        "defense": {
+          "armor": 131,
+          "dodge": 131,
+          "shield_deflect": 131
+        },
+        "health": {
+          "hull_health": 2560,
+          "shield_health": 2560
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 236,
+            "armor_pierce": 236,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 1168,
+            "max_damage": 1108,
+            "min_damage": 923,
+            "shield_pierce": 236
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 1,
+          "weapon_stats": {
+            "accuracy": 236,
+            "armor_pierce": 236,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 1168,
+            "max_damage": 1108,
+            "min_damage": 923,
+            "shield_pierce": 236
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 11
+        "bonus1": 11.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 13600
+            "type": "dilithium",
+            "value": 8
           },
           {
             "type": "tritanium",
             "value": 400
           },
           {
-            "type": "dilithium",
-            "value": 8
+            "type": "parsteel",
+            "value": 13600
           }
         ]
       },
@@ -365,31 +906,113 @@
       "level": 11,
       "requirements": [
         {
-          "name": "Drydock D",
+          "name": "drydock d",
           "level": 11
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 260,
+          "armor_pierce": 260,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 4782,
+          "shield_pierce": 260
+        },
+        "defense": {
+          "armor": 153,
+          "dodge": 153,
+          "shield_deflect": 153
+        },
+        "health": {
+          "hull_health": 2740,
+          "shield_health": 2740
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 260,
+            "armor_pierce": 260,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 1594,
+            "max_damage": 1512,
+            "min_damage": 1260,
+            "shield_pierce": 260
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 1,
+          "weapon_stats": {
+            "accuracy": 260,
+            "armor_pierce": 260,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 1594,
+            "max_damage": 1512,
+            "min_damage": 1260,
+            "shield_pierce": 260
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 12
+        "bonus1": 12.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 18700
+            "type": "dilithium",
+            "value": 22
           },
           {
             "type": "tritanium",
             "value": 550
           },
           {
-            "type": "dilithium",
-            "value": 22
+            "type": "parsteel",
+            "value": 18700
           }
         ]
       },
@@ -398,31 +1021,113 @@
       "level": 12,
       "requirements": [
         {
-          "name": "Drydock D",
+          "name": "drydock d",
           "level": 12
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 340,
+          "armor_pierce": 340,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 5142,
+          "shield_pierce": 340
+        },
+        "defense": {
+          "armor": 213,
+          "dodge": 213,
+          "shield_deflect": 213
+        },
+        "health": {
+          "hull_health": 2880,
+          "shield_health": 2880
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 340,
+            "armor_pierce": 340,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 1714,
+            "max_damage": 1626,
+            "min_damage": 1355,
+            "shield_pierce": 340
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 1,
+          "weapon_stats": {
+            "accuracy": 340,
+            "armor_pierce": 340,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 1714,
+            "max_damage": 1626,
+            "min_damage": 1355,
+            "shield_pierce": 340
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 13
+        "bonus1": 13.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 27200
+            "type": "dilithium",
+            "value": 48
           },
           {
             "type": "tritanium",
             "value": 800
           },
           {
-            "type": "dilithium",
-            "value": 48
+            "type": "parsteel",
+            "value": 27200
           }
         ]
       },
@@ -431,31 +1136,113 @@
       "level": 13,
       "requirements": [
         {
-          "name": "Drydock D",
+          "name": "drydock d",
           "level": 13
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 438,
+          "armor_pierce": 438,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 5572,
+          "shield_pierce": 438
+        },
+        "defense": {
+          "armor": 274,
+          "dodge": 274,
+          "shield_deflect": 274
+        },
+        "health": {
+          "hull_health": 3350,
+          "shield_health": 3350
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 438,
+            "armor_pierce": 438,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 1857,
+            "max_damage": 1762,
+            "min_damage": 1468,
+            "shield_pierce": 438
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 1,
+          "weapon_stats": {
+            "accuracy": 438,
+            "armor_pierce": 438,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 1857,
+            "max_damage": 1762,
+            "min_damage": 1468,
+            "shield_pierce": 438
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 14
+        "bonus1": 14.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 37400
+            "type": "dilithium",
+            "value": 88
           },
           {
             "type": "tritanium",
             "value": 1100
           },
           {
-            "type": "dilithium",
-            "value": 88
+            "type": "parsteel",
+            "value": 37400
           }
         ]
       },
@@ -464,27 +1251,109 @@
       "level": 14,
       "requirements": [
         {
-          "name": "Drydock D",
+          "name": "drydock d",
           "level": 14
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 454,
+          "armor_pierce": 454,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 5730,
+          "shield_pierce": 454
+        },
+        "defense": {
+          "armor": 371,
+          "dodge": 371,
+          "shield_deflect": 371
+        },
+        "health": {
+          "hull_health": 3460,
+          "shield_health": 3460
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 454,
+            "armor_pierce": 454,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 1910,
+            "max_damage": 1812,
+            "min_damage": 1510,
+            "shield_pierce": 454
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 1,
+          "weapon_stats": {
+            "accuracy": 454,
+            "armor_pierce": 454,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 1910,
+            "max_damage": 1812,
+            "min_damage": 1510,
+            "shield_pierce": 454
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 15
+        "bonus1": 15.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 51000
-          },
-          {
             "type": "tritanium",
             "value": 1500
+          },
+          {
+            "type": "parsteel",
+            "value": 51000
           },
           {
             "type": "dilithium",
@@ -497,31 +1366,113 @@
       "level": 15,
       "requirements": [
         {
-          "name": "Drydock D",
+          "name": "drydock d",
           "level": 15
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 475,
+          "armor_pierce": 475,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 5863,
+          "shield_pierce": 475
+        },
+        "defense": {
+          "armor": 400,
+          "dodge": 400,
+          "shield_deflect": 400
+        },
+        "health": {
+          "hull_health": 3730,
+          "shield_health": 3730
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 475,
+            "armor_pierce": 475,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 1954,
+            "max_damage": 1854,
+            "min_damage": 1545,
+            "shield_pierce": 475
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 1,
+          "weapon_stats": {
+            "accuracy": 475,
+            "armor_pierce": 475,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 1954,
+            "max_damage": 1854,
+            "min_damage": 1545,
+            "shield_pierce": 475
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 16
+        "bonus1": 16.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 68000
+            "type": "dilithium",
+            "value": 200
           },
           {
             "type": "tritanium",
             "value": 2000
           },
           {
-            "type": "dilithium",
-            "value": 200
+            "type": "parsteel",
+            "value": 68000
           }
         ]
       },
@@ -530,20 +1481,106 @@
       "level": 16,
       "requirements": [
         {
-          "name": "Drydock D",
+          "name": "drydock d",
           "level": 16
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 556,
+          "armor_pierce": 556,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 7476,
+          "shield_pierce": 556
+        },
+        "defense": {
+          "armor": 479,
+          "dodge": 479,
+          "shield_deflect": 479
+        },
+        "health": {
+          "hull_health": 4750,
+          "shield_health": 4750
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 556,
+            "armor_pierce": 556,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 2492,
+            "max_damage": 2364,
+            "min_damage": 1970,
+            "shield_pierce": 556
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 1,
+          "weapon_stats": {
+            "accuracy": 556,
+            "armor_pierce": 556,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 2492,
+            "max_damage": 2364,
+            "min_damage": 1970,
+            "shield_pierce": 556
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 17
+        "bonus1": 17.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
+          {
+            "type": "dilithium",
+            "value": 280
+          },
           {
             "type": "parsteel",
             "value": 95200
@@ -551,10 +1588,6 @@
           {
             "type": "tritanium",
             "value": 2800
-          },
-          {
-            "type": "dilithium",
-            "value": 280
           }
         ]
       },
@@ -563,15 +1596,97 @@
       "level": 17,
       "requirements": [
         {
-          "name": "Drydock D",
+          "name": "drydock d",
           "level": 17
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 649,
+          "armor_pierce": 649,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 8779,
+          "shield_pierce": 649
+        },
+        "defense": {
+          "armor": 535,
+          "dodge": 535,
+          "shield_deflect": 535
+        },
+        "health": {
+          "hull_health": 5620,
+          "shield_health": 5620
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 649,
+            "armor_pierce": 649,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 2926,
+            "max_damage": 2776,
+            "min_damage": 2313,
+            "shield_pierce": 649
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 1,
+          "weapon_stats": {
+            "accuracy": 649,
+            "armor_pierce": 649,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 2926,
+            "max_damage": 2776,
+            "min_damage": 2313,
+            "shield_pierce": 649
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 18
+        "bonus1": 18.0
       },
       "build_costs": {
         "materials": [],
@@ -582,12 +1697,12 @@
             "value": 136000
           },
           {
-            "type": "tritanium",
-            "value": 4000
-          },
-          {
             "type": "dilithium",
             "value": 400
+          },
+          {
+            "type": "tritanium",
+            "value": 4000
           }
         ]
       },
@@ -596,27 +1711,109 @@
       "level": 18,
       "requirements": [
         {
-          "name": "Drydock D",
+          "name": "drydock d",
           "level": 18
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 672,
+          "armor_pierce": 672,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 10265,
+          "shield_pierce": 672
+        },
+        "defense": {
+          "armor": 560,
+          "dodge": 560,
+          "shield_deflect": 560
+        },
+        "health": {
+          "hull_health": 6120,
+          "shield_health": 6120
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 672,
+            "armor_pierce": 672,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 3422,
+            "max_damage": 3246,
+            "min_damage": 2705,
+            "shield_pierce": 672
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 1,
+          "weapon_stats": {
+            "accuracy": 672,
+            "armor_pierce": 672,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 3422,
+            "max_damage": 3246,
+            "min_damage": 2705,
+            "shield_pierce": 672
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 19
+        "bonus1": 19.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 204000
-          },
-          {
             "type": "tritanium",
             "value": 6000
+          },
+          {
+            "type": "parsteel",
+            "value": 204000
           },
           {
             "type": "dilithium",
@@ -629,31 +1826,113 @@
       "level": 19,
       "requirements": [
         {
-          "name": "Drydock D",
+          "name": "drydock d",
           "level": 19
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 2023,
+          "armor_pierce": 2023,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 10823,
+          "shield_pierce": 2023
+        },
+        "defense": {
+          "armor": 674,
+          "dodge": 674,
+          "shield_deflect": 674
+        },
+        "health": {
+          "hull_health": 6500,
+          "shield_health": 6500
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 2023,
+            "armor_pierce": 2023,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 3608,
+            "max_damage": 3422,
+            "min_damage": 2852,
+            "shield_pierce": 2023
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 1,
+          "weapon_stats": {
+            "accuracy": 2023,
+            "armor_pierce": 2023,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 3608,
+            "max_damage": 3422,
+            "min_damage": 2852,
+            "shield_pierce": 2023
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 20
+        "bonus1": 20.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 289000
+            "type": "dilithium",
+            "value": 850
           },
           {
             "type": "tritanium",
             "value": 8500
           },
           {
-            "type": "dilithium",
-            "value": 850
+            "type": "parsteel",
+            "value": 289000
           }
         ]
       },
@@ -662,28 +1941,106 @@
       "level": 20,
       "requirements": [
         {
-          "name": "Drydock D",
+          "name": "drydock d",
           "level": 20
         },
         {
-          "name": "Defense Technologies",
+          "name": "defense technologies",
           "level": 20
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 2755,
+          "armor_pierce": 2755,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 11173,
+          "shield_pierce": 2755
+        },
+        "defense": {
+          "armor": 689,
+          "dodge": 689,
+          "shield_deflect": 689
+        },
+        "health": {
+          "hull_health": 9860,
+          "shield_health": 6570
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 2755,
+            "armor_pierce": 2755,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 2793,
+            "max_damage": 2650,
+            "min_damage": 2208,
+            "shield_pierce": 2755
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 2755,
+            "armor_pierce": 2755,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 2793,
+            "max_damage": 2650,
+            "min_damage": 2208,
+            "shield_pierce": 2755
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 21
+        "bonus1": 21.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
-          {
-            "type": "parsteel",
-            "value": 486540
-          },
           {
             "type": "tritanium",
             "value": 14310
@@ -691,6 +2048,10 @@
           {
             "type": "dilithium",
             "value": 1431
+          },
+          {
+            "type": "parsteel",
+            "value": 486540
           }
         ]
       },
@@ -699,24 +2060,102 @@
       "level": 21,
       "requirements": [
         {
-          "name": "Drydock D",
+          "name": "drydock d",
           "level": 21
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 3494,
+          "armor_pierce": 3494,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 11360,
+          "shield_pierce": 3494
+        },
+        "defense": {
+          "armor": 699,
+          "dodge": 699,
+          "shield_deflect": 699
+        },
+        "health": {
+          "hull_health": 13540,
+          "shield_health": 6770
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 3494,
+            "armor_pierce": 3494,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 2840,
+            "max_damage": 2694,
+            "min_damage": 2245,
+            "shield_pierce": 3494
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 3494,
+            "armor_pierce": 3494,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 2840,
+            "max_damage": 2694,
+            "min_damage": 2245,
+            "shield_pierce": 3494
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 22
+        "bonus1": 22.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
-          {
-            "type": "parsteel",
-            "value": 756840
-          },
           {
             "type": "tritanium",
             "value": 22260
@@ -724,6 +2163,10 @@
           {
             "type": "dilithium",
             "value": 2226
+          },
+          {
+            "type": "parsteel",
+            "value": 756840
           }
         ]
       },
@@ -732,20 +2175,106 @@
       "level": 22,
       "requirements": [
         {
-          "name": "Drydock D",
+          "name": "drydock d",
           "level": 22
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 35000,
+          "armor_pierce": 35000,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 17528,
+          "shield_pierce": 35000
+        },
+        "defense": {
+          "armor": 1701,
+          "dodge": 1701,
+          "shield_deflect": 1701
+        },
+        "health": {
+          "hull_health": 25246,
+          "shield_health": 6840
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 35000,
+            "armor_pierce": 35000,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 4382,
+            "max_damage": 4157,
+            "min_damage": 3464,
+            "shield_pierce": 35000
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 35000,
+            "armor_pierce": 35000,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 4382,
+            "max_damage": 4157,
+            "min_damage": 3464,
+            "shield_pierce": 35000
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 23
+        "bonus1": 23.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
+          {
+            "type": "dilithium",
+            "value": 3663
+          },
           {
             "type": "parsteel",
             "value": 1245420
@@ -753,10 +2282,6 @@
           {
             "type": "tritanium",
             "value": 36630
-          },
-          {
-            "type": "dilithium",
-            "value": 3663
           }
         ]
       },
@@ -765,15 +2290,97 @@
       "level": 23,
       "requirements": [
         {
-          "name": "Drydock D",
+          "name": "drydock d",
           "level": 23
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 36150,
+          "armor_pierce": 37625,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 21243,
+          "shield_pierce": 37625
+        },
+        "defense": {
+          "armor": 2724,
+          "dodge": 2724,
+          "shield_deflect": 2724
+        },
+        "health": {
+          "hull_health": 25582,
+          "shield_health": 6910
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 36150,
+            "armor_pierce": 37625,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 5311,
+            "max_damage": 5038,
+            "min_damage": 4198,
+            "shield_pierce": 37625
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 36150,
+            "armor_pierce": 37625,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 5311,
+            "max_damage": 5038,
+            "min_damage": 4198,
+            "shield_pierce": 37625
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 24
+        "bonus1": 24.0
       },
       "build_costs": {
         "materials": [],
@@ -784,12 +2391,12 @@
             "value": 1962480
           },
           {
-            "type": "tritanium",
-            "value": 57720
-          },
-          {
             "type": "dilithium",
             "value": 5772
+          },
+          {
+            "type": "tritanium",
+            "value": 57720
           }
         ]
       },
@@ -798,15 +2405,97 @@
       "level": 24,
       "requirements": [
         {
-          "name": "Drydock D",
+          "name": "drydock d",
           "level": 24
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 36300,
+          "armor_pierce": 43125,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 22211,
+          "shield_pierce": 43125
+        },
+        "defense": {
+          "armor": 3571,
+          "dodge": 3571,
+          "shield_deflect": 3571
+        },
+        "health": {
+          "hull_health": 25671,
+          "shield_health": 7020
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 36300,
+            "armor_pierce": 43125,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 5553,
+            "max_damage": 5267,
+            "min_damage": 4390,
+            "shield_pierce": 43125
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 36300,
+            "armor_pierce": 43125,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 5553,
+            "max_damage": 5267,
+            "min_damage": 4390,
+            "shield_pierce": 43125
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 25
+        "bonus1": 25.0
       },
       "build_costs": {
         "materials": [
@@ -838,19 +2527,101 @@
       "level": 25,
       "requirements": [
         {
-          "name": "Defense Technologies",
+          "name": "drydock d",
           "level": 25
         },
         {
-          "name": "Drydock D",
+          "name": "defense technologies",
           "level": 25
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 36425,
+          "armor_pierce": 43750,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 27400,
+          "shield_pierce": 43750
+        },
+        "defense": {
+          "armor": 4865,
+          "dodge": 4865,
+          "shield_deflect": 4865
+        },
+        "health": {
+          "hull_health": 28013,
+          "shield_health": 7780
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 36425,
+            "armor_pierce": 43750,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 6850,
+            "max_damage": 6498,
+            "min_damage": 5415,
+            "shield_pierce": 43750
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 36425,
+            "armor_pierce": 43750,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 6850,
+            "max_damage": 6498,
+            "min_damage": 5415,
+            "shield_pierce": 43750
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 26
+        "bonus1": 26.0
       },
       "build_costs": {
         "materials": [
@@ -864,16 +2635,16 @@
         "others": [],
         "resources": [
           {
+            "type": "dilithium",
+            "value": 14625
+          },
+          {
             "type": "parsteel",
             "value": 4972500
           },
           {
             "type": "tritanium",
             "value": 146250
-          },
-          {
-            "type": "dilithium",
-            "value": 14625
           }
         ]
       },
@@ -882,15 +2653,97 @@
       "level": 26,
       "requirements": [
         {
-          "name": "Drydock D",
+          "name": "drydock d",
           "level": 26
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 38710,
+          "armor_pierce": 46875,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 28775,
+          "shield_pierce": 46875
+        },
+        "defense": {
+          "armor": 5687,
+          "dodge": 5687,
+          "shield_deflect": 5687
+        },
+        "health": {
+          "hull_health": 32009,
+          "shield_health": 9000
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 38710,
+            "armor_pierce": 46875,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 7194,
+            "max_damage": 6824,
+            "min_damage": 5687,
+            "shield_pierce": 46875
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 38710,
+            "armor_pierce": 46875,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 7194,
+            "max_damage": 6824,
+            "min_damage": 5687,
+            "shield_pierce": 46875
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 27
+        "bonus1": 27.0
       },
       "build_costs": {
         "materials": [
@@ -904,16 +2757,16 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 7588800
+            "type": "dilithium",
+            "value": 22320
           },
           {
             "type": "tritanium",
             "value": 223200
           },
           {
-            "type": "dilithium",
-            "value": 22320
+            "type": "parsteel",
+            "value": 7588800
           }
         ]
       },
@@ -922,15 +2775,97 @@
       "level": 27,
       "requirements": [
         {
-          "name": "Drydock D",
+          "name": "drydock d",
           "level": 27
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 44516,
+          "armor_pierce": 57500,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 30811,
+          "shield_pierce": 57500
+        },
+        "defense": {
+          "armor": 6303,
+          "dodge": 6302,
+          "shield_deflect": 6302
+        },
+        "health": {
+          "hull_health": 40145,
+          "shield_health": 11340
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 44516,
+            "armor_pierce": 57500,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 7703,
+            "max_damage": 7307,
+            "min_damage": 6089,
+            "shield_pierce": 57500
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 44516,
+            "armor_pierce": 57500,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 7703,
+            "max_damage": 7307,
+            "min_damage": 6089,
+            "shield_pierce": 57500
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 28
+        "bonus1": 28.0
       },
       "build_costs": {
         "materials": [
@@ -948,12 +2883,12 @@
             "value": 11383200
           },
           {
-            "type": "tritanium",
-            "value": 334800
-          },
-          {
             "type": "dilithium",
             "value": 33480
+          },
+          {
+            "type": "tritanium",
+            "value": 334800
           }
         ]
       },
@@ -962,29 +2897,111 @@
       "level": 28,
       "requirements": [
         {
-          "name": "Drydock D",
+          "name": "drydock d",
           "level": 28
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 56473,
+          "armor_pierce": 68750,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 32324,
+          "shield_pierce": 68750
+        },
+        "defense": {
+          "armor": 8052,
+          "dodge": 8052,
+          "shield_deflect": 8052
+        },
+        "health": {
+          "hull_health": 50751,
+          "shield_health": 14400
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 56473,
+            "armor_pierce": 68750,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 8081,
+            "max_damage": 7666,
+            "min_damage": 6388,
+            "shield_pierce": 68750
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 56473,
+            "armor_pierce": 68750,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 8081,
+            "max_damage": 7666,
+            "min_damage": 6388,
+            "shield_pierce": 68750
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 29
+        "bonus1": 29.0
       },
       "build_costs": {
         "materials": [
           {
             "type": "gas",
             "grade": 3,
-            "rarity": "common",
-            "value": 450
+            "rarity": "uncommon",
+            "value": 30
           },
           {
             "type": "gas",
             "grade": 3,
-            "rarity": "uncommon",
-            "value": 30
+            "rarity": "common",
+            "value": 450
           }
         ],
         "others": [],
@@ -1008,15 +3025,97 @@
       "level": 29,
       "requirements": [
         {
-          "name": "Drydock D",
+          "name": "drydock d",
           "level": 29
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 62448,
+          "armor_pierce": 74375,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 35841,
+          "shield_pierce": 74375
+        },
+        "defense": {
+          "armor": 8908,
+          "dodge": 8908,
+          "shield_deflect": 8908
+        },
+        "health": {
+          "hull_health": 59028,
+          "shield_health": 16830
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 62448,
+            "armor_pierce": 74375,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 8960,
+            "max_damage": 8500,
+            "min_damage": 7083,
+            "shield_pierce": 74375
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 62448,
+            "armor_pierce": 74375,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 8960,
+            "max_damage": 8500,
+            "min_damage": 7083,
+            "shield_pierce": 74375
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 30
+        "bonus1": 30.0
       },
       "build_costs": {
         "materials": [
@@ -1036,16 +3135,16 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 26520000
+            "type": "dilithium",
+            "value": 78000
           },
           {
             "type": "tritanium",
             "value": 780000
           },
           {
-            "type": "dilithium",
-            "value": 78000
+            "type": "parsteel",
+            "value": 26520000
           }
         ]
       },
@@ -1054,19 +3153,101 @@
       "level": 30,
       "requirements": [
         {
-          "name": "Defense Technologies",
+          "name": "drydock d",
           "level": 30
         },
         {
-          "name": "Drydock D",
+          "name": "defense technologies",
           "level": 30
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 77490,
+          "armor_pierce": 76125,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 37780,
+          "shield_pierce": 76125
+        },
+        "defense": {
+          "armor": 10611,
+          "dodge": 10611,
+          "shield_deflect": 10611
+        },
+        "health": {
+          "hull_health": 67494,
+          "shield_health": 17230
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 77490,
+            "armor_pierce": 76125,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 9445,
+            "max_damage": 8960,
+            "min_damage": 7466,
+            "shield_pierce": 76125
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 77490,
+            "armor_pierce": 76125,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 9445,
+            "max_damage": 8960,
+            "min_damage": 7466,
+            "shield_pierce": 76125
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 31
+        "bonus1": 31.0
       },
       "build_costs": {
         "materials": [
@@ -1084,12 +3265,12 @@
             "value": 41922000
           },
           {
-            "type": "tritanium",
-            "value": 1233000
-          },
-          {
             "type": "dilithium",
             "value": 123300
+          },
+          {
+            "type": "tritanium",
+            "value": 1233000
           }
         ]
       },
@@ -1098,15 +3279,97 @@
       "level": 31,
       "requirements": [
         {
-          "name": "Drydock D",
+          "name": "drydock d",
           "level": 31
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 87436,
+          "armor_pierce": 89375,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 40278,
+          "shield_pierce": 89375
+        },
+        "defense": {
+          "armor": 12016,
+          "dodge": 12016,
+          "shield_deflect": 12016
+        },
+        "health": {
+          "hull_health": 77484,
+          "shield_health": 19910
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 87436,
+            "armor_pierce": 89375,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 10069,
+            "max_damage": 9552,
+            "min_damage": 7960,
+            "shield_pierce": 89375
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 87436,
+            "armor_pierce": 89375,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 10069,
+            "max_damage": 9552,
+            "min_damage": 7960,
+            "shield_pierce": 89375
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 32
+        "bonus1": 32.0
       },
       "build_costs": {
         "materials": [
@@ -1138,29 +3401,111 @@
       "level": 32,
       "requirements": [
         {
-          "name": "Drydock D",
+          "name": "drydock d",
           "level": 32
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 91746,
+          "armor_pierce": 123750,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 45600,
+          "shield_pierce": 123750
+        },
+        "defense": {
+          "armor": 13124,
+          "dodge": 13124,
+          "shield_deflect": 13124
+        },
+        "health": {
+          "hull_health": 83090,
+          "shield_health": 20120
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 91746,
+            "armor_pierce": 123750,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 11400,
+            "max_damage": 10814,
+            "min_damage": 9012,
+            "shield_pierce": 123750
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 91746,
+            "armor_pierce": 123750,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 11400,
+            "max_damage": 10814,
+            "min_damage": 9012,
+            "shield_pierce": 123750
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 33
+        "bonus1": 33.0
       },
       "build_costs": {
         "materials": [
           {
             "type": "gas",
             "grade": 3,
-            "rarity": "common",
-            "value": 1000
+            "rarity": "uncommon",
+            "value": 110
           },
           {
             "type": "gas",
             "grade": 3,
-            "rarity": "uncommon",
-            "value": 110
+            "rarity": "common",
+            "value": 1000
           }
         ],
         "others": [],
@@ -1170,12 +3515,12 @@
             "value": 93670000
           },
           {
-            "type": "tritanium",
-            "value": 2755000
-          },
-          {
             "type": "dilithium",
             "value": 275500
+          },
+          {
+            "type": "tritanium",
+            "value": 2755000
           }
         ]
       },
@@ -1184,19 +3529,101 @@
       "level": 33,
       "requirements": [
         {
-          "name": "Defense Platform C",
+          "name": "drydock d",
           "level": 33
         },
         {
-          "name": "Drydock D",
+          "name": "defense platform c",
           "level": 33
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 94480,
+          "armor_pierce": 144038,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 47773,
+          "shield_pierce": 144038
+        },
+        "defense": {
+          "armor": 13560,
+          "dodge": 13560,
+          "shield_deflect": 13560
+        },
+        "health": {
+          "hull_health": 92622,
+          "shield_health": 21830
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 94480,
+            "armor_pierce": 144038,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 11943,
+            "max_damage": 11330,
+            "min_damage": 9441,
+            "shield_pierce": 144038
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 94480,
+            "armor_pierce": 144038,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 11943,
+            "max_damage": 11330,
+            "min_damage": 9441,
+            "shield_pierce": 144038
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 34
+        "bonus1": 34.0
       },
       "build_costs": {
         "materials": [
@@ -1210,12 +3637,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 147900000
-          },
-          {
             "type": "tritanium",
             "value": 4350000
+          },
+          {
+            "type": "parsteel",
+            "value": 147900000
           },
           {
             "type": "dilithium",
@@ -1228,15 +3655,97 @@
       "level": 34,
       "requirements": [
         {
-          "name": "Drydock D",
+          "name": "drydock d",
           "level": 34
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 100000,
+          "armor_pierce": 161563,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 50660,
+          "shield_pierce": 161563
+        },
+        "defense": {
+          "armor": 14845,
+          "dodge": 14845,
+          "shield_deflect": 14845
+        },
+        "health": {
+          "hull_health": 102230,
+          "shield_health": 22770
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 100000,
+            "armor_pierce": 161563,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 12665,
+            "max_damage": 12014,
+            "min_damage": 10012,
+            "shield_pierce": 161563
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 100000,
+            "armor_pierce": 161563,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 12665,
+            "max_damage": 12014,
+            "min_damage": 10012,
+            "shield_pierce": 161563
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 35
+        "bonus1": 35.0
       },
       "build_costs": {
         "materials": [
@@ -1260,12 +3769,12 @@
             "value": 228888000
           },
           {
-            "type": "tritanium",
-            "value": 6732000
-          },
-          {
             "type": "dilithium",
             "value": 673200
+          },
+          {
+            "type": "tritanium",
+            "value": 6732000
           }
         ]
       },
@@ -1274,19 +3783,101 @@
       "level": 35,
       "requirements": [
         {
-          "name": "Defense Technologies",
+          "name": "drydock d",
           "level": 35
         },
         {
-          "name": "Drydock D",
+          "name": "defense technologies",
           "level": 35
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 109796,
+          "armor_pierce": 196875,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 59319,
+          "shield_pierce": 196875
+        },
+        "defense": {
+          "armor": 16480,
+          "dodge": 16480,
+          "shield_deflect": 16480
+        },
+        "health": {
+          "hull_health": 118699,
+          "shield_health": 28350
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 109796,
+            "armor_pierce": 196875,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 14830,
+            "max_damage": 14068,
+            "min_damage": 11723,
+            "shield_pierce": 196875
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 109796,
+            "armor_pierce": 196875,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 14830,
+            "max_damage": 14068,
+            "min_damage": 11723,
+            "shield_pierce": 196875
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 36
+        "bonus1": 36.0
       },
       "build_costs": {
         "materials": [
@@ -1300,16 +3891,16 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 322524000
+            "type": "dilithium",
+            "value": 948600
           },
           {
             "type": "tritanium",
             "value": 9486000
           },
           {
-            "type": "dilithium",
-            "value": 948600
+            "type": "parsteel",
+            "value": 322524000
           }
         ]
       },
@@ -1318,15 +3909,97 @@
       "level": 36,
       "requirements": [
         {
-          "name": "Drydock D",
+          "name": "drydock d",
           "level": 36
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 119489,
+          "armor_pierce": 227807,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 71792,
+          "shield_pierce": 227807
+        },
+        "defense": {
+          "armor": 17855,
+          "dodge": 17855,
+          "shield_deflect": 17855
+        },
+        "health": {
+          "hull_health": 138605,
+          "shield_health": 32610
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 119489,
+            "armor_pierce": 227807,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 17948,
+            "max_damage": 17026,
+            "min_damage": 14188,
+            "shield_pierce": 227807
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 119489,
+            "armor_pierce": 227807,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 17948,
+            "max_damage": 17026,
+            "min_damage": 14188,
+            "shield_pierce": 227807
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 37
+        "bonus1": 37.0
       },
       "build_costs": {
         "materials": [
@@ -1350,12 +4023,12 @@
             "value": 495720000
           },
           {
-            "type": "tritanium",
-            "value": 14580000
-          },
-          {
             "type": "dilithium",
             "value": 1458000
+          },
+          {
+            "type": "tritanium",
+            "value": 14580000
           }
         ]
       },
@@ -1364,15 +4037,97 @@
       "level": 37,
       "requirements": [
         {
-          "name": "Drydock D",
+          "name": "drydock d",
           "level": 37
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 132418,
+          "armor_pierce": 247922,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 77781,
+          "shield_pierce": 247922
+        },
+        "defense": {
+          "armor": 18489,
+          "dodge": 18489,
+          "shield_deflect": 18489
+        },
+        "health": {
+          "hull_health": 163789,
+          "shield_health": 35710
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 132418,
+            "armor_pierce": 247922,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 19445,
+            "max_damage": 18446,
+            "min_damage": 15372,
+            "shield_pierce": 247922
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 132418,
+            "armor_pierce": 247922,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 19445,
+            "max_damage": 18446,
+            "min_damage": 15372,
+            "shield_pierce": 247922
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 38
+        "bonus1": 38.0
       },
       "build_costs": {
         "materials": [
@@ -1392,16 +4147,16 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 771120000
+            "type": "dilithium",
+            "value": 2268000
           },
           {
             "type": "tritanium",
             "value": 22680000
           },
           {
-            "type": "dilithium",
-            "value": 2268000
+            "type": "parsteel",
+            "value": 771120000
           }
         ]
       },
@@ -1410,35 +4165,117 @@
       "level": 38,
       "requirements": [
         {
-          "name": "Defense Platform C",
+          "name": "drydock d",
           "level": 38
         },
         {
-          "name": "Drydock D",
+          "name": "defense platform c",
           "level": 38
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 144918,
+          "armor_pierce": 286066,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 89173,
+          "shield_pierce": 286066
+        },
+        "defense": {
+          "armor": 20112,
+          "dodge": 20112,
+          "shield_deflect": 20112
+        },
+        "health": {
+          "hull_health": 188609,
+          "shield_health": 41570
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 144918,
+            "armor_pierce": 286066,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 22293,
+            "max_damage": 21148,
+            "min_damage": 17623,
+            "shield_pierce": 286066
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 144918,
+            "armor_pierce": 286066,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 22293,
+            "max_damage": 21148,
+            "min_damage": 17623,
+            "shield_pierce": 286066
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 39
+        "bonus1": 39.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 1315800000
+            "type": "dilithium",
+            "value": 3870000
           },
           {
             "type": "tritanium",
             "value": 38700000
           },
           {
-            "type": "dilithium",
-            "value": 3870000
+            "type": "parsteel",
+            "value": 1315800000
           }
         ]
       },
@@ -1447,19 +4284,101 @@
       "level": 39,
       "requirements": [
         {
-          "name": "Defense Platform C",
+          "name": "drydock d",
           "level": 39
         },
         {
-          "name": "Drydock D",
+          "name": "defense platform c",
           "level": 39
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 159412,
+          "armor_pierce": 333789,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 103443,
+          "shield_pierce": 333789
+        },
+        "defense": {
+          "armor": 22010,
+          "dodge": 22010,
+          "shield_deflect": 22010
+        },
+        "health": {
+          "hull_health": 221741,
+          "shield_health": 48900
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 159412,
+            "armor_pierce": 333789,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 25861,
+            "max_damage": 24532,
+            "min_damage": 20443,
+            "shield_pierce": 333789
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 159412,
+            "armor_pierce": 333789,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 25861,
+            "max_damage": 24532,
+            "min_damage": 20443,
+            "shield_pierce": 333789
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 40
+        "bonus1": 40.0
       },
       "build_costs": {
         "materials": [
@@ -1479,16 +4398,16 @@
         "others": [],
         "resources": [
           {
+            "type": "dilithium",
+            "value": 6020000
+          },
+          {
             "type": "parsteel",
             "value": 5731040000
           },
           {
             "type": "tritanium",
             "value": 60200000
-          },
-          {
-            "type": "dilithium",
-            "value": 6020000
           }
         ]
       },
@@ -1497,15 +4416,128 @@
       "level": 40,
       "requirements": [
         {
-          "name": "Drydock D",
+          "name": "drydock d",
           "level": 40
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 362912,
+          "armor_pierce": 362912,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 140585,
+          "shield_pierce": 362912
+        },
+        "defense": {
+          "armor": 23930,
+          "dodge": 23930,
+          "shield_deflect": 23930
+        },
+        "health": {
+          "hull_health": 241088,
+          "shield_health": 53167
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 362912,
+            "armor_pierce": 362912,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 28117,
+            "max_damage": 26672,
+            "min_damage": 22227,
+            "shield_pierce": 362912
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 362912,
+            "armor_pierce": 362912,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 28117,
+            "max_damage": 26672,
+            "min_damage": 22227,
+            "shield_pierce": 362912
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 1,
+          "weapon_stats": {
+            "accuracy": 362912,
+            "armor_pierce": 362912,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 28117,
+            "max_damage": 26672,
+            "min_damage": 22227,
+            "shield_pierce": 362912
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 41
+        "bonus1": 41.0
       },
       "build_costs": {
         "materials": [
@@ -1525,16 +4557,16 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 5848000000
+            "type": "dilithium",
+            "value": 8600000
           },
           {
             "type": "tritanium",
             "value": 86000000
           },
           {
-            "type": "dilithium",
-            "value": 8600000
+            "type": "parsteel",
+            "value": 5848000000
           }
         ]
       },
@@ -1543,19 +4575,132 @@
       "level": 41,
       "requirements": [
         {
-          "name": "Drydock D",
+          "name": "drydock d",
           "level": 41
         },
         {
-          "name": "Defense Platform C",
+          "name": "defense platform c",
           "level": 41
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 393258,
+          "armor_pierce": 393258,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 152343,
+          "shield_pierce": 393258
+        },
+        "defense": {
+          "armor": 25931,
+          "dodge": 26457,
+          "shield_deflect": 26457
+        },
+        "health": {
+          "hull_health": 261247,
+          "shield_health": 58781
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 393258,
+            "armor_pierce": 393258,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 30469,
+            "max_damage": 28903,
+            "min_damage": 24086,
+            "shield_pierce": 393258
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 393258,
+            "armor_pierce": 393258,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 30469,
+            "max_damage": 28903,
+            "min_damage": 24086,
+            "shield_pierce": 393258
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 1,
+          "weapon_stats": {
+            "accuracy": 393258,
+            "armor_pierce": 393258,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 30469,
+            "max_damage": 28903,
+            "min_damage": 24086,
+            "shield_pierce": 393258
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 42
+        "bonus1": 42.0
       },
       "build_costs": {
         "materials": [
@@ -1575,16 +4720,16 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 8710800000
-          },
-          {
             "type": "tritanium",
             "value": 128100000
           },
           {
             "type": "dilithium",
             "value": 12810000
+          },
+          {
+            "type": "parsteel",
+            "value": 8710800000
           }
         ]
       },
@@ -1593,29 +4738,142 @@
       "level": 42,
       "requirements": [
         {
-          "name": "Drydock D",
+          "name": "drydock d",
           "level": 42
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 426142,
+          "armor_pierce": 426142,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 165083,
+          "shield_pierce": 426142
+        },
+        "defense": {
+          "armor": 28099,
+          "dodge": 29251,
+          "shield_deflect": 29251
+        },
+        "health": {
+          "hull_health": 283092,
+          "shield_health": 64988
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 426142,
+            "armor_pierce": 426142,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 33016,
+            "max_damage": 31320,
+            "min_damage": 26100,
+            "shield_pierce": 426142
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 426142,
+            "armor_pierce": 426142,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 33016,
+            "max_damage": 31320,
+            "min_damage": 26100,
+            "shield_pierce": 426142
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 1,
+          "weapon_stats": {
+            "accuracy": 426142,
+            "armor_pierce": 426142,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 33016,
+            "max_damage": 31320,
+            "min_damage": 26100,
+            "shield_pierce": 426142
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 43
+        "bonus1": 43.0
       },
       "build_costs": {
         "materials": [
           {
             "type": "gas",
             "grade": 4,
-            "rarity": "uncommon",
-            "value": 6000
+            "rarity": "rare",
+            "value": 750
           },
           {
             "type": "gas",
             "grade": 4,
-            "rarity": "rare",
-            "value": 750
+            "rarity": "uncommon",
+            "value": 6000
           }
         ],
         "others": [],
@@ -1639,15 +4897,128 @@
       "level": 43,
       "requirements": [
         {
-          "name": "Drydock D",
+          "name": "drydock d",
           "level": 43
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 461775,
+          "armor_pierce": 461775,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 178883,
+          "shield_pierce": 461775
+        },
+        "defense": {
+          "armor": 30449,
+          "dodge": 32339,
+          "shield_deflect": 32339
+        },
+        "health": {
+          "hull_health": 306764,
+          "shield_health": 71850
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 461775,
+            "armor_pierce": 461775,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 35776,
+            "max_damage": 33938,
+            "min_damage": 28282,
+            "shield_pierce": 461775
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 461775,
+            "armor_pierce": 461775,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 35776,
+            "max_damage": 33938,
+            "min_damage": 28282,
+            "shield_pierce": 461775
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 1,
+          "weapon_stats": {
+            "accuracy": 461775,
+            "armor_pierce": 461775,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 35776,
+            "max_damage": 33938,
+            "min_damage": 28282,
+            "shield_pierce": 461775
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 44
+        "bonus1": 44.0
       },
       "build_costs": {
         "materials": [
@@ -1665,12 +5036,12 @@
             "value": 18666000000
           },
           {
-            "type": "tritanium",
-            "value": 274500000
-          },
-          {
             "type": "dilithium",
             "value": 27450000
+          },
+          {
+            "type": "tritanium",
+            "value": 274500000
           }
         ]
       },
@@ -1679,19 +5050,132 @@
       "level": 44,
       "requirements": [
         {
-          "name": "Defense Platform C",
+          "name": "drydock d",
           "level": 44
         },
         {
-          "name": "Drydock D",
+          "name": "defense platform c",
           "level": 44
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 500387,
+          "armor_pierce": 500387,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 193841,
+          "shield_pierce": 500387
+        },
+        "defense": {
+          "armor": 32995,
+          "dodge": 35754,
+          "shield_deflect": 35754
+        },
+        "health": {
+          "hull_health": 332415,
+          "shield_health": 79437
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 500387,
+            "armor_pierce": 500387,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 38768,
+            "max_damage": 36776,
+            "min_damage": 30647,
+            "shield_pierce": 500387
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 500387,
+            "armor_pierce": 500387,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 38768,
+            "max_damage": 36776,
+            "min_damage": 30647,
+            "shield_pierce": 500387
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 1,
+          "weapon_stats": {
+            "accuracy": 500387,
+            "armor_pierce": 500387,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 38768,
+            "max_damage": 36776,
+            "min_damage": 30647,
+            "shield_pierce": 500387
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 45
+        "bonus1": 45.0
       },
       "build_costs": {
         "materials": [
@@ -1711,16 +5195,16 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 26520000000
-          },
-          {
             "type": "tritanium",
             "value": 390000000
           },
           {
             "type": "dilithium",
             "value": 39000000
+          },
+          {
+            "type": "parsteel",
+            "value": 26520000000
           }
         ]
       },
@@ -1729,44 +5213,157 @@
       "level": 45,
       "requirements": [
         {
-          "name": "Defense Technologies",
+          "name": "drydock d",
           "level": 45
         },
         {
-          "name": "Drydock D",
+          "name": "defense technologies",
           "level": 45
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 542229,
+          "armor_pierce": 542229,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 210048,
+          "shield_pierce": 542229
+        },
+        "defense": {
+          "armor": 35754,
+          "dodge": 39529,
+          "shield_deflect": 39529
+        },
+        "health": {
+          "hull_health": 360211,
+          "shield_health": 87825
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 542229,
+            "armor_pierce": 542229,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 42010,
+            "max_damage": 39851,
+            "min_damage": 33209,
+            "shield_pierce": 542229
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 542229,
+            "armor_pierce": 542229,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 42010,
+            "max_damage": 39851,
+            "min_damage": 33209,
+            "shield_pierce": 542229
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 1,
+          "weapon_stats": {
+            "accuracy": 542229,
+            "armor_pierce": 542229,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 42010,
+            "max_damage": 39851,
+            "min_damage": 33209,
+            "shield_pierce": 542229
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 46
+        "bonus1": 46.0
       },
       "build_costs": {
         "materials": [
           {
             "type": "gas",
             "grade": 4,
-            "rarity": "common",
-            "value": 30000
+            "rarity": "rare",
+            "value": 1800
           },
           {
             "type": "gas",
             "grade": 4,
-            "rarity": "rare",
-            "value": 1800
+            "rarity": "common",
+            "value": 30000
           }
         ],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 36465000000
-          },
-          {
             "type": "tritanium",
             "value": 536250000
+          },
+          {
+            "type": "parsteel",
+            "value": 36465000000
           },
           {
             "type": "dilithium",
@@ -1779,19 +5376,132 @@
       "level": 46,
       "requirements": [
         {
-          "name": "Defense Platform C",
+          "name": "drydock d",
           "level": 46
         },
         {
-          "name": "Drydock D",
+          "name": "defense platform c",
           "level": 46
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 587569,
+          "armor_pierce": 587569,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 227614,
+          "shield_pierce": 587569
+        },
+        "defense": {
+          "armor": 38744,
+          "dodge": 43703,
+          "shield_deflect": 43703
+        },
+        "health": {
+          "hull_health": 390331,
+          "shield_health": 97099
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 587569,
+            "armor_pierce": 587569,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 45523,
+            "max_damage": 43184,
+            "min_damage": 35986,
+            "shield_pierce": 587569
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 587569,
+            "armor_pierce": 587569,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 45523,
+            "max_damage": 43184,
+            "min_damage": 35986,
+            "shield_pierce": 587569
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 1,
+          "weapon_stats": {
+            "accuracy": 587569,
+            "armor_pierce": 587569,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 45523,
+            "max_damage": 43184,
+            "min_damage": 35986,
+            "shield_pierce": 587569
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 47
+        "bonus1": 47.0
       },
       "build_costs": {
         "materials": [
@@ -1811,16 +5521,16 @@
         "others": [],
         "resources": [
           {
+            "type": "dilithium",
+            "value": 78000000
+          },
+          {
             "type": "parsteel",
             "value": 53040000000
           },
           {
             "type": "tritanium",
             "value": 780000000
-          },
-          {
-            "type": "dilithium",
-            "value": 78000000
           }
         ]
       },
@@ -1829,44 +5539,157 @@
       "level": 47,
       "requirements": [
         {
-          "name": "Drydock D",
+          "name": "drydock d",
           "level": 47
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 636700,
+          "armor_pierce": 636700,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 246649,
+          "shield_pierce": 636700
+        },
+        "defense": {
+          "armor": 41983,
+          "dodge": 48318,
+          "shield_deflect": 48318
+        },
+        "health": {
+          "hull_health": 422970,
+          "shield_health": 107352
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 636700,
+            "armor_pierce": 636700,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 49330,
+            "max_damage": 46795,
+            "min_damage": 38996,
+            "shield_pierce": 636700
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 636700,
+            "armor_pierce": 636700,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 49330,
+            "max_damage": 46795,
+            "min_damage": 38996,
+            "shield_pierce": 636700
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 1,
+          "weapon_stats": {
+            "accuracy": 636700,
+            "armor_pierce": 636700,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 49330,
+            "max_damage": 46795,
+            "min_damage": 38996,
+            "shield_pierce": 636700
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 48
+        "bonus1": 48.0
       },
       "build_costs": {
         "materials": [
           {
             "type": "gas",
             "grade": 4,
-            "rarity": "common",
-            "value": 75000
+            "rarity": "uncommon",
+            "value": 4000
           },
           {
             "type": "gas",
             "grade": 4,
-            "rarity": "uncommon",
-            "value": 4000
+            "rarity": "common",
+            "value": 75000
           }
         ],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 85680000000
+            "type": "dilithium",
+            "value": 126000000
           },
           {
             "type": "tritanium",
             "value": 1260000000
           },
           {
-            "type": "dilithium",
-            "value": 126000000
+            "type": "parsteel",
+            "value": 85680000000
           }
         ]
       },
@@ -1875,15 +5698,128 @@
       "level": 48,
       "requirements": [
         {
-          "name": "Drydock D",
+          "name": "drydock d",
           "level": 48
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 689940,
+          "armor_pierce": 689940,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 267272,
+          "shield_pierce": 689940
+        },
+        "defense": {
+          "armor": 45494,
+          "dodge": 53420,
+          "shield_deflect": 53420
+        },
+        "health": {
+          "hull_health": 458338,
+          "shield_health": 118687
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 689940,
+            "armor_pierce": 689940,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 53454,
+            "max_damage": 50708,
+            "min_damage": 42256,
+            "shield_pierce": 689940
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 689940,
+            "armor_pierce": 689940,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 53454,
+            "max_damage": 50708,
+            "min_damage": 42256,
+            "shield_pierce": 689940
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 1,
+          "weapon_stats": {
+            "accuracy": 689940,
+            "armor_pierce": 689940,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 53454,
+            "max_damage": 50708,
+            "min_damage": 42256,
+            "shield_pierce": 689940
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 49
+        "bonus1": 49.0
       },
       "build_costs": {
         "materials": [
@@ -1903,12 +5839,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 142800000000
-          },
-          {
             "type": "tritanium",
             "value": 2100000000
+          },
+          {
+            "type": "parsteel",
+            "value": 142800000000
           },
           {
             "type": "dilithium",
@@ -1921,31 +5857,144 @@
       "level": 49,
       "requirements": [
         {
-          "name": "Defense Platform C",
+          "name": "drydock d",
           "level": 49
         },
         {
-          "name": "Drydock D",
+          "name": "defense platform c",
           "level": 49
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 747632,
+          "armor_pierce": 747632,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 289622,
+          "shield_pierce": 747632
+        },
+        "defense": {
+          "armor": 49298,
+          "dodge": 59061,
+          "shield_deflect": 59061
+        },
+        "health": {
+          "hull_health": 496663,
+          "shield_health": 131220
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 747632,
+            "armor_pierce": 747632,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 57924,
+            "max_damage": 54948,
+            "min_damage": 45790,
+            "shield_pierce": 747632
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 747632,
+            "armor_pierce": 747632,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 57924,
+            "max_damage": 54948,
+            "min_damage": 45790,
+            "shield_pierce": 747632
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 1,
+          "weapon_stats": {
+            "accuracy": 747632,
+            "armor_pierce": 747632,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 57924,
+            "max_damage": 54948,
+            "min_damage": 45790,
+            "shield_pierce": 747632
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 50
+        "bonus1": 50.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 249900000000
-          },
-          {
             "type": "tritanium",
             "value": 3675000000
+          },
+          {
+            "type": "parsteel",
+            "value": 249900000000
           },
           {
             "type": "dilithium",
@@ -1958,11 +6007,931 @@
       "level": 50,
       "requirements": [
         {
-          "name": "Drydock D",
+          "name": "drydock d",
           "level": 50
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 810147,
+          "armor_pierce": 810147,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 313835,
+          "shield_pierce": 810147
+        },
+        "defense": {
+          "armor": 53420,
+          "dodge": 65297,
+          "shield_deflect": 65297
+        },
+        "health": {
+          "hull_health": 538193,
+          "shield_health": 145076
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 810147,
+            "armor_pierce": 810147,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 62767,
+            "max_damage": 59542,
+            "min_damage": 49618,
+            "shield_pierce": 810147
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 810147,
+            "armor_pierce": 810147,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 62767,
+            "max_damage": 59542,
+            "min_damage": 49618,
+            "shield_pierce": 810147
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 1,
+          "weapon_stats": {
+            "accuracy": 810147,
+            "armor_pierce": 810147,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 62767,
+            "max_damage": 59542,
+            "min_damage": 49618,
+            "shield_pierce": 810147
+          },
+          "weapon_type": "energy"
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 51.0
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "gas",
+            "grade": 5,
+            "rarity": "uncommon",
+            "value": 1900
+          },
+          {
+            "type": "gas",
+            "grade": 5,
+            "rarity": "common",
+            "value": 21700
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 7800000000
+          },
+          {
+            "type": "dilithium",
+            "value": 780000000
+          },
+          {
+            "type": "parsteel",
+            "value": 1246440000000
+          }
+        ]
+      },
+      "build_time": 104346720,
+      "increased_power": 1216045,
+      "level": 51,
+      "requirements": [
+        {
+          "name": "drydock d",
+          "level": 51
+        }
+      ],
+      "stats": {
+        "attack": {
+          "accuracy": 931669,
+          "armor_pierce": 931669,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 360910,
+          "shield_pierce": 931669
+        },
+        "defense": {
+          "armor": 75092,
+          "dodge": 75092,
+          "shield_deflect": 75092
+        },
+        "health": {
+          "hull_health": 618922,
+          "shield_health": 166837
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 931669,
+            "armor_pierce": 931669,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 72182,
+            "max_damage": 68473,
+            "min_damage": 57061,
+            "shield_pierce": 931669
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 931669,
+            "armor_pierce": 931669,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 72182,
+            "max_damage": 68473,
+            "min_damage": 57061,
+            "shield_pierce": 931669
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 1,
+          "weapon_stats": {
+            "accuracy": 931669,
+            "armor_pierce": 931669,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 72182,
+            "max_damage": 68473,
+            "min_damage": 57061,
+            "shield_pierce": 931669
+          },
+          "weapon_type": "energy"
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 52.0
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "gas",
+            "grade": 5,
+            "rarity": "common",
+            "value": 37500
+          },
+          {
+            "type": "gas",
+            "grade": 5,
+            "rarity": "uncommon",
+            "value": 4300
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 2254200000000
+          },
+          {
+            "type": "dilithium",
+            "value": 1326000000
+          },
+          {
+            "type": "tritanium",
+            "value": 13260000000
+          }
+        ]
+      },
+      "build_time": 110606400,
+      "increased_power": 2571112,
+      "level": 52,
+      "requirements": [
+        {
+          "name": "drydock d",
+          "level": 52
+        },
+        {
+          "name": "defense platform c",
+          "level": 52
+        }
+      ],
+      "stats": {
+        "attack": {
+          "accuracy": 1174713,
+          "armor_pierce": 1174713,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 712868,
+          "shield_pierce": 1174713
+        },
+        "defense": {
+          "armor": 94681,
+          "dodge": 94681,
+          "shield_deflect": 94681
+        },
+        "health": {
+          "hull_health": 780380,
+          "shield_health": 210360
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 1174713,
+            "armor_pierce": 1174713,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 142574,
+            "max_damage": 161618,
+            "min_damage": 86336,
+            "shield_pierce": 1174713
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 1174713,
+            "armor_pierce": 1174713,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 142574,
+            "max_damage": 161618,
+            "min_damage": 86336,
+            "shield_pierce": 1174713
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 1,
+          "weapon_stats": {
+            "accuracy": 1174713,
+            "armor_pierce": 1174713,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 142574,
+            "max_damage": 161618,
+            "min_damage": 86336,
+            "shield_pierce": 1174713
+          },
+          "weapon_type": "energy"
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 53.0
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "gas",
+            "grade": 5,
+            "rarity": "uncommon",
+            "value": 15500
+          },
+          {
+            "type": "gas",
+            "grade": 5,
+            "rarity": "common",
+            "value": 88900
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "dilithium",
+            "value": 2320000000
+          },
+          {
+            "type": "tritanium",
+            "value": 23200000000
+          },
+          {
+            "type": "parsteel",
+            "value": 3786240000000
+          }
+        ]
+      },
+      "build_time": 117243360,
+      "increased_power": 9914492,
+      "level": 53,
+      "requirements": [
+        {
+          "name": "drydock d",
+          "level": 53
+        },
+        {
+          "name": "defense platform c",
+          "level": 53
+        }
+      ],
+      "stats": {
+        "attack": {
+          "accuracy": 2187397,
+          "armor_pierce": 2187397,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 1380871,
+          "shield_pierce": 2187397
+        },
+        "defense": {
+          "armor": 176302,
+          "dodge": 176302,
+          "shield_deflect": 176302
+        },
+        "health": {
+          "hull_health": 1453121,
+          "shield_health": 391705
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 2187397,
+            "armor_pierce": 2187397,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 276174,
+            "max_damage": 319540,
+            "min_damage": 160763,
+            "shield_pierce": 2187397
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 2187397,
+            "armor_pierce": 2187397,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 276174,
+            "max_damage": 319540,
+            "min_damage": 160763,
+            "shield_pierce": 2187397
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 1,
+          "weapon_stats": {
+            "accuracy": 2187397,
+            "armor_pierce": 2187397,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 276174,
+            "max_damage": 319540,
+            "min_damage": 160763,
+            "shield_pierce": 2187397
+          },
+          "weapon_type": "energy"
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 54.0
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "gas",
+            "grade": 5,
+            "rarity": "rare",
+            "value": 7000
+          },
+          {
+            "type": "gas",
+            "grade": 5,
+            "rarity": "common",
+            "value": 76500
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "dilithium",
+            "value": 3480000000
+          },
+          {
+            "type": "tritanium",
+            "value": 34800000000
+          },
+          {
+            "type": "parsteel",
+            "value": 5679360000000
+          }
+        ]
+      },
+      "build_time": 124277760,
+      "increased_power": 2449504,
+      "level": 54,
+      "requirements": [
+        {
+          "name": "drydock d",
+          "level": 54
+        },
+        {
+          "name": "defense platform c",
+          "level": 54
+        }
+      ],
+      "stats": {
+        "attack": {
+          "accuracy": 2430441,
+          "armor_pierce": 2430441,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 1611219,
+          "shield_pierce": 2430441
+        },
+        "defense": {
+          "armor": 195891,
+          "dodge": 195891,
+          "shield_deflect": 195891
+        },
+        "health": {
+          "hull_health": 1614579,
+          "shield_health": 435228
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 2430441,
+            "armor_pierce": 2430441,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 322244,
+            "max_damage": 381798,
+            "min_damage": 178626,
+            "shield_pierce": 2430441
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 2430441,
+            "armor_pierce": 2430441,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 322244,
+            "max_damage": 381798,
+            "min_damage": 178626,
+            "shield_pierce": 2430441
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 1,
+          "weapon_stats": {
+            "accuracy": 2430441,
+            "armor_pierce": 2430441,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 322244,
+            "max_damage": 381798,
+            "min_damage": 178626,
+            "shield_pierce": 2430441
+          },
+          "weapon_type": "energy"
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 55.0
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "gas",
+            "grade": 5,
+            "rarity": "rare",
+            "value": 8100
+          },
+          {
+            "type": "gas",
+            "grade": 5,
+            "rarity": "uncommon",
+            "value": 22300
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 54600000000
+          },
+          {
+            "type": "parsteel",
+            "value": 9653280000000
+          },
+          {
+            "type": "dilithium",
+            "value": 5460000000
+          }
+        ]
+      },
+      "build_time": 131734080,
+      "increased_power": 4869860,
+      "level": 55,
+      "requirements": [
+        {
+          "name": "drydock d",
+          "level": 55
+        }
+      ],
+      "stats": {
+        "attack": {
+          "accuracy": 2916529,
+          "armor_pierce": 2916529,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 2042768,
+          "shield_pierce": 2916529
+        },
+        "defense": {
+          "armor": 235069,
+          "dodge": 235069,
+          "shield_deflect": 235069
+        },
+        "health": {
+          "hull_health": 1937495,
+          "shield_health": 522274
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 2916529,
+            "armor_pierce": 2916529,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 408554,
+            "max_damage": 496177,
+            "min_damage": 214351,
+            "shield_pierce": 2916529
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 2916529,
+            "armor_pierce": 2916529,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 408554,
+            "max_damage": 496177,
+            "min_damage": 214351,
+            "shield_pierce": 2916529
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 1,
+          "weapon_stats": {
+            "accuracy": 2916529,
+            "armor_pierce": 2916529,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 408554,
+            "max_damage": 496177,
+            "min_damage": 214351,
+            "shield_pierce": 2916529
+          },
+          "weapon_type": "energy"
+        }
+      ]
     }
   ]
 }

--- a/buildings/defense_platform_e.json
+++ b/buildings/defense_platform_e.json
@@ -2,7 +2,7 @@
   "description": "Defense Platforms are the last line of Defense for the Station. Behind defending ships they provide additional fire support. Upgrade to increase the Platform's combat performance.",
   "bonuses": {
     "bonus1": {
-      "name": "Power Level",
+      "name": "power level",
       "percentage": false
     }
   },
@@ -10,23 +10,23 @@
   "levels": [
     {
       "bonuses": {
-        "bonus1": 1
+        "bonus1": 1.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 136
+            "type": "dilithium",
+            "value": 50
           },
           {
             "type": "tritanium",
             "value": 500
           },
           {
-            "type": "dilithium",
-            "value": 50
+            "type": "parsteel",
+            "value": 136
           }
         ]
       },
@@ -35,15 +35,66 @@
       "level": 1,
       "requirements": [
         {
-          "name": "Defense Platforms",
+          "name": "defense platforms",
           "level": 4
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 18,
+          "armor_pierce": 18,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 506,
+          "shield_pierce": 18
+        },
+        "defense": {
+          "armor": 9,
+          "dodge": 9,
+          "shield_deflect": 9
+        },
+        "health": {
+          "hull_health": 250,
+          "shield_health": 250
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 18,
+            "armor_pierce": 18,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 253,
+            "max_damage": 240,
+            "min_damage": 200,
+            "shield_pierce": 18
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 2
+        "bonus1": 2.0
       },
       "build_costs": {
         "materials": [],
@@ -54,12 +105,12 @@
             "value": 5500
           },
           {
-            "type": "tritanium",
-            "value": 400
-          },
-          {
             "type": "dilithium",
             "value": 40
+          },
+          {
+            "type": "tritanium",
+            "value": 400
           }
         ]
       },
@@ -68,15 +119,66 @@
       "level": 2,
       "requirements": [
         {
-          "name": "Drydock E",
+          "name": "drydock e",
           "level": 2
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 19,
+          "armor_pierce": 19,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 527,
+          "shield_pierce": 19
+        },
+        "defense": {
+          "armor": 9,
+          "dodge": 9,
+          "shield_deflect": 9
+        },
+        "health": {
+          "hull_health": 270,
+          "shield_health": 270
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 19,
+            "armor_pierce": 19,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 263,
+            "max_damage": 250,
+            "min_damage": 208,
+            "shield_pierce": 19
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 3
+        "bonus1": 3.0
       },
       "build_costs": {
         "materials": [],
@@ -101,27 +203,78 @@
       "level": 3,
       "requirements": [
         {
-          "name": "Drydock E",
+          "name": "drydock e",
           "level": 3
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 27,
+          "armor_pierce": 27,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 587,
+          "shield_pierce": 27
+        },
+        "defense": {
+          "armor": 14,
+          "dodge": 14,
+          "shield_deflect": 14
+        },
+        "health": {
+          "hull_health": 290,
+          "shield_health": 290
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 27,
+            "armor_pierce": 27,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 293,
+            "max_damage": 278,
+            "min_damage": 232,
+            "shield_pierce": 27
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 4
+        "bonus1": 4.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 7000
-          },
-          {
             "type": "tritanium",
             "value": 440
+          },
+          {
+            "type": "parsteel",
+            "value": 7000
           },
           {
             "type": "dilithium",
@@ -134,15 +287,66 @@
       "level": 4,
       "requirements": [
         {
-          "name": "Drydock E",
+          "name": "drydock e",
           "level": 4
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 36,
+          "armor_pierce": 36,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 662,
+          "shield_pierce": 36
+        },
+        "defense": {
+          "armor": 18,
+          "dodge": 18,
+          "shield_deflect": 18
+        },
+        "health": {
+          "hull_health": 360,
+          "shield_health": 360
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 36,
+            "armor_pierce": 36,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 331,
+            "max_damage": 314,
+            "min_damage": 262,
+            "shield_pierce": 36
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 5
+        "bonus1": 5.0
       },
       "build_costs": {
         "materials": [],
@@ -167,27 +371,78 @@
       "level": 5,
       "requirements": [
         {
-          "name": "Drydock E",
+          "name": "drydock e",
           "level": 5
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 46,
+          "armor_pierce": 46,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 818,
+          "shield_pierce": 46
+        },
+        "defense": {
+          "armor": 23,
+          "dodge": 23,
+          "shield_deflect": 23
+        },
+        "health": {
+          "hull_health": 500,
+          "shield_health": 500
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 46,
+            "armor_pierce": 46,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 409,
+            "max_damage": 388,
+            "min_damage": 323,
+            "shield_pierce": 46
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 6
+        "bonus1": 6.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 8500
-          },
-          {
             "type": "tritanium",
             "value": 480
+          },
+          {
+            "type": "parsteel",
+            "value": 8500
           },
           {
             "type": "dilithium",
@@ -200,20 +455,75 @@
       "level": 6,
       "requirements": [
         {
-          "name": "Drydock E",
+          "name": "drydock e",
           "level": 6
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 63,
+          "armor_pierce": 63,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 1045,
+          "shield_pierce": 63
+        },
+        "defense": {
+          "armor": 32,
+          "dodge": 32,
+          "shield_deflect": 32
+        },
+        "health": {
+          "hull_health": 660,
+          "shield_health": 660
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 63,
+            "armor_pierce": 63,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 523,
+            "max_damage": 496,
+            "min_damage": 413,
+            "shield_pierce": 63
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 7
+        "bonus1": 7.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
+          {
+            "type": "dilithium",
+            "value": 50
+          },
           {
             "type": "parsteel",
             "value": 9250
@@ -221,10 +531,6 @@
           {
             "type": "tritanium",
             "value": 500
-          },
-          {
-            "type": "dilithium",
-            "value": 50
           }
         ]
       },
@@ -233,24 +539,71 @@
       "level": 7,
       "requirements": [
         {
-          "name": "Drydock E",
+          "name": "drydock e",
           "level": 7
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 94,
+          "armor_pierce": 94,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 1298,
+          "shield_pierce": 94
+        },
+        "defense": {
+          "armor": 47,
+          "dodge": 47,
+          "shield_deflect": 47
+        },
+        "health": {
+          "hull_health": 960,
+          "shield_health": 960
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 94,
+            "armor_pierce": 94,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 649,
+            "max_damage": 616,
+            "min_damage": 513,
+            "shield_pierce": 94
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 8
+        "bonus1": 8.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
-          {
-            "type": "parsteel",
-            "value": 10000
-          },
           {
             "type": "tritanium",
             "value": 520
@@ -258,6 +611,10 @@
           {
             "type": "dilithium",
             "value": 52
+          },
+          {
+            "type": "parsteel",
+            "value": 10000
           }
         ]
       },
@@ -266,15 +623,66 @@
       "level": 8,
       "requirements": [
         {
-          "name": "Drydock E",
+          "name": "drydock e",
           "level": 8
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 138,
+          "armor_pierce": 138,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 1948,
+          "shield_pierce": 138
+        },
+        "defense": {
+          "armor": 69,
+          "dodge": 69,
+          "shield_deflect": 69
+        },
+        "health": {
+          "hull_health": 1370,
+          "shield_health": 1370
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 138,
+            "armor_pierce": 138,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 974,
+            "max_damage": 924,
+            "min_damage": 770,
+            "shield_pierce": 138
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 9
+        "bonus1": 9.0
       },
       "build_costs": {
         "materials": [],
@@ -299,15 +707,66 @@
       "level": 9,
       "requirements": [
         {
-          "name": "Drydock E",
+          "name": "drydock e",
           "level": 9
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 200,
+          "armor_pierce": 200,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 2728,
+          "shield_pierce": 200
+        },
+        "defense": {
+          "armor": 100,
+          "dodge": 100,
+          "shield_deflect": 100
+        },
+        "health": {
+          "hull_health": 2020,
+          "shield_health": 2020
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 200,
+            "armor_pierce": 200,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 1364,
+            "max_damage": 1294,
+            "min_damage": 1078,
+            "shield_pierce": 200
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 10
+        "bonus1": 10.0
       },
       "build_costs": {
         "materials": [],
@@ -318,12 +777,12 @@
             "value": 12500
           },
           {
-            "type": "tritanium",
-            "value": 600
-          },
-          {
             "type": "dilithium",
             "value": 60
+          },
+          {
+            "type": "tritanium",
+            "value": 600
           }
         ]
       },
@@ -332,31 +791,113 @@
       "level": 10,
       "requirements": [
         {
-          "name": "Drydock E",
+          "name": "drydock e",
           "level": 10
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 236,
+          "armor_pierce": 236,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 3503,
+          "shield_pierce": 236
+        },
+        "defense": {
+          "armor": 131,
+          "dodge": 131,
+          "shield_deflect": 131
+        },
+        "health": {
+          "hull_health": 2560,
+          "shield_health": 2560
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 236,
+            "armor_pierce": 236,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 1168,
+            "max_damage": 1108,
+            "min_damage": 923,
+            "shield_pierce": 236
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 1,
+          "weapon_stats": {
+            "accuracy": 236,
+            "armor_pierce": 236,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 1168,
+            "max_damage": 1108,
+            "min_damage": 923,
+            "shield_pierce": 236
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 11
+        "bonus1": 11.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 13600
+            "type": "dilithium",
+            "value": 8
           },
           {
             "type": "tritanium",
             "value": 400
           },
           {
-            "type": "dilithium",
-            "value": 8
+            "type": "parsteel",
+            "value": 13600
           }
         ]
       },
@@ -365,24 +906,102 @@
       "level": 11,
       "requirements": [
         {
-          "name": "Drydock E",
+          "name": "drydock e",
           "level": 11
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 260,
+          "armor_pierce": 260,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 4782,
+          "shield_pierce": 260
+        },
+        "defense": {
+          "armor": 153,
+          "dodge": 153,
+          "shield_deflect": 153
+        },
+        "health": {
+          "hull_health": 2740,
+          "shield_health": 2740
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 260,
+            "armor_pierce": 260,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 1594,
+            "max_damage": 1512,
+            "min_damage": 1260,
+            "shield_pierce": 260
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 1,
+          "weapon_stats": {
+            "accuracy": 260,
+            "armor_pierce": 260,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 1594,
+            "max_damage": 1512,
+            "min_damage": 1260,
+            "shield_pierce": 260
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 12
+        "bonus1": 12.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
-          {
-            "type": "parsteel",
-            "value": 18700
-          },
           {
             "type": "tritanium",
             "value": 550
@@ -390,6 +1009,10 @@
           {
             "type": "dilithium",
             "value": 22
+          },
+          {
+            "type": "parsteel",
+            "value": 18700
           }
         ]
       },
@@ -398,24 +1021,102 @@
       "level": 12,
       "requirements": [
         {
-          "name": "Drydock E",
+          "name": "drydock e",
           "level": 12
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 340,
+          "armor_pierce": 340,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 5142,
+          "shield_pierce": 340
+        },
+        "defense": {
+          "armor": 213,
+          "dodge": 213,
+          "shield_deflect": 213
+        },
+        "health": {
+          "hull_health": 2880,
+          "shield_health": 2880
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 340,
+            "armor_pierce": 340,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 1714,
+            "max_damage": 1626,
+            "min_damage": 1355,
+            "shield_pierce": 340
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 1,
+          "weapon_stats": {
+            "accuracy": 340,
+            "armor_pierce": 340,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 1714,
+            "max_damage": 1626,
+            "min_damage": 1355,
+            "shield_pierce": 340
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 13
+        "bonus1": 13.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
-          {
-            "type": "parsteel",
-            "value": 27200
-          },
           {
             "type": "tritanium",
             "value": 800
@@ -423,6 +1124,10 @@
           {
             "type": "dilithium",
             "value": 48
+          },
+          {
+            "type": "parsteel",
+            "value": 27200
           }
         ]
       },
@@ -431,27 +1136,109 @@
       "level": 13,
       "requirements": [
         {
-          "name": "Drydock E",
+          "name": "drydock e",
           "level": 13
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 438,
+          "armor_pierce": 438,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 5572,
+          "shield_pierce": 438
+        },
+        "defense": {
+          "armor": 274,
+          "dodge": 274,
+          "shield_deflect": 274
+        },
+        "health": {
+          "hull_health": 3350,
+          "shield_health": 3350
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 438,
+            "armor_pierce": 438,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 1857,
+            "max_damage": 1762,
+            "min_damage": 1468,
+            "shield_pierce": 438
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 1,
+          "weapon_stats": {
+            "accuracy": 438,
+            "armor_pierce": 438,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 1857,
+            "max_damage": 1762,
+            "min_damage": 1468,
+            "shield_pierce": 438
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 14
+        "bonus1": 14.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 37400
-          },
-          {
             "type": "tritanium",
             "value": 1100
+          },
+          {
+            "type": "parsteel",
+            "value": 37400
           },
           {
             "type": "dilithium",
@@ -464,27 +1251,109 @@
       "level": 14,
       "requirements": [
         {
-          "name": "Drydock E",
+          "name": "drydock e",
           "level": 14
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 454,
+          "armor_pierce": 454,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 5730,
+          "shield_pierce": 454
+        },
+        "defense": {
+          "armor": 371,
+          "dodge": 371,
+          "shield_deflect": 371
+        },
+        "health": {
+          "hull_health": 3460,
+          "shield_health": 3460
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 454,
+            "armor_pierce": 454,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 1910,
+            "max_damage": 1812,
+            "min_damage": 1510,
+            "shield_pierce": 454
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 1,
+          "weapon_stats": {
+            "accuracy": 454,
+            "armor_pierce": 454,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 1910,
+            "max_damage": 1812,
+            "min_damage": 1510,
+            "shield_pierce": 454
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 15
+        "bonus1": 15.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 51000
-          },
-          {
             "type": "tritanium",
             "value": 1500
+          },
+          {
+            "type": "parsteel",
+            "value": 51000
           },
           {
             "type": "dilithium",
@@ -497,31 +1366,113 @@
       "level": 15,
       "requirements": [
         {
-          "name": "Drydock E",
+          "name": "drydock e",
           "level": 15
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 475,
+          "armor_pierce": 475,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 5863,
+          "shield_pierce": 475
+        },
+        "defense": {
+          "armor": 400,
+          "dodge": 400,
+          "shield_deflect": 400
+        },
+        "health": {
+          "hull_health": 3730,
+          "shield_health": 3730
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 475,
+            "armor_pierce": 475,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 1954,
+            "max_damage": 1854,
+            "min_damage": 1545,
+            "shield_pierce": 475
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 1,
+          "weapon_stats": {
+            "accuracy": 475,
+            "armor_pierce": 475,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 1954,
+            "max_damage": 1854,
+            "min_damage": 1545,
+            "shield_pierce": 475
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 16
+        "bonus1": 16.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 68000
+            "type": "dilithium",
+            "value": 200
           },
           {
             "type": "tritanium",
             "value": 2000
           },
           {
-            "type": "dilithium",
-            "value": 200
+            "type": "parsteel",
+            "value": 68000
           }
         ]
       },
@@ -530,15 +1481,97 @@
       "level": 16,
       "requirements": [
         {
-          "name": "Drydock E",
+          "name": "drydock e",
           "level": 16
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 556,
+          "armor_pierce": 556,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 7476,
+          "shield_pierce": 556
+        },
+        "defense": {
+          "armor": 479,
+          "dodge": 479,
+          "shield_deflect": 479
+        },
+        "health": {
+          "hull_health": 4750,
+          "shield_health": 4750
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 556,
+            "armor_pierce": 556,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 2492,
+            "max_damage": 2364,
+            "min_damage": 1970,
+            "shield_pierce": 556
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 1,
+          "weapon_stats": {
+            "accuracy": 556,
+            "armor_pierce": 556,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 2492,
+            "max_damage": 2364,
+            "min_damage": 1970,
+            "shield_pierce": 556
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 17
+        "bonus1": 17.0
       },
       "build_costs": {
         "materials": [],
@@ -549,12 +1582,12 @@
             "value": 95200
           },
           {
-            "type": "tritanium",
-            "value": 2800
-          },
-          {
             "type": "dilithium",
             "value": 280
+          },
+          {
+            "type": "tritanium",
+            "value": 2800
           }
         ]
       },
@@ -563,15 +1596,97 @@
       "level": 17,
       "requirements": [
         {
-          "name": "Drydock E",
+          "name": "drydock e",
           "level": 17
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 649,
+          "armor_pierce": 649,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 8779,
+          "shield_pierce": 649
+        },
+        "defense": {
+          "armor": 535,
+          "dodge": 535,
+          "shield_deflect": 535
+        },
+        "health": {
+          "hull_health": 5620,
+          "shield_health": 5620
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 649,
+            "armor_pierce": 649,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 2926,
+            "max_damage": 2776,
+            "min_damage": 2313,
+            "shield_pierce": 649
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 1,
+          "weapon_stats": {
+            "accuracy": 649,
+            "armor_pierce": 649,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 2926,
+            "max_damage": 2776,
+            "min_damage": 2313,
+            "shield_pierce": 649
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 18
+        "bonus1": 18.0
       },
       "build_costs": {
         "materials": [],
@@ -596,15 +1711,97 @@
       "level": 18,
       "requirements": [
         {
-          "name": "Drydock E",
+          "name": "drydock e",
           "level": 18
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 672,
+          "armor_pierce": 672,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 10265,
+          "shield_pierce": 672
+        },
+        "defense": {
+          "armor": 560,
+          "dodge": 560,
+          "shield_deflect": 560
+        },
+        "health": {
+          "hull_health": 6120,
+          "shield_health": 6120
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 672,
+            "armor_pierce": 672,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 3422,
+            "max_damage": 3246,
+            "min_damage": 2705,
+            "shield_pierce": 672
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 1,
+          "weapon_stats": {
+            "accuracy": 672,
+            "armor_pierce": 672,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 3422,
+            "max_damage": 3246,
+            "min_damage": 2705,
+            "shield_pierce": 672
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 19
+        "bonus1": 19.0
       },
       "build_costs": {
         "materials": [],
@@ -629,27 +1826,109 @@
       "level": 19,
       "requirements": [
         {
-          "name": "Drydock E",
+          "name": "drydock e",
           "level": 19
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 2023,
+          "armor_pierce": 2023,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 10823,
+          "shield_pierce": 2023
+        },
+        "defense": {
+          "armor": 674,
+          "dodge": 674,
+          "shield_deflect": 674
+        },
+        "health": {
+          "hull_health": 6500,
+          "shield_health": 6500
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 2023,
+            "armor_pierce": 2023,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 3608,
+            "max_damage": 3422,
+            "min_damage": 2852,
+            "shield_pierce": 2023
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 1,
+          "weapon_stats": {
+            "accuracy": 2023,
+            "armor_pierce": 2023,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 3608,
+            "max_damage": 3422,
+            "min_damage": 2852,
+            "shield_pierce": 2023
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 20
+        "bonus1": 20.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 289000
-          },
-          {
             "type": "tritanium",
             "value": 8500
+          },
+          {
+            "type": "parsteel",
+            "value": 289000
           },
           {
             "type": "dilithium",
@@ -662,27 +1941,109 @@
       "level": 20,
       "requirements": [
         {
-          "name": "Drydock E",
+          "name": "drydock e",
           "level": 20
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 2755,
+          "armor_pierce": 2755,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 11173,
+          "shield_pierce": 2755
+        },
+        "defense": {
+          "armor": 689,
+          "dodge": 689,
+          "shield_deflect": 689
+        },
+        "health": {
+          "hull_health": 9860,
+          "shield_health": 6570
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 2755,
+            "armor_pierce": 2755,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 2793,
+            "max_damage": 2650,
+            "min_damage": 2208,
+            "shield_pierce": 2755
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 2755,
+            "armor_pierce": 2755,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 2793,
+            "max_damage": 2650,
+            "min_damage": 2208,
+            "shield_pierce": 2755
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 21
+        "bonus1": 21.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 486540
-          },
-          {
             "type": "tritanium",
             "value": 14310
+          },
+          {
+            "type": "parsteel",
+            "value": 486540
           },
           {
             "type": "dilithium",
@@ -695,15 +2056,97 @@
       "level": 21,
       "requirements": [
         {
-          "name": "Drydock E",
+          "name": "drydock e",
           "level": 21
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 3494,
+          "armor_pierce": 3494,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 11360,
+          "shield_pierce": 3494
+        },
+        "defense": {
+          "armor": 699,
+          "dodge": 699,
+          "shield_deflect": 699
+        },
+        "health": {
+          "hull_health": 13540,
+          "shield_health": 6770
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 3494,
+            "armor_pierce": 3494,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 2840,
+            "max_damage": 2694,
+            "min_damage": 2245,
+            "shield_pierce": 3494
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 3494,
+            "armor_pierce": 3494,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 2840,
+            "max_damage": 2694,
+            "min_damage": 2245,
+            "shield_pierce": 3494
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 22
+        "bonus1": 22.0
       },
       "build_costs": {
         "materials": [],
@@ -728,15 +2171,97 @@
       "level": 22,
       "requirements": [
         {
-          "name": "Drydock E",
+          "name": "drydock e",
           "level": 22
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 35000,
+          "armor_pierce": 35000,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 17528,
+          "shield_pierce": 35000
+        },
+        "defense": {
+          "armor": 1701,
+          "dodge": 1701,
+          "shield_deflect": 1701
+        },
+        "health": {
+          "hull_health": 25246,
+          "shield_health": 6840
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 35000,
+            "armor_pierce": 35000,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 4382,
+            "max_damage": 4157,
+            "min_damage": 3464,
+            "shield_pierce": 35000
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 35000,
+            "armor_pierce": 35000,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 4382,
+            "max_damage": 4157,
+            "min_damage": 3464,
+            "shield_pierce": 35000
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 23
+        "bonus1": 23.0
       },
       "build_costs": {
         "materials": [],
@@ -747,12 +2272,12 @@
             "value": 1245420
           },
           {
-            "type": "tritanium",
-            "value": 36630
-          },
-          {
             "type": "dilithium",
             "value": 3663
+          },
+          {
+            "type": "tritanium",
+            "value": 36630
           }
         ]
       },
@@ -761,24 +2286,102 @@
       "level": 23,
       "requirements": [
         {
-          "name": "Drydock E",
+          "name": "drydock e",
           "level": 23
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 36150,
+          "armor_pierce": 37625,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 21243,
+          "shield_pierce": 37625
+        },
+        "defense": {
+          "armor": 2724,
+          "dodge": 2724,
+          "shield_deflect": 2724
+        },
+        "health": {
+          "hull_health": 25582,
+          "shield_health": 6910
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 36150,
+            "armor_pierce": 37625,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 5311,
+            "max_damage": 5038,
+            "min_damage": 4198,
+            "shield_pierce": 37625
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 36150,
+            "armor_pierce": 37625,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 5311,
+            "max_damage": 5038,
+            "min_damage": 4198,
+            "shield_pierce": 37625
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 24
+        "bonus1": 24.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
-          {
-            "type": "parsteel",
-            "value": 1962480
-          },
           {
             "type": "tritanium",
             "value": 57720
@@ -786,6 +2389,10 @@
           {
             "type": "dilithium",
             "value": 5772
+          },
+          {
+            "type": "parsteel",
+            "value": 1962480
           }
         ]
       },
@@ -794,31 +2401,113 @@
       "level": 24,
       "requirements": [
         {
-          "name": "Drydock E",
+          "name": "drydock e",
           "level": 24
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 36300,
+          "armor_pierce": 43125,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 22211,
+          "shield_pierce": 43125
+        },
+        "defense": {
+          "armor": 3571,
+          "dodge": 3571,
+          "shield_deflect": 3571
+        },
+        "health": {
+          "hull_health": 25671,
+          "shield_health": 7020
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 36300,
+            "armor_pierce": 43125,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 5553,
+            "max_damage": 5267,
+            "min_damage": 4390,
+            "shield_pierce": 43125
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 36300,
+            "armor_pierce": 43125,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 5553,
+            "max_damage": 5267,
+            "min_damage": 4390,
+            "shield_pierce": 43125
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 25
+        "bonus1": 25.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 3182400
+            "type": "dilithium",
+            "value": 9360
           },
           {
             "type": "tritanium",
             "value": 93600
           },
           {
-            "type": "dilithium",
-            "value": 9360
+            "type": "parsteel",
+            "value": 3182400
           }
         ]
       },
@@ -827,20 +2516,106 @@
       "level": 25,
       "requirements": [
         {
-          "name": "Drydock E",
+          "name": "drydock e",
           "level": 25
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 36425,
+          "armor_pierce": 43750,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 27400,
+          "shield_pierce": 43750
+        },
+        "defense": {
+          "armor": 4865,
+          "dodge": 4865,
+          "shield_deflect": 4865
+        },
+        "health": {
+          "hull_health": 28013,
+          "shield_health": 7780
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 36425,
+            "armor_pierce": 43750,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 6850,
+            "max_damage": 6498,
+            "min_damage": 5415,
+            "shield_pierce": 43750
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 36425,
+            "armor_pierce": 43750,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 6850,
+            "max_damage": 6498,
+            "min_damage": 5415,
+            "shield_pierce": 43750
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 26
+        "bonus1": 26.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
+          {
+            "type": "dilithium",
+            "value": 14625
+          },
           {
             "type": "parsteel",
             "value": 4972500
@@ -848,10 +2623,6 @@
           {
             "type": "tritanium",
             "value": 146250
-          },
-          {
-            "type": "dilithium",
-            "value": 14625
           }
         ]
       },
@@ -860,15 +2631,97 @@
       "level": 26,
       "requirements": [
         {
-          "name": "Drydock E",
+          "name": "drydock e",
           "level": 26
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 38710,
+          "armor_pierce": 46875,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 28775,
+          "shield_pierce": 46875
+        },
+        "defense": {
+          "armor": 5687,
+          "dodge": 5687,
+          "shield_deflect": 5687
+        },
+        "health": {
+          "hull_health": 32009,
+          "shield_health": 9000
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 38710,
+            "armor_pierce": 46875,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 7194,
+            "max_damage": 6824,
+            "min_damage": 5687,
+            "shield_pierce": 46875
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 38710,
+            "armor_pierce": 46875,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 7194,
+            "max_damage": 6824,
+            "min_damage": 5687,
+            "shield_pierce": 46875
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 27
+        "bonus1": 27.0
       },
       "build_costs": {
         "materials": [],
@@ -893,27 +2746,109 @@
       "level": 27,
       "requirements": [
         {
-          "name": "Drydock E",
+          "name": "drydock e",
           "level": 27
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 44516,
+          "armor_pierce": 57500,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 30811,
+          "shield_pierce": 57500
+        },
+        "defense": {
+          "armor": 6303,
+          "dodge": 6302,
+          "shield_deflect": 6302
+        },
+        "health": {
+          "hull_health": 40145,
+          "shield_health": 11340
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 44516,
+            "armor_pierce": 57500,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 7703,
+            "max_damage": 7307,
+            "min_damage": 6089,
+            "shield_pierce": 57500
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 44516,
+            "armor_pierce": 57500,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 7703,
+            "max_damage": 7307,
+            "min_damage": 6089,
+            "shield_pierce": 57500
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 28
+        "bonus1": 28.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 11383200
-          },
-          {
             "type": "tritanium",
             "value": 334800
+          },
+          {
+            "type": "parsteel",
+            "value": 11383200
           },
           {
             "type": "dilithium",
@@ -926,27 +2861,109 @@
       "level": 28,
       "requirements": [
         {
-          "name": "Drydock E",
+          "name": "drydock e",
           "level": 28
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 56473,
+          "armor_pierce": 68750,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 32324,
+          "shield_pierce": 68750
+        },
+        "defense": {
+          "armor": 8052,
+          "dodge": 8052,
+          "shield_deflect": 8052
+        },
+        "health": {
+          "hull_health": 50751,
+          "shield_health": 14400
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 56473,
+            "armor_pierce": 68750,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 8081,
+            "max_damage": 7666,
+            "min_damage": 6388,
+            "shield_pierce": 68750
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 56473,
+            "armor_pierce": 68750,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 8081,
+            "max_damage": 7666,
+            "min_damage": 6388,
+            "shield_pierce": 68750
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 29
+        "bonus1": 29.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 18122000
-          },
-          {
             "type": "tritanium",
             "value": 533000
+          },
+          {
+            "type": "parsteel",
+            "value": 18122000
           },
           {
             "type": "dilithium",
@@ -959,20 +2976,106 @@
       "level": 29,
       "requirements": [
         {
-          "name": "Drydock E",
+          "name": "drydock e",
           "level": 29
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 62448,
+          "armor_pierce": 74375,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 35841,
+          "shield_pierce": 74375
+        },
+        "defense": {
+          "armor": 8908,
+          "dodge": 8908,
+          "shield_deflect": 8908
+        },
+        "health": {
+          "hull_health": 59028,
+          "shield_health": 16830
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 62448,
+            "armor_pierce": 74375,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 8960,
+            "max_damage": 8500,
+            "min_damage": 7083,
+            "shield_pierce": 74375
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 62448,
+            "armor_pierce": 74375,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 8960,
+            "max_damage": 8500,
+            "min_damage": 7083,
+            "shield_pierce": 74375
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 30
+        "bonus1": 30.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
+          {
+            "type": "dilithium",
+            "value": 78000
+          },
           {
             "type": "parsteel",
             "value": 26520000
@@ -980,10 +3083,6 @@
           {
             "type": "tritanium",
             "value": 780000
-          },
-          {
-            "type": "dilithium",
-            "value": 78000
           }
         ]
       },
@@ -992,31 +3091,113 @@
       "level": 30,
       "requirements": [
         {
-          "name": "Drydock E",
+          "name": "drydock e",
           "level": 30
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 77490,
+          "armor_pierce": 76125,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 37780,
+          "shield_pierce": 76125
+        },
+        "defense": {
+          "armor": 10611,
+          "dodge": 10611,
+          "shield_deflect": 10611
+        },
+        "health": {
+          "hull_health": 67494,
+          "shield_health": 17230
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 77490,
+            "armor_pierce": 76125,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 9445,
+            "max_damage": 8960,
+            "min_damage": 7466,
+            "shield_pierce": 76125
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 77490,
+            "armor_pierce": 76125,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 9445,
+            "max_damage": 8960,
+            "min_damage": 7466,
+            "shield_pierce": 76125
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 31
+        "bonus1": 31.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 41922000
+            "type": "dilithium",
+            "value": 123300
           },
           {
             "type": "tritanium",
             "value": 1233000
           },
           {
-            "type": "dilithium",
-            "value": 123300
+            "type": "parsteel",
+            "value": 41922000
           }
         ]
       },
@@ -1025,15 +3206,97 @@
       "level": 31,
       "requirements": [
         {
-          "name": "Drydock E",
+          "name": "drydock e",
           "level": 31
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 87436,
+          "armor_pierce": 89375,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 40278,
+          "shield_pierce": 89375
+        },
+        "defense": {
+          "armor": 12016,
+          "dodge": 12016,
+          "shield_deflect": 12016
+        },
+        "health": {
+          "hull_health": 77484,
+          "shield_health": 19910
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 87436,
+            "armor_pierce": 89375,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 10069,
+            "max_damage": 9552,
+            "min_damage": 7960,
+            "shield_pierce": 89375
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 87436,
+            "armor_pierce": 89375,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 10069,
+            "max_damage": 9552,
+            "min_damage": 7960,
+            "shield_pierce": 89375
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 32
+        "bonus1": 32.0
       },
       "build_costs": {
         "materials": [],
@@ -1044,12 +3307,12 @@
             "value": 60554000
           },
           {
-            "type": "tritanium",
-            "value": 1781000
-          },
-          {
             "type": "dilithium",
             "value": 178100
+          },
+          {
+            "type": "tritanium",
+            "value": 1781000
           }
         ]
       },
@@ -1058,24 +3321,102 @@
       "level": 32,
       "requirements": [
         {
-          "name": "Drydock E",
+          "name": "drydock e",
           "level": 32
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 91746,
+          "armor_pierce": 123750,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 45600,
+          "shield_pierce": 123750
+        },
+        "defense": {
+          "armor": 13124,
+          "dodge": 13124,
+          "shield_deflect": 13124
+        },
+        "health": {
+          "hull_health": 83090,
+          "shield_health": 20120
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 91746,
+            "armor_pierce": 123750,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 11400,
+            "max_damage": 10814,
+            "min_damage": 9012,
+            "shield_pierce": 123750
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 91746,
+            "armor_pierce": 123750,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 11400,
+            "max_damage": 10814,
+            "min_damage": 9012,
+            "shield_pierce": 123750
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 33
+        "bonus1": 33.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
-          {
-            "type": "parsteel",
-            "value": 93670000
-          },
           {
             "type": "tritanium",
             "value": 2755000
@@ -1083,6 +3424,10 @@
           {
             "type": "dilithium",
             "value": 275500
+          },
+          {
+            "type": "parsteel",
+            "value": 93670000
           }
         ]
       },
@@ -1091,15 +3436,97 @@
       "level": 33,
       "requirements": [
         {
-          "name": "Drydock E",
+          "name": "drydock e",
           "level": 33
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 94480,
+          "armor_pierce": 144038,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 47773,
+          "shield_pierce": 144038
+        },
+        "defense": {
+          "armor": 13560,
+          "dodge": 13560,
+          "shield_deflect": 13560
+        },
+        "health": {
+          "hull_health": 92622,
+          "shield_health": 21830
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 94480,
+            "armor_pierce": 144038,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 11943,
+            "max_damage": 11330,
+            "min_damage": 9441,
+            "shield_pierce": 144038
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 94480,
+            "armor_pierce": 144038,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 11943,
+            "max_damage": 11330,
+            "min_damage": 9441,
+            "shield_pierce": 144038
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 34
+        "bonus1": 34.0
       },
       "build_costs": {
         "materials": [],
@@ -1124,20 +3551,106 @@
       "level": 34,
       "requirements": [
         {
-          "name": "Drydock E",
+          "name": "drydock e",
           "level": 34
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 100000,
+          "armor_pierce": 161563,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 50660,
+          "shield_pierce": 161563
+        },
+        "defense": {
+          "armor": 14845,
+          "dodge": 14845,
+          "shield_deflect": 14845
+        },
+        "health": {
+          "hull_health": 102230,
+          "shield_health": 22770
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 100000,
+            "armor_pierce": 161563,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 12665,
+            "max_damage": 12014,
+            "min_damage": 10012,
+            "shield_pierce": 161563
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 100000,
+            "armor_pierce": 161563,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 12665,
+            "max_damage": 12014,
+            "min_damage": 10012,
+            "shield_pierce": 161563
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 35
+        "bonus1": 35.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
+          {
+            "type": "dilithium",
+            "value": 673200
+          },
           {
             "type": "parsteel",
             "value": 228888000
@@ -1145,10 +3658,6 @@
           {
             "type": "tritanium",
             "value": 6732000
-          },
-          {
-            "type": "dilithium",
-            "value": 673200
           }
         ]
       },
@@ -1157,24 +3666,102 @@
       "level": 35,
       "requirements": [
         {
-          "name": "Drydock E",
+          "name": "drydock e",
           "level": 35
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 109796,
+          "armor_pierce": 196875,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 59319,
+          "shield_pierce": 196875
+        },
+        "defense": {
+          "armor": 16480,
+          "dodge": 16480,
+          "shield_deflect": 16480
+        },
+        "health": {
+          "hull_health": 118699,
+          "shield_health": 28350
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 109796,
+            "armor_pierce": 196875,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 14830,
+            "max_damage": 14068,
+            "min_damage": 11723,
+            "shield_pierce": 196875
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 109796,
+            "armor_pierce": 196875,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 14830,
+            "max_damage": 14068,
+            "min_damage": 11723,
+            "shield_pierce": 196875
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 36
+        "bonus1": 36.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
-          {
-            "type": "parsteel",
-            "value": 322524000
-          },
           {
             "type": "tritanium",
             "value": 9486000
@@ -1182,6 +3769,10 @@
           {
             "type": "dilithium",
             "value": 948600
+          },
+          {
+            "type": "parsteel",
+            "value": 322524000
           }
         ]
       },
@@ -1190,31 +3781,113 @@
       "level": 36,
       "requirements": [
         {
-          "name": "Drydock E",
+          "name": "drydock e",
           "level": 36
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 119489,
+          "armor_pierce": 227807,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 71792,
+          "shield_pierce": 227807
+        },
+        "defense": {
+          "armor": 17855,
+          "dodge": 17855,
+          "shield_deflect": 17855
+        },
+        "health": {
+          "hull_health": 138605,
+          "shield_health": 32610
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 119489,
+            "armor_pierce": 227807,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 17948,
+            "max_damage": 17026,
+            "min_damage": 14188,
+            "shield_pierce": 227807
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 119489,
+            "armor_pierce": 227807,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 17948,
+            "max_damage": 17026,
+            "min_damage": 14188,
+            "shield_pierce": 227807
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 37
+        "bonus1": 37.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 495720000
+            "type": "dilithium",
+            "value": 1458000
           },
           {
             "type": "tritanium",
             "value": 14580000
           },
           {
-            "type": "dilithium",
-            "value": 1458000
+            "type": "parsteel",
+            "value": 495720000
           }
         ]
       },
@@ -1223,27 +3896,109 @@
       "level": 37,
       "requirements": [
         {
-          "name": "Drydock E",
+          "name": "drydock e",
           "level": 37
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 132418,
+          "armor_pierce": 247922,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 77781,
+          "shield_pierce": 247922
+        },
+        "defense": {
+          "armor": 18489,
+          "dodge": 18489,
+          "shield_deflect": 18489
+        },
+        "health": {
+          "hull_health": 163789,
+          "shield_health": 35710
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 132418,
+            "armor_pierce": 247922,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 19445,
+            "max_damage": 18446,
+            "min_damage": 15372,
+            "shield_pierce": 247922
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 132418,
+            "armor_pierce": 247922,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 19445,
+            "max_damage": 18446,
+            "min_damage": 15372,
+            "shield_pierce": 247922
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 38
+        "bonus1": 38.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 771120000
-          },
-          {
             "type": "tritanium",
             "value": 22680000
+          },
+          {
+            "type": "parsteel",
+            "value": 771120000
           },
           {
             "type": "dilithium",
@@ -1256,24 +4011,102 @@
       "level": 38,
       "requirements": [
         {
-          "name": "Drydock E",
+          "name": "drydock e",
           "level": 38
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 144918,
+          "armor_pierce": 286066,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 89173,
+          "shield_pierce": 286066
+        },
+        "defense": {
+          "armor": 20112,
+          "dodge": 20112,
+          "shield_deflect": 20112
+        },
+        "health": {
+          "hull_health": 188609,
+          "shield_health": 41570
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 144918,
+            "armor_pierce": 286066,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 22293,
+            "max_damage": 21148,
+            "min_damage": 17623,
+            "shield_pierce": 286066
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 144918,
+            "armor_pierce": 286066,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 22293,
+            "max_damage": 21148,
+            "min_damage": 17623,
+            "shield_pierce": 286066
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 39
+        "bonus1": 39.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
-          {
-            "type": "parsteel",
-            "value": 1315800000
-          },
           {
             "type": "tritanium",
             "value": 38700000
@@ -1281,6 +4114,10 @@
           {
             "type": "dilithium",
             "value": 3870000
+          },
+          {
+            "type": "parsteel",
+            "value": 1315800000
           }
         ]
       },
@@ -1289,33 +4126,119 @@
       "level": 39,
       "requirements": [
         {
-          "name": "Drydock E",
+          "name": "drydock e",
           "level": 39
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 159412,
+          "armor_pierce": 333789,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 103443,
+          "shield_pierce": 333789
+        },
+        "defense": {
+          "armor": 22010,
+          "dodge": 22010,
+          "shield_deflect": 22010
+        },
+        "health": {
+          "hull_health": 221741,
+          "shield_health": 48900
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 159412,
+            "armor_pierce": 333789,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 25861,
+            "max_damage": 24532,
+            "min_damage": 20443,
+            "shield_pierce": 333789
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 159412,
+            "armor_pierce": 333789,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 25861,
+            "max_damage": 24532,
+            "min_damage": 20443,
+            "shield_pierce": 333789
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 40
+        "bonus1": 40.0
       },
       "build_costs": {
         "materials": [
           {
             "type": "gas",
             "grade": 4,
-            "rarity": "uncommon",
-            "value": 3800
+            "rarity": "rare",
+            "value": 4000
           },
           {
             "type": "gas",
             "grade": 4,
-            "rarity": "rare",
-            "value": 4000
+            "rarity": "uncommon",
+            "value": 3800
           }
         ],
         "others": [],
         "resources": [
+          {
+            "type": "dilithium",
+            "value": 6020000
+          },
           {
             "type": "parsteel",
             "value": 5731040000
@@ -1323,10 +4246,6 @@
           {
             "type": "tritanium",
             "value": 60200000
-          },
-          {
-            "type": "dilithium",
-            "value": 6020000
           }
         ]
       },
@@ -1335,40 +4254,153 @@
       "level": 40,
       "requirements": [
         {
-          "name": "Drydock E",
+          "name": "drydock e",
           "level": 40
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 362912,
+          "armor_pierce": 362912,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 140585,
+          "shield_pierce": 362912
+        },
+        "defense": {
+          "armor": 23930,
+          "dodge": 23930,
+          "shield_deflect": 23930
+        },
+        "health": {
+          "hull_health": 241088,
+          "shield_health": 53167
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 362912,
+            "armor_pierce": 362912,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 28117,
+            "max_damage": 26672,
+            "min_damage": 22227,
+            "shield_pierce": 362912
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 362912,
+            "armor_pierce": 362912,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 28117,
+            "max_damage": 26672,
+            "min_damage": 22227,
+            "shield_pierce": 362912
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 1,
+          "weapon_stats": {
+            "accuracy": 362912,
+            "armor_pierce": 362912,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 28117,
+            "max_damage": 26672,
+            "min_damage": 22227,
+            "shield_pierce": 362912
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 41
+        "bonus1": 41.0
       },
       "build_costs": {
         "materials": [
           {
             "type": "gas",
             "grade": 4,
-            "rarity": "common",
-            "value": 8000
+            "rarity": "uncommon",
+            "value": 4000
           },
           {
             "type": "gas",
             "grade": 4,
-            "rarity": "uncommon",
-            "value": 4000
+            "rarity": "common",
+            "value": 8000
           }
         ],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 5848000000
-          },
-          {
             "type": "tritanium",
             "value": 86000000
+          },
+          {
+            "type": "parsteel",
+            "value": 5848000000
           },
           {
             "type": "dilithium",
@@ -1381,19 +4413,132 @@
       "level": 41,
       "requirements": [
         {
-          "name": "Defense Platform D",
+          "name": "drydock e",
           "level": 41
         },
         {
-          "name": "Drydock E",
+          "name": "defense platform d",
           "level": 41
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 393258,
+          "armor_pierce": 393258,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 152343,
+          "shield_pierce": 393258
+        },
+        "defense": {
+          "armor": 25931,
+          "dodge": 26457,
+          "shield_deflect": 26457
+        },
+        "health": {
+          "hull_health": 261247,
+          "shield_health": 58781
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 393258,
+            "armor_pierce": 393258,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 30469,
+            "max_damage": 28903,
+            "min_damage": 24086,
+            "shield_pierce": 393258
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 393258,
+            "armor_pierce": 393258,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 30469,
+            "max_damage": 28903,
+            "min_damage": 24086,
+            "shield_pierce": 393258
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 1,
+          "weapon_stats": {
+            "accuracy": 393258,
+            "armor_pierce": 393258,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 30469,
+            "max_damage": 28903,
+            "min_damage": 24086,
+            "shield_pierce": 393258
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 42
+        "bonus1": 42.0
       },
       "build_costs": {
         "materials": [
@@ -1431,29 +4576,142 @@
       "level": 42,
       "requirements": [
         {
-          "name": "Drydock E",
+          "name": "drydock e",
           "level": 42
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 426142,
+          "armor_pierce": 426142,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 165083,
+          "shield_pierce": 426142
+        },
+        "defense": {
+          "armor": 28099,
+          "dodge": 29251,
+          "shield_deflect": 29251
+        },
+        "health": {
+          "hull_health": 283092,
+          "shield_health": 64988
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 426142,
+            "armor_pierce": 426142,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 33016,
+            "max_damage": 31320,
+            "min_damage": 26100,
+            "shield_pierce": 426142
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 426142,
+            "armor_pierce": 426142,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 33016,
+            "max_damage": 31320,
+            "min_damage": 26100,
+            "shield_pierce": 426142
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 1,
+          "weapon_stats": {
+            "accuracy": 426142,
+            "armor_pierce": 426142,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 33016,
+            "max_damage": 31320,
+            "min_damage": 26100,
+            "shield_pierce": 426142
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 43
+        "bonus1": 43.0
       },
       "build_costs": {
         "materials": [
           {
             "type": "gas",
             "grade": 4,
-            "rarity": "common",
-            "value": 16000
+            "rarity": "uncommon",
+            "value": 6000
           },
           {
             "type": "gas",
             "grade": 4,
-            "rarity": "uncommon",
-            "value": 6000
+            "rarity": "common",
+            "value": 16000
           }
         ],
         "others": [],
@@ -1463,12 +4721,12 @@
             "value": 12444000000
           },
           {
-            "type": "tritanium",
-            "value": 183000000
-          },
-          {
             "type": "dilithium",
             "value": 18300000
+          },
+          {
+            "type": "tritanium",
+            "value": 183000000
           }
         ]
       },
@@ -1477,44 +4735,157 @@
       "level": 43,
       "requirements": [
         {
-          "name": "Drydock E",
+          "name": "drydock e",
           "level": 43
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 461775,
+          "armor_pierce": 461775,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 178883,
+          "shield_pierce": 461775
+        },
+        "defense": {
+          "armor": 30449,
+          "dodge": 32339,
+          "shield_deflect": 32339
+        },
+        "health": {
+          "hull_health": 306764,
+          "shield_health": 71850
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 461775,
+            "armor_pierce": 461775,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 35776,
+            "max_damage": 33938,
+            "min_damage": 28282,
+            "shield_pierce": 461775
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 461775,
+            "armor_pierce": 461775,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 35776,
+            "max_damage": 33938,
+            "min_damage": 28282,
+            "shield_pierce": 461775
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 1,
+          "weapon_stats": {
+            "accuracy": 461775,
+            "armor_pierce": 461775,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 35776,
+            "max_damage": 33938,
+            "min_damage": 28282,
+            "shield_pierce": 461775
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 44
+        "bonus1": 44.0
       },
       "build_costs": {
         "materials": [
           {
             "type": "gas",
             "grade": 4,
-            "rarity": "common",
-            "value": 20000
+            "rarity": "uncommon",
+            "value": 7000
           },
           {
             "type": "gas",
             "grade": 4,
-            "rarity": "uncommon",
-            "value": 7000
+            "rarity": "common",
+            "value": 20000
           }
         ],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 18666000000
+            "type": "dilithium",
+            "value": 27450000
           },
           {
             "type": "tritanium",
             "value": 274500000
           },
           {
-            "type": "dilithium",
-            "value": 27450000
+            "type": "parsteel",
+            "value": 18666000000
           }
         ]
       },
@@ -1523,15 +4894,128 @@
       "level": 44,
       "requirements": [
         {
-          "name": "Drydock E",
+          "name": "drydock e",
           "level": 44
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 500387,
+          "armor_pierce": 500387,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 193841,
+          "shield_pierce": 500387
+        },
+        "defense": {
+          "armor": 32995,
+          "dodge": 35754,
+          "shield_deflect": 35754
+        },
+        "health": {
+          "hull_health": 332415,
+          "shield_health": 79437
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 500387,
+            "armor_pierce": 500387,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 38768,
+            "max_damage": 36776,
+            "min_damage": 30647,
+            "shield_pierce": 500387
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 500387,
+            "armor_pierce": 500387,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 38768,
+            "max_damage": 36776,
+            "min_damage": 30647,
+            "shield_pierce": 500387
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 1,
+          "weapon_stats": {
+            "accuracy": 500387,
+            "armor_pierce": 500387,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 38768,
+            "max_damage": 36776,
+            "min_damage": 30647,
+            "shield_pierce": 500387
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 45
+        "bonus1": 45.0
       },
       "build_costs": {
         "materials": [
@@ -1555,12 +5039,12 @@
             "value": 26520000000
           },
           {
-            "type": "tritanium",
-            "value": 390000000
-          },
-          {
             "type": "dilithium",
             "value": 39000000
+          },
+          {
+            "type": "tritanium",
+            "value": 390000000
           }
         ]
       },
@@ -1569,19 +5053,132 @@
       "level": 45,
       "requirements": [
         {
-          "name": "Defense Technologies",
+          "name": "drydock e",
           "level": 45
         },
         {
-          "name": "Drydock E",
+          "name": "defense technologies",
           "level": 45
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 542229,
+          "armor_pierce": 542229,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 210048,
+          "shield_pierce": 542229
+        },
+        "defense": {
+          "armor": 35754,
+          "dodge": 39529,
+          "shield_deflect": 39529
+        },
+        "health": {
+          "hull_health": 360211,
+          "shield_health": 87825
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 542229,
+            "armor_pierce": 542229,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 42010,
+            "max_damage": 39851,
+            "min_damage": 33209,
+            "shield_pierce": 542229
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 542229,
+            "armor_pierce": 542229,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 42010,
+            "max_damage": 39851,
+            "min_damage": 33209,
+            "shield_pierce": 542229
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 1,
+          "weapon_stats": {
+            "accuracy": 542229,
+            "armor_pierce": 542229,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 42010,
+            "max_damage": 39851,
+            "min_damage": 33209,
+            "shield_pierce": 542229
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 46
+        "bonus1": 46.0
       },
       "build_costs": {
         "materials": [
@@ -1605,12 +5202,12 @@
             "value": 36465000000
           },
           {
-            "type": "tritanium",
-            "value": 536250000
-          },
-          {
             "type": "dilithium",
             "value": 53625000
+          },
+          {
+            "type": "tritanium",
+            "value": 536250000
           }
         ]
       },
@@ -1619,33 +5216,146 @@
       "level": 46,
       "requirements": [
         {
-          "name": "Defense Platform D",
+          "name": "drydock e",
           "level": 46
         },
         {
-          "name": "Drydock E",
+          "name": "defense platform d",
           "level": 46
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 587569,
+          "armor_pierce": 587569,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 227614,
+          "shield_pierce": 587569
+        },
+        "defense": {
+          "armor": 38744,
+          "dodge": 43703,
+          "shield_deflect": 43703
+        },
+        "health": {
+          "hull_health": 390331,
+          "shield_health": 97099
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 587569,
+            "armor_pierce": 587569,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 45523,
+            "max_damage": 43184,
+            "min_damage": 35986,
+            "shield_pierce": 587569
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 587569,
+            "armor_pierce": 587569,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 45523,
+            "max_damage": 43184,
+            "min_damage": 35986,
+            "shield_pierce": 587569
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 1,
+          "weapon_stats": {
+            "accuracy": 587569,
+            "armor_pierce": 587569,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 45523,
+            "max_damage": 43184,
+            "min_damage": 35986,
+            "shield_pierce": 587569
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 47
+        "bonus1": 47.0
       },
       "build_costs": {
         "materials": [
           {
             "type": "gas",
             "grade": 4,
-            "rarity": "common",
-            "value": 45000
+            "rarity": "uncommon",
+            "value": 2500
           },
           {
             "type": "gas",
             "grade": 4,
-            "rarity": "uncommon",
-            "value": 2500
+            "rarity": "common",
+            "value": 45000
           }
         ],
         "others": [],
@@ -1655,12 +5365,12 @@
             "value": 53040000000
           },
           {
-            "type": "tritanium",
-            "value": 780000000
-          },
-          {
             "type": "dilithium",
             "value": 78000000
+          },
+          {
+            "type": "tritanium",
+            "value": 780000000
           }
         ]
       },
@@ -1669,15 +5379,128 @@
       "level": 47,
       "requirements": [
         {
-          "name": "Drydock E",
+          "name": "drydock e",
           "level": 47
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 636700,
+          "armor_pierce": 636700,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 246649,
+          "shield_pierce": 636700
+        },
+        "defense": {
+          "armor": 41983,
+          "dodge": 48318,
+          "shield_deflect": 48318
+        },
+        "health": {
+          "hull_health": 422970,
+          "shield_health": 107352
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 636700,
+            "armor_pierce": 636700,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 49330,
+            "max_damage": 46795,
+            "min_damage": 38996,
+            "shield_pierce": 636700
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 636700,
+            "armor_pierce": 636700,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 49330,
+            "max_damage": 46795,
+            "min_damage": 38996,
+            "shield_pierce": 636700
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 1,
+          "weapon_stats": {
+            "accuracy": 636700,
+            "armor_pierce": 636700,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 49330,
+            "max_damage": 46795,
+            "min_damage": 38996,
+            "shield_pierce": 636700
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 48
+        "bonus1": 48.0
       },
       "build_costs": {
         "materials": [
@@ -1715,40 +5538,153 @@
       "level": 48,
       "requirements": [
         {
-          "name": "Drydock E",
+          "name": "drydock e",
           "level": 48
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 689940,
+          "armor_pierce": 689940,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 267272,
+          "shield_pierce": 689940
+        },
+        "defense": {
+          "armor": 45494,
+          "dodge": 53420,
+          "shield_deflect": 53420
+        },
+        "health": {
+          "hull_health": 458338,
+          "shield_health": 118687
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 689940,
+            "armor_pierce": 689940,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 53454,
+            "max_damage": 50708,
+            "min_damage": 42256,
+            "shield_pierce": 689940
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 689940,
+            "armor_pierce": 689940,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 53454,
+            "max_damage": 50708,
+            "min_damage": 42256,
+            "shield_pierce": 689940
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 1,
+          "weapon_stats": {
+            "accuracy": 689940,
+            "armor_pierce": 689940,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 53454,
+            "max_damage": 50708,
+            "min_damage": 42256,
+            "shield_pierce": 689940
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 49
+        "bonus1": 49.0
       },
       "build_costs": {
         "materials": [
           {
             "type": "gas",
             "grade": 4,
-            "rarity": "uncommon",
-            "value": 25000
+            "rarity": "rare",
+            "value": 6500
           },
           {
             "type": "gas",
             "grade": 4,
-            "rarity": "rare",
-            "value": 6500
+            "rarity": "uncommon",
+            "value": 25000
           }
         ],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 142800000000
-          },
-          {
             "type": "tritanium",
             "value": 2100000000
+          },
+          {
+            "type": "parsteel",
+            "value": 142800000000
           },
           {
             "type": "dilithium",
@@ -1761,31 +5697,144 @@
       "level": 49,
       "requirements": [
         {
-          "name": "Defense Platform D",
+          "name": "drydock e",
           "level": 49
         },
         {
-          "name": "Drydock E",
+          "name": "defense platform d",
           "level": 49
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 747632,
+          "armor_pierce": 747632,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 289622,
+          "shield_pierce": 747632
+        },
+        "defense": {
+          "armor": 49298,
+          "dodge": 59061,
+          "shield_deflect": 59061
+        },
+        "health": {
+          "hull_health": 496663,
+          "shield_health": 131220
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 747632,
+            "armor_pierce": 747632,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 57924,
+            "max_damage": 54948,
+            "min_damage": 45790,
+            "shield_pierce": 747632
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 747632,
+            "armor_pierce": 747632,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 57924,
+            "max_damage": 54948,
+            "min_damage": 45790,
+            "shield_pierce": 747632
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 1,
+          "weapon_stats": {
+            "accuracy": 747632,
+            "armor_pierce": 747632,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 57924,
+            "max_damage": 54948,
+            "min_damage": 45790,
+            "shield_pierce": 747632
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 50
+        "bonus1": 50.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 249900000000
-          },
-          {
             "type": "tritanium",
             "value": 3675000000
+          },
+          {
+            "type": "parsteel",
+            "value": 249900000000
           },
           {
             "type": "dilithium",
@@ -1798,11 +5847,931 @@
       "level": 50,
       "requirements": [
         {
-          "name": "Drydock E",
+          "name": "drydock e",
           "level": 50
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 810147,
+          "armor_pierce": 810147,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 313835,
+          "shield_pierce": 810147
+        },
+        "defense": {
+          "armor": 53420,
+          "dodge": 65297,
+          "shield_deflect": 65297
+        },
+        "health": {
+          "hull_health": 538193,
+          "shield_health": 145076
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 810147,
+            "armor_pierce": 810147,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 62767,
+            "max_damage": 59542,
+            "min_damage": 49618,
+            "shield_pierce": 810147
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 810147,
+            "armor_pierce": 810147,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 62767,
+            "max_damage": 59542,
+            "min_damage": 49618,
+            "shield_pierce": 810147
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 1,
+          "weapon_stats": {
+            "accuracy": 810147,
+            "armor_pierce": 810147,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 62767,
+            "max_damage": 59542,
+            "min_damage": 49618,
+            "shield_pierce": 810147
+          },
+          "weapon_type": "energy"
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 51.0
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "gas",
+            "grade": 5,
+            "rarity": "common",
+            "value": 21700
+          },
+          {
+            "type": "gas",
+            "grade": 5,
+            "rarity": "uncommon",
+            "value": 1900
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "dilithium",
+            "value": 780000000
+          },
+          {
+            "type": "tritanium",
+            "value": 7800000000
+          },
+          {
+            "type": "parsteel",
+            "value": 1246440000000
+          }
+        ]
+      },
+      "build_time": 104346720,
+      "increased_power": 1216045,
+      "level": 51,
+      "requirements": [
+        {
+          "name": "drydock e",
+          "level": 51
+        }
+      ],
+      "stats": {
+        "attack": {
+          "accuracy": 931669,
+          "armor_pierce": 931669,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 360910,
+          "shield_pierce": 931669
+        },
+        "defense": {
+          "armor": 75092,
+          "dodge": 75092,
+          "shield_deflect": 75092
+        },
+        "health": {
+          "hull_health": 618922,
+          "shield_health": 166837
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 931669,
+            "armor_pierce": 931669,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 72182,
+            "max_damage": 68473,
+            "min_damage": 57061,
+            "shield_pierce": 931669
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 931669,
+            "armor_pierce": 931669,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 72182,
+            "max_damage": 68473,
+            "min_damage": 57061,
+            "shield_pierce": 931669
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 1,
+          "weapon_stats": {
+            "accuracy": 931669,
+            "armor_pierce": 931669,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 72182,
+            "max_damage": 68473,
+            "min_damage": 57061,
+            "shield_pierce": 931669
+          },
+          "weapon_type": "energy"
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 52.0
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "gas",
+            "grade": 5,
+            "rarity": "common",
+            "value": 37500
+          },
+          {
+            "type": "gas",
+            "grade": 5,
+            "rarity": "uncommon",
+            "value": 4300
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "dilithium",
+            "value": 1326000000
+          },
+          {
+            "type": "tritanium",
+            "value": 13260000000
+          },
+          {
+            "type": "parsteel",
+            "value": 2254200000000
+          }
+        ]
+      },
+      "build_time": 110606400,
+      "increased_power": 2571112,
+      "level": 52,
+      "requirements": [
+        {
+          "name": "drydock e",
+          "level": 52
+        },
+        {
+          "name": "defense platform d",
+          "level": 52
+        }
+      ],
+      "stats": {
+        "attack": {
+          "accuracy": 1174713,
+          "armor_pierce": 1174713,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 712868,
+          "shield_pierce": 1174713
+        },
+        "defense": {
+          "armor": 94681,
+          "dodge": 94681,
+          "shield_deflect": 94681
+        },
+        "health": {
+          "hull_health": 780380,
+          "shield_health": 210360
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 1174713,
+            "armor_pierce": 1174713,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 142574,
+            "max_damage": 161618,
+            "min_damage": 86336,
+            "shield_pierce": 1174713
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 1174713,
+            "armor_pierce": 1174713,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 142574,
+            "max_damage": 161618,
+            "min_damage": 86336,
+            "shield_pierce": 1174713
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 1,
+          "weapon_stats": {
+            "accuracy": 1174713,
+            "armor_pierce": 1174713,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 142574,
+            "max_damage": 161618,
+            "min_damage": 86336,
+            "shield_pierce": 1174713
+          },
+          "weapon_type": "energy"
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 53.0
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "gas",
+            "grade": 5,
+            "rarity": "common",
+            "value": 88900
+          },
+          {
+            "type": "gas",
+            "grade": 5,
+            "rarity": "uncommon",
+            "value": 15500
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 3786240000000
+          },
+          {
+            "type": "tritanium",
+            "value": 23200000000
+          },
+          {
+            "type": "dilithium",
+            "value": 2320000000
+          }
+        ]
+      },
+      "build_time": 117243360,
+      "increased_power": 9914492,
+      "level": 53,
+      "requirements": [
+        {
+          "name": "drydock e",
+          "level": 53
+        },
+        {
+          "name": "defense platform d",
+          "level": 53
+        }
+      ],
+      "stats": {
+        "attack": {
+          "accuracy": 2187397,
+          "armor_pierce": 2187397,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 1380871,
+          "shield_pierce": 2187397
+        },
+        "defense": {
+          "armor": 176302,
+          "dodge": 176302,
+          "shield_deflect": 176302
+        },
+        "health": {
+          "hull_health": 1453121,
+          "shield_health": 391705
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 2187397,
+            "armor_pierce": 2187397,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 276174,
+            "max_damage": 319540,
+            "min_damage": 160763,
+            "shield_pierce": 2187397
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 2187397,
+            "armor_pierce": 2187397,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 276174,
+            "max_damage": 319540,
+            "min_damage": 160763,
+            "shield_pierce": 2187397
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 1,
+          "weapon_stats": {
+            "accuracy": 2187397,
+            "armor_pierce": 2187397,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 276174,
+            "max_damage": 319540,
+            "min_damage": 160763,
+            "shield_pierce": 2187397
+          },
+          "weapon_type": "energy"
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 54.0
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "gas",
+            "grade": 5,
+            "rarity": "common",
+            "value": 76500
+          },
+          {
+            "type": "gas",
+            "grade": 5,
+            "rarity": "rare",
+            "value": 7000
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 5679360000000
+          },
+          {
+            "type": "tritanium",
+            "value": 34800000000
+          },
+          {
+            "type": "dilithium",
+            "value": 3480000000
+          }
+        ]
+      },
+      "build_time": 124277760,
+      "increased_power": 2449504,
+      "level": 54,
+      "requirements": [
+        {
+          "name": "drydock e",
+          "level": 54
+        },
+        {
+          "name": "defense platform d",
+          "level": 54
+        }
+      ],
+      "stats": {
+        "attack": {
+          "accuracy": 2430441,
+          "armor_pierce": 2430441,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 1611219,
+          "shield_pierce": 2430441
+        },
+        "defense": {
+          "armor": 195891,
+          "dodge": 195891,
+          "shield_deflect": 195891
+        },
+        "health": {
+          "hull_health": 1614579,
+          "shield_health": 435228
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 2430441,
+            "armor_pierce": 2430441,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 322244,
+            "max_damage": 381798,
+            "min_damage": 178626,
+            "shield_pierce": 2430441
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 2430441,
+            "armor_pierce": 2430441,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 322244,
+            "max_damage": 381798,
+            "min_damage": 178626,
+            "shield_pierce": 2430441
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 1,
+          "weapon_stats": {
+            "accuracy": 2430441,
+            "armor_pierce": 2430441,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 322244,
+            "max_damage": 381798,
+            "min_damage": 178626,
+            "shield_pierce": 2430441
+          },
+          "weapon_type": "energy"
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 55.0
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "gas",
+            "grade": 5,
+            "rarity": "rare",
+            "value": 8100
+          },
+          {
+            "type": "gas",
+            "grade": 5,
+            "rarity": "uncommon",
+            "value": 22300
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "dilithium",
+            "value": 5460000000
+          },
+          {
+            "type": "parsteel",
+            "value": 9653280000000
+          },
+          {
+            "type": "tritanium",
+            "value": 54600000000
+          }
+        ]
+      },
+      "build_time": 131734080,
+      "increased_power": 4869860,
+      "level": 55,
+      "requirements": [
+        {
+          "name": "drydock e",
+          "level": 55
+        }
+      ],
+      "stats": {
+        "attack": {
+          "accuracy": 2916529,
+          "armor_pierce": 2916529,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 2042768,
+          "shield_pierce": 2916529
+        },
+        "defense": {
+          "armor": 235069,
+          "dodge": 235069,
+          "shield_deflect": 235069
+        },
+        "health": {
+          "hull_health": 1937495,
+          "shield_health": 522274
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 2916529,
+            "armor_pierce": 2916529,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 408554,
+            "max_damage": 496177,
+            "min_damage": 214351,
+            "shield_pierce": 2916529
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 2916529,
+            "armor_pierce": 2916529,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 408554,
+            "max_damage": 496177,
+            "min_damage": 214351,
+            "shield_pierce": 2916529
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 1,
+          "weapon_stats": {
+            "accuracy": 2916529,
+            "armor_pierce": 2916529,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 408554,
+            "max_damage": 496177,
+            "min_damage": 214351,
+            "shield_pierce": 2916529
+          },
+          "weapon_type": "energy"
+        }
+      ]
     }
   ]
 }

--- a/buildings/defense_platform_f.json
+++ b/buildings/defense_platform_f.json
@@ -2,7 +2,7 @@
   "description": "Defense Platforms are the last line of Defense for the Station. Behind defending ships they provide additional fire support. Upgrade to increase the Platform's combat performance.",
   "bonuses": {
     "bonus1": {
-      "name": "Power Level",
+      "name": "power level",
       "percentage": false
     }
   },
@@ -10,23 +10,23 @@
   "levels": [
     {
       "bonuses": {
-        "bonus1": 1
+        "bonus1": 1.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 136
+            "type": "dilithium",
+            "value": 50
           },
           {
             "type": "tritanium",
             "value": 500
           },
           {
-            "type": "dilithium",
-            "value": 50
+            "type": "parsteel",
+            "value": 136
           }
         ]
       },
@@ -35,15 +35,66 @@
       "level": 1,
       "requirements": [
         {
-          "name": "Defense Platforms",
+          "name": "defense platforms",
           "level": 5
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 18,
+          "armor_pierce": 18,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 506,
+          "shield_pierce": 18
+        },
+        "defense": {
+          "armor": 9,
+          "dodge": 9,
+          "shield_deflect": 9
+        },
+        "health": {
+          "hull_health": 250,
+          "shield_health": 250
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 18,
+            "armor_pierce": 18,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 253,
+            "max_damage": 240,
+            "min_damage": 200,
+            "shield_pierce": 18
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 2
+        "bonus1": 2.0
       },
       "build_costs": {
         "materials": [],
@@ -68,15 +119,66 @@
       "level": 2,
       "requirements": [
         {
-          "name": "Drydock F",
+          "name": "drydock f",
           "level": 2
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 19,
+          "armor_pierce": 19,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 527,
+          "shield_pierce": 19
+        },
+        "defense": {
+          "armor": 9,
+          "dodge": 9,
+          "shield_deflect": 9
+        },
+        "health": {
+          "hull_health": 270,
+          "shield_health": 270
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 19,
+            "armor_pierce": 19,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 263,
+            "max_damage": 250,
+            "min_damage": 208,
+            "shield_pierce": 19
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 3
+        "bonus1": 3.0
       },
       "build_costs": {
         "materials": [],
@@ -87,12 +189,12 @@
             "value": 6250
           },
           {
-            "type": "tritanium",
-            "value": 420
-          },
-          {
             "type": "dilithium",
             "value": 42
+          },
+          {
+            "type": "tritanium",
+            "value": 420
           }
         ]
       },
@@ -101,27 +203,78 @@
       "level": 3,
       "requirements": [
         {
-          "name": "Drydock F",
+          "name": "drydock f",
           "level": 3
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 27,
+          "armor_pierce": 27,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 587,
+          "shield_pierce": 27
+        },
+        "defense": {
+          "armor": 14,
+          "dodge": 14,
+          "shield_deflect": 14
+        },
+        "health": {
+          "hull_health": 290,
+          "shield_health": 290
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 27,
+            "armor_pierce": 27,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 293,
+            "max_damage": 278,
+            "min_damage": 232,
+            "shield_pierce": 27
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 4
+        "bonus1": 4.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 7000
-          },
-          {
             "type": "tritanium",
             "value": 440
+          },
+          {
+            "type": "parsteel",
+            "value": 7000
           },
           {
             "type": "dilithium",
@@ -134,24 +287,71 @@
       "level": 4,
       "requirements": [
         {
-          "name": "Drydock F",
+          "name": "drydock f",
           "level": 4
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 36,
+          "armor_pierce": 36,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 662,
+          "shield_pierce": 36
+        },
+        "defense": {
+          "armor": 18,
+          "dodge": 18,
+          "shield_deflect": 18
+        },
+        "health": {
+          "hull_health": 360,
+          "shield_health": 360
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 36,
+            "armor_pierce": 36,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 331,
+            "max_damage": 314,
+            "min_damage": 262,
+            "shield_pierce": 36
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 5
+        "bonus1": 5.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
-          {
-            "type": "parsteel",
-            "value": 7750
-          },
           {
             "type": "tritanium",
             "value": 460
@@ -159,6 +359,10 @@
           {
             "type": "dilithium",
             "value": 46
+          },
+          {
+            "type": "parsteel",
+            "value": 7750
           }
         ]
       },
@@ -167,15 +371,66 @@
       "level": 5,
       "requirements": [
         {
-          "name": "Drydock F",
+          "name": "drydock f",
           "level": 5
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 46,
+          "armor_pierce": 46,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 818,
+          "shield_pierce": 46
+        },
+        "defense": {
+          "armor": 23,
+          "dodge": 23,
+          "shield_deflect": 23
+        },
+        "health": {
+          "hull_health": 500,
+          "shield_health": 500
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 46,
+            "armor_pierce": 46,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 409,
+            "max_damage": 388,
+            "min_damage": 323,
+            "shield_pierce": 46
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 6
+        "bonus1": 6.0
       },
       "build_costs": {
         "materials": [],
@@ -200,27 +455,78 @@
       "level": 6,
       "requirements": [
         {
-          "name": "Drydock F",
+          "name": "drydock f",
           "level": 6
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 63,
+          "armor_pierce": 63,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 1045,
+          "shield_pierce": 63
+        },
+        "defense": {
+          "armor": 32,
+          "dodge": 32,
+          "shield_deflect": 32
+        },
+        "health": {
+          "hull_health": 660,
+          "shield_health": 660
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 63,
+            "armor_pierce": 63,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 523,
+            "max_damage": 496,
+            "min_damage": 413,
+            "shield_pierce": 63
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 7
+        "bonus1": 7.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 9250
-          },
-          {
             "type": "tritanium",
             "value": 500
+          },
+          {
+            "type": "parsteel",
+            "value": 9250
           },
           {
             "type": "dilithium",
@@ -233,31 +539,82 @@
       "level": 7,
       "requirements": [
         {
-          "name": "Drydock F",
+          "name": "drydock f",
           "level": 7
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 94,
+          "armor_pierce": 94,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 1298,
+          "shield_pierce": 94
+        },
+        "defense": {
+          "armor": 47,
+          "dodge": 47,
+          "shield_deflect": 47
+        },
+        "health": {
+          "hull_health": 960,
+          "shield_health": 960
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 94,
+            "armor_pierce": 94,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 649,
+            "max_damage": 616,
+            "min_damage": 513,
+            "shield_pierce": 94
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 8
+        "bonus1": 8.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 10000
+            "type": "dilithium",
+            "value": 52
           },
           {
             "type": "tritanium",
             "value": 520
           },
           {
-            "type": "dilithium",
-            "value": 52
+            "type": "parsteel",
+            "value": 10000
           }
         ]
       },
@@ -266,20 +623,75 @@
       "level": 8,
       "requirements": [
         {
-          "name": "Drydock F",
+          "name": "drydock f",
           "level": 8
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 138,
+          "armor_pierce": 138,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 1948,
+          "shield_pierce": 138
+        },
+        "defense": {
+          "armor": 69,
+          "dodge": 69,
+          "shield_deflect": 69
+        },
+        "health": {
+          "hull_health": 1370,
+          "shield_health": 1370
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 138,
+            "armor_pierce": 138,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 974,
+            "max_damage": 924,
+            "min_damage": 770,
+            "shield_pierce": 138
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 9
+        "bonus1": 9.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
+          {
+            "type": "dilithium",
+            "value": 54
+          },
           {
             "type": "parsteel",
             "value": 11000
@@ -287,10 +699,6 @@
           {
             "type": "tritanium",
             "value": 540
-          },
-          {
-            "type": "dilithium",
-            "value": 54
           }
         ]
       },
@@ -299,24 +707,71 @@
       "level": 9,
       "requirements": [
         {
-          "name": "Drydock F",
+          "name": "drydock f",
           "level": 9
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 200,
+          "armor_pierce": 200,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 2728,
+          "shield_pierce": 200
+        },
+        "defense": {
+          "armor": 100,
+          "dodge": 100,
+          "shield_deflect": 100
+        },
+        "health": {
+          "hull_health": 2020,
+          "shield_health": 2020
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 200,
+            "armor_pierce": 200,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 1364,
+            "max_damage": 1294,
+            "min_damage": 1078,
+            "shield_pierce": 200
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 10
+        "bonus1": 10.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
-          {
-            "type": "parsteel",
-            "value": 12500
-          },
           {
             "type": "tritanium",
             "value": 600
@@ -324,6 +779,10 @@
           {
             "type": "dilithium",
             "value": 60
+          },
+          {
+            "type": "parsteel",
+            "value": 12500
           }
         ]
       },
@@ -332,27 +791,109 @@
       "level": 10,
       "requirements": [
         {
-          "name": "Drydock F",
+          "name": "drydock f",
           "level": 10
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 236,
+          "armor_pierce": 236,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 3503,
+          "shield_pierce": 236
+        },
+        "defense": {
+          "armor": 131,
+          "dodge": 131,
+          "shield_deflect": 131
+        },
+        "health": {
+          "hull_health": 2560,
+          "shield_health": 2560
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 236,
+            "armor_pierce": 236,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 1168,
+            "max_damage": 1108,
+            "min_damage": 923,
+            "shield_pierce": 236
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 1,
+          "weapon_stats": {
+            "accuracy": 236,
+            "armor_pierce": 236,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 1168,
+            "max_damage": 1108,
+            "min_damage": 923,
+            "shield_pierce": 236
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 11
+        "bonus1": 11.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 13600
-          },
-          {
             "type": "tritanium",
             "value": 400
+          },
+          {
+            "type": "parsteel",
+            "value": 13600
           },
           {
             "type": "dilithium",
@@ -365,15 +906,97 @@
       "level": 11,
       "requirements": [
         {
-          "name": "Drydock F",
+          "name": "drydock f",
           "level": 11
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 260,
+          "armor_pierce": 260,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 4782,
+          "shield_pierce": 260
+        },
+        "defense": {
+          "armor": 153,
+          "dodge": 153,
+          "shield_deflect": 153
+        },
+        "health": {
+          "hull_health": 2740,
+          "shield_health": 2740
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 260,
+            "armor_pierce": 260,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 1594,
+            "max_damage": 1512,
+            "min_damage": 1260,
+            "shield_pierce": 260
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 1,
+          "weapon_stats": {
+            "accuracy": 260,
+            "armor_pierce": 260,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 1594,
+            "max_damage": 1512,
+            "min_damage": 1260,
+            "shield_pierce": 260
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 12
+        "bonus1": 12.0
       },
       "build_costs": {
         "materials": [],
@@ -384,12 +1007,12 @@
             "value": 18700
           },
           {
-            "type": "tritanium",
-            "value": 550
-          },
-          {
             "type": "dilithium",
             "value": 22
+          },
+          {
+            "type": "tritanium",
+            "value": 550
           }
         ]
       },
@@ -398,24 +1021,102 @@
       "level": 12,
       "requirements": [
         {
-          "name": "Drydock F",
+          "name": "drydock f",
           "level": 12
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 340,
+          "armor_pierce": 340,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 5142,
+          "shield_pierce": 340
+        },
+        "defense": {
+          "armor": 213,
+          "dodge": 213,
+          "shield_deflect": 213
+        },
+        "health": {
+          "hull_health": 2880,
+          "shield_health": 2880
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 340,
+            "armor_pierce": 340,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 1714,
+            "max_damage": 1626,
+            "min_damage": 1355,
+            "shield_pierce": 340
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 1,
+          "weapon_stats": {
+            "accuracy": 340,
+            "armor_pierce": 340,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 1714,
+            "max_damage": 1626,
+            "min_damage": 1355,
+            "shield_pierce": 340
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 13
+        "bonus1": 13.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
-          {
-            "type": "parsteel",
-            "value": 27200
-          },
           {
             "type": "tritanium",
             "value": 800
@@ -423,6 +1124,10 @@
           {
             "type": "dilithium",
             "value": 48
+          },
+          {
+            "type": "parsteel",
+            "value": 27200
           }
         ]
       },
@@ -431,31 +1136,113 @@
       "level": 13,
       "requirements": [
         {
-          "name": "Drydock F",
+          "name": "drydock f",
           "level": 13
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 438,
+          "armor_pierce": 438,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 5572,
+          "shield_pierce": 438
+        },
+        "defense": {
+          "armor": 274,
+          "dodge": 274,
+          "shield_deflect": 274
+        },
+        "health": {
+          "hull_health": 3350,
+          "shield_health": 3350
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 438,
+            "armor_pierce": 438,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 1857,
+            "max_damage": 1762,
+            "min_damage": 1468,
+            "shield_pierce": 438
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 1,
+          "weapon_stats": {
+            "accuracy": 438,
+            "armor_pierce": 438,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 1857,
+            "max_damage": 1762,
+            "min_damage": 1468,
+            "shield_pierce": 438
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 14
+        "bonus1": 14.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 37400
+            "type": "dilithium",
+            "value": 88
           },
           {
             "type": "tritanium",
             "value": 1100
           },
           {
-            "type": "dilithium",
-            "value": 88
+            "type": "parsteel",
+            "value": 37400
           }
         ]
       },
@@ -464,15 +1251,97 @@
       "level": 14,
       "requirements": [
         {
-          "name": "Drydock F",
+          "name": "drydock f",
           "level": 14
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 454,
+          "armor_pierce": 454,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 5730,
+          "shield_pierce": 454
+        },
+        "defense": {
+          "armor": 371,
+          "dodge": 371,
+          "shield_deflect": 371
+        },
+        "health": {
+          "hull_health": 3460,
+          "shield_health": 3460
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 454,
+            "armor_pierce": 454,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 1910,
+            "max_damage": 1812,
+            "min_damage": 1510,
+            "shield_pierce": 454
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 1,
+          "weapon_stats": {
+            "accuracy": 454,
+            "armor_pierce": 454,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 1910,
+            "max_damage": 1812,
+            "min_damage": 1510,
+            "shield_pierce": 454
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 15
+        "bonus1": 15.0
       },
       "build_costs": {
         "materials": [],
@@ -483,12 +1352,12 @@
             "value": 51000
           },
           {
-            "type": "tritanium",
-            "value": 1500
-          },
-          {
             "type": "dilithium",
             "value": 150
+          },
+          {
+            "type": "tritanium",
+            "value": 1500
           }
         ]
       },
@@ -497,27 +1366,109 @@
       "level": 15,
       "requirements": [
         {
-          "name": "Drydock F",
+          "name": "drydock f",
           "level": 15
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 475,
+          "armor_pierce": 475,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 5863,
+          "shield_pierce": 475
+        },
+        "defense": {
+          "armor": 400,
+          "dodge": 400,
+          "shield_deflect": 400
+        },
+        "health": {
+          "hull_health": 3730,
+          "shield_health": 3730
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 475,
+            "armor_pierce": 475,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 1954,
+            "max_damage": 1854,
+            "min_damage": 1545,
+            "shield_pierce": 475
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 1,
+          "weapon_stats": {
+            "accuracy": 475,
+            "armor_pierce": 475,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 1954,
+            "max_damage": 1854,
+            "min_damage": 1545,
+            "shield_pierce": 475
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 16
+        "bonus1": 16.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 68000
-          },
-          {
             "type": "tritanium",
             "value": 2000
+          },
+          {
+            "type": "parsteel",
+            "value": 68000
           },
           {
             "type": "dilithium",
@@ -530,31 +1481,113 @@
       "level": 16,
       "requirements": [
         {
-          "name": "Drydock F",
+          "name": "drydock f",
           "level": 16
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 556,
+          "armor_pierce": 556,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 7476,
+          "shield_pierce": 556
+        },
+        "defense": {
+          "armor": 479,
+          "dodge": 479,
+          "shield_deflect": 479
+        },
+        "health": {
+          "hull_health": 4750,
+          "shield_health": 4750
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 556,
+            "armor_pierce": 556,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 2492,
+            "max_damage": 2364,
+            "min_damage": 1970,
+            "shield_pierce": 556
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 1,
+          "weapon_stats": {
+            "accuracy": 556,
+            "armor_pierce": 556,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 2492,
+            "max_damage": 2364,
+            "min_damage": 1970,
+            "shield_pierce": 556
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 17
+        "bonus1": 17.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 95200
+            "type": "dilithium",
+            "value": 280
           },
           {
             "type": "tritanium",
             "value": 2800
           },
           {
-            "type": "dilithium",
-            "value": 280
+            "type": "parsteel",
+            "value": 95200
           }
         ]
       },
@@ -563,27 +1596,109 @@
       "level": 17,
       "requirements": [
         {
-          "name": "Drydock F",
+          "name": "drydock f",
           "level": 17
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 649,
+          "armor_pierce": 649,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 8779,
+          "shield_pierce": 649
+        },
+        "defense": {
+          "armor": 535,
+          "dodge": 535,
+          "shield_deflect": 535
+        },
+        "health": {
+          "hull_health": 5620,
+          "shield_health": 5620
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 649,
+            "armor_pierce": 649,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 2926,
+            "max_damage": 2776,
+            "min_damage": 2313,
+            "shield_pierce": 649
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 1,
+          "weapon_stats": {
+            "accuracy": 649,
+            "armor_pierce": 649,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 2926,
+            "max_damage": 2776,
+            "min_damage": 2313,
+            "shield_pierce": 649
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 18
+        "bonus1": 18.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 136000
-          },
-          {
             "type": "tritanium",
             "value": 4000
+          },
+          {
+            "type": "parsteel",
+            "value": 136000
           },
           {
             "type": "dilithium",
@@ -596,27 +1711,109 @@
       "level": 18,
       "requirements": [
         {
-          "name": "Drydock F",
+          "name": "drydock f",
           "level": 18
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 672,
+          "armor_pierce": 672,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 10265,
+          "shield_pierce": 672
+        },
+        "defense": {
+          "armor": 560,
+          "dodge": 560,
+          "shield_deflect": 560
+        },
+        "health": {
+          "hull_health": 6120,
+          "shield_health": 6120
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 672,
+            "armor_pierce": 672,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 3422,
+            "max_damage": 3246,
+            "min_damage": 2705,
+            "shield_pierce": 672
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 1,
+          "weapon_stats": {
+            "accuracy": 672,
+            "armor_pierce": 672,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 3422,
+            "max_damage": 3246,
+            "min_damage": 2705,
+            "shield_pierce": 672
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 19
+        "bonus1": 19.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 204000
-          },
-          {
             "type": "tritanium",
             "value": 6000
+          },
+          {
+            "type": "parsteel",
+            "value": 204000
           },
           {
             "type": "dilithium",
@@ -629,31 +1826,113 @@
       "level": 19,
       "requirements": [
         {
-          "name": "Drydock F",
+          "name": "drydock f",
           "level": 19
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 2023,
+          "armor_pierce": 2023,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 10823,
+          "shield_pierce": 2023
+        },
+        "defense": {
+          "armor": 674,
+          "dodge": 674,
+          "shield_deflect": 674
+        },
+        "health": {
+          "hull_health": 6500,
+          "shield_health": 6500
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 2023,
+            "armor_pierce": 2023,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 3608,
+            "max_damage": 3422,
+            "min_damage": 2852,
+            "shield_pierce": 2023
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 1,
+          "weapon_stats": {
+            "accuracy": 2023,
+            "armor_pierce": 2023,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 3608,
+            "max_damage": 3422,
+            "min_damage": 2852,
+            "shield_pierce": 2023
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 20
+        "bonus1": 20.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 289000
+            "type": "dilithium",
+            "value": 850
           },
           {
             "type": "tritanium",
             "value": 8500
           },
           {
-            "type": "dilithium",
-            "value": 850
+            "type": "parsteel",
+            "value": 289000
           }
         ]
       },
@@ -662,15 +1941,97 @@
       "level": 20,
       "requirements": [
         {
-          "name": "Drydock F",
+          "name": "drydock f",
           "level": 20
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 2755,
+          "armor_pierce": 2755,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 11173,
+          "shield_pierce": 2755
+        },
+        "defense": {
+          "armor": 689,
+          "dodge": 689,
+          "shield_deflect": 689
+        },
+        "health": {
+          "hull_health": 9860,
+          "shield_health": 6570
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 2755,
+            "armor_pierce": 2755,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 2793,
+            "max_damage": 2650,
+            "min_damage": 2208,
+            "shield_pierce": 2755
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 2755,
+            "armor_pierce": 2755,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 2793,
+            "max_damage": 2650,
+            "min_damage": 2208,
+            "shield_pierce": 2755
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 21
+        "bonus1": 21.0
       },
       "build_costs": {
         "materials": [],
@@ -695,15 +2056,97 @@
       "level": 21,
       "requirements": [
         {
-          "name": "Drydock F",
+          "name": "drydock f",
           "level": 21
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 3494,
+          "armor_pierce": 3494,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 11360,
+          "shield_pierce": 3494
+        },
+        "defense": {
+          "armor": 699,
+          "dodge": 699,
+          "shield_deflect": 699
+        },
+        "health": {
+          "hull_health": 13540,
+          "shield_health": 6770
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 3494,
+            "armor_pierce": 3494,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 2840,
+            "max_damage": 2694,
+            "min_damage": 2245,
+            "shield_pierce": 3494
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 3494,
+            "armor_pierce": 3494,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 2840,
+            "max_damage": 2694,
+            "min_damage": 2245,
+            "shield_pierce": 3494
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 22
+        "bonus1": 22.0
       },
       "build_costs": {
         "materials": [],
@@ -728,15 +2171,97 @@
       "level": 22,
       "requirements": [
         {
-          "name": "Drydock F",
+          "name": "drydock f",
           "level": 22
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 35000,
+          "armor_pierce": 35000,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 17528,
+          "shield_pierce": 35000
+        },
+        "defense": {
+          "armor": 1701,
+          "dodge": 1701,
+          "shield_deflect": 1701
+        },
+        "health": {
+          "hull_health": 25246,
+          "shield_health": 6840
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 35000,
+            "armor_pierce": 35000,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 4382,
+            "max_damage": 4157,
+            "min_damage": 3464,
+            "shield_pierce": 35000
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 35000,
+            "armor_pierce": 35000,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 4382,
+            "max_damage": 4157,
+            "min_damage": 3464,
+            "shield_pierce": 35000
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 23
+        "bonus1": 23.0
       },
       "build_costs": {
         "materials": [],
@@ -761,15 +2286,97 @@
       "level": 23,
       "requirements": [
         {
-          "name": "Drydock F",
+          "name": "drydock f",
           "level": 23
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 36150,
+          "armor_pierce": 37625,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 21243,
+          "shield_pierce": 37625
+        },
+        "defense": {
+          "armor": 2724,
+          "dodge": 2724,
+          "shield_deflect": 2724
+        },
+        "health": {
+          "hull_health": 25582,
+          "shield_health": 6910
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 36150,
+            "armor_pierce": 37625,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 5311,
+            "max_damage": 5038,
+            "min_damage": 4198,
+            "shield_pierce": 37625
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 36150,
+            "armor_pierce": 37625,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 5311,
+            "max_damage": 5038,
+            "min_damage": 4198,
+            "shield_pierce": 37625
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 24
+        "bonus1": 24.0
       },
       "build_costs": {
         "materials": [],
@@ -780,12 +2387,12 @@
             "value": 1962480
           },
           {
-            "type": "tritanium",
-            "value": 57720
-          },
-          {
             "type": "dilithium",
             "value": 5772
+          },
+          {
+            "type": "tritanium",
+            "value": 57720
           }
         ]
       },
@@ -794,15 +2401,97 @@
       "level": 24,
       "requirements": [
         {
-          "name": "Drydock F",
+          "name": "drydock f",
           "level": 24
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 36300,
+          "armor_pierce": 43125,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 22211,
+          "shield_pierce": 43125
+        },
+        "defense": {
+          "armor": 3571,
+          "dodge": 3571,
+          "shield_deflect": 3571
+        },
+        "health": {
+          "hull_health": 25671,
+          "shield_health": 7020
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 36300,
+            "armor_pierce": 43125,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 5553,
+            "max_damage": 5267,
+            "min_damage": 4390,
+            "shield_pierce": 43125
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 36300,
+            "armor_pierce": 43125,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 5553,
+            "max_damage": 5267,
+            "min_damage": 4390,
+            "shield_pierce": 43125
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 25
+        "bonus1": 25.0
       },
       "build_costs": {
         "materials": [],
@@ -813,12 +2502,12 @@
             "value": 3182400
           },
           {
-            "type": "tritanium",
-            "value": 93600
-          },
-          {
             "type": "dilithium",
             "value": 9360
+          },
+          {
+            "type": "tritanium",
+            "value": 93600
           }
         ]
       },
@@ -827,27 +2516,109 @@
       "level": 25,
       "requirements": [
         {
-          "name": "Drydock F",
+          "name": "drydock f",
           "level": 25
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 36425,
+          "armor_pierce": 43750,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 27400,
+          "shield_pierce": 43750
+        },
+        "defense": {
+          "armor": 4865,
+          "dodge": 4865,
+          "shield_deflect": 4865
+        },
+        "health": {
+          "hull_health": 28013,
+          "shield_health": 7780
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 36425,
+            "armor_pierce": 43750,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 6850,
+            "max_damage": 6498,
+            "min_damage": 5415,
+            "shield_pierce": 43750
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 36425,
+            "armor_pierce": 43750,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 6850,
+            "max_damage": 6498,
+            "min_damage": 5415,
+            "shield_pierce": 43750
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 26
+        "bonus1": 26.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 4972500
-          },
-          {
             "type": "tritanium",
             "value": 146250
+          },
+          {
+            "type": "parsteel",
+            "value": 4972500
           },
           {
             "type": "dilithium",
@@ -860,27 +2631,109 @@
       "level": 26,
       "requirements": [
         {
-          "name": "Drydock F",
+          "name": "drydock f",
           "level": 26
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 38710,
+          "armor_pierce": 46875,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 28775,
+          "shield_pierce": 46875
+        },
+        "defense": {
+          "armor": 5687,
+          "dodge": 5687,
+          "shield_deflect": 5687
+        },
+        "health": {
+          "hull_health": 32009,
+          "shield_health": 9000
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 38710,
+            "armor_pierce": 46875,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 7194,
+            "max_damage": 6824,
+            "min_damage": 5687,
+            "shield_pierce": 46875
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 38710,
+            "armor_pierce": 46875,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 7194,
+            "max_damage": 6824,
+            "min_damage": 5687,
+            "shield_pierce": 46875
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 27
+        "bonus1": 27.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 7588800
-          },
-          {
             "type": "tritanium",
             "value": 223200
+          },
+          {
+            "type": "parsteel",
+            "value": 7588800
           },
           {
             "type": "dilithium",
@@ -893,15 +2746,97 @@
       "level": 27,
       "requirements": [
         {
-          "name": "Drydock F",
+          "name": "drydock f",
           "level": 27
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 44516,
+          "armor_pierce": 57500,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 30811,
+          "shield_pierce": 57500
+        },
+        "defense": {
+          "armor": 6303,
+          "dodge": 6302,
+          "shield_deflect": 6302
+        },
+        "health": {
+          "hull_health": 40145,
+          "shield_health": 11340
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 44516,
+            "armor_pierce": 57500,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 7703,
+            "max_damage": 7307,
+            "min_damage": 6089,
+            "shield_pierce": 57500
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 44516,
+            "armor_pierce": 57500,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 7703,
+            "max_damage": 7307,
+            "min_damage": 6089,
+            "shield_pierce": 57500
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 28
+        "bonus1": 28.0
       },
       "build_costs": {
         "materials": [],
@@ -912,12 +2847,12 @@
             "value": 11383200
           },
           {
-            "type": "tritanium",
-            "value": 334800
-          },
-          {
             "type": "dilithium",
             "value": 33480
+          },
+          {
+            "type": "tritanium",
+            "value": 334800
           }
         ]
       },
@@ -926,27 +2861,109 @@
       "level": 28,
       "requirements": [
         {
-          "name": "Drydock F",
+          "name": "drydock f",
           "level": 28
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 56473,
+          "armor_pierce": 68750,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 32324,
+          "shield_pierce": 68750
+        },
+        "defense": {
+          "armor": 8052,
+          "dodge": 8052,
+          "shield_deflect": 8052
+        },
+        "health": {
+          "hull_health": 50751,
+          "shield_health": 14400
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 56473,
+            "armor_pierce": 68750,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 8081,
+            "max_damage": 7666,
+            "min_damage": 6388,
+            "shield_pierce": 68750
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 56473,
+            "armor_pierce": 68750,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 8081,
+            "max_damage": 7666,
+            "min_damage": 6388,
+            "shield_pierce": 68750
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 29
+        "bonus1": 29.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 18122000
-          },
-          {
             "type": "tritanium",
             "value": 533000
+          },
+          {
+            "type": "parsteel",
+            "value": 18122000
           },
           {
             "type": "dilithium",
@@ -959,31 +2976,113 @@
       "level": 29,
       "requirements": [
         {
-          "name": "Drydock F",
+          "name": "drydock f",
           "level": 29
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 62448,
+          "armor_pierce": 74375,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 35841,
+          "shield_pierce": 74375
+        },
+        "defense": {
+          "armor": 8908,
+          "dodge": 8908,
+          "shield_deflect": 8908
+        },
+        "health": {
+          "hull_health": 59028,
+          "shield_health": 16830
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 62448,
+            "armor_pierce": 74375,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 8960,
+            "max_damage": 8500,
+            "min_damage": 7083,
+            "shield_pierce": 74375
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 62448,
+            "armor_pierce": 74375,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 8960,
+            "max_damage": 8500,
+            "min_damage": 7083,
+            "shield_pierce": 74375
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 30
+        "bonus1": 30.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 26520000
+            "type": "dilithium",
+            "value": 78000
           },
           {
             "type": "tritanium",
             "value": 780000
           },
           {
-            "type": "dilithium",
-            "value": 78000
+            "type": "parsteel",
+            "value": 26520000
           }
         ]
       },
@@ -992,15 +3091,97 @@
       "level": 30,
       "requirements": [
         {
-          "name": "Drydock F",
+          "name": "drydock f",
           "level": 30
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 77490,
+          "armor_pierce": 76125,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 37780,
+          "shield_pierce": 76125
+        },
+        "defense": {
+          "armor": 10611,
+          "dodge": 10611,
+          "shield_deflect": 10611
+        },
+        "health": {
+          "hull_health": 67494,
+          "shield_health": 17230
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 77490,
+            "armor_pierce": 76125,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 9445,
+            "max_damage": 8960,
+            "min_damage": 7466,
+            "shield_pierce": 76125
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 77490,
+            "armor_pierce": 76125,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 9445,
+            "max_damage": 8960,
+            "min_damage": 7466,
+            "shield_pierce": 76125
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 31
+        "bonus1": 31.0
       },
       "build_costs": {
         "materials": [],
@@ -1011,12 +3192,12 @@
             "value": 41922000
           },
           {
-            "type": "tritanium",
-            "value": 1233000
-          },
-          {
             "type": "dilithium",
             "value": 123300
+          },
+          {
+            "type": "tritanium",
+            "value": 1233000
           }
         ]
       },
@@ -1025,31 +3206,113 @@
       "level": 31,
       "requirements": [
         {
-          "name": "Drydock F",
+          "name": "drydock f",
           "level": 31
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 87436,
+          "armor_pierce": 89375,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 40278,
+          "shield_pierce": 89375
+        },
+        "defense": {
+          "armor": 12016,
+          "dodge": 12016,
+          "shield_deflect": 12016
+        },
+        "health": {
+          "hull_health": 77484,
+          "shield_health": 19910
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 87436,
+            "armor_pierce": 89375,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 10069,
+            "max_damage": 9552,
+            "min_damage": 7960,
+            "shield_pierce": 89375
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 87436,
+            "armor_pierce": 89375,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 10069,
+            "max_damage": 9552,
+            "min_damage": 7960,
+            "shield_pierce": 89375
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 32
+        "bonus1": 32.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 60554000
+            "type": "dilithium",
+            "value": 178100
           },
           {
             "type": "tritanium",
             "value": 1781000
           },
           {
-            "type": "dilithium",
-            "value": 178100
+            "type": "parsteel",
+            "value": 60554000
           }
         ]
       },
@@ -1058,20 +3321,106 @@
       "level": 32,
       "requirements": [
         {
-          "name": "Drydock F",
+          "name": "drydock f",
           "level": 32
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 91746,
+          "armor_pierce": 123750,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 45600,
+          "shield_pierce": 123750
+        },
+        "defense": {
+          "armor": 13124,
+          "dodge": 13124,
+          "shield_deflect": 13124
+        },
+        "health": {
+          "hull_health": 83090,
+          "shield_health": 20120
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 91746,
+            "armor_pierce": 123750,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 11400,
+            "max_damage": 10814,
+            "min_damage": 9012,
+            "shield_pierce": 123750
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 91746,
+            "armor_pierce": 123750,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 11400,
+            "max_damage": 10814,
+            "min_damage": 9012,
+            "shield_pierce": 123750
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 33
+        "bonus1": 33.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
+          {
+            "type": "dilithium",
+            "value": 275500
+          },
           {
             "type": "parsteel",
             "value": 93670000
@@ -1079,10 +3428,6 @@
           {
             "type": "tritanium",
             "value": 2755000
-          },
-          {
-            "type": "dilithium",
-            "value": 275500
           }
         ]
       },
@@ -1091,24 +3436,102 @@
       "level": 33,
       "requirements": [
         {
-          "name": "Drydock F",
+          "name": "drydock f",
           "level": 33
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 94480,
+          "armor_pierce": 144038,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 47773,
+          "shield_pierce": 144038
+        },
+        "defense": {
+          "armor": 13560,
+          "dodge": 13560,
+          "shield_deflect": 13560
+        },
+        "health": {
+          "hull_health": 92622,
+          "shield_health": 21830
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 94480,
+            "armor_pierce": 144038,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 11943,
+            "max_damage": 11330,
+            "min_damage": 9441,
+            "shield_pierce": 144038
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 94480,
+            "armor_pierce": 144038,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 11943,
+            "max_damage": 11330,
+            "min_damage": 9441,
+            "shield_pierce": 144038
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 34
+        "bonus1": 34.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
-          {
-            "type": "parsteel",
-            "value": 147900000
-          },
           {
             "type": "tritanium",
             "value": 4350000
@@ -1116,6 +3539,10 @@
           {
             "type": "dilithium",
             "value": 435000
+          },
+          {
+            "type": "parsteel",
+            "value": 147900000
           }
         ]
       },
@@ -1124,27 +3551,109 @@
       "level": 34,
       "requirements": [
         {
-          "name": "Drydock F",
+          "name": "drydock f",
           "level": 34
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 100000,
+          "armor_pierce": 161563,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 50660,
+          "shield_pierce": 161563
+        },
+        "defense": {
+          "armor": 14845,
+          "dodge": 14845,
+          "shield_deflect": 14845
+        },
+        "health": {
+          "hull_health": 102230,
+          "shield_health": 22770
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 100000,
+            "armor_pierce": 161563,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 12665,
+            "max_damage": 12014,
+            "min_damage": 10012,
+            "shield_pierce": 161563
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 100000,
+            "armor_pierce": 161563,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 12665,
+            "max_damage": 12014,
+            "min_damage": 10012,
+            "shield_pierce": 161563
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 35
+        "bonus1": 35.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 228888000
-          },
-          {
             "type": "tritanium",
             "value": 6732000
+          },
+          {
+            "type": "parsteel",
+            "value": 228888000
           },
           {
             "type": "dilithium",
@@ -1157,27 +3666,109 @@
       "level": 35,
       "requirements": [
         {
-          "name": "Drydock F",
+          "name": "drydock f",
           "level": 35
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 109796,
+          "armor_pierce": 196875,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 59319,
+          "shield_pierce": 196875
+        },
+        "defense": {
+          "armor": 16480,
+          "dodge": 16480,
+          "shield_deflect": 16480
+        },
+        "health": {
+          "hull_health": 118699,
+          "shield_health": 28350
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 109796,
+            "armor_pierce": 196875,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 14830,
+            "max_damage": 14068,
+            "min_damage": 11723,
+            "shield_pierce": 196875
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 109796,
+            "armor_pierce": 196875,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 14830,
+            "max_damage": 14068,
+            "min_damage": 11723,
+            "shield_pierce": 196875
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 36
+        "bonus1": 36.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 322524000
-          },
-          {
             "type": "tritanium",
             "value": 9486000
+          },
+          {
+            "type": "parsteel",
+            "value": 322524000
           },
           {
             "type": "dilithium",
@@ -1190,15 +3781,97 @@
       "level": 36,
       "requirements": [
         {
-          "name": "Drydock F",
+          "name": "drydock f",
           "level": 36
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 119489,
+          "armor_pierce": 227807,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 71792,
+          "shield_pierce": 227807
+        },
+        "defense": {
+          "armor": 17855,
+          "dodge": 17855,
+          "shield_deflect": 17855
+        },
+        "health": {
+          "hull_health": 138605,
+          "shield_health": 32610
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 119489,
+            "armor_pierce": 227807,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 17948,
+            "max_damage": 17026,
+            "min_damage": 14188,
+            "shield_pierce": 227807
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 119489,
+            "armor_pierce": 227807,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 17948,
+            "max_damage": 17026,
+            "min_damage": 14188,
+            "shield_pierce": 227807
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 37
+        "bonus1": 37.0
       },
       "build_costs": {
         "materials": [],
@@ -1209,12 +3882,12 @@
             "value": 495720000
           },
           {
-            "type": "tritanium",
-            "value": 14580000
-          },
-          {
             "type": "dilithium",
             "value": 1458000
+          },
+          {
+            "type": "tritanium",
+            "value": 14580000
           }
         ]
       },
@@ -1223,27 +3896,109 @@
       "level": 37,
       "requirements": [
         {
-          "name": "Drydock F",
+          "name": "drydock f",
           "level": 37
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 132418,
+          "armor_pierce": 247922,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 77781,
+          "shield_pierce": 247922
+        },
+        "defense": {
+          "armor": 18489,
+          "dodge": 18489,
+          "shield_deflect": 18489
+        },
+        "health": {
+          "hull_health": 163789,
+          "shield_health": 35710
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 132418,
+            "armor_pierce": 247922,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 19445,
+            "max_damage": 18446,
+            "min_damage": 15372,
+            "shield_pierce": 247922
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 132418,
+            "armor_pierce": 247922,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 19445,
+            "max_damage": 18446,
+            "min_damage": 15372,
+            "shield_pierce": 247922
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 38
+        "bonus1": 38.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 771120000
-          },
-          {
             "type": "tritanium",
             "value": 22680000
+          },
+          {
+            "type": "parsteel",
+            "value": 771120000
           },
           {
             "type": "dilithium",
@@ -1256,15 +4011,97 @@
       "level": 38,
       "requirements": [
         {
-          "name": "Drydock F",
+          "name": "drydock f",
           "level": 38
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 144918,
+          "armor_pierce": 286066,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 89173,
+          "shield_pierce": 286066
+        },
+        "defense": {
+          "armor": 20112,
+          "dodge": 20112,
+          "shield_deflect": 20112
+        },
+        "health": {
+          "hull_health": 188609,
+          "shield_health": 41570
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 144918,
+            "armor_pierce": 286066,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 22293,
+            "max_damage": 21148,
+            "min_damage": 17623,
+            "shield_pierce": 286066
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 144918,
+            "armor_pierce": 286066,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 22293,
+            "max_damage": 21148,
+            "min_damage": 17623,
+            "shield_pierce": 286066
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 39
+        "bonus1": 39.0
       },
       "build_costs": {
         "materials": [],
@@ -1289,15 +4126,97 @@
       "level": 39,
       "requirements": [
         {
-          "name": "Drydock F",
+          "name": "drydock f",
           "level": 39
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 159412,
+          "armor_pierce": 333789,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 103443,
+          "shield_pierce": 333789
+        },
+        "defense": {
+          "armor": 22010,
+          "dodge": 22010,
+          "shield_deflect": 22010
+        },
+        "health": {
+          "hull_health": 221741,
+          "shield_health": 48900
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 159412,
+            "armor_pierce": 333789,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 25861,
+            "max_damage": 24532,
+            "min_damage": 20443,
+            "shield_pierce": 333789
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 159412,
+            "armor_pierce": 333789,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 25861,
+            "max_damage": 24532,
+            "min_damage": 20443,
+            "shield_pierce": 333789
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 40
+        "bonus1": 40.0
       },
       "build_costs": {
         "materials": [
@@ -1317,16 +4236,16 @@
         "others": [],
         "resources": [
           {
+            "type": "dilithium",
+            "value": 6020000
+          },
+          {
             "type": "parsteel",
             "value": 5731040000
           },
           {
             "type": "tritanium",
             "value": 60200000
-          },
-          {
-            "type": "dilithium",
-            "value": 6020000
           }
         ]
       },
@@ -1335,15 +4254,128 @@
       "level": 40,
       "requirements": [
         {
-          "name": "Drydock F",
+          "name": "drydock f",
           "level": 40
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 362912,
+          "armor_pierce": 362912,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 140585,
+          "shield_pierce": 362912
+        },
+        "defense": {
+          "armor": 23930,
+          "dodge": 23930,
+          "shield_deflect": 23930
+        },
+        "health": {
+          "hull_health": 241088,
+          "shield_health": 53167
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 362912,
+            "armor_pierce": 362912,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 28117,
+            "max_damage": 26672,
+            "min_damage": 22227,
+            "shield_pierce": 362912
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 362912,
+            "armor_pierce": 362912,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 28117,
+            "max_damage": 26672,
+            "min_damage": 22227,
+            "shield_pierce": 362912
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 1,
+          "weapon_stats": {
+            "accuracy": 362912,
+            "armor_pierce": 362912,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 28117,
+            "max_damage": 26672,
+            "min_damage": 22227,
+            "shield_pierce": 362912
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 41
+        "bonus1": 41.0
       },
       "build_costs": {
         "materials": [
@@ -1363,16 +4395,16 @@
         "others": [],
         "resources": [
           {
+            "type": "dilithium",
+            "value": 8600000
+          },
+          {
             "type": "parsteel",
             "value": 5848000000
           },
           {
             "type": "tritanium",
             "value": 86000000
-          },
-          {
-            "type": "dilithium",
-            "value": 8600000
           }
         ]
       },
@@ -1381,15 +4413,128 @@
       "level": 41,
       "requirements": [
         {
-          "name": "Drydock F",
+          "name": "drydock f",
           "level": 41
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 393258,
+          "armor_pierce": 393258,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 152343,
+          "shield_pierce": 393258
+        },
+        "defense": {
+          "armor": 25931,
+          "dodge": 26457,
+          "shield_deflect": 26457
+        },
+        "health": {
+          "hull_health": 261247,
+          "shield_health": 58781
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 393258,
+            "armor_pierce": 393258,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 30469,
+            "max_damage": 28903,
+            "min_damage": 24086,
+            "shield_pierce": 393258
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 393258,
+            "armor_pierce": 393258,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 30469,
+            "max_damage": 28903,
+            "min_damage": 24086,
+            "shield_pierce": 393258
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 1,
+          "weapon_stats": {
+            "accuracy": 393258,
+            "armor_pierce": 393258,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 30469,
+            "max_damage": 28903,
+            "min_damage": 24086,
+            "shield_pierce": 393258
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 42
+        "bonus1": 42.0
       },
       "build_costs": {
         "materials": [
@@ -1409,16 +4554,16 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 8710800000
-          },
-          {
             "type": "tritanium",
             "value": 128100000
           },
           {
             "type": "dilithium",
             "value": 12810000
+          },
+          {
+            "type": "parsteel",
+            "value": 8710800000
           }
         ]
       },
@@ -1427,15 +4572,128 @@
       "level": 42,
       "requirements": [
         {
-          "name": "Drydock F",
+          "name": "drydock f",
           "level": 42
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 426142,
+          "armor_pierce": 426142,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 165083,
+          "shield_pierce": 426142
+        },
+        "defense": {
+          "armor": 28099,
+          "dodge": 29251,
+          "shield_deflect": 29251
+        },
+        "health": {
+          "hull_health": 283092,
+          "shield_health": 64988
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 426142,
+            "armor_pierce": 426142,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 33016,
+            "max_damage": 31320,
+            "min_damage": 26100,
+            "shield_pierce": 426142
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 426142,
+            "armor_pierce": 426142,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 33016,
+            "max_damage": 31320,
+            "min_damage": 26100,
+            "shield_pierce": 426142
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 1,
+          "weapon_stats": {
+            "accuracy": 426142,
+            "armor_pierce": 426142,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 33016,
+            "max_damage": 31320,
+            "min_damage": 26100,
+            "shield_pierce": 426142
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 43
+        "bonus1": 43.0
       },
       "build_costs": {
         "materials": [
@@ -1459,12 +4717,12 @@
             "value": 12444000000
           },
           {
-            "type": "tritanium",
-            "value": 183000000
-          },
-          {
             "type": "dilithium",
             "value": 18300000
+          },
+          {
+            "type": "tritanium",
+            "value": 183000000
           }
         ]
       },
@@ -1473,15 +4731,128 @@
       "level": 43,
       "requirements": [
         {
-          "name": "Drydock F",
+          "name": "drydock f",
           "level": 43
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 461775,
+          "armor_pierce": 461775,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 178883,
+          "shield_pierce": 461775
+        },
+        "defense": {
+          "armor": 30449,
+          "dodge": 32339,
+          "shield_deflect": 32339
+        },
+        "health": {
+          "hull_health": 306764,
+          "shield_health": 71850
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 461775,
+            "armor_pierce": 461775,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 35776,
+            "max_damage": 33938,
+            "min_damage": 28282,
+            "shield_pierce": 461775
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 461775,
+            "armor_pierce": 461775,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 35776,
+            "max_damage": 33938,
+            "min_damage": 28282,
+            "shield_pierce": 461775
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 1,
+          "weapon_stats": {
+            "accuracy": 461775,
+            "armor_pierce": 461775,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 35776,
+            "max_damage": 33938,
+            "min_damage": 28282,
+            "shield_pierce": 461775
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 44
+        "bonus1": 44.0
       },
       "build_costs": {
         "materials": [
@@ -1501,12 +4872,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 18666000000
-          },
-          {
             "type": "tritanium",
             "value": 274500000
+          },
+          {
+            "type": "parsteel",
+            "value": 18666000000
           },
           {
             "type": "dilithium",
@@ -1519,15 +4890,128 @@
       "level": 44,
       "requirements": [
         {
-          "name": "Drydock F",
+          "name": "drydock f",
           "level": 44
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 500387,
+          "armor_pierce": 500387,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 193841,
+          "shield_pierce": 500387
+        },
+        "defense": {
+          "armor": 32995,
+          "dodge": 35754,
+          "shield_deflect": 35754
+        },
+        "health": {
+          "hull_health": 332415,
+          "shield_health": 79437
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 500387,
+            "armor_pierce": 500387,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 38768,
+            "max_damage": 36776,
+            "min_damage": 30647,
+            "shield_pierce": 500387
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 500387,
+            "armor_pierce": 500387,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 38768,
+            "max_damage": 36776,
+            "min_damage": 30647,
+            "shield_pierce": 500387
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 1,
+          "weapon_stats": {
+            "accuracy": 500387,
+            "armor_pierce": 500387,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 38768,
+            "max_damage": 36776,
+            "min_damage": 30647,
+            "shield_pierce": 500387
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 45
+        "bonus1": 45.0
       },
       "build_costs": {
         "materials": [
@@ -1547,16 +5031,16 @@
         "others": [],
         "resources": [
           {
+            "type": "dilithium",
+            "value": 39000000
+          },
+          {
             "type": "parsteel",
             "value": 26520000000
           },
           {
             "type": "tritanium",
             "value": 390000000
-          },
-          {
-            "type": "dilithium",
-            "value": 39000000
           }
         ]
       },
@@ -1565,33 +5049,146 @@
       "level": 45,
       "requirements": [
         {
-          "name": "Defense Technologies",
+          "name": "drydock f",
           "level": 45
         },
         {
-          "name": "Drydock F",
+          "name": "defense technologies",
           "level": 45
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 542229,
+          "armor_pierce": 542229,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 210048,
+          "shield_pierce": 542229
+        },
+        "defense": {
+          "armor": 35754,
+          "dodge": 39529,
+          "shield_deflect": 39529
+        },
+        "health": {
+          "hull_health": 360211,
+          "shield_health": 87825
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 542229,
+            "armor_pierce": 542229,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 42010,
+            "max_damage": 39851,
+            "min_damage": 33209,
+            "shield_pierce": 542229
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 542229,
+            "armor_pierce": 542229,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 42010,
+            "max_damage": 39851,
+            "min_damage": 33209,
+            "shield_pierce": 542229
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 1,
+          "weapon_stats": {
+            "accuracy": 542229,
+            "armor_pierce": 542229,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 42010,
+            "max_damage": 39851,
+            "min_damage": 33209,
+            "shield_pierce": 542229
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 46
+        "bonus1": 46.0
       },
       "build_costs": {
         "materials": [
           {
             "type": "gas",
             "grade": 4,
-            "rarity": "common",
-            "value": 40000
+            "rarity": "rare",
+            "value": 1800
           },
           {
             "type": "gas",
             "grade": 4,
-            "rarity": "rare",
-            "value": 1800
+            "rarity": "common",
+            "value": 40000
           }
         ],
         "others": [],
@@ -1601,12 +5198,12 @@
             "value": 36465000000
           },
           {
-            "type": "tritanium",
-            "value": 536250000
-          },
-          {
             "type": "dilithium",
             "value": 53625000
+          },
+          {
+            "type": "tritanium",
+            "value": 536250000
           }
         ]
       },
@@ -1615,15 +5212,128 @@
       "level": 46,
       "requirements": [
         {
-          "name": "Drydock F",
+          "name": "drydock f",
           "level": 46
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 587569,
+          "armor_pierce": 587569,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 227614,
+          "shield_pierce": 587569
+        },
+        "defense": {
+          "armor": 38744,
+          "dodge": 43703,
+          "shield_deflect": 43703
+        },
+        "health": {
+          "hull_health": 390331,
+          "shield_health": 97099
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 587569,
+            "armor_pierce": 587569,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 45523,
+            "max_damage": 43184,
+            "min_damage": 35986,
+            "shield_pierce": 587569
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 587569,
+            "armor_pierce": 587569,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 45523,
+            "max_damage": 43184,
+            "min_damage": 35986,
+            "shield_pierce": 587569
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 1,
+          "weapon_stats": {
+            "accuracy": 587569,
+            "armor_pierce": 587569,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 45523,
+            "max_damage": 43184,
+            "min_damage": 35986,
+            "shield_pierce": 587569
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 47
+        "bonus1": 47.0
       },
       "build_costs": {
         "materials": [
@@ -1643,16 +5353,16 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 53040000000
-          },
-          {
             "type": "tritanium",
             "value": 780000000
           },
           {
             "type": "dilithium",
             "value": 78000000
+          },
+          {
+            "type": "parsteel",
+            "value": 53040000000
           }
         ]
       },
@@ -1661,29 +5371,142 @@
       "level": 47,
       "requirements": [
         {
-          "name": "Drydock F",
+          "name": "drydock f",
           "level": 47
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 636700,
+          "armor_pierce": 636700,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 246649,
+          "shield_pierce": 636700
+        },
+        "defense": {
+          "armor": 41983,
+          "dodge": 48318,
+          "shield_deflect": 48318
+        },
+        "health": {
+          "hull_health": 422970,
+          "shield_health": 107352
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 636700,
+            "armor_pierce": 636700,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 49330,
+            "max_damage": 46795,
+            "min_damage": 38996,
+            "shield_pierce": 636700
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 636700,
+            "armor_pierce": 636700,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 49330,
+            "max_damage": 46795,
+            "min_damage": 38996,
+            "shield_pierce": 636700
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 1,
+          "weapon_stats": {
+            "accuracy": 636700,
+            "armor_pierce": 636700,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 49330,
+            "max_damage": 46795,
+            "min_damage": 38996,
+            "shield_pierce": 636700
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 48
+        "bonus1": 48.0
       },
       "build_costs": {
         "materials": [
           {
             "type": "gas",
             "grade": 4,
-            "rarity": "common",
-            "value": 75000
+            "rarity": "uncommon",
+            "value": 4000
           },
           {
             "type": "gas",
             "grade": 4,
-            "rarity": "uncommon",
-            "value": 4000
+            "rarity": "common",
+            "value": 75000
           }
         ],
         "others": [],
@@ -1693,12 +5516,12 @@
             "value": 85680000000
           },
           {
-            "type": "tritanium",
-            "value": 1260000000
-          },
-          {
             "type": "dilithium",
             "value": 126000000
+          },
+          {
+            "type": "tritanium",
+            "value": 1260000000
           }
         ]
       },
@@ -1707,29 +5530,142 @@
       "level": 48,
       "requirements": [
         {
-          "name": "Drydock F",
+          "name": "drydock f",
           "level": 48
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 689940,
+          "armor_pierce": 689940,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 267272,
+          "shield_pierce": 689940
+        },
+        "defense": {
+          "armor": 45494,
+          "dodge": 53420,
+          "shield_deflect": 53420
+        },
+        "health": {
+          "hull_health": 458338,
+          "shield_health": 118687
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 689940,
+            "armor_pierce": 689940,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 53454,
+            "max_damage": 50708,
+            "min_damage": 42256,
+            "shield_pierce": 689940
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 689940,
+            "armor_pierce": 689940,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 53454,
+            "max_damage": 50708,
+            "min_damage": 42256,
+            "shield_pierce": 689940
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 1,
+          "weapon_stats": {
+            "accuracy": 689940,
+            "armor_pierce": 689940,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 53454,
+            "max_damage": 50708,
+            "min_damage": 42256,
+            "shield_pierce": 689940
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 49
+        "bonus1": 49.0
       },
       "build_costs": {
         "materials": [
           {
             "type": "gas",
             "grade": 4,
-            "rarity": "uncommon",
-            "value": 25000
+            "rarity": "rare",
+            "value": 4000
           },
           {
             "type": "gas",
             "grade": 4,
-            "rarity": "rare",
-            "value": 4000
+            "rarity": "uncommon",
+            "value": 25000
           }
         ],
         "others": [],
@@ -1753,15 +5689,128 @@
       "level": 49,
       "requirements": [
         {
-          "name": "Drydock F",
+          "name": "drydock f",
           "level": 49
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 747632,
+          "armor_pierce": 747632,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 289622,
+          "shield_pierce": 747632
+        },
+        "defense": {
+          "armor": 49298,
+          "dodge": 59061,
+          "shield_deflect": 59061
+        },
+        "health": {
+          "hull_health": 496663,
+          "shield_health": 131220
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 747632,
+            "armor_pierce": 747632,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 57924,
+            "max_damage": 54948,
+            "min_damage": 45790,
+            "shield_pierce": 747632
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 747632,
+            "armor_pierce": 747632,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 57924,
+            "max_damage": 54948,
+            "min_damage": 45790,
+            "shield_pierce": 747632
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 1,
+          "weapon_stats": {
+            "accuracy": 747632,
+            "armor_pierce": 747632,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 57924,
+            "max_damage": 54948,
+            "min_damage": 45790,
+            "shield_pierce": 747632
+          },
+          "weapon_type": "energy"
+        }
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 50
+        "bonus1": 50.0
       },
       "build_costs": {
         "materials": [],
@@ -1772,12 +5821,12 @@
             "value": 249900000000
           },
           {
-            "type": "tritanium",
-            "value": 3675000000
-          },
-          {
             "type": "dilithium",
             "value": 367500000
+          },
+          {
+            "type": "tritanium",
+            "value": 3675000000
           }
         ]
       },
@@ -1786,11 +5835,919 @@
       "level": 50,
       "requirements": [
         {
-          "name": "Drydock F",
+          "name": "drydock f",
           "level": 50
         }
       ],
-      "rewards": []
+      "stats": {
+        "attack": {
+          "accuracy": 810147,
+          "armor_pierce": 810147,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 313835,
+          "shield_pierce": 810147
+        },
+        "defense": {
+          "armor": 53420,
+          "dodge": 65297,
+          "shield_deflect": 65297
+        },
+        "health": {
+          "hull_health": 538193,
+          "shield_health": 145076
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 810147,
+            "armor_pierce": 810147,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 62767,
+            "max_damage": 59542,
+            "min_damage": 49618,
+            "shield_pierce": 810147
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 810147,
+            "armor_pierce": 810147,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 62767,
+            "max_damage": 59542,
+            "min_damage": 49618,
+            "shield_pierce": 810147
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 1,
+          "weapon_stats": {
+            "accuracy": 810147,
+            "armor_pierce": 810147,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 62767,
+            "max_damage": 59542,
+            "min_damage": 49618,
+            "shield_pierce": 810147
+          },
+          "weapon_type": "energy"
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 51.0
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "gas",
+            "grade": 5,
+            "rarity": "uncommon",
+            "value": 2100
+          },
+          {
+            "type": "gas",
+            "grade": 5,
+            "rarity": "common",
+            "value": 23400
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 7800000000
+          },
+          {
+            "type": "dilithium",
+            "value": 780000000
+          },
+          {
+            "type": "parsteel",
+            "value": 1246440000000
+          }
+        ]
+      },
+      "build_time": 104346720,
+      "increased_power": 1216045,
+      "level": 51,
+      "requirements": [
+        {
+          "name": "drydock f",
+          "level": 51
+        }
+      ],
+      "stats": {
+        "attack": {
+          "accuracy": 931669,
+          "armor_pierce": 931669,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 360910,
+          "shield_pierce": 931669
+        },
+        "defense": {
+          "armor": 75092,
+          "dodge": 75092,
+          "shield_deflect": 75092
+        },
+        "health": {
+          "hull_health": 618922,
+          "shield_health": 166837
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 931669,
+            "armor_pierce": 931669,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 72182,
+            "max_damage": 68473,
+            "min_damage": 57061,
+            "shield_pierce": 931669
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 931669,
+            "armor_pierce": 931669,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 72182,
+            "max_damage": 68473,
+            "min_damage": 57061,
+            "shield_pierce": 931669
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 1,
+          "weapon_stats": {
+            "accuracy": 931669,
+            "armor_pierce": 931669,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 72182,
+            "max_damage": 68473,
+            "min_damage": 57061,
+            "shield_pierce": 931669
+          },
+          "weapon_type": "energy"
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 52.0
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "gas",
+            "grade": 5,
+            "rarity": "common",
+            "value": 40600
+          },
+          {
+            "type": "gas",
+            "grade": 5,
+            "rarity": "uncommon",
+            "value": 4600
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 13260000000
+          },
+          {
+            "type": "dilithium",
+            "value": 1326000000
+          },
+          {
+            "type": "parsteel",
+            "value": 2254200000000
+          }
+        ]
+      },
+      "build_time": 110606400,
+      "increased_power": 2571112,
+      "level": 52,
+      "requirements": [
+        {
+          "name": "drydock f",
+          "level": 52
+        }
+      ],
+      "stats": {
+        "attack": {
+          "accuracy": 1174713,
+          "armor_pierce": 1174713,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 712868,
+          "shield_pierce": 1174713
+        },
+        "defense": {
+          "armor": 94681,
+          "dodge": 94681,
+          "shield_deflect": 94681
+        },
+        "health": {
+          "hull_health": 780380,
+          "shield_health": 210360
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 1174713,
+            "armor_pierce": 1174713,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 142574,
+            "max_damage": 161618,
+            "min_damage": 86336,
+            "shield_pierce": 1174713
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 1174713,
+            "armor_pierce": 1174713,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 142574,
+            "max_damage": 161618,
+            "min_damage": 86336,
+            "shield_pierce": 1174713
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 1,
+          "weapon_stats": {
+            "accuracy": 1174713,
+            "armor_pierce": 1174713,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 142574,
+            "max_damage": 161618,
+            "min_damage": 86336,
+            "shield_pierce": 1174713
+          },
+          "weapon_type": "energy"
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 53.0
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "gas",
+            "grade": 5,
+            "rarity": "common",
+            "value": 93600
+          },
+          {
+            "type": "gas",
+            "grade": 5,
+            "rarity": "uncommon",
+            "value": 16300
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 3786240000000
+          },
+          {
+            "type": "dilithium",
+            "value": 2320000000
+          },
+          {
+            "type": "tritanium",
+            "value": 23200000000
+          }
+        ]
+      },
+      "build_time": 117243360,
+      "increased_power": 9914492,
+      "level": 53,
+      "requirements": [
+        {
+          "name": "drydock f",
+          "level": 53
+        }
+      ],
+      "stats": {
+        "attack": {
+          "accuracy": 2187397,
+          "armor_pierce": 2187397,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 1380871,
+          "shield_pierce": 2187397
+        },
+        "defense": {
+          "armor": 176302,
+          "dodge": 176302,
+          "shield_deflect": 176302
+        },
+        "health": {
+          "hull_health": 1453121,
+          "shield_health": 391705
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 2187397,
+            "armor_pierce": 2187397,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 276174,
+            "max_damage": 319540,
+            "min_damage": 160763,
+            "shield_pierce": 2187397
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 2187397,
+            "armor_pierce": 2187397,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 276174,
+            "max_damage": 319540,
+            "min_damage": 160763,
+            "shield_pierce": 2187397
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 1,
+          "weapon_stats": {
+            "accuracy": 2187397,
+            "armor_pierce": 2187397,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 276174,
+            "max_damage": 319540,
+            "min_damage": 160763,
+            "shield_pierce": 2187397
+          },
+          "weapon_type": "energy"
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 54.0
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "gas",
+            "grade": 5,
+            "rarity": "rare",
+            "value": 7300
+          },
+          {
+            "type": "gas",
+            "grade": 5,
+            "rarity": "common",
+            "value": 79600
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 5679360000000
+          },
+          {
+            "type": "tritanium",
+            "value": 34800000000
+          },
+          {
+            "type": "dilithium",
+            "value": 3480000000
+          }
+        ]
+      },
+      "build_time": 124277760,
+      "increased_power": 2449504,
+      "level": 54,
+      "requirements": [
+        {
+          "name": "drydock f",
+          "level": 54
+        }
+      ],
+      "stats": {
+        "attack": {
+          "accuracy": 2430441,
+          "armor_pierce": 2430441,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 1611219,
+          "shield_pierce": 2430441
+        },
+        "defense": {
+          "armor": 195891,
+          "dodge": 195891,
+          "shield_deflect": 195891
+        },
+        "health": {
+          "hull_health": 1614579,
+          "shield_health": 435228
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 2430441,
+            "armor_pierce": 2430441,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 322244,
+            "max_damage": 381798,
+            "min_damage": 178626,
+            "shield_pierce": 2430441
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 2430441,
+            "armor_pierce": 2430441,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 322244,
+            "max_damage": 381798,
+            "min_damage": 178626,
+            "shield_pierce": 2430441
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 1,
+          "weapon_stats": {
+            "accuracy": 2430441,
+            "armor_pierce": 2430441,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 322244,
+            "max_damage": 381798,
+            "min_damage": 178626,
+            "shield_pierce": 2430441
+          },
+          "weapon_type": "energy"
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 55.0
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "gas",
+            "grade": 5,
+            "rarity": "rare",
+            "value": 8200
+          },
+          {
+            "type": "gas",
+            "grade": 5,
+            "rarity": "uncommon",
+            "value": 22600
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "dilithium",
+            "value": 5460000000
+          },
+          {
+            "type": "tritanium",
+            "value": 54600000000
+          },
+          {
+            "type": "parsteel",
+            "value": 9653280000000
+          }
+        ]
+      },
+      "build_time": 131734080,
+      "increased_power": 4869860,
+      "level": 55,
+      "requirements": [
+        {
+          "name": "drydock f",
+          "level": 55
+        }
+      ],
+      "stats": {
+        "attack": {
+          "accuracy": 2916529,
+          "armor_pierce": 2916529,
+          "crit_chance": 0.1,
+          "crit_damage": 1.5,
+          "damage_per_round": 2042768,
+          "shield_pierce": 2916529
+        },
+        "defense": {
+          "armor": 235069,
+          "dodge": 235069,
+          "shield_deflect": 235069
+        },
+        "health": {
+          "hull_health": 1937495,
+          "shield_health": 522274
+        }
+      },
+      "weapons": [
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 2916529,
+            "armor_pierce": 2916529,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 408554,
+            "max_damage": 496177,
+            "min_damage": 214351,
+            "shield_pierce": 2916529
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 2,
+          "weapon_stats": {
+            "accuracy": 2916529,
+            "armor_pierce": 2916529,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 408554,
+            "max_damage": 496177,
+            "min_damage": 214351,
+            "shield_pierce": 2916529
+          },
+          "weapon_type": "energy"
+        },
+        {
+          "firing_pattern": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "quantity": 1,
+          "weapon_stats": {
+            "accuracy": 2916529,
+            "armor_pierce": 2916529,
+            "crit_chance": 0.1,
+            "crit_damage": 1.5,
+            "damage_per_round": 408554,
+            "max_damage": 496177,
+            "min_damage": 214351,
+            "shield_pierce": 2916529
+          },
+          "weapon_type": "energy"
+        }
+      ]
     }
   ]
 }

--- a/buildings/defense_technologies.json
+++ b/buildings/defense_technologies.json
@@ -2,11 +2,11 @@
   "description": "Defense Tech Research facility.",
   "bonuses": {
     "bonus1": {
-      "name": "Defense Platform Damage Bonus",
+      "name": "defense platform damage bonus",
       "percentage": true
     },
     "bonus2": {
-      "name": "Defense Platform Defensive Bonus",
+      "name": "defense platform defensive bonus",
       "percentage": true
     }
   },
@@ -14,8 +14,8 @@
   "levels": [
     {
       "bonuses": {
-        "bonus1": 1,
-        "bonus2": 0
+        "bonus1": 0.01,
+        "bonus2": 0.0
       },
       "build_costs": {
         "materials": [],
@@ -32,16 +32,15 @@
       "level": 1,
       "requirements": [
         {
-          "name": "Defense Technology",
+          "name": "defense technology",
           "level": 1
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 2,
-        "bonus2": 0
+        "bonus1": 0.02,
+        "bonus2": 0.0
       },
       "build_costs": {
         "materials": [],
@@ -58,20 +57,19 @@
       "level": 2,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 2
         },
         {
-          "name": "R&D Department",
+          "name": "r&d department",
           "level": 2
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 3,
-        "bonus2": 0
+        "bonus1": 0.03,
+        "bonus2": 0.0
       },
       "build_costs": {
         "materials": [],
@@ -88,20 +86,19 @@
       "level": 3,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 3
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 3
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 4,
-        "bonus2": 0
+        "bonus1": 0.04,
+        "bonus2": 0.0
       },
       "build_costs": {
         "materials": [],
@@ -118,20 +115,19 @@
       "level": 4,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 4
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 4
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 5,
-        "bonus2": 0
+        "bonus1": 0.05,
+        "bonus2": 0.0
       },
       "build_costs": {
         "materials": [],
@@ -148,20 +144,19 @@
       "level": 5,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 5
         },
         {
-          "name": "R&D Department",
+          "name": "r&d department",
           "level": 5
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 6,
-        "bonus2": 0
+        "bonus1": 0.06,
+        "bonus2": 0.0
       },
       "build_costs": {
         "materials": [],
@@ -178,32 +173,31 @@
       "level": 6,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 6
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 6
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 7,
-        "bonus2": 0
+        "bonus1": 0.07,
+        "bonus2": 0.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 3000
-          },
-          {
             "type": "tritanium",
             "value": 38
+          },
+          {
+            "type": "parsteel",
+            "value": 3000
           }
         ]
       },
@@ -212,32 +206,31 @@
       "level": 7,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 7
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 7
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 8,
-        "bonus2": 1
+        "bonus1": 0.08,
+        "bonus2": 0.01
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 4000
-          },
-          {
             "type": "tritanium",
             "value": 120
+          },
+          {
+            "type": "parsteel",
+            "value": 4000
           }
         ]
       },
@@ -246,32 +239,31 @@
       "level": 8,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 8
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 8
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 9,
-        "bonus2": 2
+        "bonus1": 0.09,
+        "bonus2": 0.02
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 5500
-          },
-          {
             "type": "tritanium",
             "value": 300
+          },
+          {
+            "type": "parsteel",
+            "value": 5500
           }
         ]
       },
@@ -280,32 +272,31 @@
       "level": 9,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 9
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 9
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 10,
-        "bonus2": 3
+        "bonus1": 0.1,
+        "bonus2": 0.03
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 7000
-          },
-          {
             "type": "tritanium",
             "value": 600
+          },
+          {
+            "type": "parsteel",
+            "value": 7000
           }
         ]
       },
@@ -314,32 +305,31 @@
       "level": 10,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 10
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 10
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 11,
-        "bonus2": 4
+        "bonus1": 0.11,
+        "bonus2": 0.04
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 6800
-          },
-          {
             "type": "tritanium",
             "value": 800
+          },
+          {
+            "type": "parsteel",
+            "value": 6800
           }
         ]
       },
@@ -348,32 +338,31 @@
       "level": 11,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 11
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 11
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 12,
-        "bonus2": 5
+        "bonus1": 0.12,
+        "bonus2": 0.05
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 9350
-          },
-          {
             "type": "tritanium",
             "value": 1100
+          },
+          {
+            "type": "parsteel",
+            "value": 9350
           }
         ]
       },
@@ -382,32 +371,31 @@
       "level": 12,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 12
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 12
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 13,
-        "bonus2": 6
+        "bonus1": 0.13,
+        "bonus2": 0.06
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 13600
-          },
-          {
             "type": "tritanium",
             "value": 1600
+          },
+          {
+            "type": "parsteel",
+            "value": 13600
           }
         ]
       },
@@ -416,20 +404,19 @@
       "level": 13,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 13
         },
         {
-          "name": "R&D Department",
+          "name": "r&d department",
           "level": 13
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 14,
-        "bonus2": 7
+        "bonus1": 0.14,
+        "bonus2": 0.07
       },
       "build_costs": {
         "materials": [],
@@ -450,20 +437,19 @@
       "level": 14,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 14
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 14
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 15,
-        "bonus2": 8
+        "bonus1": 0.15,
+        "bonus2": 0.08
       },
       "build_costs": {
         "materials": [],
@@ -484,32 +470,31 @@
       "level": 15,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 15
         },
         {
-          "name": "R&D Department",
+          "name": "r&d department",
           "level": 15
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 16,
-        "bonus2": 9
+        "bonus1": 0.16,
+        "bonus2": 0.09
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 34000
-          },
-          {
             "type": "tritanium",
             "value": 4000
+          },
+          {
+            "type": "parsteel",
+            "value": 34000
           }
         ]
       },
@@ -518,24 +503,23 @@
       "level": 16,
       "requirements": [
         {
-          "name": "Astronautics Studio",
+          "name": "operations",
+          "level": 16
+        },
+        {
+          "name": "r&d department",
+          "level": 16
+        },
+        {
+          "name": "astronautics studio",
           "level": 13
-        },
-        {
-          "name": "R&D Department",
-          "level": 16
-        },
-        {
-          "name": "Operations",
-          "level": 16
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 17,
-        "bonus2": 10
+        "bonus1": 0.17,
+        "bonus2": 0.1
       },
       "build_costs": {
         "materials": [
@@ -549,12 +533,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 47600
-          },
-          {
             "type": "tritanium",
             "value": 5600
+          },
+          {
+            "type": "parsteel",
+            "value": 47600
           }
         ]
       },
@@ -563,20 +547,19 @@
       "level": 17,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 17
         },
         {
-          "name": "R&D Department",
+          "name": "r&d department",
           "level": 17
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 18,
-        "bonus2": 11
+        "bonus1": 0.18,
+        "bonus2": 0.11
       },
       "build_costs": {
         "materials": [
@@ -590,12 +573,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 68000
-          },
-          {
             "type": "tritanium",
             "value": 8000
+          },
+          {
+            "type": "parsteel",
+            "value": 68000
           }
         ]
       },
@@ -604,20 +587,19 @@
       "level": 18,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 18
         },
         {
-          "name": "R&D Department",
+          "name": "r&d department",
           "level": 18
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 19,
-        "bonus2": 22
+        "bonus1": 0.19,
+        "bonus2": 0.22
       },
       "build_costs": {
         "materials": [
@@ -645,36 +627,35 @@
       "level": 19,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 19
         },
         {
-          "name": "Defense Platform A",
+          "name": "defense platform a",
           "level": 19
         },
         {
-          "name": "Astronautics Studio",
+          "name": "astronautics studio",
           "level": 19
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 20,
-        "bonus2": 44
+        "bonus1": 0.2,
+        "bonus2": 0.44
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 144500
-          },
-          {
             "type": "tritanium",
             "value": 17000
+          },
+          {
+            "type": "parsteel",
+            "value": 144500
           }
         ]
       },
@@ -683,32 +664,31 @@
       "level": 20,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 20
         },
         {
-          "name": "R&D Department",
+          "name": "r&d department",
           "level": 20
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 21,
-        "bonus2": 66
+        "bonus1": 0.21,
+        "bonus2": 0.66
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 243270
-          },
-          {
             "type": "tritanium",
             "value": 28620
+          },
+          {
+            "type": "parsteel",
+            "value": 243270
           }
         ]
       },
@@ -717,20 +697,19 @@
       "level": 21,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 21
         },
         {
-          "name": "R&D Department",
+          "name": "r&d department",
           "level": 21
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 22,
-        "bonus2": 88
+        "bonus1": 0.22,
+        "bonus2": 0.88
       },
       "build_costs": {
         "materials": [],
@@ -751,32 +730,31 @@
       "level": 22,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 22
         },
         {
-          "name": "R&D Department",
+          "name": "r&d department",
           "level": 22
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 23,
-        "bonus2": 92
+        "bonus1": 0.23,
+        "bonus2": 0.92
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 622710
-          },
-          {
             "type": "tritanium",
             "value": 73260
+          },
+          {
+            "type": "parsteel",
+            "value": 622710
           }
         ]
       },
@@ -785,20 +763,19 @@
       "level": 23,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 23
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 23
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 24,
-        "bonus2": 96
+        "bonus1": 0.24,
+        "bonus2": 0.96
       },
       "build_costs": {
         "materials": [
@@ -812,12 +789,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 981240
-          },
-          {
             "type": "tritanium",
             "value": 115440
+          },
+          {
+            "type": "parsteel",
+            "value": 981240
           }
         ]
       },
@@ -826,24 +803,23 @@
       "level": 24,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 24
         },
         {
-          "name": "R&D Department",
+          "name": "r&d department",
           "level": 24
         },
         {
-          "name": "Science Lab",
+          "name": "science lab",
           "level": 20
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 25,
-        "bonus2": 100
+        "bonus1": 0.25,
+        "bonus2": 1.0
       },
       "build_costs": {
         "materials": [
@@ -877,24 +853,23 @@
       "level": 25,
       "requirements": [
         {
-          "name": "Science Lab",
+          "name": "science lab",
           "level": 25
         },
         {
-          "name": "Engine Technology Lab",
+          "name": "engine technology lab",
           "level": 25
         },
         {
-          "name": "Foundry",
+          "name": "foundry",
           "level": 25
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 26,
-        "bonus2": 104
+        "bonus1": 0.26,
+        "bonus2": 1.04
       },
       "build_costs": {
         "materials": [
@@ -928,45 +903,44 @@
       "level": 26,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 26
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 26
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 27,
-        "bonus2": 108
+        "bonus1": 0.27,
+        "bonus2": 1.08
       },
       "build_costs": {
         "materials": [
           {
             "type": "gas",
             "grade": 3,
-            "rarity": "common",
-            "value": 290
+            "rarity": "uncommon",
+            "value": 10
           },
           {
             "type": "gas",
             "grade": 3,
-            "rarity": "uncommon",
-            "value": 10
+            "rarity": "common",
+            "value": 290
           }
         ],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 3794400
-          },
-          {
             "type": "tritanium",
             "value": 446400
+          },
+          {
+            "type": "parsteel",
+            "value": 3794400
           }
         ]
       },
@@ -975,20 +949,19 @@
       "level": 27,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 27
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 27
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 28,
-        "bonus2": 112
+        "bonus1": 0.28,
+        "bonus2": 1.12
       },
       "build_costs": {
         "materials": [
@@ -1002,12 +975,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 5691600
-          },
-          {
             "type": "tritanium",
             "value": 669600
+          },
+          {
+            "type": "parsteel",
+            "value": 5691600
           }
         ]
       },
@@ -1016,45 +989,44 @@
       "level": 28,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 28
         },
         {
-          "name": "R&D Department",
+          "name": "r&d department",
           "level": 28
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 29,
-        "bonus2": 116
+        "bonus1": 0.29,
+        "bonus2": 1.16
       },
       "build_costs": {
         "materials": [
           {
             "type": "gas",
             "grade": 3,
-            "rarity": "common",
-            "value": 450
+            "rarity": "uncommon",
+            "value": 30
           },
           {
             "type": "gas",
             "grade": 3,
-            "rarity": "uncommon",
-            "value": 30
+            "rarity": "common",
+            "value": 450
           }
         ],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 9061000
-          },
-          {
             "type": "tritanium",
             "value": 1066000
+          },
+          {
+            "type": "parsteel",
+            "value": 9061000
           }
         ]
       },
@@ -1063,20 +1035,19 @@
       "level": 29,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 29
         },
         {
-          "name": "R&D Department",
+          "name": "r&d department",
           "level": 29
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 30,
-        "bonus2": 120
+        "bonus1": 0.3,
+        "bonus2": 1.2
       },
       "build_costs": {
         "materials": [
@@ -1090,12 +1061,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 13260000
-          },
-          {
             "type": "tritanium",
             "value": 1560000
+          },
+          {
+            "type": "parsteel",
+            "value": 13260000
           }
         ]
       },
@@ -1104,24 +1075,23 @@
       "level": 30,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 30
         },
         {
-          "name": "R&D Department",
+          "name": "r&d department",
           "level": 30
         },
         {
-          "name": "Astronautics Studio",
+          "name": "astronautics studio",
           "level": 29
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 31,
-        "bonus2": 124
+        "bonus1": 0.31,
+        "bonus2": 1.24
       },
       "build_costs": {
         "materials": [
@@ -1135,12 +1105,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 20961000
-          },
-          {
             "type": "tritanium",
             "value": 2466000
+          },
+          {
+            "type": "parsteel",
+            "value": 20961000
           }
         ]
       },
@@ -1149,45 +1119,44 @@
       "level": 31,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 31
         },
         {
-          "name": "R&D Department",
+          "name": "r&d department",
           "level": 31
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 32,
-        "bonus2": 128
+        "bonus1": 0.32,
+        "bonus2": 1.28
       },
       "build_costs": {
         "materials": [
           {
             "type": "gas",
             "grade": 3,
-            "rarity": "common",
-            "value": 800
+            "rarity": "uncommon",
+            "value": 87
           },
           {
             "type": "gas",
             "grade": 3,
-            "rarity": "uncommon",
-            "value": 87
+            "rarity": "common",
+            "value": 800
           }
         ],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 30277000
-          },
-          {
             "type": "tritanium",
             "value": 3562000
+          },
+          {
+            "type": "parsteel",
+            "value": 30277000
           }
         ]
       },
@@ -1196,24 +1165,23 @@
       "level": 32,
       "requirements": [
         {
-          "name": "Science Lab",
+          "name": "operations",
+          "level": 32
+        },
+        {
+          "name": "r&d department",
+          "level": 32
+        },
+        {
+          "name": "science lab",
           "level": 30
-        },
-        {
-          "name": "R&D Department",
-          "level": 32
-        },
-        {
-          "name": "Operations",
-          "level": 32
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 33,
-        "bonus2": 132
+        "bonus1": 0.33,
+        "bonus2": 1.32
       },
       "build_costs": {
         "materials": [
@@ -1241,49 +1209,48 @@
       "level": 33,
       "requirements": [
         {
-          "name": "Astronautics Studio",
+          "name": "operations",
+          "level": 33
+        },
+        {
+          "name": "r&d department",
+          "level": 33
+        },
+        {
+          "name": "astronautics studio",
           "level": 32
-        },
-        {
-          "name": "Operations",
-          "level": 33
-        },
-        {
-          "name": "R&D Department",
-          "level": 33
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 34,
-        "bonus2": 136
+        "bonus1": 0.34,
+        "bonus2": 1.36
       },
       "build_costs": {
         "materials": [
           {
             "type": "gas",
             "grade": 3,
-            "rarity": "common",
-            "value": 1100
+            "rarity": "uncommon",
+            "value": 140
           },
           {
             "type": "gas",
             "grade": 3,
-            "rarity": "uncommon",
-            "value": 140
+            "rarity": "common",
+            "value": 1100
           }
         ],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 73950000
-          },
-          {
             "type": "tritanium",
             "value": 8700000
+          },
+          {
+            "type": "parsteel",
+            "value": 73950000
           }
         ]
       },
@@ -1292,24 +1259,23 @@
       "level": 34,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 34
         },
         {
-          "name": "Foundry",
+          "name": "r&d department",
+          "level": 34
+        },
+        {
+          "name": "foundry",
           "level": 33
-        },
-        {
-          "name": "Operations",
-          "level": 34
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 35,
-        "bonus2": 140
+        "bonus1": 0.35,
+        "bonus2": 1.4
       },
       "build_costs": {
         "materials": [
@@ -1323,12 +1289,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 114444000
-          },
-          {
             "type": "tritanium",
             "value": 13464000
+          },
+          {
+            "type": "parsteel",
+            "value": 114444000
           }
         ]
       },
@@ -1337,49 +1303,48 @@
       "level": 35,
       "requirements": [
         {
-          "name": "Engine Technology Lab",
+          "name": "science lab",
           "level": 35
         },
         {
-          "name": "Foundry",
+          "name": "engine technology lab",
           "level": 35
         },
         {
-          "name": "Science Lab",
+          "name": "foundry",
           "level": 35
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 36,
-        "bonus2": 144
+        "bonus1": 0.36,
+        "bonus2": 1.44
       },
       "build_costs": {
         "materials": [
           {
             "type": "gas",
             "grade": 3,
-            "rarity": "common",
-            "value": 1600
+            "rarity": "uncommon",
+            "value": 220
           },
           {
             "type": "gas",
             "grade": 3,
-            "rarity": "uncommon",
-            "value": 220
+            "rarity": "common",
+            "value": 1600
           }
         ],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 161262000
-          },
-          {
             "type": "tritanium",
             "value": 18972000
+          },
+          {
+            "type": "parsteel",
+            "value": 161262000
           }
         ]
       },
@@ -1388,24 +1353,23 @@
       "level": 36,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 36
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 36
         },
         {
-          "name": "Engine Technology Lab",
+          "name": "engine technology lab",
           "level": 36
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 37,
-        "bonus2": 148
+        "bonus1": 0.37,
+        "bonus2": 1.48
       },
       "build_costs": {
         "materials": [
@@ -1419,12 +1383,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 247860000
-          },
-          {
             "type": "tritanium",
             "value": 29160000
+          },
+          {
+            "type": "parsteel",
+            "value": 247860000
           }
         ]
       },
@@ -1433,38 +1397,37 @@
       "level": 37,
       "requirements": [
         {
-          "name": "Astronautics Studio",
+          "name": "operations",
+          "level": 37
+        },
+        {
+          "name": "r&d department",
+          "level": 37
+        },
+        {
+          "name": "astronautics studio",
           "level": 36
-        },
-        {
-          "name": "R&D Department",
-          "level": 37
-        },
-        {
-          "name": "Operations",
-          "level": 37
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 38,
-        "bonus2": 152
+        "bonus1": 0.38,
+        "bonus2": 1.52
       },
       "build_costs": {
         "materials": [
           {
             "type": "gas",
             "grade": 3,
-            "rarity": "common",
-            "value": 2100
+            "rarity": "uncommon",
+            "value": 310
           },
           {
             "type": "gas",
             "grade": 3,
-            "rarity": "uncommon",
-            "value": 310
+            "rarity": "common",
+            "value": 2100
           }
         ],
         "others": [],
@@ -1484,36 +1447,35 @@
       "level": 38,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 38
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 38
         },
         {
-          "name": "Foundry",
+          "name": "foundry",
           "level": 38
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 39,
-        "bonus2": 156
+        "bonus1": 0.39,
+        "bonus2": 1.56
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 657900000
-          },
-          {
             "type": "tritanium",
             "value": 77400000
+          },
+          {
+            "type": "parsteel",
+            "value": 657900000
           }
         ]
       },
@@ -1522,24 +1484,23 @@
       "level": 39,
       "requirements": [
         {
-          "name": "Foundry",
+          "name": "operations",
           "level": 39
         },
         {
-          "name": "R&D Department",
+          "name": "r&d department",
           "level": 39
         },
         {
-          "name": "Operations",
+          "name": "foundry",
           "level": 39
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 40,
-        "bonus2": 158
+        "bonus1": 0.4,
+        "bonus2": 1.58
       },
       "build_costs": {
         "materials": [
@@ -1559,12 +1520,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 2865520000
-          },
-          {
             "type": "tritanium",
             "value": 120400000
+          },
+          {
+            "type": "parsteel",
+            "value": 2865520000
           }
         ]
       },
@@ -1573,34 +1534,33 @@
       "level": 40,
       "requirements": [
         {
-          "name": "Engine Technology Lab",
+          "name": "science lab",
           "level": 40
         },
         {
-          "name": "Science Lab",
+          "name": "engine technology lab",
           "level": 40
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 41,
-        "bonus2": 160
+        "bonus1": 0.41,
+        "bonus2": 1.6
       },
       "build_costs": {
         "materials": [
           {
             "type": "gas",
             "grade": 4,
-            "rarity": "common",
-            "value": 10000
+            "rarity": "uncommon",
+            "value": 2000
           },
           {
             "type": "gas",
             "grade": 4,
-            "rarity": "uncommon",
-            "value": 2000
+            "rarity": "common",
+            "value": 10000
           }
         ],
         "others": [],
@@ -1620,45 +1580,44 @@
       "level": 41,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 41
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 41
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 42,
-        "bonus2": 162
+        "bonus1": 0.42,
+        "bonus2": 1.62
       },
       "build_costs": {
         "materials": [
           {
             "type": "gas",
             "grade": 4,
-            "rarity": "common",
-            "value": 25000
+            "rarity": "uncommon",
+            "value": 3000
           },
           {
             "type": "gas",
             "grade": 4,
-            "rarity": "uncommon",
-            "value": 3000
+            "rarity": "common",
+            "value": 25000
           }
         ],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 4355400000
-          },
-          {
             "type": "tritanium",
             "value": 256200000
+          },
+          {
+            "type": "parsteel",
+            "value": 4355400000
           }
         ]
       },
@@ -1667,20 +1626,19 @@
       "level": 42,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 42
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 42
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 43,
-        "bonus2": 164
+        "bonus1": 0.43,
+        "bonus2": 1.64
       },
       "build_costs": {
         "materials": [
@@ -1700,12 +1658,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 6222000000
-          },
-          {
             "type": "tritanium",
             "value": 366000000
+          },
+          {
+            "type": "parsteel",
+            "value": 6222000000
           }
         ]
       },
@@ -1714,34 +1672,33 @@
       "level": 43,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 43
         },
         {
-          "name": "R&D Department",
+          "name": "r&d department",
           "level": 43
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 44,
-        "bonus2": 166
+        "bonus1": 0.44,
+        "bonus2": 1.66
       },
       "build_costs": {
         "materials": [
           {
             "type": "gas",
             "grade": 4,
-            "rarity": "common",
-            "value": 50000
+            "rarity": "uncommon",
+            "value": 7000
           },
           {
             "type": "gas",
             "grade": 4,
-            "rarity": "uncommon",
-            "value": 7000
+            "rarity": "common",
+            "value": 50000
           }
         ],
         "others": [],
@@ -1761,24 +1718,23 @@
       "level": 44,
       "requirements": [
         {
-          "name": "Astronautics Studio",
+          "name": "operations",
           "level": 44
         },
         {
-          "name": "R&D Department",
+          "name": "r&d department",
           "level": 44
         },
         {
-          "name": "Operations",
+          "name": "astronautics studio",
           "level": 44
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 45,
-        "bonus2": 168
+        "bonus1": 0.45,
+        "bonus2": 1.68
       },
       "build_costs": {
         "materials": [
@@ -1812,49 +1768,48 @@
       "level": 45,
       "requirements": [
         {
-          "name": "Foundry",
+          "name": "science lab",
           "level": 45
         },
         {
-          "name": "Engine Technology Lab",
+          "name": "engine technology lab",
           "level": 45
         },
         {
-          "name": "Science Lab",
+          "name": "foundry",
           "level": 45
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 46,
-        "bonus2": 170
+        "bonus1": 0.46,
+        "bonus2": 1.7
       },
       "build_costs": {
         "materials": [
           {
             "type": "gas",
             "grade": 4,
-            "rarity": "common",
-            "value": 25000
+            "rarity": "uncommon",
+            "value": 4000
           },
           {
             "type": "gas",
             "grade": 4,
-            "rarity": "uncommon",
-            "value": 4000
+            "rarity": "common",
+            "value": 25000
           }
         ],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 18232500000
-          },
-          {
             "type": "tritanium",
             "value": 1072500000
+          },
+          {
+            "type": "parsteel",
+            "value": 18232500000
           }
         ]
       },
@@ -1863,34 +1818,33 @@
       "level": 46,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 46
         },
         {
-          "name": "R&D Department",
+          "name": "r&d department",
           "level": 46
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 47,
-        "bonus2": 172
+        "bonus1": 0.47,
+        "bonus2": 1.72
       },
       "build_costs": {
         "materials": [
           {
             "type": "gas",
             "grade": 4,
-            "rarity": "common",
-            "value": 40000
+            "rarity": "uncommon",
+            "value": 5000
           },
           {
             "type": "gas",
             "grade": 4,
-            "rarity": "uncommon",
-            "value": 5000
+            "rarity": "common",
+            "value": 40000
           }
         ],
         "others": [],
@@ -1910,34 +1864,33 @@
       "level": 47,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 47
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 47
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 48,
-        "bonus2": 174
+        "bonus1": 0.48,
+        "bonus2": 1.74
       },
       "build_costs": {
         "materials": [
           {
             "type": "gas",
             "grade": 4,
-            "rarity": "common",
-            "value": 55000
+            "rarity": "uncommon",
+            "value": 6000
           },
           {
             "type": "gas",
             "grade": 4,
-            "rarity": "uncommon",
-            "value": 6000
+            "rarity": "common",
+            "value": 55000
           }
         ],
         "others": [],
@@ -1957,20 +1910,19 @@
       "level": 48,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 48
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 48
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 49,
-        "bonus2": 176
+        "bonus1": 0.49,
+        "bonus2": 1.76
       },
       "build_costs": {
         "materials": [
@@ -2004,36 +1956,35 @@
       "level": 49,
       "requirements": [
         {
-          "name": "Astronautics Studio",
+          "name": "operations",
           "level": 49
         },
         {
-          "name": "R&D Department",
+          "name": "r&d department",
           "level": 49
         },
         {
-          "name": "Operations",
+          "name": "astronautics studio",
           "level": 49
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 50,
-        "bonus2": 178
+        "bonus1": 0.5,
+        "bonus2": 1.78
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 124950000000
-          },
-          {
             "type": "tritanium",
             "value": 7350000000
+          },
+          {
+            "type": "parsteel",
+            "value": 124950000000
           }
         ]
       },
@@ -2042,15 +1993,248 @@
       "level": 50,
       "requirements": [
         {
-          "name": "Engine Technology Lab",
+          "name": "science lab",
           "level": 50
         },
         {
-          "name": "Science Lab",
+          "name": "engine technology lab",
           "level": 50
         }
-      ],
-      "rewards": []
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 0.51,
+        "bonus2": 1.8
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "gas",
+            "grade": 5,
+            "rarity": "uncommon",
+            "value": 2600
+          },
+          {
+            "type": "gas",
+            "grade": 5,
+            "rarity": "common",
+            "value": 13600
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 15600000000
+          },
+          {
+            "type": "parsteel",
+            "value": 623220000000
+          }
+        ]
+      },
+      "build_time": 59626080,
+      "increased_power": 5000,
+      "level": 51,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 51
+        },
+        {
+          "name": "r&d department",
+          "level": 51
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 0.52,
+        "bonus2": 1.82
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "gas",
+            "grade": 5,
+            "rarity": "uncommon",
+            "value": 5800
+          },
+          {
+            "type": "gas",
+            "grade": 5,
+            "rarity": "common",
+            "value": 24100
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 26520000000
+          },
+          {
+            "type": "parsteel",
+            "value": 1127100000000
+          }
+        ]
+      },
+      "build_time": 63204480,
+      "increased_power": 6000,
+      "level": 52,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 52
+        },
+        {
+          "name": "r&d department",
+          "level": 52
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 0.53,
+        "bonus2": 1.84
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "gas",
+            "grade": 5,
+            "rarity": "common",
+            "value": 55500
+          },
+          {
+            "type": "gas",
+            "grade": 5,
+            "rarity": "uncommon",
+            "value": 14300
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 46400000000
+          },
+          {
+            "type": "parsteel",
+            "value": 1893120000000
+          }
+        ]
+      },
+      "build_time": 66996000,
+      "increased_power": 5000,
+      "level": 53,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 53
+        },
+        {
+          "name": "r&d department",
+          "level": 53
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 0.54,
+        "bonus2": 1.86
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "gas",
+            "grade": 5,
+            "rarity": "common",
+            "value": 47200
+          },
+          {
+            "type": "gas",
+            "grade": 5,
+            "rarity": "uncommon",
+            "value": 16100
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 69600000000
+          },
+          {
+            "type": "parsteel",
+            "value": 2839680000000
+          }
+        ]
+      },
+      "build_time": 71016480,
+      "increased_power": 6000,
+      "level": 54,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 54
+        },
+        {
+          "name": "r&d department",
+          "level": 54
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 0.55,
+        "bonus2": 1.88
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "gas",
+            "grade": 5,
+            "rarity": "rare",
+            "value": 4800
+          },
+          {
+            "type": "gas",
+            "grade": 5,
+            "rarity": "common",
+            "value": 77800
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 4826640000000
+          },
+          {
+            "type": "tritanium",
+            "value": 109200000000
+          }
+        ]
+      },
+      "build_time": 75277440,
+      "increased_power": 6000,
+      "level": 55,
+      "requirements": [
+        {
+          "name": "science lab",
+          "level": 55
+        },
+        {
+          "name": "engine technology lab",
+          "level": 55
+        },
+        {
+          "name": "foundry",
+          "level": 55
+        }
+      ]
     }
   ]
 }

--- a/buildings/dilithium_generator_a.json
+++ b/buildings/dilithium_generator_a.json
@@ -2,11 +2,11 @@
   "description": "Produces Dilithium, a crystalline mineral required when building buildings and advanced ship components. Upgrading Dilithium Generators increases the amount of Dilithium that is produced.",
   "bonuses": {
     "bonus1": {
-      "name": "Dilithium Storage",
+      "name": "dilithium production",
       "percentage": false
     },
     "bonus2": {
-      "name": "Dilithium Production",
+      "name": "dilithium storage",
       "percentage": false
     }
   },
@@ -14,8 +14,8 @@
   "levels": [
     {
       "bonuses": {
-        "bonus1": 1,
-        "bonus2": 2
+        "bonus1": 2.0,
+        "bonus2": 1.0
       },
       "build_costs": {
         "materials": [],
@@ -36,28 +36,27 @@
       "level": 1,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 10
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 2,
-        "bonus2": 4
+        "bonus1": 4.0,
+        "bonus2": 2.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 500
-          },
-          {
             "type": "tritanium",
             "value": 350
+          },
+          {
+            "type": "parsteel",
+            "value": 500
           }
         ]
       },
@@ -66,20 +65,19 @@
       "level": 2,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 10
         },
         {
-          "name": "Dilithium Warehouse",
+          "name": "dilithium warehouse",
           "level": 1
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 6,
-        "bonus2": 6
+        "bonus1": 6.0,
+        "bonus2": 6.0
       },
       "build_costs": {
         "materials": [],
@@ -100,32 +98,31 @@
       "level": 3,
       "requirements": [
         {
-          "name": "Dilithium Warehouse",
-          "level": 1
+          "name": "operations",
+          "level": 10
         },
         {
-          "name": "Operations",
-          "level": 10
+          "name": "dilithium warehouse",
+          "level": 1
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 13,
-        "bonus2": 8
+        "bonus1": 8.0,
+        "bonus2": 13.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 700
-          },
-          {
             "type": "tritanium",
             "value": 450
+          },
+          {
+            "type": "parsteel",
+            "value": 700
           }
         ]
       },
@@ -134,32 +131,31 @@
       "level": 4,
       "requirements": [
         {
-          "name": "Dilithium Warehouse",
-          "level": 3
+          "name": "operations",
+          "level": 10
         },
         {
-          "name": "Operations",
-          "level": 10
+          "name": "dilithium warehouse",
+          "level": 3
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 24,
-        "bonus2": 12
+        "bonus1": 12.0,
+        "bonus2": 24.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 800
-          },
-          {
             "type": "tritanium",
             "value": 500
+          },
+          {
+            "type": "parsteel",
+            "value": 800
           }
         ]
       },
@@ -168,32 +164,31 @@
       "level": 5,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 10
         },
         {
-          "name": "Dilithium Warehouse",
+          "name": "dilithium warehouse",
           "level": 3
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 36,
-        "bonus2": 15
+        "bonus1": 15.0,
+        "bonus2": 36.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 1000
-          },
-          {
             "type": "tritanium",
             "value": 550
+          },
+          {
+            "type": "parsteel",
+            "value": 1000
           }
         ]
       },
@@ -202,20 +197,19 @@
       "level": 6,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 10
         },
         {
-          "name": "Dilithium Warehouse",
+          "name": "dilithium warehouse",
           "level": 5
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 48,
-        "bonus2": 17
+        "bonus1": 17.0,
+        "bonus2": 48.0
       },
       "build_costs": {
         "materials": [],
@@ -236,32 +230,31 @@
       "level": 7,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 10
         },
         {
-          "name": "Dilithium Warehouse",
+          "name": "dilithium warehouse",
           "level": 5
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 64,
-        "bonus2": 20
+        "bonus1": 20.0,
+        "bonus2": 64.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 1400
-          },
-          {
             "type": "tritanium",
             "value": 650
+          },
+          {
+            "type": "parsteel",
+            "value": 1400
           }
         ]
       },
@@ -270,20 +263,19 @@
       "level": 8,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 10
         },
         {
-          "name": "Dilithium Warehouse",
+          "name": "dilithium warehouse",
           "level": 5
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 79,
-        "bonus2": 22
+        "bonus1": 22.0,
+        "bonus2": 79.0
       },
       "build_costs": {
         "materials": [],
@@ -304,28 +296,27 @@
       "level": 9,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 10
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 150,
-        "bonus2": 37
+        "bonus1": 37.0,
+        "bonus2": 150.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 2000
-          },
-          {
             "type": "tritanium",
             "value": 1500
+          },
+          {
+            "type": "parsteel",
+            "value": 2000
           }
         ]
       },
@@ -334,16 +325,15 @@
       "level": 10,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 10
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 170,
-        "bonus2": 40
+        "bonus1": 40.0,
+        "bonus2": 170.0
       },
       "build_costs": {
         "materials": [],
@@ -364,16 +354,15 @@
       "level": 11,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 11
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 195,
-        "bonus2": 44
+        "bonus1": 44.0,
+        "bonus2": 195.0
       },
       "build_costs": {
         "materials": [],
@@ -394,16 +383,15 @@
       "level": 12,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 12
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 230,
-        "bonus2": 48
+        "bonus1": 48.0,
+        "bonus2": 230.0
       },
       "build_costs": {
         "materials": [],
@@ -424,16 +412,15 @@
       "level": 13,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 13
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 280,
-        "bonus2": 52
+        "bonus1": 52.0,
+        "bonus2": 280.0
       },
       "build_costs": {
         "materials": [],
@@ -454,16 +441,15 @@
       "level": 14,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 14
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 355,
-        "bonus2": 61
+        "bonus1": 61.0,
+        "bonus2": 355.0
       },
       "build_costs": {
         "materials": [],
@@ -484,16 +470,15 @@
       "level": 15,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 15
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 410,
-        "bonus2": 66
+        "bonus1": 66.0,
+        "bonus2": 410.0
       },
       "build_costs": {
         "materials": [],
@@ -514,16 +499,15 @@
       "level": 16,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 16
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 460,
-        "bonus2": 70
+        "bonus1": 70.0,
+        "bonus2": 460.0
       },
       "build_costs": {
         "materials": [],
@@ -544,28 +528,27 @@
       "level": 17,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 17
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 530,
-        "bonus2": 74
+        "bonus1": 74.0,
+        "bonus2": 530.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 27200
-          },
-          {
             "type": "tritanium",
             "value": 20000
+          },
+          {
+            "type": "parsteel",
+            "value": 27200
           }
         ]
       },
@@ -574,28 +557,27 @@
       "level": 18,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 18
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 590,
-        "bonus2": 78
+        "bonus1": 78.0,
+        "bonus2": 590.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 40800
-          },
-          {
             "type": "tritanium",
             "value": 30000
+          },
+          {
+            "type": "parsteel",
+            "value": 40800
           }
         ]
       },
@@ -604,16 +586,15 @@
       "level": 19,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 19
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 780,
-        "bonus2": 98
+        "bonus1": 98.0,
+        "bonus2": 780.0
       },
       "build_costs": {
         "materials": [],
@@ -634,16 +615,15 @@
       "level": 20,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 20
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 860,
-        "bonus2": 105
+        "bonus1": 105.0,
+        "bonus2": 860.0
       },
       "build_costs": {
         "materials": [],
@@ -664,16 +644,15 @@
       "level": 21,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 21
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 900,
-        "bonus2": 110
+        "bonus1": 110.0,
+        "bonus2": 900.0
       },
       "build_costs": {
         "materials": [],
@@ -694,28 +673,27 @@
       "level": 22,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 22
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 970,
-        "bonus2": 115
+        "bonus1": 115.0,
+        "bonus2": 970.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 249084
-          },
-          {
             "type": "tritanium",
             "value": 183150
+          },
+          {
+            "type": "parsteel",
+            "value": 249084
           }
         ]
       },
@@ -724,16 +702,15 @@
       "level": 23,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 23
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 1010,
-        "bonus2": 120
+        "bonus1": 120.0,
+        "bonus2": 1010.0
       },
       "build_costs": {
         "materials": [],
@@ -754,28 +731,27 @@
       "level": 24,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 24
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 1250,
-        "bonus2": 145
+        "bonus1": 145.0,
+        "bonus2": 1250.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 636480
-          },
-          {
             "type": "tritanium",
             "value": 468000
+          },
+          {
+            "type": "parsteel",
+            "value": 636480
           }
         ]
       },
@@ -784,16 +760,15 @@
       "level": 25,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 25
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 1290,
-        "bonus2": 150
+        "bonus1": 150.0,
+        "bonus2": 1290.0
       },
       "build_costs": {
         "materials": [],
@@ -814,28 +789,27 @@
       "level": 26,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 26
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 1360,
-        "bonus2": 155
+        "bonus1": 155.0,
+        "bonus2": 1360.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 1517760
-          },
-          {
             "type": "tritanium",
             "value": 1116000
+          },
+          {
+            "type": "parsteel",
+            "value": 1517760
           }
         ]
       },
@@ -844,28 +818,27 @@
       "level": 27,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 27
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 1400,
-        "bonus2": 160
+        "bonus1": 160.0,
+        "bonus2": 1400.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 2276640
-          },
-          {
             "type": "tritanium",
             "value": 1674000
+          },
+          {
+            "type": "parsteel",
+            "value": 2276640
           }
         ]
       },
@@ -874,28 +847,27 @@
       "level": 28,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 28
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 1475,
-        "bonus2": 165
+        "bonus1": 165.0,
+        "bonus2": 1475.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 3624400
-          },
-          {
             "type": "tritanium",
             "value": 2665000
+          },
+          {
+            "type": "parsteel",
+            "value": 3624400
           }
         ]
       },
@@ -904,16 +876,15 @@
       "level": 29,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 29
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 1750,
-        "bonus2": 195
+        "bonus1": 195.0,
+        "bonus2": 1750.0
       },
       "build_costs": {
         "materials": [],
@@ -934,28 +905,27 @@
       "level": 30,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 30
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 1850,
-        "bonus2": 205
+        "bonus1": 205.0,
+        "bonus2": 1850.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 8384400
-          },
-          {
             "type": "tritanium",
             "value": 6165000
+          },
+          {
+            "type": "parsteel",
+            "value": 8384400
           }
         ]
       },
@@ -964,16 +934,15 @@
       "level": 31,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 31
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 2052,
-        "bonus2": 210
+        "bonus1": 210.0,
+        "bonus2": 2052.0
       },
       "build_costs": {
         "materials": [],
@@ -994,28 +963,27 @@
       "level": 32,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 32
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 2233,
-        "bonus2": 215
+        "bonus1": 215.0,
+        "bonus2": 2233.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 18734000
-          },
-          {
             "type": "tritanium",
             "value": 13775000
+          },
+          {
+            "type": "parsteel",
+            "value": 18734000
           }
         ]
       },
@@ -1024,28 +992,27 @@
       "level": 33,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 33
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 2349,
-        "bonus2": 225
+        "bonus1": 225.0,
+        "bonus2": 2349.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 29580000
-          },
-          {
             "type": "tritanium",
             "value": 21750000
+          },
+          {
+            "type": "parsteel",
+            "value": 29580000
           }
         ]
       },
@@ -1054,16 +1021,15 @@
       "level": 34,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 34
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 2914,
-        "bonus2": 260
+        "bonus1": 260.0,
+        "bonus2": 2914.0
       },
       "build_costs": {
         "materials": [],
@@ -1084,28 +1050,27 @@
       "level": 35,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 35
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 3159,
-        "bonus2": 265
+        "bonus1": 265.0,
+        "bonus2": 3159.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 64504800
-          },
-          {
             "type": "tritanium",
             "value": 47430000
+          },
+          {
+            "type": "parsteel",
+            "value": 64504800
           }
         ]
       },
@@ -1114,16 +1079,15 @@
       "level": 36,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 36
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 3292,
-        "bonus2": 275
+        "bonus1": 275.0,
+        "bonus2": 3292.0
       },
       "build_costs": {
         "materials": [],
@@ -1144,28 +1108,27 @@
       "level": 37,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 37
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 3586,
-        "bonus2": 280
+        "bonus1": 280.0,
+        "bonus2": 3586.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 154224000
-          },
-          {
             "type": "tritanium",
             "value": 113400000
+          },
+          {
+            "type": "parsteel",
+            "value": 154224000
           }
         ]
       },
@@ -1174,28 +1137,27 @@
       "level": 38,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 38
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 3978,
-        "bonus2": 290
+        "bonus1": 290.0,
+        "bonus2": 3978.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 263160000
-          },
-          {
             "type": "tritanium",
             "value": 193500000
+          },
+          {
+            "type": "parsteel",
+            "value": 263160000
           }
         ]
       },
@@ -1204,16 +1166,15 @@
       "level": 39,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 39
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 5011,
-        "bonus2": 365
+        "bonus1": 365.0,
+        "bonus2": 5011.0
       },
       "build_costs": {
         "materials": [
@@ -1247,41 +1208,40 @@
       "level": 40,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 40
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 5486,
-        "bonus2": 370
+        "bonus1": 370.0,
+        "bonus2": 5486.0
       },
       "build_costs": {
         "materials": [
           {
             "type": "ore",
             "grade": 4,
-            "rarity": "common",
-            "value": 4000
+            "rarity": "uncommon",
+            "value": 5000
           },
           {
             "type": "ore",
             "grade": 4,
-            "rarity": "uncommon",
-            "value": 5000
+            "rarity": "common",
+            "value": 4000
           }
         ],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 1169600000
-          },
-          {
             "type": "tritanium",
             "value": 430000000
+          },
+          {
+            "type": "parsteel",
+            "value": 1169600000
           }
         ]
       },
@@ -1290,16 +1250,15 @@
       "level": 41,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 41
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 6199,
-        "bonus2": 380
+        "bonus1": 380.0,
+        "bonus2": 6199.0
       },
       "build_costs": {
         "materials": [
@@ -1327,16 +1286,15 @@
       "level": 42,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 42
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 6335,
-        "bonus2": 390
+        "bonus1": 390.0,
+        "bonus2": 6335.0
       },
       "build_costs": {
         "materials": [
@@ -1350,12 +1308,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 2488800000
-          },
-          {
             "type": "tritanium",
             "value": 915000000
+          },
+          {
+            "type": "parsteel",
+            "value": 2488800000
           }
         ]
       },
@@ -1364,16 +1322,15 @@
       "level": 43,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 43
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 7200,
-        "bonus2": 400
+        "bonus1": 400.0,
+        "bonus2": 7200.0
       },
       "build_costs": {
         "materials": [
@@ -1387,12 +1344,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 3733200000
-          },
-          {
             "type": "tritanium",
             "value": 1372500000
+          },
+          {
+            "type": "parsteel",
+            "value": 3733200000
           }
         ]
       },
@@ -1401,16 +1358,15 @@
       "level": 44,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 44
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 9394,
-        "bonus2": 465
+        "bonus1": 465.0,
+        "bonus2": 9394.0
       },
       "build_costs": {
         "materials": [
@@ -1438,41 +1394,40 @@
       "level": 45,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 45
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 9619,
-        "bonus2": 475
+        "bonus1": 475.0,
+        "bonus2": 9619.0
       },
       "build_costs": {
         "materials": [
           {
             "type": "ore",
             "grade": 4,
-            "rarity": "common",
-            "value": 25000
+            "rarity": "uncommon",
+            "value": 1500
           },
           {
             "type": "ore",
             "grade": 4,
-            "rarity": "uncommon",
-            "value": 1500
+            "rarity": "common",
+            "value": 25000
           }
         ],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 7293000000
-          },
-          {
             "type": "tritanium",
             "value": 2681250000
+          },
+          {
+            "type": "parsteel",
+            "value": 7293000000
           }
         ]
       },
@@ -1481,30 +1436,29 @@
       "level": 46,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 46
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 9844,
-        "bonus2": 485
+        "bonus1": 485.0,
+        "bonus2": 9844.0
       },
       "build_costs": {
         "materials": [
           {
             "type": "ore",
             "grade": 4,
-            "rarity": "common",
-            "value": 50000
+            "rarity": "uncommon",
+            "value": 2500
           },
           {
             "type": "ore",
             "grade": 4,
-            "rarity": "uncommon",
-            "value": 2500
+            "rarity": "common",
+            "value": 50000
           }
         ],
         "others": [],
@@ -1524,30 +1478,29 @@
       "level": 47,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 47
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 10013,
-        "bonus2": 495
+        "bonus1": 495.0,
+        "bonus2": 10013.0
       },
       "build_costs": {
         "materials": [
           {
             "type": "ore",
             "grade": 4,
-            "rarity": "common",
-            "value": 15000
+            "rarity": "uncommon",
+            "value": 6000
           },
           {
             "type": "ore",
             "grade": 4,
-            "rarity": "uncommon",
-            "value": 6000
+            "rarity": "common",
+            "value": 15000
           }
         ],
         "others": [],
@@ -1567,30 +1520,29 @@
       "level": 48,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 48
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 10350,
-        "bonus2": 510
+        "bonus1": 510.0,
+        "bonus2": 10350.0
       },
       "build_costs": {
         "materials": [
           {
             "type": "ore",
             "grade": 4,
-            "rarity": "common",
-            "value": 20000
+            "rarity": "uncommon",
+            "value": 13250
           },
           {
             "type": "ore",
             "grade": 4,
-            "rarity": "uncommon",
-            "value": 13250
+            "rarity": "common",
+            "value": 20000
           }
         ],
         "others": [],
@@ -1610,16 +1562,15 @@
       "level": 49,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 49
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 12600,
-        "bonus2": 620
+        "bonus1": 620.0,
+        "bonus2": 12600.0
       },
       "build_costs": {
         "materials": [],
@@ -1640,11 +1591,190 @@
       "level": 50,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 50
         }
-      ],
-      "rewards": []
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 635.0,
+        "bonus2": 12891.0
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "ore",
+            "grade": 5,
+            "rarity": "common",
+            "value": 9300
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 249288000000
+          },
+          {
+            "type": "tritanium",
+            "value": 39000000000
+          }
+        ]
+      },
+      "build_time": 59626080,
+      "increased_power": 2000,
+      "level": 51,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 51
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 650.0,
+        "bonus2": 13195.0
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "ore",
+            "grade": 5,
+            "rarity": "common",
+            "value": 21100
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 66300000000
+          },
+          {
+            "type": "parsteel",
+            "value": 450840000000
+          }
+        ]
+      },
+      "build_time": 63204480,
+      "increased_power": 1500,
+      "level": 52,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 52
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 655.0,
+        "bonus2": 13297.0
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "ore",
+            "grade": 5,
+            "rarity": "common",
+            "value": 41100
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 116000000000
+          },
+          {
+            "type": "parsteel",
+            "value": 757248000000
+          }
+        ]
+      },
+      "build_time": 66996000,
+      "increased_power": 2000,
+      "level": 53,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 53
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 670.0,
+        "bonus2": 13601.0
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "ore",
+            "grade": 5,
+            "rarity": "common",
+            "value": 43100
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 1135872000000
+          },
+          {
+            "type": "tritanium",
+            "value": 174000000000
+          }
+        ]
+      },
+      "build_time": 71016480,
+      "increased_power": 2000,
+      "level": 54,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 54
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 800.0,
+        "bonus2": 16240.0
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "ore",
+            "grade": 5,
+            "rarity": "common",
+            "value": 74800
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 273000000000
+          },
+          {
+            "type": "parsteel",
+            "value": 1930656000000
+          }
+        ]
+      },
+      "build_time": 75277440,
+      "increased_power": 2000,
+      "level": 55,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 55
+        }
+      ]
     }
   ]
 }

--- a/buildings/dilithium_generator_b.json
+++ b/buildings/dilithium_generator_b.json
@@ -2,11 +2,11 @@
   "description": "Produces Dilithium, a crystalline mineral required when building buildings and advanced ship components. Upgrading Dilithium Generators increases the amount of Dilithium that is produced.",
   "bonuses": {
     "bonus1": {
-      "name": "Dilithium Production",
+      "name": "dilithium production",
       "percentage": false
     },
     "bonus2": {
-      "name": "Dilithium Storage",
+      "name": "dilithium storage",
       "percentage": false
     }
   },
@@ -14,20 +14,20 @@
   "levels": [
     {
       "bonuses": {
-        "bonus1": 2,
-        "bonus2": 1
+        "bonus1": 2.0,
+        "bonus2": 1.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 400
-          },
-          {
             "type": "tritanium",
             "value": 300
+          },
+          {
+            "type": "parsteel",
+            "value": 400
           }
         ]
       },
@@ -36,32 +36,31 @@
       "level": 1,
       "requirements": [
         {
-          "name": "Operations",
-          "level": 20
+          "name": "operations",
+          "level": 13
         },
         {
-          "name": "Dilithium Generator A",
+          "name": "dilithium generator a",
           "level": 1
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 4,
-        "bonus2": 2
+        "bonus1": 4.0,
+        "bonus2": 2.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 500
-          },
-          {
             "type": "tritanium",
             "value": 350
+          },
+          {
+            "type": "parsteel",
+            "value": 500
           }
         ]
       },
@@ -70,19 +69,19 @@
       "level": 2,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 2
         },
         {
-          "name": "Dilithium Generator A",
+          "name": "dilithium generator a",
           "level": 2
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 6,
-        "bonus2": 6
+        "bonus1": 6.0,
+        "bonus2": 6.0
       },
       "build_costs": {
         "materials": [],
@@ -103,31 +102,31 @@
       "level": 3,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 3
         },
         {
-          "name": "Dilithium Generator A",
+          "name": "dilithium generator a",
           "level": 3
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 8,
-        "bonus2": 13
+        "bonus1": 8.0,
+        "bonus2": 13.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 700
-          },
-          {
             "type": "tritanium",
             "value": 450
+          },
+          {
+            "type": "parsteel",
+            "value": 700
           }
         ]
       },
@@ -136,31 +135,31 @@
       "level": 4,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 4
         },
         {
-          "name": "Dilithium Generator A",
+          "name": "dilithium generator a",
           "level": 4
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 12,
-        "bonus2": 24
+        "bonus1": 12.0,
+        "bonus2": 24.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 800
-          },
-          {
             "type": "tritanium",
             "value": 500
+          },
+          {
+            "type": "parsteel",
+            "value": 800
           }
         ]
       },
@@ -169,19 +168,19 @@
       "level": 5,
       "requirements": [
         {
-          "name": "Dilithium Generator A",
+          "name": "operations",
           "level": 5
         },
         {
-          "name": "Operations",
+          "name": "dilithium generator a",
           "level": 5
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 15,
-        "bonus2": 36
+        "bonus1": 15.0,
+        "bonus2": 36.0
       },
       "build_costs": {
         "materials": [],
@@ -202,19 +201,19 @@
       "level": 6,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 6
         },
         {
-          "name": "Dilithium Generator A",
+          "name": "dilithium generator a",
           "level": 6
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 17,
-        "bonus2": 48
+        "bonus1": 17.0,
+        "bonus2": 48.0
       },
       "build_costs": {
         "materials": [],
@@ -235,32 +234,31 @@
       "level": 7,
       "requirements": [
         {
-          "name": "Dilithium Generator A",
+          "name": "operations",
           "level": 7
         },
         {
-          "name": "Operations",
+          "name": "dilithium generator a",
           "level": 7
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 20,
-        "bonus2": 64
+        "bonus1": 20.0,
+        "bonus2": 64.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 1400
-          },
-          {
             "type": "tritanium",
             "value": 650
+          },
+          {
+            "type": "parsteel",
+            "value": 1400
           }
         ]
       },
@@ -269,32 +267,31 @@
       "level": 8,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 8
         },
         {
-          "name": "Dilithium Generator A",
+          "name": "dilithium generator a",
           "level": 8
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 22,
-        "bonus2": 79
+        "bonus1": 22.0,
+        "bonus2": 79.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 1600
-          },
-          {
             "type": "tritanium",
             "value": 700
+          },
+          {
+            "type": "parsteel",
+            "value": 1600
           }
         ]
       },
@@ -303,32 +300,31 @@
       "level": 9,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 9
         },
         {
-          "name": "Dilithium Generator A",
+          "name": "dilithium generator a",
           "level": 9
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 37,
-        "bonus2": 150
+        "bonus1": 37.0,
+        "bonus2": 150.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 2000
-          },
-          {
             "type": "tritanium",
             "value": 1500
+          },
+          {
+            "type": "parsteel",
+            "value": 2000
           }
         ]
       },
@@ -337,32 +333,31 @@
       "level": 10,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 10
         },
         {
-          "name": "Dilithium Generator A",
+          "name": "dilithium generator a",
           "level": 10
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 40,
-        "bonus2": 170
+        "bonus1": 40.0,
+        "bonus2": 170.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 2720
-          },
-          {
             "type": "tritanium",
             "value": 2000
+          },
+          {
+            "type": "parsteel",
+            "value": 2720
           }
         ]
       },
@@ -371,32 +366,31 @@
       "level": 11,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 11
         },
         {
-          "name": "Dilithium Generator A",
+          "name": "dilithium generator a",
           "level": 11
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 44,
-        "bonus2": 195
+        "bonus1": 44.0,
+        "bonus2": 195.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 3740
-          },
-          {
             "type": "tritanium",
             "value": 2750
+          },
+          {
+            "type": "parsteel",
+            "value": 3740
           }
         ]
       },
@@ -405,32 +399,31 @@
       "level": 12,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 12
         },
         {
-          "name": "Dilithium Generator A",
+          "name": "dilithium generator a",
           "level": 12
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 48,
-        "bonus2": 230
+        "bonus1": 48.0,
+        "bonus2": 230.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 5440
-          },
-          {
             "type": "tritanium",
             "value": 4000
+          },
+          {
+            "type": "parsteel",
+            "value": 5440
           }
         ]
       },
@@ -439,20 +432,19 @@
       "level": 13,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 13
         },
         {
-          "name": "Dilithium Generator A",
+          "name": "dilithium generator a",
           "level": 13
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 52,
-        "bonus2": 280
+        "bonus1": 52.0,
+        "bonus2": 280.0
       },
       "build_costs": {
         "materials": [],
@@ -473,20 +465,19 @@
       "level": 14,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 14
         },
         {
-          "name": "Dilithium Generator A",
+          "name": "dilithium generator a",
           "level": 14
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 61,
-        "bonus2": 355
+        "bonus1": 61.0,
+        "bonus2": 355.0
       },
       "build_costs": {
         "materials": [],
@@ -507,20 +498,19 @@
       "level": 15,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 15
         },
         {
-          "name": "Dilithium Generator A",
+          "name": "dilithium generator a",
           "level": 15
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 66,
-        "bonus2": 410
+        "bonus1": 66.0,
+        "bonus2": 410.0
       },
       "build_costs": {
         "materials": [],
@@ -541,32 +531,31 @@
       "level": 16,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 16
         },
         {
-          "name": "Dilithium Generator A",
+          "name": "dilithium generator a",
           "level": 16
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 70,
-        "bonus2": 460
+        "bonus1": 70.0,
+        "bonus2": 460.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 19040
-          },
-          {
             "type": "tritanium",
             "value": 14000
+          },
+          {
+            "type": "parsteel",
+            "value": 19040
           }
         ]
       },
@@ -575,20 +564,19 @@
       "level": 17,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 17
         },
         {
-          "name": "Dilithium Generator A",
+          "name": "dilithium generator a",
           "level": 17
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 74,
-        "bonus2": 530
+        "bonus1": 74.0,
+        "bonus2": 530.0
       },
       "build_costs": {
         "materials": [],
@@ -609,32 +597,31 @@
       "level": 18,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 18
         },
         {
-          "name": "Dilithium Generator A",
+          "name": "dilithium generator a",
           "level": 18
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 78,
-        "bonus2": 590
+        "bonus1": 78.0,
+        "bonus2": 590.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 40800
-          },
-          {
             "type": "tritanium",
             "value": 30000
+          },
+          {
+            "type": "parsteel",
+            "value": 40800
           }
         ]
       },
@@ -643,32 +630,31 @@
       "level": 19,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 19
         },
         {
-          "name": "Dilithium Generator A",
+          "name": "dilithium generator a",
           "level": 19
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 98,
-        "bonus2": 780
+        "bonus1": 98.0,
+        "bonus2": 780.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 57800
-          },
-          {
             "type": "tritanium",
             "value": 42500
+          },
+          {
+            "type": "parsteel",
+            "value": 57800
           }
         ]
       },
@@ -677,20 +663,19 @@
       "level": 20,
       "requirements": [
         {
-          "name": "Dilithium Generator A",
+          "name": "operations",
           "level": 20
         },
         {
-          "name": "Operations",
+          "name": "dilithium generator a",
           "level": 20
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 105,
-        "bonus2": 860
+        "bonus1": 105.0,
+        "bonus2": 860.0
       },
       "build_costs": {
         "materials": [],
@@ -711,32 +696,31 @@
       "level": 21,
       "requirements": [
         {
-          "name": "Dilithium Generator A",
+          "name": "operations",
           "level": 21
         },
         {
-          "name": "Operations",
+          "name": "dilithium generator a",
           "level": 21
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 110,
-        "bonus2": 900
+        "bonus1": 110.0,
+        "bonus2": 900.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 151368
-          },
-          {
             "type": "tritanium",
             "value": 111300
+          },
+          {
+            "type": "parsteel",
+            "value": 151368
           }
         ]
       },
@@ -745,32 +729,31 @@
       "level": 22,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 22
         },
         {
-          "name": "Dilithium Generator A",
+          "name": "dilithium generator a",
           "level": 22
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 115,
-        "bonus2": 970
+        "bonus1": 115.0,
+        "bonus2": 970.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 249084
-          },
-          {
             "type": "tritanium",
             "value": 183150
+          },
+          {
+            "type": "parsteel",
+            "value": 249084
           }
         ]
       },
@@ -779,20 +762,19 @@
       "level": 23,
       "requirements": [
         {
-          "name": "Dilithium Generator A",
+          "name": "operations",
           "level": 23
         },
         {
-          "name": "Operations",
+          "name": "dilithium generator a",
           "level": 23
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 120,
-        "bonus2": 1010
+        "bonus1": 120.0,
+        "bonus2": 1010.0
       },
       "build_costs": {
         "materials": [],
@@ -813,32 +795,31 @@
       "level": 24,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 24
         },
         {
-          "name": "Dilithium Generator A",
+          "name": "dilithium generator a",
           "level": 24
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 145,
-        "bonus2": 1250
+        "bonus1": 145.0,
+        "bonus2": 1250.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 636480
-          },
-          {
             "type": "tritanium",
             "value": 468000
+          },
+          {
+            "type": "parsteel",
+            "value": 636480
           }
         ]
       },
@@ -847,32 +828,31 @@
       "level": 25,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 25
         },
         {
-          "name": "Dilithium Generator A",
+          "name": "dilithium generator a",
           "level": 25
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 150,
-        "bonus2": 1290
+        "bonus1": 150.0,
+        "bonus2": 1290.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 994500
-          },
-          {
             "type": "tritanium",
             "value": 731250
+          },
+          {
+            "type": "parsteel",
+            "value": 994500
           }
         ]
       },
@@ -881,32 +861,31 @@
       "level": 26,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 26
         },
         {
-          "name": "Dilithium Generator A",
+          "name": "dilithium generator a",
           "level": 26
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 155,
-        "bonus2": 1360
+        "bonus1": 155.0,
+        "bonus2": 1360.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 1517760
-          },
-          {
             "type": "tritanium",
             "value": 1116000
+          },
+          {
+            "type": "parsteel",
+            "value": 1517760
           }
         ]
       },
@@ -915,32 +894,31 @@
       "level": 27,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 27
         },
         {
-          "name": "Dilithium Generator A",
+          "name": "dilithium generator a",
           "level": 27
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 160,
-        "bonus2": 1400
+        "bonus1": 160.0,
+        "bonus2": 1400.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 2276640
-          },
-          {
             "type": "tritanium",
             "value": 1674000
+          },
+          {
+            "type": "parsteel",
+            "value": 2276640
           }
         ]
       },
@@ -949,20 +927,19 @@
       "level": 28,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 28
         },
         {
-          "name": "Dilithium Generator A",
+          "name": "dilithium generator a",
           "level": 28
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 165,
-        "bonus2": 1475
+        "bonus1": 165.0,
+        "bonus2": 1475.0
       },
       "build_costs": {
         "materials": [],
@@ -983,32 +960,31 @@
       "level": 29,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 29
         },
         {
-          "name": "Dilithium Generator A",
+          "name": "dilithium generator a",
           "level": 29
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 195,
-        "bonus2": 1750
+        "bonus1": 195.0,
+        "bonus2": 1750.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 5304000
-          },
-          {
             "type": "tritanium",
             "value": 3900000
+          },
+          {
+            "type": "parsteel",
+            "value": 5304000
           }
         ]
       },
@@ -1017,32 +993,31 @@
       "level": 30,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 30
         },
         {
-          "name": "Dilithium Generator A",
+          "name": "dilithium generator a",
           "level": 30
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 205,
-        "bonus2": 1850
+        "bonus1": 205.0,
+        "bonus2": 1850.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 8384400
-          },
-          {
             "type": "tritanium",
             "value": 6165000
+          },
+          {
+            "type": "parsteel",
+            "value": 8384400
           }
         ]
       },
@@ -1051,20 +1026,19 @@
       "level": 31,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 31
         },
         {
-          "name": "Dilithium Generator A",
+          "name": "dilithium generator a",
           "level": 31
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 210,
-        "bonus2": 2052
+        "bonus1": 210.0,
+        "bonus2": 2052.0
       },
       "build_costs": {
         "materials": [],
@@ -1085,32 +1059,31 @@
       "level": 32,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 32
         },
         {
-          "name": "Dilithium Generator A",
+          "name": "dilithium generator a",
           "level": 32
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 215,
-        "bonus2": 2233
+        "bonus1": 215.0,
+        "bonus2": 2233.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 18734000
-          },
-          {
             "type": "tritanium",
             "value": 13775000
+          },
+          {
+            "type": "parsteel",
+            "value": 18734000
           }
         ]
       },
@@ -1119,32 +1092,31 @@
       "level": 33,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 33
         },
         {
-          "name": "Dilithium Generator A",
+          "name": "dilithium generator a",
           "level": 33
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 225,
-        "bonus2": 2349
+        "bonus1": 225.0,
+        "bonus2": 2349.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 29580000
-          },
-          {
             "type": "tritanium",
             "value": 21750000
+          },
+          {
+            "type": "parsteel",
+            "value": 29580000
           }
         ]
       },
@@ -1153,32 +1125,31 @@
       "level": 34,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 34
         },
         {
-          "name": "Dilithium Generator A",
+          "name": "dilithium generator a",
           "level": 34
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 260,
-        "bonus2": 2914
+        "bonus1": 260.0,
+        "bonus2": 2914.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 45777600
-          },
-          {
             "type": "tritanium",
             "value": 33660000
+          },
+          {
+            "type": "parsteel",
+            "value": 45777600
           }
         ]
       },
@@ -1187,32 +1158,31 @@
       "level": 35,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 35
         },
         {
-          "name": "Dilithium Generator A",
+          "name": "dilithium generator a",
           "level": 35
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 265,
-        "bonus2": 3159
+        "bonus1": 265.0,
+        "bonus2": 3159.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 64504800
-          },
-          {
             "type": "tritanium",
             "value": 47430000
+          },
+          {
+            "type": "parsteel",
+            "value": 64504800
           }
         ]
       },
@@ -1221,20 +1191,19 @@
       "level": 36,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 36
         },
         {
-          "name": "Dilithium Generator A",
+          "name": "dilithium generator a",
           "level": 36
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 275,
-        "bonus2": 3292
+        "bonus1": 275.0,
+        "bonus2": 3292.0
       },
       "build_costs": {
         "materials": [],
@@ -1255,32 +1224,31 @@
       "level": 37,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 37
         },
         {
-          "name": "Dilithium Generator A",
+          "name": "dilithium generator a",
           "level": 37
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 280,
-        "bonus2": 3586
+        "bonus1": 280.0,
+        "bonus2": 3586.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 154224000
-          },
-          {
             "type": "tritanium",
             "value": 113400000
+          },
+          {
+            "type": "parsteel",
+            "value": 154224000
           }
         ]
       },
@@ -1289,20 +1257,19 @@
       "level": 38,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 38
         },
         {
-          "name": "Dilithium Generator A",
+          "name": "dilithium generator a",
           "level": 38
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 290,
-        "bonus2": 3978
+        "bonus1": 290.0,
+        "bonus2": 3978.0
       },
       "build_costs": {
         "materials": [],
@@ -1323,23 +1290,35 @@
       "level": 39,
       "requirements": [
         {
-          "name": "Dilithium Generator A",
+          "name": "operations",
           "level": 39
         },
         {
-          "name": "Operations",
+          "name": "dilithium generator a",
           "level": 39
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 365,
-        "bonus2": 5011
+        "bonus1": 365.0,
+        "bonus2": 5011.0
       },
       "build_costs": {
-        "materials": [],
+        "materials": [
+          {
+            "type": "ore",
+            "grade": 4,
+            "rarity": "common",
+            "value": 3000
+          },
+          {
+            "type": "ore",
+            "grade": 4,
+            "rarity": "uncommon",
+            "value": 2400
+          }
+        ],
         "others": [],
         "resources": [
           {
@@ -1357,32 +1336,44 @@
       "level": 40,
       "requirements": [
         {
-          "name": "Dilithium Generator A",
+          "name": "operations",
           "level": 40
         },
         {
-          "name": "Operations",
+          "name": "dilithium generator a",
           "level": 40
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 370,
-        "bonus2": 5486
+        "bonus1": 370.0,
+        "bonus2": 5486.0
       },
       "build_costs": {
-        "materials": [],
+        "materials": [
+          {
+            "type": "ore",
+            "grade": 4,
+            "rarity": "uncommon",
+            "value": 5000
+          },
+          {
+            "type": "ore",
+            "grade": 4,
+            "rarity": "common",
+            "value": 4000
+          }
+        ],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 1169600000
-          },
-          {
             "type": "tritanium",
             "value": 430000000
+          },
+          {
+            "type": "parsteel",
+            "value": 1169600000
           }
         ]
       },
@@ -1391,23 +1382,29 @@
       "level": 41,
       "requirements": [
         {
-          "name": "Dilithium Generator A",
+          "name": "operations",
           "level": 41
         },
         {
-          "name": "Operations",
+          "name": "dilithium generator a",
           "level": 41
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 380,
-        "bonus2": 6199
+        "bonus1": 380.0,
+        "bonus2": 6199.0
       },
       "build_costs": {
-        "materials": [],
+        "materials": [
+          {
+            "type": "ore",
+            "grade": 4,
+            "rarity": "common",
+            "value": 5000
+          }
+        ],
         "others": [],
         "resources": [
           {
@@ -1425,23 +1422,29 @@
       "level": 42,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 42
         },
         {
-          "name": "Dilithium Generator A",
+          "name": "dilithium generator a",
           "level": 42
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 390,
-        "bonus2": 6335
+        "bonus1": 390.0,
+        "bonus2": 6335.0
       },
       "build_costs": {
-        "materials": [],
+        "materials": [
+          {
+            "type": "ore",
+            "grade": 4,
+            "rarity": "common",
+            "value": 4500
+          }
+        ],
         "others": [],
         "resources": [
           {
@@ -1459,23 +1462,29 @@
       "level": 43,
       "requirements": [
         {
-          "name": "Dilithium Generator A",
+          "name": "operations",
           "level": 43
         },
         {
-          "name": "Operations",
+          "name": "dilithium generator a",
           "level": 43
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 400,
-        "bonus2": 7200
+        "bonus1": 400.0,
+        "bonus2": 7200.0
       },
       "build_costs": {
-        "materials": [],
+        "materials": [
+          {
+            "type": "ore",
+            "grade": 4,
+            "rarity": "common",
+            "value": 5000
+          }
+        ],
         "others": [],
         "resources": [
           {
@@ -1493,32 +1502,38 @@
       "level": 44,
       "requirements": [
         {
-          "name": "Dilithium Generator A",
+          "name": "operations",
           "level": 44
         },
         {
-          "name": "Operations",
+          "name": "dilithium generator a",
           "level": 44
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 465,
-        "bonus2": 9394
+        "bonus1": 465.0,
+        "bonus2": 9394.0
       },
       "build_costs": {
-        "materials": [],
+        "materials": [
+          {
+            "type": "ore",
+            "grade": 4,
+            "rarity": "common",
+            "value": 8000
+          }
+        ],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 5304000000
-          },
-          {
             "type": "tritanium",
             "value": 1950000000
+          },
+          {
+            "type": "parsteel",
+            "value": 5304000000
           }
         ]
       },
@@ -1527,32 +1542,44 @@
       "level": 45,
       "requirements": [
         {
-          "name": "Dilithium Generator A",
+          "name": "operations",
           "level": 45
         },
         {
-          "name": "Operations",
+          "name": "dilithium generator a",
           "level": 45
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 475,
-        "bonus2": 9619
+        "bonus1": 475.0,
+        "bonus2": 9619.0
       },
       "build_costs": {
-        "materials": [],
+        "materials": [
+          {
+            "type": "ore",
+            "grade": 4,
+            "rarity": "common",
+            "value": 25000
+          },
+          {
+            "type": "ore",
+            "grade": 4,
+            "rarity": "uncommon",
+            "value": 1500
+          }
+        ],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 7293000000
-          },
-          {
             "type": "tritanium",
             "value": 2681250000
+          },
+          {
+            "type": "parsteel",
+            "value": 7293000000
           }
         ]
       },
@@ -1561,32 +1588,44 @@
       "level": 46,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 46
         },
         {
-          "name": "Dilithium Generator A",
+          "name": "dilithium generator a",
           "level": 46
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 485,
-        "bonus2": 9844
+        "bonus1": 485.0,
+        "bonus2": 9844.0
       },
       "build_costs": {
-        "materials": [],
+        "materials": [
+          {
+            "type": "ore",
+            "grade": 4,
+            "rarity": "uncommon",
+            "value": 2500
+          },
+          {
+            "type": "ore",
+            "grade": 4,
+            "rarity": "common",
+            "value": 50000
+          }
+        ],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 10608000000
-          },
-          {
             "type": "tritanium",
             "value": 3900000000
+          },
+          {
+            "type": "parsteel",
+            "value": 10608000000
           }
         ]
       },
@@ -1595,23 +1634,35 @@
       "level": 47,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 47
         },
         {
-          "name": "Dilithium Generator A",
+          "name": "dilithium generator a",
           "level": 47
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 495,
-        "bonus2": 10013
+        "bonus1": 495.0,
+        "bonus2": 10013.0
       },
       "build_costs": {
-        "materials": [],
+        "materials": [
+          {
+            "type": "ore",
+            "grade": 4,
+            "rarity": "uncommon",
+            "value": 6000
+          },
+          {
+            "type": "ore",
+            "grade": 4,
+            "rarity": "common",
+            "value": 15000
+          }
+        ],
         "others": [],
         "resources": [
           {
@@ -1629,23 +1680,35 @@
       "level": 48,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 48
         },
         {
-          "name": "Dilithium Generator A",
+          "name": "dilithium generator a",
           "level": 48
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 510,
-        "bonus2": 10350
+        "bonus1": 510.0,
+        "bonus2": 10350.0
       },
       "build_costs": {
-        "materials": [],
+        "materials": [
+          {
+            "type": "ore",
+            "grade": 4,
+            "rarity": "uncommon",
+            "value": 13250
+          },
+          {
+            "type": "ore",
+            "grade": 4,
+            "rarity": "common",
+            "value": 20000
+          }
+        ],
         "others": [],
         "resources": [
           {
@@ -1663,20 +1726,19 @@
       "level": 49,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 49
         },
         {
-          "name": "Dilithium Generator A",
+          "name": "dilithium generator a",
           "level": 49
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 620,
-        "bonus2": 12600
+        "bonus1": 620.0,
+        "bonus2": 12600.0
       },
       "build_costs": {
         "materials": [],
@@ -1697,15 +1759,214 @@
       "level": 50,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 50
         },
         {
-          "name": "Dilithium Generator A",
+          "name": "dilithium generator a",
           "level": 50
         }
-      ],
-      "rewards": []
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 635.0,
+        "bonus2": 12891.0
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "ore",
+            "grade": 5,
+            "rarity": "common",
+            "value": 9300
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 249288000000
+          },
+          {
+            "type": "tritanium",
+            "value": 39000000000
+          }
+        ]
+      },
+      "build_time": 59626080,
+      "increased_power": 2000,
+      "level": 51,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 51
+        },
+        {
+          "name": "dilithium generator a",
+          "level": 51
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 650.0,
+        "bonus2": 13195.0
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "ore",
+            "grade": 5,
+            "rarity": "common",
+            "value": 21100
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 66300000000
+          },
+          {
+            "type": "parsteel",
+            "value": 450840000000
+          }
+        ]
+      },
+      "build_time": 63204480,
+      "increased_power": 1500,
+      "level": 52,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 52
+        },
+        {
+          "name": "dilithium generator a",
+          "level": 52
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 655.0,
+        "bonus2": 13297.0
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "ore",
+            "grade": 5,
+            "rarity": "common",
+            "value": 41100
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 757248000000
+          },
+          {
+            "type": "tritanium",
+            "value": 116000000000
+          }
+        ]
+      },
+      "build_time": 66996000,
+      "increased_power": 2000,
+      "level": 53,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 53
+        },
+        {
+          "name": "dilithium generator a",
+          "level": 53
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 670.0,
+        "bonus2": 13601.0
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "ore",
+            "grade": 5,
+            "rarity": "common",
+            "value": 43100
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 174000000000
+          },
+          {
+            "type": "parsteel",
+            "value": 1135872000000
+          }
+        ]
+      },
+      "build_time": 71016480,
+      "increased_power": 2000,
+      "level": 54,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 54
+        },
+        {
+          "name": "dilithium generator a",
+          "level": 54
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 800.0,
+        "bonus2": 16240.0
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "ore",
+            "grade": 5,
+            "rarity": "common",
+            "value": 74800
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 1930656000000
+          },
+          {
+            "type": "tritanium",
+            "value": 273000000000
+          }
+        ]
+      },
+      "build_time": 75277440,
+      "increased_power": 2000,
+      "level": 55,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 55
+        },
+        {
+          "name": "dilithium generator a",
+          "level": 55
+        }
+      ]
     }
   ]
 }

--- a/buildings/dilithium_generator_c.json
+++ b/buildings/dilithium_generator_c.json
@@ -2,11 +2,11 @@
   "description": "Produces Dilithium, a crystalline mineral required when building buildings and advanced ship components. Upgrading Dilithium Generators increases the amount of Dilithium that is produced.",
   "bonuses": {
     "bonus1": {
-      "name": "Dilithium Production",
+      "name": "dilithium production",
       "percentage": false
     },
     "bonus2": {
-      "name": "Dilithium Storage",
+      "name": "dilithium storage",
       "percentage": false
     }
   },
@@ -14,20 +14,20 @@
   "levels": [
     {
       "bonuses": {
-        "bonus1": 2,
-        "bonus2": 1
+        "bonus1": 2.0,
+        "bonus2": 1.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 400
-          },
-          {
             "type": "tritanium",
             "value": 300
+          },
+          {
+            "type": "parsteel",
+            "value": 400
           }
         ]
       },
@@ -36,20 +36,19 @@
       "level": 1,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 20
         },
         {
-          "name": "Dilithium Generator A",
+          "name": "dilithium generator a",
           "level": 1
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 4,
-        "bonus2": 2
+        "bonus1": 4.0,
+        "bonus2": 2.0
       },
       "build_costs": {
         "materials": [],
@@ -70,32 +69,31 @@
       "level": 2,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 2
         },
         {
-          "name": "Dilithium Generator A",
+          "name": "dilithium generator a",
           "level": 2
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 6,
-        "bonus2": 6
+        "bonus1": 6.0,
+        "bonus2": 6.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 600
-          },
-          {
             "type": "tritanium",
             "value": 400
+          },
+          {
+            "type": "parsteel",
+            "value": 600
           }
         ]
       },
@@ -104,20 +102,19 @@
       "level": 3,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 3
         },
         {
-          "name": "Dilithium Generator A",
+          "name": "dilithium generator a",
           "level": 3
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 8,
-        "bonus2": 13
+        "bonus1": 8.0,
+        "bonus2": 13.0
       },
       "build_costs": {
         "materials": [],
@@ -138,20 +135,19 @@
       "level": 4,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 4
         },
         {
-          "name": "Dilithium Generator A",
+          "name": "dilithium generator a",
           "level": 4
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 12,
-        "bonus2": 24
+        "bonus1": 12.0,
+        "bonus2": 24.0
       },
       "build_costs": {
         "materials": [],
@@ -172,32 +168,31 @@
       "level": 5,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 5
         },
         {
-          "name": "Dilithium Generator A",
+          "name": "dilithium generator a",
           "level": 5
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 15,
-        "bonus2": 36
+        "bonus1": 15.0,
+        "bonus2": 36.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 1000
-          },
-          {
             "type": "tritanium",
             "value": 550
+          },
+          {
+            "type": "parsteel",
+            "value": 1000
           }
         ]
       },
@@ -206,32 +201,31 @@
       "level": 6,
       "requirements": [
         {
-          "name": "Dilithium Generator A",
+          "name": "operations",
           "level": 6
         },
         {
-          "name": "Operations",
+          "name": "dilithium generator a",
           "level": 6
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 17,
-        "bonus2": 48
+        "bonus1": 17.0,
+        "bonus2": 48.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 1200
-          },
-          {
             "type": "tritanium",
             "value": 600
+          },
+          {
+            "type": "parsteel",
+            "value": 1200
           }
         ]
       },
@@ -240,20 +234,19 @@
       "level": 7,
       "requirements": [
         {
-          "name": "Dilithium Generator A",
+          "name": "operations",
           "level": 7
         },
         {
-          "name": "Operations",
+          "name": "dilithium generator a",
           "level": 7
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 20,
-        "bonus2": 64
+        "bonus1": 20.0,
+        "bonus2": 64.0
       },
       "build_costs": {
         "materials": [],
@@ -274,20 +267,19 @@
       "level": 8,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 8
         },
         {
-          "name": "Dilithium Generator A",
+          "name": "dilithium generator a",
           "level": 8
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 22,
-        "bonus2": 79
+        "bonus1": 22.0,
+        "bonus2": 79.0
       },
       "build_costs": {
         "materials": [],
@@ -308,32 +300,31 @@
       "level": 9,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 9
         },
         {
-          "name": "Dilithium Generator A",
+          "name": "dilithium generator a",
           "level": 9
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 37,
-        "bonus2": 150
+        "bonus1": 37.0,
+        "bonus2": 150.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 2000
-          },
-          {
             "type": "tritanium",
             "value": 1500
+          },
+          {
+            "type": "parsteel",
+            "value": 2000
           }
         ]
       },
@@ -342,32 +333,31 @@
       "level": 10,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 10
         },
         {
-          "name": "Dilithium Generator A",
+          "name": "dilithium generator a",
           "level": 10
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 40,
-        "bonus2": 170
+        "bonus1": 40.0,
+        "bonus2": 170.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 2720
-          },
-          {
             "type": "tritanium",
             "value": 2000
+          },
+          {
+            "type": "parsteel",
+            "value": 2720
           }
         ]
       },
@@ -376,20 +366,19 @@
       "level": 11,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 11
         },
         {
-          "name": "Dilithium Generator A",
+          "name": "dilithium generator a",
           "level": 11
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 44,
-        "bonus2": 195
+        "bonus1": 44.0,
+        "bonus2": 195.0
       },
       "build_costs": {
         "materials": [],
@@ -410,20 +399,19 @@
       "level": 12,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 12
         },
         {
-          "name": "Dilithium Generator A",
+          "name": "dilithium generator a",
           "level": 12
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 48,
-        "bonus2": 230
+        "bonus1": 48.0,
+        "bonus2": 230.0
       },
       "build_costs": {
         "materials": [],
@@ -444,32 +432,31 @@
       "level": 13,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 13
         },
         {
-          "name": "Dilithium Generator A",
+          "name": "dilithium generator a",
           "level": 13
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 52,
-        "bonus2": 280
+        "bonus1": 52.0,
+        "bonus2": 280.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 7480
-          },
-          {
             "type": "tritanium",
             "value": 5500
+          },
+          {
+            "type": "parsteel",
+            "value": 7480
           }
         ]
       },
@@ -478,20 +465,19 @@
       "level": 14,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 14
         },
         {
-          "name": "Dilithium Generator A",
+          "name": "dilithium generator a",
           "level": 14
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 61,
-        "bonus2": 355
+        "bonus1": 61.0,
+        "bonus2": 355.0
       },
       "build_costs": {
         "materials": [],
@@ -512,20 +498,19 @@
       "level": 15,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 15
         },
         {
-          "name": "Dilithium Generator A",
+          "name": "dilithium generator a",
           "level": 15
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 66,
-        "bonus2": 410
+        "bonus1": 66.0,
+        "bonus2": 410.0
       },
       "build_costs": {
         "materials": [],
@@ -546,20 +531,19 @@
       "level": 16,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 16
         },
         {
-          "name": "Dilithium Generator A",
+          "name": "dilithium generator a",
           "level": 16
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 70,
-        "bonus2": 460
+        "bonus1": 70.0,
+        "bonus2": 460.0
       },
       "build_costs": {
         "materials": [],
@@ -580,20 +564,19 @@
       "level": 17,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 17
         },
         {
-          "name": "Dilithium Generator A",
+          "name": "dilithium generator a",
           "level": 17
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 74,
-        "bonus2": 530
+        "bonus1": 74.0,
+        "bonus2": 530.0
       },
       "build_costs": {
         "materials": [],
@@ -614,32 +597,31 @@
       "level": 18,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 18
         },
         {
-          "name": "Dilithium Generator A",
+          "name": "dilithium generator a",
           "level": 18
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 78,
-        "bonus2": 590
+        "bonus1": 78.0,
+        "bonus2": 590.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 40800
-          },
-          {
             "type": "tritanium",
             "value": 30000
+          },
+          {
+            "type": "parsteel",
+            "value": 40800
           }
         ]
       },
@@ -648,32 +630,31 @@
       "level": 19,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 19
         },
         {
-          "name": "Dilithium Generator A",
+          "name": "dilithium generator a",
           "level": 19
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 98,
-        "bonus2": 780
+        "bonus1": 98.0,
+        "bonus2": 780.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 57800
-          },
-          {
             "type": "tritanium",
             "value": 42500
+          },
+          {
+            "type": "parsteel",
+            "value": 57800
           }
         ]
       },
@@ -682,20 +663,19 @@
       "level": 20,
       "requirements": [
         {
-          "name": "Dilithium Generator A",
+          "name": "operations",
           "level": 20
         },
         {
-          "name": "Operations",
+          "name": "dilithium generator a",
           "level": 20
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 105,
-        "bonus2": 860
+        "bonus1": 105.0,
+        "bonus2": 860.0
       },
       "build_costs": {
         "materials": [],
@@ -716,20 +696,19 @@
       "level": 21,
       "requirements": [
         {
-          "name": "Dilithium Generator A",
+          "name": "operations",
           "level": 21
         },
         {
-          "name": "Operations",
+          "name": "dilithium generator a",
           "level": 21
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 110,
-        "bonus2": 900
+        "bonus1": 110.0,
+        "bonus2": 900.0
       },
       "build_costs": {
         "materials": [],
@@ -750,32 +729,31 @@
       "level": 22,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 22
         },
         {
-          "name": "Dilithium Generator A",
+          "name": "dilithium generator a",
           "level": 22
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 115,
-        "bonus2": 970
+        "bonus1": 115.0,
+        "bonus2": 970.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 249084
-          },
-          {
             "type": "tritanium",
             "value": 183150
+          },
+          {
+            "type": "parsteel",
+            "value": 249084
           }
         ]
       },
@@ -784,32 +762,31 @@
       "level": 23,
       "requirements": [
         {
-          "name": "Dilithium Generator A",
+          "name": "operations",
           "level": 23
         },
         {
-          "name": "Operations",
+          "name": "dilithium generator a",
           "level": 23
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 120,
-        "bonus2": 1010
+        "bonus1": 120.0,
+        "bonus2": 1010.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 392496
-          },
-          {
             "type": "tritanium",
             "value": 288600
+          },
+          {
+            "type": "parsteel",
+            "value": 392496
           }
         ]
       },
@@ -818,32 +795,31 @@
       "level": 24,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 24
         },
         {
-          "name": "Dilithium Generator A",
+          "name": "dilithium generator a",
           "level": 24
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 145,
-        "bonus2": 1250
+        "bonus1": 145.0,
+        "bonus2": 1250.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 636480
-          },
-          {
             "type": "tritanium",
             "value": 468000
+          },
+          {
+            "type": "parsteel",
+            "value": 636480
           }
         ]
       },
@@ -852,20 +828,19 @@
       "level": 25,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 25
         },
         {
-          "name": "Dilithium Generator A",
+          "name": "dilithium generator a",
           "level": 25
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 150,
-        "bonus2": 1290
+        "bonus1": 150.0,
+        "bonus2": 1290.0
       },
       "build_costs": {
         "materials": [],
@@ -886,20 +861,19 @@
       "level": 26,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 26
         },
         {
-          "name": "Dilithium Generator A",
+          "name": "dilithium generator a",
           "level": 26
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 155,
-        "bonus2": 1360
+        "bonus1": 155.0,
+        "bonus2": 1360.0
       },
       "build_costs": {
         "materials": [],
@@ -920,32 +894,31 @@
       "level": 27,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 27
         },
         {
-          "name": "Dilithium Generator A",
+          "name": "dilithium generator a",
           "level": 27
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 160,
-        "bonus2": 1400
+        "bonus1": 160.0,
+        "bonus2": 1400.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 2276640
-          },
-          {
             "type": "tritanium",
             "value": 1674000
+          },
+          {
+            "type": "parsteel",
+            "value": 2276640
           }
         ]
       },
@@ -954,20 +927,19 @@
       "level": 28,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 28
         },
         {
-          "name": "Dilithium Generator A",
+          "name": "dilithium generator a",
           "level": 28
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 165,
-        "bonus2": 1475
+        "bonus1": 165.0,
+        "bonus2": 1475.0
       },
       "build_costs": {
         "materials": [],
@@ -988,32 +960,31 @@
       "level": 29,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 29
         },
         {
-          "name": "Dilithium Generator A",
+          "name": "dilithium generator a",
           "level": 29
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 195,
-        "bonus2": 1750
+        "bonus1": 195.0,
+        "bonus2": 1750.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 5304000
-          },
-          {
             "type": "tritanium",
             "value": 3900000
+          },
+          {
+            "type": "parsteel",
+            "value": 5304000
           }
         ]
       },
@@ -1022,32 +993,31 @@
       "level": 30,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 30
         },
         {
-          "name": "Dilithium Generator A",
+          "name": "dilithium generator a",
           "level": 30
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 205,
-        "bonus2": 1850
+        "bonus1": 205.0,
+        "bonus2": 1850.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 8384400
-          },
-          {
             "type": "tritanium",
             "value": 6165000
+          },
+          {
+            "type": "parsteel",
+            "value": 8384400
           }
         ]
       },
@@ -1056,32 +1026,31 @@
       "level": 31,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 31
         },
         {
-          "name": "Dilithium Generator A",
+          "name": "dilithium generator a",
           "level": 31
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 210,
-        "bonus2": 2052
+        "bonus1": 210.0,
+        "bonus2": 2052.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 12110800
-          },
-          {
             "type": "tritanium",
             "value": 8905000
+          },
+          {
+            "type": "parsteel",
+            "value": 12110800
           }
         ]
       },
@@ -1090,20 +1059,19 @@
       "level": 32,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 32
         },
         {
-          "name": "Dilithium Generator A",
+          "name": "dilithium generator a",
           "level": 32
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 215,
-        "bonus2": 2233
+        "bonus1": 215.0,
+        "bonus2": 2233.0
       },
       "build_costs": {
         "materials": [],
@@ -1124,32 +1092,31 @@
       "level": 33,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 33
         },
         {
-          "name": "Dilithium Generator A",
+          "name": "dilithium generator a",
           "level": 33
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 225,
-        "bonus2": 2349
+        "bonus1": 225.0,
+        "bonus2": 2349.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 29580000
-          },
-          {
             "type": "tritanium",
             "value": 21750000
+          },
+          {
+            "type": "parsteel",
+            "value": 29580000
           }
         ]
       },
@@ -1158,32 +1125,31 @@
       "level": 34,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 34
         },
         {
-          "name": "Dilithium Generator A",
+          "name": "dilithium generator a",
           "level": 34
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 260,
-        "bonus2": 2914
+        "bonus1": 260.0,
+        "bonus2": 2914.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 45777600
-          },
-          {
             "type": "tritanium",
             "value": 33660000
+          },
+          {
+            "type": "parsteel",
+            "value": 45777600
           }
         ]
       },
@@ -1192,20 +1158,19 @@
       "level": 35,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 35
         },
         {
-          "name": "Dilithium Generator A",
+          "name": "dilithium generator a",
           "level": 35
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 265,
-        "bonus2": 3159
+        "bonus1": 265.0,
+        "bonus2": 3159.0
       },
       "build_costs": {
         "materials": [],
@@ -1226,20 +1191,19 @@
       "level": 36,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 36
         },
         {
-          "name": "Dilithium Generator A",
+          "name": "dilithium generator a",
           "level": 36
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 275,
-        "bonus2": 3292
+        "bonus1": 275.0,
+        "bonus2": 3292.0
       },
       "build_costs": {
         "materials": [],
@@ -1260,20 +1224,19 @@
       "level": 37,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 37
         },
         {
-          "name": "Dilithium Generator A",
+          "name": "dilithium generator a",
           "level": 37
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 280,
-        "bonus2": 3586
+        "bonus1": 280.0,
+        "bonus2": 3586.0
       },
       "build_costs": {
         "materials": [],
@@ -1294,20 +1257,19 @@
       "level": 38,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 38
         },
         {
-          "name": "Dilithium Generator A",
+          "name": "dilithium generator a",
           "level": 38
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 290,
-        "bonus2": 3978
+        "bonus1": 290.0,
+        "bonus2": 3978.0
       },
       "build_costs": {
         "materials": [],
@@ -1328,20 +1290,19 @@
       "level": 39,
       "requirements": [
         {
-          "name": "Dilithium Generator A",
+          "name": "operations",
           "level": 39
         },
         {
-          "name": "Operations",
+          "name": "dilithium generator a",
           "level": 39
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 365,
-        "bonus2": 5011
+        "bonus1": 365.0,
+        "bonus2": 5011.0
       },
       "build_costs": {
         "materials": [],
@@ -1362,32 +1323,31 @@
       "level": 40,
       "requirements": [
         {
-          "name": "Dilithium Generator A",
+          "name": "operations",
           "level": 40
         },
         {
-          "name": "Operations",
+          "name": "dilithium generator a",
           "level": 40
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 370,
-        "bonus2": 5486
+        "bonus1": 370.0,
+        "bonus2": 5486.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 1169600000
-          },
-          {
             "type": "tritanium",
             "value": 430000000
+          },
+          {
+            "type": "parsteel",
+            "value": 1169600000
           }
         ]
       },
@@ -1396,20 +1356,19 @@
       "level": 41,
       "requirements": [
         {
-          "name": "Dilithium Generator A",
+          "name": "operations",
           "level": 41
         },
         {
-          "name": "Operations",
+          "name": "dilithium generator a",
           "level": 41
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 380,
-        "bonus2": 6199
+        "bonus1": 380.0,
+        "bonus2": 6199.0
       },
       "build_costs": {
         "materials": [],
@@ -1430,32 +1389,31 @@
       "level": 42,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 42
         },
         {
-          "name": "Dilithium Generator A",
+          "name": "dilithium generator a",
           "level": 42
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 390,
-        "bonus2": 6335
+        "bonus1": 390.0,
+        "bonus2": 6335.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 2488800000
-          },
-          {
             "type": "tritanium",
             "value": 915000000
+          },
+          {
+            "type": "parsteel",
+            "value": 2488800000
           }
         ]
       },
@@ -1464,32 +1422,31 @@
       "level": 43,
       "requirements": [
         {
-          "name": "Dilithium Generator A",
+          "name": "operations",
           "level": 43
         },
         {
-          "name": "Operations",
+          "name": "dilithium generator a",
           "level": 43
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 400,
-        "bonus2": 7200
+        "bonus1": 400.0,
+        "bonus2": 7200.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 3733200000
-          },
-          {
             "type": "tritanium",
             "value": 1372500000
+          },
+          {
+            "type": "parsteel",
+            "value": 3733200000
           }
         ]
       },
@@ -1498,32 +1455,31 @@
       "level": 44,
       "requirements": [
         {
-          "name": "Dilithium Generator A",
+          "name": "operations",
           "level": 44
         },
         {
-          "name": "Operations",
+          "name": "dilithium generator a",
           "level": 44
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 465,
-        "bonus2": 9394
+        "bonus1": 465.0,
+        "bonus2": 9394.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 5304000000
-          },
-          {
             "type": "tritanium",
             "value": 1950000000
+          },
+          {
+            "type": "parsteel",
+            "value": 5304000000
           }
         ]
       },
@@ -1532,32 +1488,31 @@
       "level": 45,
       "requirements": [
         {
-          "name": "Dilithium Generator A",
+          "name": "operations",
           "level": 45
         },
         {
-          "name": "Operations",
+          "name": "dilithium generator a",
           "level": 45
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 475,
-        "bonus2": 9619
+        "bonus1": 475.0,
+        "bonus2": 9619.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 7293000000
-          },
-          {
             "type": "tritanium",
             "value": 2681250000
+          },
+          {
+            "type": "parsteel",
+            "value": 7293000000
           }
         ]
       },
@@ -1566,32 +1521,31 @@
       "level": 46,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 46
         },
         {
-          "name": "Dilithium Generator A",
+          "name": "dilithium generator a",
           "level": 46
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 485,
-        "bonus2": 9844
+        "bonus1": 485.0,
+        "bonus2": 9844.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 10608000000
-          },
-          {
             "type": "tritanium",
             "value": 3900000000
+          },
+          {
+            "type": "parsteel",
+            "value": 10608000000
           }
         ]
       },
@@ -1600,32 +1554,31 @@
       "level": 47,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 47
         },
         {
-          "name": "Dilithium Generator A",
+          "name": "dilithium generator a",
           "level": 47
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 495,
-        "bonus2": 10013
+        "bonus1": 495.0,
+        "bonus2": 10013.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 17136000000
-          },
-          {
             "type": "tritanium",
             "value": 6300000000
+          },
+          {
+            "type": "parsteel",
+            "value": 17136000000
           }
         ]
       },
@@ -1634,32 +1587,31 @@
       "level": 48,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 48
         },
         {
-          "name": "Dilithium Generator A",
+          "name": "dilithium generator a",
           "level": 48
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 510,
-        "bonus2": 10350
+        "bonus1": 510.0,
+        "bonus2": 10350.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 28560000000
-          },
-          {
             "type": "tritanium",
             "value": 10500000000
+          },
+          {
+            "type": "parsteel",
+            "value": 28560000000
           }
         ]
       },
@@ -1668,32 +1620,31 @@
       "level": 49,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 49
         },
         {
-          "name": "Dilithium Generator A",
+          "name": "dilithium generator a",
           "level": 49
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 620,
-        "bonus2": 12600
+        "bonus1": 620.0,
+        "bonus2": 12600.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 49980000000
-          },
-          {
             "type": "tritanium",
             "value": 18375000000
+          },
+          {
+            "type": "parsteel",
+            "value": 49980000000
           }
         ]
       },
@@ -1702,15 +1653,179 @@
       "level": 50,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 50
         },
         {
-          "name": "Dilithium Generator A",
+          "name": "dilithium generator a",
           "level": 50
         }
-      ],
-      "rewards": []
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 635.0,
+        "bonus2": 12891.0
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 249288000000
+          },
+          {
+            "type": "tritanium",
+            "value": 39000000000
+          }
+        ]
+      },
+      "build_time": 59626080,
+      "increased_power": 2000,
+      "level": 51,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 51
+        },
+        {
+          "name": "dilithium generator a",
+          "level": 51
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 650.0,
+        "bonus2": 13195.0
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 66300000000
+          },
+          {
+            "type": "parsteel",
+            "value": 450840000000
+          }
+        ]
+      },
+      "build_time": 63204480,
+      "increased_power": 1500,
+      "level": 52,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 52
+        },
+        {
+          "name": "dilithium generator a",
+          "level": 52
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 655.0,
+        "bonus2": 13297.0
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 116000000000
+          },
+          {
+            "type": "parsteel",
+            "value": 757248000000
+          }
+        ]
+      },
+      "build_time": 66996000,
+      "increased_power": 2000,
+      "level": 53,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 53
+        },
+        {
+          "name": "dilithium generator a",
+          "level": 53
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 670.0,
+        "bonus2": 13601.0
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 1135872000000
+          },
+          {
+            "type": "tritanium",
+            "value": 174000000000
+          }
+        ]
+      },
+      "build_time": 71016480,
+      "increased_power": 2000,
+      "level": 54,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 54
+        },
+        {
+          "name": "dilithium generator a",
+          "level": 54
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 800.0,
+        "bonus2": 16240.0
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 273000000000
+          },
+          {
+            "type": "parsteel",
+            "value": 1930656000000
+          }
+        ]
+      },
+      "build_time": 75277440,
+      "increased_power": 2000,
+      "level": 55,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 55
+        },
+        {
+          "name": "dilithium generator a",
+          "level": 55
+        }
+      ]
     }
   ]
 }

--- a/buildings/dilithium_generator_d.json
+++ b/buildings/dilithium_generator_d.json
@@ -2,11 +2,11 @@
   "description": "Produces Dilithium, a crystalline mineral required when building buildings and advanced ship components. Upgrading Dilithium Generators increases the amount of Dilithium that is produced.",
   "bonuses": {
     "bonus1": {
-      "name": "Dilithium Production",
+      "name": "dilithium production",
       "percentage": false
     },
     "bonus2": {
-      "name": "Dilithium Storage",
+      "name": "dilithium storage",
       "percentage": false
     }
   },
@@ -14,8 +14,8 @@
   "levels": [
     {
       "bonuses": {
-        "bonus1": 2,
-        "bonus2": 1
+        "bonus1": 2.0,
+        "bonus2": 1.0
       },
       "build_costs": {
         "materials": [],
@@ -36,20 +36,19 @@
       "level": 1,
       "requirements": [
         {
-          "name": "Operations",
-          "level": 20
+          "name": "operations",
+          "level": 30
         },
         {
-          "name": "Dilithium Generator B",
+          "name": "dilithium generator b",
           "level": 1
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 4,
-        "bonus2": 2
+        "bonus1": 4.0,
+        "bonus2": 2.0
       },
       "build_costs": {
         "materials": [],
@@ -70,32 +69,31 @@
       "level": 2,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 2
         },
         {
-          "name": "Dilithium Generator B",
+          "name": "dilithium generator b",
           "level": 2
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 6,
-        "bonus2": 6
+        "bonus1": 6.0,
+        "bonus2": 6.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 600
-          },
-          {
             "type": "tritanium",
             "value": 400
+          },
+          {
+            "type": "parsteel",
+            "value": 600
           }
         ]
       },
@@ -104,31 +102,31 @@
       "level": 3,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 3
         },
         {
-          "name": "Dilithium Generator B",
+          "name": "dilithium generator b",
           "level": 3
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 8,
-        "bonus2": 13
+        "bonus1": 8.0,
+        "bonus2": 13.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 700
-          },
-          {
             "type": "tritanium",
             "value": 450
+          },
+          {
+            "type": "parsteel",
+            "value": 700
           }
         ]
       },
@@ -137,32 +135,31 @@
       "level": 4,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 4
         },
         {
-          "name": "Dilithium Generator B",
+          "name": "dilithium generator b",
           "level": 4
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 12,
-        "bonus2": 24
+        "bonus1": 12.0,
+        "bonus2": 24.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 800
-          },
-          {
             "type": "tritanium",
             "value": 500
+          },
+          {
+            "type": "parsteel",
+            "value": 800
           }
         ]
       },
@@ -171,31 +168,31 @@
       "level": 5,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 5
         },
         {
-          "name": "Dilithium Generator B",
+          "name": "dilithium generator b",
           "level": 5
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 15,
-        "bonus2": 36
+        "bonus1": 15.0,
+        "bonus2": 36.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 1000
-          },
-          {
             "type": "tritanium",
             "value": 550
+          },
+          {
+            "type": "parsteel",
+            "value": 1000
           }
         ]
       },
@@ -204,19 +201,19 @@
       "level": 6,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 6
         },
         {
-          "name": "Dilithium Generator B",
+          "name": "dilithium generator b",
           "level": 6
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 17,
-        "bonus2": 48
+        "bonus1": 17.0,
+        "bonus2": 48.0
       },
       "build_costs": {
         "materials": [],
@@ -237,32 +234,31 @@
       "level": 7,
       "requirements": [
         {
-          "name": "Dilithium Generator B",
+          "name": "operations",
           "level": 7
         },
         {
-          "name": "Operations",
+          "name": "dilithium generator b",
           "level": 7
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 20,
-        "bonus2": 64
+        "bonus1": 20.0,
+        "bonus2": 64.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 1400
-          },
-          {
             "type": "tritanium",
             "value": 650
+          },
+          {
+            "type": "parsteel",
+            "value": 1400
           }
         ]
       },
@@ -271,32 +267,31 @@
       "level": 8,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 8
         },
         {
-          "name": "Dilithium Generator B",
+          "name": "dilithium generator b",
           "level": 8
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 22,
-        "bonus2": 79
+        "bonus1": 22.0,
+        "bonus2": 79.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 1600
-          },
-          {
             "type": "tritanium",
             "value": 700
+          },
+          {
+            "type": "parsteel",
+            "value": 1600
           }
         ]
       },
@@ -305,32 +300,31 @@
       "level": 9,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 9
         },
         {
-          "name": "Dilithium Generator B",
+          "name": "dilithium generator b",
           "level": 9
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 37,
-        "bonus2": 150
+        "bonus1": 37.0,
+        "bonus2": 150.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 2000
-          },
-          {
             "type": "tritanium",
             "value": 1500
+          },
+          {
+            "type": "parsteel",
+            "value": 2000
           }
         ]
       },
@@ -339,20 +333,19 @@
       "level": 10,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 10
         },
         {
-          "name": "Dilithium Generator B",
+          "name": "dilithium generator b",
           "level": 10
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 40,
-        "bonus2": 170
+        "bonus1": 40.0,
+        "bonus2": 170.0
       },
       "build_costs": {
         "materials": [],
@@ -373,31 +366,31 @@
       "level": 11,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 11
         },
         {
-          "name": "Dilithium Generator B",
+          "name": "dilithium generator b",
           "level": 11
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 44,
-        "bonus2": 195
+        "bonus1": 44.0,
+        "bonus2": 195.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 3740
-          },
-          {
             "type": "tritanium",
             "value": 2750
+          },
+          {
+            "type": "parsteel",
+            "value": 3740
           }
         ]
       },
@@ -406,31 +399,31 @@
       "level": 12,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 12
         },
         {
-          "name": "Dilithium Generator B",
+          "name": "dilithium generator b",
           "level": 12
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 48,
-        "bonus2": 230
+        "bonus1": 48.0,
+        "bonus2": 230.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 5440
-          },
-          {
             "type": "tritanium",
             "value": 4000
+          },
+          {
+            "type": "parsteel",
+            "value": 5440
           }
         ]
       },
@@ -439,31 +432,31 @@
       "level": 13,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 13
         },
         {
-          "name": "Dilithium Generator B",
+          "name": "dilithium generator b",
           "level": 13
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 52,
-        "bonus2": 280
+        "bonus1": 52.0,
+        "bonus2": 280.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 7480
-          },
-          {
             "type": "tritanium",
             "value": 5500
+          },
+          {
+            "type": "parsteel",
+            "value": 7480
           }
         ]
       },
@@ -472,32 +465,31 @@
       "level": 14,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 14
         },
         {
-          "name": "Dilithium Generator B",
+          "name": "dilithium generator b",
           "level": 14
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 61,
-        "bonus2": 355
+        "bonus1": 61.0,
+        "bonus2": 355.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 10200
-          },
-          {
             "type": "tritanium",
             "value": 7500
+          },
+          {
+            "type": "parsteel",
+            "value": 10200
           }
         ]
       },
@@ -506,19 +498,19 @@
       "level": 15,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 15
         },
         {
-          "name": "Dilithium Generator B",
+          "name": "dilithium generator b",
           "level": 15
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 66,
-        "bonus2": 410
+        "bonus1": 66.0,
+        "bonus2": 410.0
       },
       "build_costs": {
         "materials": [],
@@ -539,19 +531,19 @@
       "level": 16,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 16
         },
         {
-          "name": "Dilithium Generator B",
+          "name": "dilithium generator b",
           "level": 16
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 70,
-        "bonus2": 460
+        "bonus1": 70.0,
+        "bonus2": 460.0
       },
       "build_costs": {
         "materials": [],
@@ -572,32 +564,31 @@
       "level": 17,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 17
         },
         {
-          "name": "Dilithium Generator B",
+          "name": "dilithium generator b",
           "level": 17
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 74,
-        "bonus2": 530
+        "bonus1": 74.0,
+        "bonus2": 530.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 27200
-          },
-          {
             "type": "tritanium",
             "value": 20000
+          },
+          {
+            "type": "parsteel",
+            "value": 27200
           }
         ]
       },
@@ -606,19 +597,19 @@
       "level": 18,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 18
         },
         {
-          "name": "Dilithium Generator B",
+          "name": "dilithium generator b",
           "level": 18
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 78,
-        "bonus2": 590
+        "bonus1": 78.0,
+        "bonus2": 590.0
       },
       "build_costs": {
         "materials": [],
@@ -639,31 +630,31 @@
       "level": 19,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 19
         },
         {
-          "name": "Dilithium Generator B",
+          "name": "dilithium generator b",
           "level": 19
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 98,
-        "bonus2": 780
+        "bonus1": 98.0,
+        "bonus2": 780.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 57800
-          },
-          {
             "type": "tritanium",
             "value": 42500
+          },
+          {
+            "type": "parsteel",
+            "value": 57800
           }
         ]
       },
@@ -672,32 +663,31 @@
       "level": 20,
       "requirements": [
         {
-          "name": "Dilithium Generator B",
+          "name": "operations",
           "level": 20
         },
         {
-          "name": "Operations",
+          "name": "dilithium generator b",
           "level": 20
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 105,
-        "bonus2": 860
+        "bonus1": 105.0,
+        "bonus2": 860.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 97308
-          },
-          {
             "type": "tritanium",
             "value": 71550
+          },
+          {
+            "type": "parsteel",
+            "value": 97308
           }
         ]
       },
@@ -706,31 +696,31 @@
       "level": 21,
       "requirements": [
         {
-          "name": "Dilithium Generator B",
+          "name": "operations",
           "level": 21
         },
         {
-          "name": "Operations",
+          "name": "dilithium generator b",
           "level": 21
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 110,
-        "bonus2": 900
+        "bonus1": 110.0,
+        "bonus2": 900.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 151368
-          },
-          {
             "type": "tritanium",
             "value": 111300
+          },
+          {
+            "type": "parsteel",
+            "value": 151368
           }
         ]
       },
@@ -739,32 +729,31 @@
       "level": 22,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 22
         },
         {
-          "name": "Dilithium Generator B",
+          "name": "dilithium generator b",
           "level": 22
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 115,
-        "bonus2": 970
+        "bonus1": 115.0,
+        "bonus2": 970.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 249084
-          },
-          {
             "type": "tritanium",
             "value": 183150
+          },
+          {
+            "type": "parsteel",
+            "value": 249084
           }
         ]
       },
@@ -773,20 +762,19 @@
       "level": 23,
       "requirements": [
         {
-          "name": "Dilithium Generator B",
+          "name": "operations",
           "level": 23
         },
         {
-          "name": "Operations",
+          "name": "dilithium generator b",
           "level": 23
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 120,
-        "bonus2": 1010
+        "bonus1": 120.0,
+        "bonus2": 1010.0
       },
       "build_costs": {
         "materials": [],
@@ -807,32 +795,31 @@
       "level": 24,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 24
         },
         {
-          "name": "Dilithium Generator B",
+          "name": "dilithium generator b",
           "level": 24
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 145,
-        "bonus2": 1250
+        "bonus1": 145.0,
+        "bonus2": 1250.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 636480
-          },
-          {
             "type": "tritanium",
             "value": 468000
+          },
+          {
+            "type": "parsteel",
+            "value": 636480
           }
         ]
       },
@@ -841,31 +828,31 @@
       "level": 25,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 25
         },
         {
-          "name": "Dilithium Generator B",
+          "name": "dilithium generator b",
           "level": 25
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 150,
-        "bonus2": 1290
+        "bonus1": 150.0,
+        "bonus2": 1290.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 994500
-          },
-          {
             "type": "tritanium",
             "value": 731250
+          },
+          {
+            "type": "parsteel",
+            "value": 994500
           }
         ]
       },
@@ -874,31 +861,31 @@
       "level": 26,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 26
         },
         {
-          "name": "Dilithium Generator B",
+          "name": "dilithium generator b",
           "level": 26
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 155,
-        "bonus2": 1360
+        "bonus1": 155.0,
+        "bonus2": 1360.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 1517760
-          },
-          {
             "type": "tritanium",
             "value": 1116000
+          },
+          {
+            "type": "parsteel",
+            "value": 1517760
           }
         ]
       },
@@ -907,32 +894,31 @@
       "level": 27,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 27
         },
         {
-          "name": "Dilithium Generator B",
+          "name": "dilithium generator b",
           "level": 27
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 160,
-        "bonus2": 1400
+        "bonus1": 160.0,
+        "bonus2": 1400.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 2276640
-          },
-          {
             "type": "tritanium",
             "value": 1674000
+          },
+          {
+            "type": "parsteel",
+            "value": 2276640
           }
         ]
       },
@@ -941,20 +927,19 @@
       "level": 28,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 28
         },
         {
-          "name": "Dilithium Generator B",
+          "name": "dilithium generator b",
           "level": 28
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 165,
-        "bonus2": 1475
+        "bonus1": 165.0,
+        "bonus2": 1475.0
       },
       "build_costs": {
         "materials": [],
@@ -975,32 +960,31 @@
       "level": 29,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 29
         },
         {
-          "name": "Dilithium Generator B",
+          "name": "dilithium generator b",
           "level": 29
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 195,
-        "bonus2": 1750
+        "bonus1": 195.0,
+        "bonus2": 1750.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 5304000
-          },
-          {
             "type": "tritanium",
             "value": 3900000
+          },
+          {
+            "type": "parsteel",
+            "value": 5304000
           }
         ]
       },
@@ -1009,20 +993,19 @@
       "level": 30,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 30
         },
         {
-          "name": "Dilithium Generator B",
+          "name": "dilithium generator b",
           "level": 30
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 205,
-        "bonus2": 1850
+        "bonus1": 205.0,
+        "bonus2": 1850.0
       },
       "build_costs": {
         "materials": [],
@@ -1043,20 +1026,19 @@
       "level": 31,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 31
         },
         {
-          "name": "Dilithium Generator B",
+          "name": "dilithium generator b",
           "level": 31
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 210,
-        "bonus2": 2052
+        "bonus1": 210.0,
+        "bonus2": 2052.0
       },
       "build_costs": {
         "materials": [],
@@ -1077,32 +1059,31 @@
       "level": 32,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 32
         },
         {
-          "name": "Dilithium Generator B",
+          "name": "dilithium generator b",
           "level": 32
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 215,
-        "bonus2": 2233
+        "bonus1": 215.0,
+        "bonus2": 2233.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 18734000
-          },
-          {
             "type": "tritanium",
             "value": 13775000
+          },
+          {
+            "type": "parsteel",
+            "value": 18734000
           }
         ]
       },
@@ -1111,20 +1092,19 @@
       "level": 33,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 33
         },
         {
-          "name": "Dilithium Generator B",
+          "name": "dilithium generator b",
           "level": 33
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 225,
-        "bonus2": 2349
+        "bonus1": 225.0,
+        "bonus2": 2349.0
       },
       "build_costs": {
         "materials": [],
@@ -1145,32 +1125,31 @@
       "level": 34,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 34
         },
         {
-          "name": "Dilithium Generator B",
+          "name": "dilithium generator b",
           "level": 34
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 260,
-        "bonus2": 2914
+        "bonus1": 260.0,
+        "bonus2": 2914.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 45777600
-          },
-          {
             "type": "tritanium",
             "value": 33660000
+          },
+          {
+            "type": "parsteel",
+            "value": 45777600
           }
         ]
       },
@@ -1179,20 +1158,19 @@
       "level": 35,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 35
         },
         {
-          "name": "Dilithium Generator B",
+          "name": "dilithium generator b",
           "level": 35
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 265,
-        "bonus2": 3159
+        "bonus1": 265.0,
+        "bonus2": 3159.0
       },
       "build_costs": {
         "materials": [],
@@ -1213,32 +1191,31 @@
       "level": 36,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 36
         },
         {
-          "name": "Dilithium Generator B",
+          "name": "dilithium generator b",
           "level": 36
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 275,
-        "bonus2": 3292
+        "bonus1": 275.0,
+        "bonus2": 3292.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 99144000
-          },
-          {
             "type": "tritanium",
             "value": 72900000
+          },
+          {
+            "type": "parsteel",
+            "value": 99144000
           }
         ]
       },
@@ -1247,32 +1224,31 @@
       "level": 37,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 37
         },
         {
-          "name": "Dilithium Generator B",
+          "name": "dilithium generator b",
           "level": 37
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 280,
-        "bonus2": 3586
+        "bonus1": 280.0,
+        "bonus2": 3586.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 154224000
-          },
-          {
             "type": "tritanium",
             "value": 113400000
+          },
+          {
+            "type": "parsteel",
+            "value": 154224000
           }
         ]
       },
@@ -1281,20 +1257,19 @@
       "level": 38,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 38
         },
         {
-          "name": "Dilithium Generator B",
+          "name": "dilithium generator b",
           "level": 38
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 290,
-        "bonus2": 3978
+        "bonus1": 290.0,
+        "bonus2": 3978.0
       },
       "build_costs": {
         "materials": [],
@@ -1315,32 +1290,31 @@
       "level": 39,
       "requirements": [
         {
-          "name": "Dilithium Generator B",
+          "name": "operations",
           "level": 39
         },
         {
-          "name": "Operations",
+          "name": "dilithium generator b",
           "level": 39
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 365,
-        "bonus2": 5011
+        "bonus1": 365.0,
+        "bonus2": 5011.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 1146208000
-          },
-          {
             "type": "tritanium",
             "value": 301000000
+          },
+          {
+            "type": "parsteel",
+            "value": 1146208000
           }
         ]
       },
@@ -1349,20 +1323,19 @@
       "level": 40,
       "requirements": [
         {
-          "name": "Dilithium Generator B",
+          "name": "operations",
           "level": 40
         },
         {
-          "name": "Operations",
+          "name": "dilithium generator b",
           "level": 40
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 370,
-        "bonus2": 5486
+        "bonus1": 370.0,
+        "bonus2": 5486.0
       },
       "build_costs": {
         "materials": [],
@@ -1383,20 +1356,19 @@
       "level": 41,
       "requirements": [
         {
-          "name": "Dilithium Generator B",
+          "name": "operations",
           "level": 41
         },
         {
-          "name": "Operations",
+          "name": "dilithium generator b",
           "level": 41
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 380,
-        "bonus2": 6199
+        "bonus1": 380.0,
+        "bonus2": 6199.0
       },
       "build_costs": {
         "materials": [],
@@ -1417,32 +1389,31 @@
       "level": 42,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 42
         },
         {
-          "name": "Dilithium Generator B",
+          "name": "dilithium generator b",
           "level": 42
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 390,
-        "bonus2": 6335
+        "bonus1": 390.0,
+        "bonus2": 6335.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 2488800000
-          },
-          {
             "type": "tritanium",
             "value": 915000000
+          },
+          {
+            "type": "parsteel",
+            "value": 2488800000
           }
         ]
       },
@@ -1451,20 +1422,19 @@
       "level": 43,
       "requirements": [
         {
-          "name": "Dilithium Generator B",
+          "name": "operations",
           "level": 43
         },
         {
-          "name": "Operations",
+          "name": "dilithium generator b",
           "level": 43
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 400,
-        "bonus2": 7200
+        "bonus1": 400.0,
+        "bonus2": 7200.0
       },
       "build_costs": {
         "materials": [],
@@ -1485,20 +1455,19 @@
       "level": 44,
       "requirements": [
         {
-          "name": "Dilithium Generator B",
+          "name": "operations",
           "level": 44
         },
         {
-          "name": "Operations",
+          "name": "dilithium generator b",
           "level": 44
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 465,
-        "bonus2": 9394
+        "bonus1": 465.0,
+        "bonus2": 9394.0
       },
       "build_costs": {
         "materials": [],
@@ -1519,32 +1488,31 @@
       "level": 45,
       "requirements": [
         {
-          "name": "Dilithium Generator B",
+          "name": "operations",
           "level": 45
         },
         {
-          "name": "Operations",
+          "name": "dilithium generator b",
           "level": 45
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 475,
-        "bonus2": 9619
+        "bonus1": 475.0,
+        "bonus2": 9619.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 7293000000
-          },
-          {
             "type": "tritanium",
             "value": 2681250000
+          },
+          {
+            "type": "parsteel",
+            "value": 7293000000
           }
         ]
       },
@@ -1553,32 +1521,31 @@
       "level": 46,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 46
         },
         {
-          "name": "Dilithium Generator B",
+          "name": "dilithium generator b",
           "level": 46
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 485,
-        "bonus2": 9844
+        "bonus1": 485.0,
+        "bonus2": 9844.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 10608000000
-          },
-          {
             "type": "tritanium",
             "value": 3900000000
+          },
+          {
+            "type": "parsteel",
+            "value": 10608000000
           }
         ]
       },
@@ -1587,32 +1554,31 @@
       "level": 47,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 47
         },
         {
-          "name": "Dilithium Generator B",
+          "name": "dilithium generator b",
           "level": 47
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 495,
-        "bonus2": 10013
+        "bonus1": 495.0,
+        "bonus2": 10013.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 17136000000
-          },
-          {
             "type": "tritanium",
             "value": 6300000000
+          },
+          {
+            "type": "parsteel",
+            "value": 17136000000
           }
         ]
       },
@@ -1621,20 +1587,19 @@
       "level": 48,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 48
         },
         {
-          "name": "Dilithium Generator B",
+          "name": "dilithium generator b",
           "level": 48
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 510,
-        "bonus2": 10350
+        "bonus1": 510.0,
+        "bonus2": 10350.0
       },
       "build_costs": {
         "materials": [],
@@ -1655,32 +1620,31 @@
       "level": 49,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 49
         },
         {
-          "name": "Dilithium Generator B",
+          "name": "dilithium generator b",
           "level": 49
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 620,
-        "bonus2": 12600
+        "bonus1": 620.0,
+        "bonus2": 12600.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 49980000000
-          },
-          {
             "type": "tritanium",
             "value": 18375000000
+          },
+          {
+            "type": "parsteel",
+            "value": 49980000000
           }
         ]
       },
@@ -1689,15 +1653,179 @@
       "level": 50,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 50
         },
         {
-          "name": "Dilithium Generator B",
+          "name": "dilithium generator b",
           "level": 50
         }
-      ],
-      "rewards": []
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 635.0,
+        "bonus2": 12891.0
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 39000000000
+          },
+          {
+            "type": "parsteel",
+            "value": 249288000000
+          }
+        ]
+      },
+      "build_time": 59626080,
+      "increased_power": 2000,
+      "level": 51,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 51
+        },
+        {
+          "name": "dilithium generator b",
+          "level": 51
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 650.0,
+        "bonus2": 13195.0
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 450840000000
+          },
+          {
+            "type": "tritanium",
+            "value": 66300000000
+          }
+        ]
+      },
+      "build_time": 63204480,
+      "increased_power": 1500,
+      "level": 52,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 52
+        },
+        {
+          "name": "dilithium generator b",
+          "level": 52
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 655.0,
+        "bonus2": 13297.0
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 116000000000
+          },
+          {
+            "type": "parsteel",
+            "value": 757248000000
+          }
+        ]
+      },
+      "build_time": 66996000,
+      "increased_power": 2000,
+      "level": 53,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 53
+        },
+        {
+          "name": "dilithium generator b",
+          "level": 53
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 670.0,
+        "bonus2": 13601.0
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 174000000000
+          },
+          {
+            "type": "parsteel",
+            "value": 1135872000000
+          }
+        ]
+      },
+      "build_time": 71016480,
+      "increased_power": 2000,
+      "level": 54,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 54
+        },
+        {
+          "name": "dilithium generator b",
+          "level": 54
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 800.0,
+        "bonus2": 16240.0
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 273000000000
+          },
+          {
+            "type": "parsteel",
+            "value": 1930656000000
+          }
+        ]
+      },
+      "build_time": 75277440,
+      "increased_power": 2000,
+      "level": 55,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 55
+        },
+        {
+          "name": "dilithium generator b",
+          "level": 55
+        }
+      ]
     }
   ]
 }

--- a/buildings/dilithium_generator_e.json
+++ b/buildings/dilithium_generator_e.json
@@ -2,11 +2,11 @@
   "description": "Produces Dilithium, a crystalline mineral required when building buildings and advanced ship components. Upgrading Dilithium Generators increases the amount of Dilithium that is produced.",
   "bonuses": {
     "bonus1": {
-      "name": "Dilithium Production",
+      "name": "dilithium production",
       "percentage": false
     },
     "bonus2": {
-      "name": "Dilithium Storage",
+      "name": "dilithium storage",
       "percentage": false
     }
   },
@@ -14,20 +14,20 @@
   "levels": [
     {
       "bonuses": {
-        "bonus1": 2,
-        "bonus2": 1
+        "bonus1": 2.0,
+        "bonus2": 1.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 400
-          },
-          {
             "type": "tritanium",
             "value": 300
+          },
+          {
+            "type": "parsteel",
+            "value": 400
           }
         ]
       },
@@ -36,20 +36,19 @@
       "level": 1,
       "requirements": [
         {
-          "name": "Operations",
-          "level": 20
+          "name": "operations",
+          "level": 40
         },
         {
-          "name": "Dilithium Generator C",
+          "name": "dilithium generator c",
           "level": 1
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 4,
-        "bonus2": 2
+        "bonus1": 4.0,
+        "bonus2": 2.0
       },
       "build_costs": {
         "materials": [],
@@ -70,20 +69,19 @@
       "level": 2,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 2
         },
         {
-          "name": "Dilithium Generator C",
+          "name": "dilithium generator c",
           "level": 2
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 6,
-        "bonus2": 6
+        "bonus1": 6.0,
+        "bonus2": 6.0
       },
       "build_costs": {
         "materials": [],
@@ -104,20 +102,19 @@
       "level": 3,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 3
         },
         {
-          "name": "Dilithium Generator C",
+          "name": "dilithium generator c",
           "level": 3
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 8,
-        "bonus2": 13
+        "bonus1": 8.0,
+        "bonus2": 13.0
       },
       "build_costs": {
         "materials": [],
@@ -138,20 +135,19 @@
       "level": 4,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 4
         },
         {
-          "name": "Dilithium Generator C",
+          "name": "dilithium generator c",
           "level": 4
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 12,
-        "bonus2": 24
+        "bonus1": 12.0,
+        "bonus2": 24.0
       },
       "build_costs": {
         "materials": [],
@@ -172,32 +168,31 @@
       "level": 5,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 5
         },
         {
-          "name": "Dilithium Generator C",
+          "name": "dilithium generator c",
           "level": 5
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 15,
-        "bonus2": 36
+        "bonus1": 15.0,
+        "bonus2": 36.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 1000
-          },
-          {
             "type": "tritanium",
             "value": 550
+          },
+          {
+            "type": "parsteel",
+            "value": 1000
           }
         ]
       },
@@ -206,32 +201,31 @@
       "level": 6,
       "requirements": [
         {
-          "name": "Dilithium Generator C",
+          "name": "operations",
           "level": 6
         },
         {
-          "name": "Operations",
+          "name": "dilithium generator c",
           "level": 6
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 17,
-        "bonus2": 48
+        "bonus1": 17.0,
+        "bonus2": 48.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 1200
-          },
-          {
             "type": "tritanium",
             "value": 600
+          },
+          {
+            "type": "parsteel",
+            "value": 1200
           }
         ]
       },
@@ -240,32 +234,31 @@
       "level": 7,
       "requirements": [
         {
-          "name": "Dilithium Generator C",
+          "name": "operations",
           "level": 7
         },
         {
-          "name": "Operations",
+          "name": "dilithium generator c",
           "level": 7
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 20,
-        "bonus2": 64
+        "bonus1": 20.0,
+        "bonus2": 64.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 1400
-          },
-          {
             "type": "tritanium",
             "value": 650
+          },
+          {
+            "type": "parsteel",
+            "value": 1400
           }
         ]
       },
@@ -274,20 +267,19 @@
       "level": 8,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 8
         },
         {
-          "name": "Dilithium Generator C",
+          "name": "dilithium generator c",
           "level": 8
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 22,
-        "bonus2": 79
+        "bonus1": 22.0,
+        "bonus2": 79.0
       },
       "build_costs": {
         "materials": [],
@@ -308,32 +300,31 @@
       "level": 9,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 9
         },
         {
-          "name": "Dilithium Generator C",
+          "name": "dilithium generator c",
           "level": 9
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 37,
-        "bonus2": 150
+        "bonus1": 37.0,
+        "bonus2": 150.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 2000
-          },
-          {
             "type": "tritanium",
             "value": 1500
+          },
+          {
+            "type": "parsteel",
+            "value": 2000
           }
         ]
       },
@@ -342,32 +333,31 @@
       "level": 10,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 10
         },
         {
-          "name": "Dilithium Generator C",
+          "name": "dilithium generator c",
           "level": 10
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 40,
-        "bonus2": 170
+        "bonus1": 40.0,
+        "bonus2": 170.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 2720
-          },
-          {
             "type": "tritanium",
             "value": 2000
+          },
+          {
+            "type": "parsteel",
+            "value": 2720
           }
         ]
       },
@@ -376,32 +366,31 @@
       "level": 11,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 11
         },
         {
-          "name": "Dilithium Generator C",
+          "name": "dilithium generator c",
           "level": 11
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 44,
-        "bonus2": 195
+        "bonus1": 44.0,
+        "bonus2": 195.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 3740
-          },
-          {
             "type": "tritanium",
             "value": 2750
+          },
+          {
+            "type": "parsteel",
+            "value": 3740
           }
         ]
       },
@@ -410,32 +399,31 @@
       "level": 12,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 12
         },
         {
-          "name": "Dilithium Generator C",
+          "name": "dilithium generator c",
           "level": 12
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 48,
-        "bonus2": 230
+        "bonus1": 48.0,
+        "bonus2": 230.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 5440
-          },
-          {
             "type": "tritanium",
             "value": 4000
+          },
+          {
+            "type": "parsteel",
+            "value": 5440
           }
         ]
       },
@@ -444,20 +432,19 @@
       "level": 13,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 13
         },
         {
-          "name": "Dilithium Generator C",
+          "name": "dilithium generator c",
           "level": 13
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 52,
-        "bonus2": 280
+        "bonus1": 52.0,
+        "bonus2": 280.0
       },
       "build_costs": {
         "materials": [],
@@ -478,20 +465,19 @@
       "level": 14,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 14
         },
         {
-          "name": "Dilithium Generator C",
+          "name": "dilithium generator c",
           "level": 14
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 61,
-        "bonus2": 355
+        "bonus1": 61.0,
+        "bonus2": 355.0
       },
       "build_costs": {
         "materials": [],
@@ -512,32 +498,31 @@
       "level": 15,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 15
         },
         {
-          "name": "Dilithium Generator C",
+          "name": "dilithium generator c",
           "level": 15
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 66,
-        "bonus2": 410
+        "bonus1": 66.0,
+        "bonus2": 410.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 13600
-          },
-          {
             "type": "tritanium",
             "value": 10000
+          },
+          {
+            "type": "parsteel",
+            "value": 13600
           }
         ]
       },
@@ -546,32 +531,31 @@
       "level": 16,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 16
         },
         {
-          "name": "Dilithium Generator C",
+          "name": "dilithium generator c",
           "level": 16
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 70,
-        "bonus2": 460
+        "bonus1": 70.0,
+        "bonus2": 460.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 19040
-          },
-          {
             "type": "tritanium",
             "value": 14000
+          },
+          {
+            "type": "parsteel",
+            "value": 19040
           }
         ]
       },
@@ -580,20 +564,19 @@
       "level": 17,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 17
         },
         {
-          "name": "Dilithium Generator C",
+          "name": "dilithium generator c",
           "level": 17
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 74,
-        "bonus2": 530
+        "bonus1": 74.0,
+        "bonus2": 530.0
       },
       "build_costs": {
         "materials": [],
@@ -614,32 +597,31 @@
       "level": 18,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 18
         },
         {
-          "name": "Dilithium Generator C",
+          "name": "dilithium generator c",
           "level": 18
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 78,
-        "bonus2": 590
+        "bonus1": 78.0,
+        "bonus2": 590.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 40800
-          },
-          {
             "type": "tritanium",
             "value": 30000
+          },
+          {
+            "type": "parsteel",
+            "value": 40800
           }
         ]
       },
@@ -648,20 +630,19 @@
       "level": 19,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 19
         },
         {
-          "name": "Dilithium Generator C",
+          "name": "dilithium generator c",
           "level": 19
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 98,
-        "bonus2": 780
+        "bonus1": 98.0,
+        "bonus2": 780.0
       },
       "build_costs": {
         "materials": [],
@@ -682,32 +663,31 @@
       "level": 20,
       "requirements": [
         {
-          "name": "Dilithium Generator C",
+          "name": "operations",
           "level": 20
         },
         {
-          "name": "Operations",
+          "name": "dilithium generator c",
           "level": 20
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 105,
-        "bonus2": 860
+        "bonus1": 105.0,
+        "bonus2": 860.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 97308
-          },
-          {
             "type": "tritanium",
             "value": 71550
+          },
+          {
+            "type": "parsteel",
+            "value": 97308
           }
         ]
       },
@@ -716,32 +696,31 @@
       "level": 21,
       "requirements": [
         {
-          "name": "Dilithium Generator C",
+          "name": "operations",
           "level": 21
         },
         {
-          "name": "Operations",
+          "name": "dilithium generator c",
           "level": 21
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 110,
-        "bonus2": 900
+        "bonus1": 110.0,
+        "bonus2": 900.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 151368
-          },
-          {
             "type": "tritanium",
             "value": 111300
+          },
+          {
+            "type": "parsteel",
+            "value": 151368
           }
         ]
       },
@@ -750,20 +729,19 @@
       "level": 22,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 22
         },
         {
-          "name": "Dilithium Generator C",
+          "name": "dilithium generator c",
           "level": 22
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 115,
-        "bonus2": 970
+        "bonus1": 115.0,
+        "bonus2": 970.0
       },
       "build_costs": {
         "materials": [],
@@ -784,20 +762,19 @@
       "level": 23,
       "requirements": [
         {
-          "name": "Dilithium Generator C",
+          "name": "operations",
           "level": 23
         },
         {
-          "name": "Operations",
+          "name": "dilithium generator c",
           "level": 23
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 120,
-        "bonus2": 1010
+        "bonus1": 120.0,
+        "bonus2": 1010.0
       },
       "build_costs": {
         "materials": [],
@@ -818,32 +795,31 @@
       "level": 24,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 24
         },
         {
-          "name": "Dilithium Generator C",
+          "name": "dilithium generator c",
           "level": 24
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 145,
-        "bonus2": 1250
+        "bonus1": 145.0,
+        "bonus2": 1250.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 636480
-          },
-          {
             "type": "tritanium",
             "value": 468000
+          },
+          {
+            "type": "parsteel",
+            "value": 636480
           }
         ]
       },
@@ -852,32 +828,31 @@
       "level": 25,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 25
         },
         {
-          "name": "Dilithium Generator C",
+          "name": "dilithium generator c",
           "level": 25
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 150,
-        "bonus2": 1290
+        "bonus1": 150.0,
+        "bonus2": 1290.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 994500
-          },
-          {
             "type": "tritanium",
             "value": 731250
+          },
+          {
+            "type": "parsteel",
+            "value": 994500
           }
         ]
       },
@@ -886,32 +861,31 @@
       "level": 26,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 26
         },
         {
-          "name": "Dilithium Generator C",
+          "name": "dilithium generator c",
           "level": 26
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 155,
-        "bonus2": 1360
+        "bonus1": 155.0,
+        "bonus2": 1360.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 1517760
-          },
-          {
             "type": "tritanium",
             "value": 1116000
+          },
+          {
+            "type": "parsteel",
+            "value": 1517760
           }
         ]
       },
@@ -920,32 +894,31 @@
       "level": 27,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 27
         },
         {
-          "name": "Dilithium Generator C",
+          "name": "dilithium generator c",
           "level": 27
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 160,
-        "bonus2": 1400
+        "bonus1": 160.0,
+        "bonus2": 1400.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 2276640
-          },
-          {
             "type": "tritanium",
             "value": 1674000
+          },
+          {
+            "type": "parsteel",
+            "value": 2276640
           }
         ]
       },
@@ -954,20 +927,19 @@
       "level": 28,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 28
         },
         {
-          "name": "Dilithium Generator C",
+          "name": "dilithium generator c",
           "level": 28
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 165,
-        "bonus2": 1475
+        "bonus1": 165.0,
+        "bonus2": 1475.0
       },
       "build_costs": {
         "materials": [],
@@ -988,32 +960,31 @@
       "level": 29,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 29
         },
         {
-          "name": "Dilithium Generator C",
+          "name": "dilithium generator c",
           "level": 29
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 195,
-        "bonus2": 1750
+        "bonus1": 195.0,
+        "bonus2": 1750.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 5304000
-          },
-          {
             "type": "tritanium",
             "value": 3900000
+          },
+          {
+            "type": "parsteel",
+            "value": 5304000
           }
         ]
       },
@@ -1022,20 +993,19 @@
       "level": 30,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 30
         },
         {
-          "name": "Dilithium Generator C",
+          "name": "dilithium generator c",
           "level": 30
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 205,
-        "bonus2": 1850
+        "bonus1": 205.0,
+        "bonus2": 1850.0
       },
       "build_costs": {
         "materials": [],
@@ -1056,20 +1026,19 @@
       "level": 31,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 31
         },
         {
-          "name": "Dilithium Generator C",
+          "name": "dilithium generator c",
           "level": 31
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 210,
-        "bonus2": 2052
+        "bonus1": 210.0,
+        "bonus2": 2052.0
       },
       "build_costs": {
         "materials": [],
@@ -1090,20 +1059,19 @@
       "level": 32,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 32
         },
         {
-          "name": "Dilithium Generator C",
+          "name": "dilithium generator c",
           "level": 32
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 215,
-        "bonus2": 2233
+        "bonus1": 215.0,
+        "bonus2": 2233.0
       },
       "build_costs": {
         "materials": [],
@@ -1124,32 +1092,31 @@
       "level": 33,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 33
         },
         {
-          "name": "Dilithium Generator C",
+          "name": "dilithium generator c",
           "level": 33
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 225,
-        "bonus2": 2349
+        "bonus1": 225.0,
+        "bonus2": 2349.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 29580000
-          },
-          {
             "type": "tritanium",
             "value": 21750000
+          },
+          {
+            "type": "parsteel",
+            "value": 29580000
           }
         ]
       },
@@ -1158,20 +1125,19 @@
       "level": 34,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 34
         },
         {
-          "name": "Dilithium Generator C",
+          "name": "dilithium generator c",
           "level": 34
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 260,
-        "bonus2": 2914
+        "bonus1": 260.0,
+        "bonus2": 2914.0
       },
       "build_costs": {
         "materials": [],
@@ -1192,32 +1158,31 @@
       "level": 35,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 35
         },
         {
-          "name": "Dilithium Generator C",
+          "name": "dilithium generator c",
           "level": 35
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 265,
-        "bonus2": 3159
+        "bonus1": 265.0,
+        "bonus2": 3159.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 64504800
-          },
-          {
             "type": "tritanium",
             "value": 47430000
+          },
+          {
+            "type": "parsteel",
+            "value": 64504800
           }
         ]
       },
@@ -1226,32 +1191,31 @@
       "level": 36,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 36
         },
         {
-          "name": "Dilithium Generator C",
+          "name": "dilithium generator c",
           "level": 36
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 275,
-        "bonus2": 3292
+        "bonus1": 275.0,
+        "bonus2": 3292.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 99144000
-          },
-          {
             "type": "tritanium",
             "value": 72900000
+          },
+          {
+            "type": "parsteel",
+            "value": 99144000
           }
         ]
       },
@@ -1260,32 +1224,31 @@
       "level": 37,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 37
         },
         {
-          "name": "Dilithium Generator C",
+          "name": "dilithium generator c",
           "level": 37
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 280,
-        "bonus2": 3586
+        "bonus1": 280.0,
+        "bonus2": 3586.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 154224000
-          },
-          {
             "type": "tritanium",
             "value": 113400000
+          },
+          {
+            "type": "parsteel",
+            "value": 154224000
           }
         ]
       },
@@ -1294,32 +1257,31 @@
       "level": 38,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 38
         },
         {
-          "name": "Dilithium Generator C",
+          "name": "dilithium generator c",
           "level": 38
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 290,
-        "bonus2": 3978
+        "bonus1": 290.0,
+        "bonus2": 3978.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 263160000
-          },
-          {
             "type": "tritanium",
             "value": 193500000
+          },
+          {
+            "type": "parsteel",
+            "value": 263160000
           }
         ]
       },
@@ -1328,20 +1290,19 @@
       "level": 39,
       "requirements": [
         {
-          "name": "Dilithium Generator C",
+          "name": "operations",
           "level": 39
         },
         {
-          "name": "Operations",
+          "name": "dilithium generator c",
           "level": 39
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 365,
-        "bonus2": 5011
+        "bonus1": 365.0,
+        "bonus2": 5011.0
       },
       "build_costs": {
         "materials": [],
@@ -1362,32 +1323,31 @@
       "level": 40,
       "requirements": [
         {
-          "name": "Dilithium Generator C",
+          "name": "operations",
           "level": 40
         },
         {
-          "name": "Operations",
+          "name": "dilithium generator c",
           "level": 40
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 370,
-        "bonus2": 5486
+        "bonus1": 370.0,
+        "bonus2": 5486.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 1169600000
-          },
-          {
             "type": "tritanium",
             "value": 430000000
+          },
+          {
+            "type": "parsteel",
+            "value": 1169600000
           }
         ]
       },
@@ -1396,20 +1356,19 @@
       "level": 41,
       "requirements": [
         {
-          "name": "Dilithium Generator C",
+          "name": "operations",
           "level": 41
         },
         {
-          "name": "Operations",
+          "name": "dilithium generator c",
           "level": 41
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 380,
-        "bonus2": 6199
+        "bonus1": 380.0,
+        "bonus2": 6199.0
       },
       "build_costs": {
         "materials": [],
@@ -1430,20 +1389,19 @@
       "level": 42,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 42
         },
         {
-          "name": "Dilithium Generator C",
+          "name": "dilithium generator c",
           "level": 42
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 390,
-        "bonus2": 6335
+        "bonus1": 390.0,
+        "bonus2": 6335.0
       },
       "build_costs": {
         "materials": [],
@@ -1464,20 +1422,19 @@
       "level": 43,
       "requirements": [
         {
-          "name": "Dilithium Generator C",
+          "name": "operations",
           "level": 43
         },
         {
-          "name": "Operations",
+          "name": "dilithium generator c",
           "level": 43
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 400,
-        "bonus2": 7200
+        "bonus1": 400.0,
+        "bonus2": 7200.0
       },
       "build_costs": {
         "materials": [],
@@ -1498,20 +1455,19 @@
       "level": 44,
       "requirements": [
         {
-          "name": "Dilithium Generator C",
+          "name": "operations",
           "level": 44
         },
         {
-          "name": "Operations",
+          "name": "dilithium generator c",
           "level": 44
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 465,
-        "bonus2": 9394
+        "bonus1": 465.0,
+        "bonus2": 9394.0
       },
       "build_costs": {
         "materials": [],
@@ -1532,20 +1488,19 @@
       "level": 45,
       "requirements": [
         {
-          "name": "Dilithium Generator C",
+          "name": "operations",
           "level": 45
         },
         {
-          "name": "Operations",
+          "name": "dilithium generator c",
           "level": 45
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 475,
-        "bonus2": 9619
+        "bonus1": 475.0,
+        "bonus2": 9619.0
       },
       "build_costs": {
         "materials": [],
@@ -1566,20 +1521,19 @@
       "level": 46,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 46
         },
         {
-          "name": "Dilithium Generator C",
+          "name": "dilithium generator c",
           "level": 46
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 485,
-        "bonus2": 9844
+        "bonus1": 485.0,
+        "bonus2": 9844.0
       },
       "build_costs": {
         "materials": [],
@@ -1600,20 +1554,19 @@
       "level": 47,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 47
         },
         {
-          "name": "Dilithium Generator C",
+          "name": "dilithium generator c",
           "level": 47
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 495,
-        "bonus2": 10013
+        "bonus1": 495.0,
+        "bonus2": 10013.0
       },
       "build_costs": {
         "materials": [],
@@ -1634,32 +1587,31 @@
       "level": 48,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 48
         },
         {
-          "name": "Dilithium Generator C",
+          "name": "dilithium generator c",
           "level": 48
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 510,
-        "bonus2": 10350
+        "bonus1": 510.0,
+        "bonus2": 10350.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 28560000000
-          },
-          {
             "type": "tritanium",
             "value": 10500000000
+          },
+          {
+            "type": "parsteel",
+            "value": 28560000000
           }
         ]
       },
@@ -1668,32 +1620,31 @@
       "level": 49,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 49
         },
         {
-          "name": "Dilithium Generator C",
+          "name": "dilithium generator c",
           "level": 49
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 620,
-        "bonus2": 12600
+        "bonus1": 620.0,
+        "bonus2": 12600.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 49980000000
-          },
-          {
             "type": "tritanium",
             "value": 18375000000
+          },
+          {
+            "type": "parsteel",
+            "value": 49980000000
           }
         ]
       },
@@ -1702,15 +1653,179 @@
       "level": 50,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 50
         },
         {
-          "name": "Dilithium Generator C",
+          "name": "dilithium generator c",
           "level": 50
         }
-      ],
-      "rewards": []
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 635.0,
+        "bonus2": 12891.0
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 249288000000
+          },
+          {
+            "type": "tritanium",
+            "value": 39000000000
+          }
+        ]
+      },
+      "build_time": 59626080,
+      "increased_power": 2000,
+      "level": 51,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 51
+        },
+        {
+          "name": "dilithium generator c",
+          "level": 51
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 650.0,
+        "bonus2": 13195.0
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 66300000000
+          },
+          {
+            "type": "parsteel",
+            "value": 450840000000
+          }
+        ]
+      },
+      "build_time": 63204480,
+      "increased_power": 1500,
+      "level": 52,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 52
+        },
+        {
+          "name": "dilithium generator c",
+          "level": 52
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 655.0,
+        "bonus2": 13297.0
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 757248000000
+          },
+          {
+            "type": "tritanium",
+            "value": 116000000000
+          }
+        ]
+      },
+      "build_time": 66996000,
+      "increased_power": 2000,
+      "level": 53,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 53
+        },
+        {
+          "name": "dilithium generator c",
+          "level": 53
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 670.0,
+        "bonus2": 13601.0
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 1135872000000
+          },
+          {
+            "type": "tritanium",
+            "value": 174000000000
+          }
+        ]
+      },
+      "build_time": 71016480,
+      "increased_power": 2000,
+      "level": 54,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 54
+        },
+        {
+          "name": "dilithium generator c",
+          "level": 54
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 800.0,
+        "bonus2": 16240.0
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 273000000000
+          },
+          {
+            "type": "parsteel",
+            "value": 1930656000000
+          }
+        ]
+      },
+      "build_time": 75277440,
+      "increased_power": 2000,
+      "level": 55,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 55
+        },
+        {
+          "name": "dilithium generator c",
+          "level": 55
+        }
+      ]
     }
   ]
 }

--- a/buildings/dilithium_generator_f.json
+++ b/buildings/dilithium_generator_f.json
@@ -2,11 +2,11 @@
   "description": "Produces Dilithium, a crystalline mineral required when building buildings and advanced ship components. Upgrading Dilithium Generators increases the amount of Dilithium that is produced.",
   "bonuses": {
     "bonus1": {
-      "name": "Dilithium Production",
+      "name": "dilithium production",
       "percentage": false
     },
     "bonus2": {
-      "name": "Dilithium Storage",
+      "name": "dilithium storage",
       "percentage": false
     }
   },
@@ -14,8 +14,8 @@
   "levels": [
     {
       "bonuses": {
-        "bonus1": 2,
-        "bonus2": 1
+        "bonus1": 2.0,
+        "bonus2": 1.0
       },
       "build_costs": {
         "materials": [],
@@ -36,20 +36,19 @@
       "level": 1,
       "requirements": [
         {
-          "name": "Operations",
-          "level": 20
+          "name": "operations",
+          "level": 50
         },
         {
-          "name": "Dilithium Generator D",
+          "name": "dilithium generator d",
           "level": 1
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 4,
-        "bonus2": 2
+        "bonus1": 4.0,
+        "bonus2": 2.0
       },
       "build_costs": {
         "materials": [],
@@ -70,32 +69,31 @@
       "level": 2,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 2
         },
         {
-          "name": "Dilithium Generator D",
+          "name": "dilithium generator d",
           "level": 2
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 6,
-        "bonus2": 6
+        "bonus1": 6.0,
+        "bonus2": 6.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 600
-          },
-          {
             "type": "tritanium",
             "value": 400
+          },
+          {
+            "type": "parsteel",
+            "value": 600
           }
         ]
       },
@@ -104,32 +102,31 @@
       "level": 3,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 3
         },
         {
-          "name": "Dilithium Generator D",
+          "name": "dilithium generator d",
           "level": 3
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 8,
-        "bonus2": 13
+        "bonus1": 8.0,
+        "bonus2": 13.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 700
-          },
-          {
             "type": "tritanium",
             "value": 450
+          },
+          {
+            "type": "parsteel",
+            "value": 700
           }
         ]
       },
@@ -138,32 +135,31 @@
       "level": 4,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 4
         },
         {
-          "name": "Dilithium Generator D",
+          "name": "dilithium generator d",
           "level": 4
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 12,
-        "bonus2": 24
+        "bonus1": 12.0,
+        "bonus2": 24.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 800
-          },
-          {
             "type": "tritanium",
             "value": 500
+          },
+          {
+            "type": "parsteel",
+            "value": 800
           }
         ]
       },
@@ -172,20 +168,19 @@
       "level": 5,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 5
         },
         {
-          "name": "Dilithium Generator D",
+          "name": "dilithium generator d",
           "level": 5
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 15,
-        "bonus2": 36
+        "bonus1": 15.0,
+        "bonus2": 36.0
       },
       "build_costs": {
         "materials": [],
@@ -206,20 +201,19 @@
       "level": 6,
       "requirements": [
         {
-          "name": "Dilithium Generator D",
+          "name": "operations",
           "level": 6
         },
         {
-          "name": "Operations",
+          "name": "dilithium generator d",
           "level": 6
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 17,
-        "bonus2": 48
+        "bonus1": 17.0,
+        "bonus2": 48.0
       },
       "build_costs": {
         "materials": [],
@@ -240,32 +234,31 @@
       "level": 7,
       "requirements": [
         {
-          "name": "Dilithium Generator D",
+          "name": "operations",
           "level": 7
         },
         {
-          "name": "Operations",
+          "name": "dilithium generator d",
           "level": 7
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 20,
-        "bonus2": 64
+        "bonus1": 20.0,
+        "bonus2": 64.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 1400
-          },
-          {
             "type": "tritanium",
             "value": 650
+          },
+          {
+            "type": "parsteel",
+            "value": 1400
           }
         ]
       },
@@ -274,32 +267,31 @@
       "level": 8,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 8
         },
         {
-          "name": "Dilithium Generator D",
+          "name": "dilithium generator d",
           "level": 8
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 22,
-        "bonus2": 79
+        "bonus1": 22.0,
+        "bonus2": 79.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 1600
-          },
-          {
             "type": "tritanium",
             "value": 700
+          },
+          {
+            "type": "parsteel",
+            "value": 1600
           }
         ]
       },
@@ -308,20 +300,19 @@
       "level": 9,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 9
         },
         {
-          "name": "Dilithium Generator D",
+          "name": "dilithium generator d",
           "level": 9
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 37,
-        "bonus2": 150
+        "bonus1": 37.0,
+        "bonus2": 150.0
       },
       "build_costs": {
         "materials": [],
@@ -342,20 +333,19 @@
       "level": 10,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 10
         },
         {
-          "name": "Dilithium Generator D",
+          "name": "dilithium generator d",
           "level": 10
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 40,
-        "bonus2": 170
+        "bonus1": 40.0,
+        "bonus2": 170.0
       },
       "build_costs": {
         "materials": [],
@@ -376,20 +366,19 @@
       "level": 11,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 11
         },
         {
-          "name": "Dilithium Generator D",
+          "name": "dilithium generator d",
           "level": 11
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 44,
-        "bonus2": 195
+        "bonus1": 44.0,
+        "bonus2": 195.0
       },
       "build_costs": {
         "materials": [],
@@ -410,20 +399,19 @@
       "level": 12,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 12
         },
         {
-          "name": "Dilithium Generator D",
+          "name": "dilithium generator d",
           "level": 12
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 48,
-        "bonus2": 230
+        "bonus1": 48.0,
+        "bonus2": 230.0
       },
       "build_costs": {
         "materials": [],
@@ -444,32 +432,31 @@
       "level": 13,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 13
         },
         {
-          "name": "Dilithium Generator D",
+          "name": "dilithium generator d",
           "level": 13
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 52,
-        "bonus2": 280
+        "bonus1": 52.0,
+        "bonus2": 280.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 7480
-          },
-          {
             "type": "tritanium",
             "value": 5500
+          },
+          {
+            "type": "parsteel",
+            "value": 7480
           }
         ]
       },
@@ -478,32 +465,31 @@
       "level": 14,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 14
         },
         {
-          "name": "Dilithium Generator D",
+          "name": "dilithium generator d",
           "level": 14
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 61,
-        "bonus2": 355
+        "bonus1": 61.0,
+        "bonus2": 355.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 10200
-          },
-          {
             "type": "tritanium",
             "value": 7500
+          },
+          {
+            "type": "parsteel",
+            "value": 10200
           }
         ]
       },
@@ -512,32 +498,31 @@
       "level": 15,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 15
         },
         {
-          "name": "Dilithium Generator D",
+          "name": "dilithium generator d",
           "level": 15
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 66,
-        "bonus2": 410
+        "bonus1": 66.0,
+        "bonus2": 410.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 13600
-          },
-          {
             "type": "tritanium",
             "value": 10000
+          },
+          {
+            "type": "parsteel",
+            "value": 13600
           }
         ]
       },
@@ -546,32 +531,31 @@
       "level": 16,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 16
         },
         {
-          "name": "Dilithium Generator D",
+          "name": "dilithium generator d",
           "level": 16
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 70,
-        "bonus2": 460
+        "bonus1": 70.0,
+        "bonus2": 460.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 19040
-          },
-          {
             "type": "tritanium",
             "value": 14000
+          },
+          {
+            "type": "parsteel",
+            "value": 19040
           }
         ]
       },
@@ -580,20 +564,19 @@
       "level": 17,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 17
         },
         {
-          "name": "Dilithium Generator D",
+          "name": "dilithium generator d",
           "level": 17
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 74,
-        "bonus2": 530
+        "bonus1": 74.0,
+        "bonus2": 530.0
       },
       "build_costs": {
         "materials": [],
@@ -614,32 +597,31 @@
       "level": 18,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 18
         },
         {
-          "name": "Dilithium Generator D",
+          "name": "dilithium generator d",
           "level": 18
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 78,
-        "bonus2": 590
+        "bonus1": 78.0,
+        "bonus2": 590.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 40800
-          },
-          {
             "type": "tritanium",
             "value": 30000
+          },
+          {
+            "type": "parsteel",
+            "value": 40800
           }
         ]
       },
@@ -648,32 +630,31 @@
       "level": 19,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 19
         },
         {
-          "name": "Dilithium Generator D",
+          "name": "dilithium generator d",
           "level": 19
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 98,
-        "bonus2": 780
+        "bonus1": 98.0,
+        "bonus2": 780.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 57800
-          },
-          {
             "type": "tritanium",
             "value": 42500
+          },
+          {
+            "type": "parsteel",
+            "value": 57800
           }
         ]
       },
@@ -682,20 +663,19 @@
       "level": 20,
       "requirements": [
         {
-          "name": "Dilithium Generator D",
+          "name": "operations",
           "level": 20
         },
         {
-          "name": "Operations",
+          "name": "dilithium generator d",
           "level": 20
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 105,
-        "bonus2": 860
+        "bonus1": 105.0,
+        "bonus2": 860.0
       },
       "build_costs": {
         "materials": [],
@@ -716,20 +696,19 @@
       "level": 21,
       "requirements": [
         {
-          "name": "Dilithium Generator D",
+          "name": "operations",
           "level": 21
         },
         {
-          "name": "Operations",
+          "name": "dilithium generator d",
           "level": 21
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 110,
-        "bonus2": 900
+        "bonus1": 110.0,
+        "bonus2": 900.0
       },
       "build_costs": {
         "materials": [],
@@ -750,32 +729,31 @@
       "level": 22,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 22
         },
         {
-          "name": "Dilithium Generator D",
+          "name": "dilithium generator d",
           "level": 22
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 115,
-        "bonus2": 970
+        "bonus1": 115.0,
+        "bonus2": 970.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 249084
-          },
-          {
             "type": "tritanium",
             "value": 183150
+          },
+          {
+            "type": "parsteel",
+            "value": 249084
           }
         ]
       },
@@ -784,20 +762,19 @@
       "level": 23,
       "requirements": [
         {
-          "name": "Dilithium Generator D",
+          "name": "operations",
           "level": 23
         },
         {
-          "name": "Operations",
+          "name": "dilithium generator d",
           "level": 23
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 120,
-        "bonus2": 1010
+        "bonus1": 120.0,
+        "bonus2": 1010.0
       },
       "build_costs": {
         "materials": [],
@@ -818,32 +795,31 @@
       "level": 24,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 24
         },
         {
-          "name": "Dilithium Generator D",
+          "name": "dilithium generator d",
           "level": 24
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 145,
-        "bonus2": 1250
+        "bonus1": 145.0,
+        "bonus2": 1250.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 636480
-          },
-          {
             "type": "tritanium",
             "value": 468000
+          },
+          {
+            "type": "parsteel",
+            "value": 636480
           }
         ]
       },
@@ -852,32 +828,31 @@
       "level": 25,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 25
         },
         {
-          "name": "Dilithium Generator D",
+          "name": "dilithium generator d",
           "level": 25
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 150,
-        "bonus2": 1290
+        "bonus1": 150.0,
+        "bonus2": 1290.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 994500
-          },
-          {
             "type": "tritanium",
             "value": 731250
+          },
+          {
+            "type": "parsteel",
+            "value": 994500
           }
         ]
       },
@@ -886,20 +861,19 @@
       "level": 26,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 26
         },
         {
-          "name": "Dilithium Generator D",
+          "name": "dilithium generator d",
           "level": 26
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 155,
-        "bonus2": 1360
+        "bonus1": 155.0,
+        "bonus2": 1360.0
       },
       "build_costs": {
         "materials": [],
@@ -920,32 +894,31 @@
       "level": 27,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 27
         },
         {
-          "name": "Dilithium Generator D",
+          "name": "dilithium generator d",
           "level": 27
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 160,
-        "bonus2": 1400
+        "bonus1": 160.0,
+        "bonus2": 1400.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 2276640
-          },
-          {
             "type": "tritanium",
             "value": 1674000
+          },
+          {
+            "type": "parsteel",
+            "value": 2276640
           }
         ]
       },
@@ -954,20 +927,19 @@
       "level": 28,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 28
         },
         {
-          "name": "Dilithium Generator D",
+          "name": "dilithium generator d",
           "level": 28
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 165,
-        "bonus2": 1475
+        "bonus1": 165.0,
+        "bonus2": 1475.0
       },
       "build_costs": {
         "materials": [],
@@ -988,20 +960,19 @@
       "level": 29,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 29
         },
         {
-          "name": "Dilithium Generator D",
+          "name": "dilithium generator d",
           "level": 29
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 195,
-        "bonus2": 1750
+        "bonus1": 195.0,
+        "bonus2": 1750.0
       },
       "build_costs": {
         "materials": [],
@@ -1022,32 +993,31 @@
       "level": 30,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 30
         },
         {
-          "name": "Dilithium Generator D",
+          "name": "dilithium generator d",
           "level": 30
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 205,
-        "bonus2": 1850
+        "bonus1": 205.0,
+        "bonus2": 1850.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 8384400
-          },
-          {
             "type": "tritanium",
             "value": 6165000
+          },
+          {
+            "type": "parsteel",
+            "value": 8384400
           }
         ]
       },
@@ -1056,32 +1026,31 @@
       "level": 31,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 31
         },
         {
-          "name": "Dilithium Generator D",
+          "name": "dilithium generator d",
           "level": 31
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 210,
-        "bonus2": 2052
+        "bonus1": 210.0,
+        "bonus2": 2052.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 12110800
-          },
-          {
             "type": "tritanium",
             "value": 8905000
+          },
+          {
+            "type": "parsteel",
+            "value": 12110800
           }
         ]
       },
@@ -1090,20 +1059,19 @@
       "level": 32,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 32
         },
         {
-          "name": "Dilithium Generator D",
+          "name": "dilithium generator d",
           "level": 32
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 215,
-        "bonus2": 2233
+        "bonus1": 215.0,
+        "bonus2": 2233.0
       },
       "build_costs": {
         "materials": [],
@@ -1124,32 +1092,31 @@
       "level": 33,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 33
         },
         {
-          "name": "Dilithium Generator D",
+          "name": "dilithium generator d",
           "level": 33
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 225,
-        "bonus2": 2349
+        "bonus1": 225.0,
+        "bonus2": 2349.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 29580000
-          },
-          {
             "type": "tritanium",
             "value": 21750000
+          },
+          {
+            "type": "parsteel",
+            "value": 29580000
           }
         ]
       },
@@ -1158,32 +1125,31 @@
       "level": 34,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 34
         },
         {
-          "name": "Dilithium Generator D",
+          "name": "dilithium generator d",
           "level": 34
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 260,
-        "bonus2": 2914
+        "bonus1": 260.0,
+        "bonus2": 2914.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 45777600
-          },
-          {
             "type": "tritanium",
             "value": 33660000
+          },
+          {
+            "type": "parsteel",
+            "value": 45777600
           }
         ]
       },
@@ -1192,32 +1158,31 @@
       "level": 35,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 35
         },
         {
-          "name": "Dilithium Generator D",
+          "name": "dilithium generator d",
           "level": 35
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 265,
-        "bonus2": 3159
+        "bonus1": 265.0,
+        "bonus2": 3159.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 64504800
-          },
-          {
             "type": "tritanium",
             "value": 47430000
+          },
+          {
+            "type": "parsteel",
+            "value": 64504800
           }
         ]
       },
@@ -1226,20 +1191,19 @@
       "level": 36,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 36
         },
         {
-          "name": "Dilithium Generator D",
+          "name": "dilithium generator d",
           "level": 36
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 275,
-        "bonus2": 3292
+        "bonus1": 275.0,
+        "bonus2": 3292.0
       },
       "build_costs": {
         "materials": [],
@@ -1260,32 +1224,31 @@
       "level": 37,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 37
         },
         {
-          "name": "Dilithium Generator D",
+          "name": "dilithium generator d",
           "level": 37
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 280,
-        "bonus2": 3586
+        "bonus1": 280.0,
+        "bonus2": 3586.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 154224000
-          },
-          {
             "type": "tritanium",
             "value": 113400000
+          },
+          {
+            "type": "parsteel",
+            "value": 154224000
           }
         ]
       },
@@ -1294,20 +1257,19 @@
       "level": 38,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 38
         },
         {
-          "name": "Dilithium Generator D",
+          "name": "dilithium generator d",
           "level": 38
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 290,
-        "bonus2": 3978
+        "bonus1": 290.0,
+        "bonus2": 3978.0
       },
       "build_costs": {
         "materials": [],
@@ -1328,32 +1290,31 @@
       "level": 39,
       "requirements": [
         {
-          "name": "Dilithium Generator D",
+          "name": "operations",
           "level": 39
         },
         {
-          "name": "Operations",
+          "name": "dilithium generator d",
           "level": 39
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 365,
-        "bonus2": 5011
+        "bonus1": 365.0,
+        "bonus2": 5011.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 1146208000
-          },
-          {
             "type": "tritanium",
             "value": 301000000
+          },
+          {
+            "type": "parsteel",
+            "value": 1146208000
           }
         ]
       },
@@ -1362,32 +1323,31 @@
       "level": 40,
       "requirements": [
         {
-          "name": "Dilithium Generator D",
+          "name": "operations",
           "level": 40
         },
         {
-          "name": "Operations",
+          "name": "dilithium generator d",
           "level": 40
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 370,
-        "bonus2": 5486
+        "bonus1": 370.0,
+        "bonus2": 5486.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 1169600000
-          },
-          {
             "type": "tritanium",
             "value": 430000000
+          },
+          {
+            "type": "parsteel",
+            "value": 1169600000
           }
         ]
       },
@@ -1396,32 +1356,31 @@
       "level": 41,
       "requirements": [
         {
-          "name": "Dilithium Generator D",
+          "name": "operations",
           "level": 41
         },
         {
-          "name": "Operations",
+          "name": "dilithium generator d",
           "level": 41
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 380,
-        "bonus2": 6199
+        "bonus1": 380.0,
+        "bonus2": 6199.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 1742160000
-          },
-          {
             "type": "tritanium",
             "value": 640500000
+          },
+          {
+            "type": "parsteel",
+            "value": 1742160000
           }
         ]
       },
@@ -1430,20 +1389,19 @@
       "level": 42,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 42
         },
         {
-          "name": "Dilithium Generator D",
+          "name": "dilithium generator d",
           "level": 42
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 390,
-        "bonus2": 6335
+        "bonus1": 390.0,
+        "bonus2": 6335.0
       },
       "build_costs": {
         "materials": [],
@@ -1464,32 +1422,31 @@
       "level": 43,
       "requirements": [
         {
-          "name": "Dilithium Generator D",
+          "name": "operations",
           "level": 43
         },
         {
-          "name": "Operations",
+          "name": "dilithium generator d",
           "level": 43
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 400,
-        "bonus2": 7200
+        "bonus1": 400.0,
+        "bonus2": 7200.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 3733200000
-          },
-          {
             "type": "tritanium",
             "value": 1372500000
+          },
+          {
+            "type": "parsteel",
+            "value": 3733200000
           }
         ]
       },
@@ -1498,32 +1455,31 @@
       "level": 44,
       "requirements": [
         {
-          "name": "Dilithium Generator D",
+          "name": "operations",
           "level": 44
         },
         {
-          "name": "Operations",
+          "name": "dilithium generator d",
           "level": 44
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 465,
-        "bonus2": 9394
+        "bonus1": 465.0,
+        "bonus2": 9394.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 5304000000
-          },
-          {
             "type": "tritanium",
             "value": 1950000000
+          },
+          {
+            "type": "parsteel",
+            "value": 5304000000
           }
         ]
       },
@@ -1532,32 +1488,31 @@
       "level": 45,
       "requirements": [
         {
-          "name": "Dilithium Generator D",
+          "name": "operations",
           "level": 45
         },
         {
-          "name": "Operations",
+          "name": "dilithium generator d",
           "level": 45
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 475,
-        "bonus2": 9619
+        "bonus1": 475.0,
+        "bonus2": 9619.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 7293000000
-          },
-          {
             "type": "tritanium",
             "value": 2681250000
+          },
+          {
+            "type": "parsteel",
+            "value": 7293000000
           }
         ]
       },
@@ -1566,32 +1521,31 @@
       "level": 46,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 46
         },
         {
-          "name": "Dilithium Generator D",
+          "name": "dilithium generator d",
           "level": 46
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 485,
-        "bonus2": 9844
+        "bonus1": 485.0,
+        "bonus2": 9844.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 10608000000
-          },
-          {
             "type": "tritanium",
             "value": 3900000000
+          },
+          {
+            "type": "parsteel",
+            "value": 10608000000
           }
         ]
       },
@@ -1600,20 +1554,19 @@
       "level": 47,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 47
         },
         {
-          "name": "Dilithium Generator D",
+          "name": "dilithium generator d",
           "level": 47
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 495,
-        "bonus2": 10013
+        "bonus1": 495.0,
+        "bonus2": 10013.0
       },
       "build_costs": {
         "materials": [],
@@ -1634,20 +1587,19 @@
       "level": 48,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 48
         },
         {
-          "name": "Dilithium Generator D",
+          "name": "dilithium generator d",
           "level": 48
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 510,
-        "bonus2": 10350
+        "bonus1": 510.0,
+        "bonus2": 10350.0
       },
       "build_costs": {
         "materials": [],
@@ -1668,20 +1620,19 @@
       "level": 49,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 49
         },
         {
-          "name": "Dilithium Generator D",
+          "name": "dilithium generator d",
           "level": 49
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 620,
-        "bonus2": 12600
+        "bonus1": 620.0,
+        "bonus2": 12600.0
       },
       "build_costs": {
         "materials": [],
@@ -1702,15 +1653,179 @@
       "level": 50,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 50
         },
         {
-          "name": "Dilithium Generator D",
+          "name": "dilithium generator d",
           "level": 50
         }
-      ],
-      "rewards": []
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 635.0,
+        "bonus2": 12891.0
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 249288000000
+          },
+          {
+            "type": "tritanium",
+            "value": 39000000000
+          }
+        ]
+      },
+      "build_time": 59626080,
+      "increased_power": 2000,
+      "level": 51,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 51
+        },
+        {
+          "name": "dilithium generator d",
+          "level": 51
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 650.0,
+        "bonus2": 13195.0
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 66300000000
+          },
+          {
+            "type": "parsteel",
+            "value": 450840000000
+          }
+        ]
+      },
+      "build_time": 63204480,
+      "increased_power": 1500,
+      "level": 52,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 52
+        },
+        {
+          "name": "dilithium generator d",
+          "level": 52
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 655.0,
+        "bonus2": 13297.0
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 116000000000
+          },
+          {
+            "type": "parsteel",
+            "value": 757248000000
+          }
+        ]
+      },
+      "build_time": 66996000,
+      "increased_power": 2000,
+      "level": 53,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 53
+        },
+        {
+          "name": "dilithium generator d",
+          "level": 53
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 670.0,
+        "bonus2": 13601.0
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 1135872000000
+          },
+          {
+            "type": "tritanium",
+            "value": 174000000000
+          }
+        ]
+      },
+      "build_time": 71016480,
+      "increased_power": 2000,
+      "level": 54,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 54
+        },
+        {
+          "name": "dilithium generator d",
+          "level": 54
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 800.0,
+        "bonus2": 16240.0
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 273000000000
+          },
+          {
+            "type": "parsteel",
+            "value": 1930656000000
+          }
+        ]
+      },
+      "build_time": 75277440,
+      "increased_power": 2000,
+      "level": 55,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 55
+        },
+        {
+          "name": "dilithium generator d",
+          "level": 55
+        }
+      ]
     }
   ]
 }

--- a/buildings/dilithium_generator_g.json
+++ b/buildings/dilithium_generator_g.json
@@ -2,11 +2,11 @@
   "description": "Produces Dilithium, a crystalline mineral required when building buildings and advanced ship components. Upgrading Dilithium Generators increases the amount of Dilithium that is produced.",
   "bonuses": {
     "bonus1": {
-      "name": "Dilithium Production",
+      "name": "dilithium production",
       "percentage": false
     },
     "bonus2": {
-      "name": "Dilithium Storage",
+      "name": "dilithium storage",
       "percentage": false
     }
   },
@@ -14,8 +14,8 @@
   "levels": [
     {
       "bonuses": {
-        "bonus1": 2,
-        "bonus2": 1
+        "bonus1": 2.0,
+        "bonus2": 1.0
       },
       "build_costs": {
         "materials": [],
@@ -36,32 +36,31 @@
       "level": 1,
       "requirements": [
         {
-          "name": "Operations",
-          "level": 20
+          "name": "operations",
+          "level": 50
         },
         {
-          "name": "Dilithium Generator E",
+          "name": "dilithium generator e",
           "level": 1
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 4,
-        "bonus2": 2
+        "bonus1": 4.0,
+        "bonus2": 2.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 500
-          },
-          {
             "type": "tritanium",
             "value": 350
+          },
+          {
+            "type": "parsteel",
+            "value": 500
           }
         ]
       },
@@ -70,20 +69,19 @@
       "level": 2,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 2
         },
         {
-          "name": "Dilithium Generator E",
+          "name": "dilithium generator e",
           "level": 2
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 6,
-        "bonus2": 6
+        "bonus1": 6.0,
+        "bonus2": 6.0
       },
       "build_costs": {
         "materials": [],
@@ -104,32 +102,31 @@
       "level": 3,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 3
         },
         {
-          "name": "Dilithium Generator E",
+          "name": "dilithium generator e",
           "level": 3
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 8,
-        "bonus2": 13
+        "bonus1": 8.0,
+        "bonus2": 13.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 700
-          },
-          {
             "type": "tritanium",
             "value": 450
+          },
+          {
+            "type": "parsteel",
+            "value": 700
           }
         ]
       },
@@ -138,20 +135,19 @@
       "level": 4,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 4
         },
         {
-          "name": "Dilithium Generator E",
+          "name": "dilithium generator e",
           "level": 4
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 12,
-        "bonus2": 24
+        "bonus1": 12.0,
+        "bonus2": 24.0
       },
       "build_costs": {
         "materials": [],
@@ -172,32 +168,31 @@
       "level": 5,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 5
         },
         {
-          "name": "Dilithium Generator E",
+          "name": "dilithium generator e",
           "level": 5
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 15,
-        "bonus2": 36
+        "bonus1": 15.0,
+        "bonus2": 36.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 1000
-          },
-          {
             "type": "tritanium",
             "value": 550
+          },
+          {
+            "type": "parsteel",
+            "value": 1000
           }
         ]
       },
@@ -206,20 +201,19 @@
       "level": 6,
       "requirements": [
         {
-          "name": "Dilithium Generator E",
+          "name": "operations",
           "level": 6
         },
         {
-          "name": "Operations",
+          "name": "dilithium generator e",
           "level": 6
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 17,
-        "bonus2": 48
+        "bonus1": 17.0,
+        "bonus2": 48.0
       },
       "build_costs": {
         "materials": [],
@@ -240,32 +234,31 @@
       "level": 7,
       "requirements": [
         {
-          "name": "Dilithium Generator E",
+          "name": "operations",
           "level": 7
         },
         {
-          "name": "Operations",
+          "name": "dilithium generator e",
           "level": 7
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 20,
-        "bonus2": 64
+        "bonus1": 20.0,
+        "bonus2": 64.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 1400
-          },
-          {
             "type": "tritanium",
             "value": 650
+          },
+          {
+            "type": "parsteel",
+            "value": 1400
           }
         ]
       },
@@ -274,20 +267,19 @@
       "level": 8,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 8
         },
         {
-          "name": "Dilithium Generator E",
+          "name": "dilithium generator e",
           "level": 8
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 22,
-        "bonus2": 79
+        "bonus1": 22.0,
+        "bonus2": 79.0
       },
       "build_costs": {
         "materials": [],
@@ -308,32 +300,31 @@
       "level": 9,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 9
         },
         {
-          "name": "Dilithium Generator E",
+          "name": "dilithium generator e",
           "level": 9
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 37,
-        "bonus2": 150
+        "bonus1": 37.0,
+        "bonus2": 150.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 2000
-          },
-          {
             "type": "tritanium",
             "value": 1500
+          },
+          {
+            "type": "parsteel",
+            "value": 2000
           }
         ]
       },
@@ -342,32 +333,31 @@
       "level": 10,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 10
         },
         {
-          "name": "Dilithium Generator E",
+          "name": "dilithium generator e",
           "level": 10
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 40,
-        "bonus2": 170
+        "bonus1": 40.0,
+        "bonus2": 170.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 2720
-          },
-          {
             "type": "tritanium",
             "value": 2000
+          },
+          {
+            "type": "parsteel",
+            "value": 2720
           }
         ]
       },
@@ -376,32 +366,31 @@
       "level": 11,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 11
         },
         {
-          "name": "Dilithium Generator E",
+          "name": "dilithium generator e",
           "level": 11
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 44,
-        "bonus2": 195
+        "bonus1": 44.0,
+        "bonus2": 195.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 3740
-          },
-          {
             "type": "tritanium",
             "value": 2750
+          },
+          {
+            "type": "parsteel",
+            "value": 3740
           }
         ]
       },
@@ -410,20 +399,19 @@
       "level": 12,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 12
         },
         {
-          "name": "Dilithium Generator E",
+          "name": "dilithium generator e",
           "level": 12
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 48,
-        "bonus2": 230
+        "bonus1": 48.0,
+        "bonus2": 230.0
       },
       "build_costs": {
         "materials": [],
@@ -444,32 +432,31 @@
       "level": 13,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 13
         },
         {
-          "name": "Dilithium Generator E",
+          "name": "dilithium generator e",
           "level": 13
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 52,
-        "bonus2": 280
+        "bonus1": 52.0,
+        "bonus2": 280.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 7480
-          },
-          {
             "type": "tritanium",
             "value": 5500
+          },
+          {
+            "type": "parsteel",
+            "value": 7480
           }
         ]
       },
@@ -478,20 +465,19 @@
       "level": 14,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 14
         },
         {
-          "name": "Dilithium Generator E",
+          "name": "dilithium generator e",
           "level": 14
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 61,
-        "bonus2": 355
+        "bonus1": 61.0,
+        "bonus2": 355.0
       },
       "build_costs": {
         "materials": [],
@@ -512,32 +498,31 @@
       "level": 15,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 15
         },
         {
-          "name": "Dilithium Generator E",
+          "name": "dilithium generator e",
           "level": 15
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 66,
-        "bonus2": 410
+        "bonus1": 66.0,
+        "bonus2": 410.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 13600
-          },
-          {
             "type": "tritanium",
             "value": 10000
+          },
+          {
+            "type": "parsteel",
+            "value": 13600
           }
         ]
       },
@@ -546,20 +531,19 @@
       "level": 16,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 16
         },
         {
-          "name": "Dilithium Generator E",
+          "name": "dilithium generator e",
           "level": 16
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 70,
-        "bonus2": 460
+        "bonus1": 70.0,
+        "bonus2": 460.0
       },
       "build_costs": {
         "materials": [],
@@ -580,20 +564,19 @@
       "level": 17,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 17
         },
         {
-          "name": "Dilithium Generator E",
+          "name": "dilithium generator e",
           "level": 17
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 74,
-        "bonus2": 530
+        "bonus1": 74.0,
+        "bonus2": 530.0
       },
       "build_costs": {
         "materials": [],
@@ -614,20 +597,19 @@
       "level": 18,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 18
         },
         {
-          "name": "Dilithium Generator E",
+          "name": "dilithium generator e",
           "level": 18
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 78,
-        "bonus2": 590
+        "bonus1": 78.0,
+        "bonus2": 590.0
       },
       "build_costs": {
         "materials": [],
@@ -648,20 +630,19 @@
       "level": 19,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 19
         },
         {
-          "name": "Dilithium Generator E",
+          "name": "dilithium generator e",
           "level": 19
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 98,
-        "bonus2": 780
+        "bonus1": 98.0,
+        "bonus2": 780.0
       },
       "build_costs": {
         "materials": [],
@@ -682,32 +663,31 @@
       "level": 20,
       "requirements": [
         {
-          "name": "Dilithium Generator E",
+          "name": "operations",
           "level": 20
         },
         {
-          "name": "Operations",
+          "name": "dilithium generator e",
           "level": 20
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 105,
-        "bonus2": 860
+        "bonus1": 105.0,
+        "bonus2": 860.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 97308
-          },
-          {
             "type": "tritanium",
             "value": 71550
+          },
+          {
+            "type": "parsteel",
+            "value": 97308
           }
         ]
       },
@@ -716,20 +696,19 @@
       "level": 21,
       "requirements": [
         {
-          "name": "Dilithium Generator E",
+          "name": "operations",
           "level": 21
         },
         {
-          "name": "Operations",
+          "name": "dilithium generator e",
           "level": 21
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 110,
-        "bonus2": 900
+        "bonus1": 110.0,
+        "bonus2": 900.0
       },
       "build_costs": {
         "materials": [],
@@ -750,32 +729,31 @@
       "level": 22,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 22
         },
         {
-          "name": "Dilithium Generator E",
+          "name": "dilithium generator e",
           "level": 22
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 115,
-        "bonus2": 970
+        "bonus1": 115.0,
+        "bonus2": 970.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 249084
-          },
-          {
             "type": "tritanium",
             "value": 183150
+          },
+          {
+            "type": "parsteel",
+            "value": 249084
           }
         ]
       },
@@ -784,32 +762,31 @@
       "level": 23,
       "requirements": [
         {
-          "name": "Dilithium Generator E",
+          "name": "operations",
           "level": 23
         },
         {
-          "name": "Operations",
+          "name": "dilithium generator e",
           "level": 23
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 120,
-        "bonus2": 1010
+        "bonus1": 120.0,
+        "bonus2": 1010.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 392496
-          },
-          {
             "type": "tritanium",
             "value": 288600
+          },
+          {
+            "type": "parsteel",
+            "value": 392496
           }
         ]
       },
@@ -818,32 +795,31 @@
       "level": 24,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 24
         },
         {
-          "name": "Dilithium Generator E",
+          "name": "dilithium generator e",
           "level": 24
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 145,
-        "bonus2": 1250
+        "bonus1": 145.0,
+        "bonus2": 1250.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 636480
-          },
-          {
             "type": "tritanium",
             "value": 468000
+          },
+          {
+            "type": "parsteel",
+            "value": 636480
           }
         ]
       },
@@ -852,32 +828,31 @@
       "level": 25,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 25
         },
         {
-          "name": "Dilithium Generator E",
+          "name": "dilithium generator e",
           "level": 25
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 150,
-        "bonus2": 1290
+        "bonus1": 150.0,
+        "bonus2": 1290.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 994500
-          },
-          {
             "type": "tritanium",
             "value": 731250
+          },
+          {
+            "type": "parsteel",
+            "value": 994500
           }
         ]
       },
@@ -886,32 +861,31 @@
       "level": 26,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 26
         },
         {
-          "name": "Dilithium Generator E",
+          "name": "dilithium generator e",
           "level": 26
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 155,
-        "bonus2": 1360
+        "bonus1": 155.0,
+        "bonus2": 1360.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 1517760
-          },
-          {
             "type": "tritanium",
             "value": 1116000
+          },
+          {
+            "type": "parsteel",
+            "value": 1517760
           }
         ]
       },
@@ -920,20 +894,19 @@
       "level": 27,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 27
         },
         {
-          "name": "Dilithium Generator E",
+          "name": "dilithium generator e",
           "level": 27
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 160,
-        "bonus2": 1400
+        "bonus1": 160.0,
+        "bonus2": 1400.0
       },
       "build_costs": {
         "materials": [],
@@ -954,20 +927,19 @@
       "level": 28,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 28
         },
         {
-          "name": "Dilithium Generator E",
+          "name": "dilithium generator e",
           "level": 28
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 165,
-        "bonus2": 1475
+        "bonus1": 165.0,
+        "bonus2": 1475.0
       },
       "build_costs": {
         "materials": [],
@@ -988,32 +960,31 @@
       "level": 29,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 29
         },
         {
-          "name": "Dilithium Generator E",
+          "name": "dilithium generator e",
           "level": 29
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 195,
-        "bonus2": 1750
+        "bonus1": 195.0,
+        "bonus2": 1750.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 5304000
-          },
-          {
             "type": "tritanium",
             "value": 3900000
+          },
+          {
+            "type": "parsteel",
+            "value": 5304000
           }
         ]
       },
@@ -1022,20 +993,19 @@
       "level": 30,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 30
         },
         {
-          "name": "Dilithium Generator E",
+          "name": "dilithium generator e",
           "level": 30
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 205,
-        "bonus2": 1850
+        "bonus1": 205.0,
+        "bonus2": 1850.0
       },
       "build_costs": {
         "materials": [],
@@ -1056,32 +1026,31 @@
       "level": 31,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 31
         },
         {
-          "name": "Dilithium Generator E",
+          "name": "dilithium generator e",
           "level": 31
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 210,
-        "bonus2": 2052
+        "bonus1": 210.0,
+        "bonus2": 2052.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 12110800
-          },
-          {
             "type": "tritanium",
             "value": 8905000
+          },
+          {
+            "type": "parsteel",
+            "value": 12110800
           }
         ]
       },
@@ -1090,20 +1059,19 @@
       "level": 32,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 32
         },
         {
-          "name": "Dilithium Generator E",
+          "name": "dilithium generator e",
           "level": 32
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 215,
-        "bonus2": 2233
+        "bonus1": 215.0,
+        "bonus2": 2233.0
       },
       "build_costs": {
         "materials": [],
@@ -1124,32 +1092,31 @@
       "level": 33,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 33
         },
         {
-          "name": "Dilithium Generator E",
+          "name": "dilithium generator e",
           "level": 33
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 225,
-        "bonus2": 2349
+        "bonus1": 225.0,
+        "bonus2": 2349.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 29580000
-          },
-          {
             "type": "tritanium",
             "value": 21750000
+          },
+          {
+            "type": "parsteel",
+            "value": 29580000
           }
         ]
       },
@@ -1158,32 +1125,31 @@
       "level": 34,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 34
         },
         {
-          "name": "Dilithium Generator E",
+          "name": "dilithium generator e",
           "level": 34
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 260,
-        "bonus2": 2914
+        "bonus1": 260.0,
+        "bonus2": 2914.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 45777600
-          },
-          {
             "type": "tritanium",
             "value": 33660000
+          },
+          {
+            "type": "parsteel",
+            "value": 45777600
           }
         ]
       },
@@ -1192,32 +1158,31 @@
       "level": 35,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 35
         },
         {
-          "name": "Dilithium Generator E",
+          "name": "dilithium generator e",
           "level": 35
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 265,
-        "bonus2": 3159
+        "bonus1": 265.0,
+        "bonus2": 3159.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 64504800
-          },
-          {
             "type": "tritanium",
             "value": 47430000
+          },
+          {
+            "type": "parsteel",
+            "value": 64504800
           }
         ]
       },
@@ -1226,32 +1191,31 @@
       "level": 36,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 36
         },
         {
-          "name": "Dilithium Generator E",
+          "name": "dilithium generator e",
           "level": 36
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 275,
-        "bonus2": 3292
+        "bonus1": 275.0,
+        "bonus2": 3292.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 99144000
-          },
-          {
             "type": "tritanium",
             "value": 72900000
+          },
+          {
+            "type": "parsteel",
+            "value": 99144000
           }
         ]
       },
@@ -1260,32 +1224,31 @@
       "level": 37,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 37
         },
         {
-          "name": "Dilithium Generator E",
+          "name": "dilithium generator e",
           "level": 37
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 280,
-        "bonus2": 3586
+        "bonus1": 280.0,
+        "bonus2": 3586.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 154224000
-          },
-          {
             "type": "tritanium",
             "value": 113400000
+          },
+          {
+            "type": "parsteel",
+            "value": 154224000
           }
         ]
       },
@@ -1294,20 +1257,19 @@
       "level": 38,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 38
         },
         {
-          "name": "Dilithium Generator E",
+          "name": "dilithium generator e",
           "level": 38
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 290,
-        "bonus2": 3978
+        "bonus1": 290.0,
+        "bonus2": 3978.0
       },
       "build_costs": {
         "materials": [],
@@ -1328,20 +1290,19 @@
       "level": 39,
       "requirements": [
         {
-          "name": "Dilithium Generator E",
+          "name": "operations",
           "level": 39
         },
         {
-          "name": "Operations",
+          "name": "dilithium generator e",
           "level": 39
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 365,
-        "bonus2": 5011
+        "bonus1": 365.0,
+        "bonus2": 5011.0
       },
       "build_costs": {
         "materials": [],
@@ -1362,20 +1323,19 @@
       "level": 40,
       "requirements": [
         {
-          "name": "Dilithium Generator E",
+          "name": "operations",
           "level": 40
         },
         {
-          "name": "Operations",
+          "name": "dilithium generator e",
           "level": 40
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 370,
-        "bonus2": 5486
+        "bonus1": 370.0,
+        "bonus2": 5486.0
       },
       "build_costs": {
         "materials": [],
@@ -1396,20 +1356,19 @@
       "level": 41,
       "requirements": [
         {
-          "name": "Dilithium Generator E",
+          "name": "operations",
           "level": 41
         },
         {
-          "name": "Operations",
+          "name": "dilithium generator e",
           "level": 41
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 380,
-        "bonus2": 6199
+        "bonus1": 380.0,
+        "bonus2": 6199.0
       },
       "build_costs": {
         "materials": [],
@@ -1430,20 +1389,19 @@
       "level": 42,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 42
         },
         {
-          "name": "Dilithium Generator E",
+          "name": "dilithium generator e",
           "level": 42
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 390,
-        "bonus2": 6335
+        "bonus1": 390.0,
+        "bonus2": 6335.0
       },
       "build_costs": {
         "materials": [],
@@ -1464,32 +1422,31 @@
       "level": 43,
       "requirements": [
         {
-          "name": "Dilithium Generator E",
+          "name": "operations",
           "level": 43
         },
         {
-          "name": "Operations",
+          "name": "dilithium generator e",
           "level": 43
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 400,
-        "bonus2": 7200
+        "bonus1": 400.0,
+        "bonus2": 7200.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 3733200000
-          },
-          {
             "type": "tritanium",
             "value": 1372500000
+          },
+          {
+            "type": "parsteel",
+            "value": 3733200000
           }
         ]
       },
@@ -1498,32 +1455,31 @@
       "level": 44,
       "requirements": [
         {
-          "name": "Dilithium Generator E",
+          "name": "operations",
           "level": 44
         },
         {
-          "name": "Operations",
+          "name": "dilithium generator e",
           "level": 44
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 465,
-        "bonus2": 9394
+        "bonus1": 465.0,
+        "bonus2": 9394.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 5304000000
-          },
-          {
             "type": "tritanium",
             "value": 1950000000
+          },
+          {
+            "type": "parsteel",
+            "value": 5304000000
           }
         ]
       },
@@ -1532,32 +1488,31 @@
       "level": 45,
       "requirements": [
         {
-          "name": "Dilithium Generator E",
+          "name": "operations",
           "level": 45
         },
         {
-          "name": "Operations",
+          "name": "dilithium generator e",
           "level": 45
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 475,
-        "bonus2": 9619
+        "bonus1": 475.0,
+        "bonus2": 9619.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 7293000000
-          },
-          {
             "type": "tritanium",
             "value": 2681250000
+          },
+          {
+            "type": "parsteel",
+            "value": 7293000000
           }
         ]
       },
@@ -1566,20 +1521,19 @@
       "level": 46,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 46
         },
         {
-          "name": "Dilithium Generator E",
+          "name": "dilithium generator e",
           "level": 46
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 485,
-        "bonus2": 9844
+        "bonus1": 485.0,
+        "bonus2": 9844.0
       },
       "build_costs": {
         "materials": [],
@@ -1600,32 +1554,31 @@
       "level": 47,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 47
         },
         {
-          "name": "Dilithium Generator E",
+          "name": "dilithium generator e",
           "level": 47
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 495,
-        "bonus2": 10013
+        "bonus1": 495.0,
+        "bonus2": 10013.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 17136000000
-          },
-          {
             "type": "tritanium",
             "value": 6300000000
+          },
+          {
+            "type": "parsteel",
+            "value": 17136000000
           }
         ]
       },
@@ -1634,20 +1587,19 @@
       "level": 48,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 48
         },
         {
-          "name": "Dilithium Generator E",
+          "name": "dilithium generator e",
           "level": 48
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 510,
-        "bonus2": 10350
+        "bonus1": 510.0,
+        "bonus2": 10350.0
       },
       "build_costs": {
         "materials": [],
@@ -1668,32 +1620,31 @@
       "level": 49,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 49
         },
         {
-          "name": "Dilithium Generator E",
+          "name": "dilithium generator e",
           "level": 49
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 620,
-        "bonus2": 12600
+        "bonus1": 620.0,
+        "bonus2": 12600.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 49980000000
-          },
-          {
             "type": "tritanium",
             "value": 18375000000
+          },
+          {
+            "type": "parsteel",
+            "value": 49980000000
           }
         ]
       },
@@ -1702,15 +1653,179 @@
       "level": 50,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 50
         },
         {
-          "name": "Dilithium Generator E",
+          "name": "dilithium generator e",
           "level": 50
         }
-      ],
-      "rewards": []
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 635.0,
+        "bonus2": 12891.0
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 249288000000
+          },
+          {
+            "type": "tritanium",
+            "value": 39000000000
+          }
+        ]
+      },
+      "build_time": 59626080,
+      "increased_power": 2000,
+      "level": 51,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 51
+        },
+        {
+          "name": "dilithium generator e",
+          "level": 51
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 650.0,
+        "bonus2": 13195.0
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 450840000000
+          },
+          {
+            "type": "tritanium",
+            "value": 66300000000
+          }
+        ]
+      },
+      "build_time": 63204480,
+      "increased_power": 1500,
+      "level": 52,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 52
+        },
+        {
+          "name": "dilithium generator e",
+          "level": 52
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 655.0,
+        "bonus2": 13297.0
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 757248000000
+          },
+          {
+            "type": "tritanium",
+            "value": 116000000000
+          }
+        ]
+      },
+      "build_time": 66996000,
+      "increased_power": 2000,
+      "level": 53,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 53
+        },
+        {
+          "name": "dilithium generator e",
+          "level": 53
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 670.0,
+        "bonus2": 13601.0
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 174000000000
+          },
+          {
+            "type": "parsteel",
+            "value": 1135872000000
+          }
+        ]
+      },
+      "build_time": 71016480,
+      "increased_power": 2000,
+      "level": 54,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 54
+        },
+        {
+          "name": "dilithium generator e",
+          "level": 54
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 800.0,
+        "bonus2": 16240.0
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 273000000000
+          },
+          {
+            "type": "parsteel",
+            "value": 1930656000000
+          }
+        ]
+      },
+      "build_time": 75277440,
+      "increased_power": 2000,
+      "level": 55,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 55
+        },
+        {
+          "name": "dilithium generator e",
+          "level": 55
+        }
+      ]
     }
   ]
 }

--- a/buildings/dilithium_generator_h.json
+++ b/buildings/dilithium_generator_h.json
@@ -2,11 +2,11 @@
   "description": "Produces Dilithium, a crystalline mineral required when building buildings and advanced ship components. Upgrading Dilithium Generators increases the amount of Dilithium that is produced.",
   "bonuses": {
     "bonus1": {
-      "name": "Dilithium Production",
+      "name": "dilithium production",
       "percentage": false
     },
     "bonus2": {
-      "name": "Dilithium Storage",
+      "name": "dilithium storage",
       "percentage": false
     }
   },
@@ -14,20 +14,20 @@
   "levels": [
     {
       "bonuses": {
-        "bonus1": 2,
-        "bonus2": 1
+        "bonus1": 2.0,
+        "bonus2": 1.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 400
-          },
-          {
             "type": "tritanium",
             "value": 300
+          },
+          {
+            "type": "parsteel",
+            "value": 400
           }
         ]
       },
@@ -36,32 +36,31 @@
       "level": 1,
       "requirements": [
         {
-          "name": "Operations",
-          "level": 20
+          "name": "operations",
+          "level": 50
         },
         {
-          "name": "Dilithium Generator F",
+          "name": "dilithium generator f",
           "level": 1
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 4,
-        "bonus2": 2
+        "bonus1": 4.0,
+        "bonus2": 2.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 500
-          },
-          {
             "type": "tritanium",
             "value": 350
+          },
+          {
+            "type": "parsteel",
+            "value": 500
           }
         ]
       },
@@ -70,32 +69,31 @@
       "level": 2,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 2
         },
         {
-          "name": "Dilithium Generator F",
+          "name": "dilithium generator f",
           "level": 2
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 6,
-        "bonus2": 6
+        "bonus1": 6.0,
+        "bonus2": 6.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 600
-          },
-          {
             "type": "tritanium",
             "value": 400
+          },
+          {
+            "type": "parsteel",
+            "value": 600
           }
         ]
       },
@@ -104,20 +102,19 @@
       "level": 3,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 3
         },
         {
-          "name": "Dilithium Generator F",
+          "name": "dilithium generator f",
           "level": 3
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 8,
-        "bonus2": 13
+        "bonus1": 8.0,
+        "bonus2": 13.0
       },
       "build_costs": {
         "materials": [],
@@ -138,32 +135,31 @@
       "level": 4,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 4
         },
         {
-          "name": "Dilithium Generator F",
+          "name": "dilithium generator f",
           "level": 4
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 12,
-        "bonus2": 24
+        "bonus1": 12.0,
+        "bonus2": 24.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 800
-          },
-          {
             "type": "tritanium",
             "value": 500
+          },
+          {
+            "type": "parsteel",
+            "value": 800
           }
         ]
       },
@@ -172,20 +168,19 @@
       "level": 5,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 5
         },
         {
-          "name": "Dilithium Generator F",
+          "name": "dilithium generator f",
           "level": 5
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 15,
-        "bonus2": 36
+        "bonus1": 15.0,
+        "bonus2": 36.0
       },
       "build_costs": {
         "materials": [],
@@ -206,20 +201,19 @@
       "level": 6,
       "requirements": [
         {
-          "name": "Dilithium Generator F",
+          "name": "operations",
           "level": 6
         },
         {
-          "name": "Operations",
+          "name": "dilithium generator f",
           "level": 6
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 17,
-        "bonus2": 48
+        "bonus1": 17.0,
+        "bonus2": 48.0
       },
       "build_costs": {
         "materials": [],
@@ -240,20 +234,19 @@
       "level": 7,
       "requirements": [
         {
-          "name": "Dilithium Generator F",
+          "name": "operations",
           "level": 7
         },
         {
-          "name": "Operations",
+          "name": "dilithium generator f",
           "level": 7
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 20,
-        "bonus2": 64
+        "bonus1": 20.0,
+        "bonus2": 64.0
       },
       "build_costs": {
         "materials": [],
@@ -274,20 +267,19 @@
       "level": 8,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 8
         },
         {
-          "name": "Dilithium Generator F",
+          "name": "dilithium generator f",
           "level": 8
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 22,
-        "bonus2": 79
+        "bonus1": 22.0,
+        "bonus2": 79.0
       },
       "build_costs": {
         "materials": [],
@@ -308,32 +300,31 @@
       "level": 9,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 9
         },
         {
-          "name": "Dilithium Generator F",
+          "name": "dilithium generator f",
           "level": 9
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 37,
-        "bonus2": 150
+        "bonus1": 37.0,
+        "bonus2": 150.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 2000
-          },
-          {
             "type": "tritanium",
             "value": 1500
+          },
+          {
+            "type": "parsteel",
+            "value": 2000
           }
         ]
       },
@@ -342,32 +333,31 @@
       "level": 10,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 10
         },
         {
-          "name": "Dilithium Generator F",
+          "name": "dilithium generator f",
           "level": 10
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 40,
-        "bonus2": 170
+        "bonus1": 40.0,
+        "bonus2": 170.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 2720
-          },
-          {
             "type": "tritanium",
             "value": 2000
+          },
+          {
+            "type": "parsteel",
+            "value": 2720
           }
         ]
       },
@@ -376,32 +366,31 @@
       "level": 11,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 11
         },
         {
-          "name": "Dilithium Generator F",
+          "name": "dilithium generator f",
           "level": 11
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 44,
-        "bonus2": 195
+        "bonus1": 44.0,
+        "bonus2": 195.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 3740
-          },
-          {
             "type": "tritanium",
             "value": 2750
+          },
+          {
+            "type": "parsteel",
+            "value": 3740
           }
         ]
       },
@@ -410,32 +399,31 @@
       "level": 12,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 12
         },
         {
-          "name": "Dilithium Generator F",
+          "name": "dilithium generator f",
           "level": 12
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 48,
-        "bonus2": 230
+        "bonus1": 48.0,
+        "bonus2": 230.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 5440
-          },
-          {
             "type": "tritanium",
             "value": 4000
+          },
+          {
+            "type": "parsteel",
+            "value": 5440
           }
         ]
       },
@@ -444,20 +432,19 @@
       "level": 13,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 13
         },
         {
-          "name": "Dilithium Generator F",
+          "name": "dilithium generator f",
           "level": 13
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 52,
-        "bonus2": 280
+        "bonus1": 52.0,
+        "bonus2": 280.0
       },
       "build_costs": {
         "materials": [],
@@ -478,32 +465,31 @@
       "level": 14,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 14
         },
         {
-          "name": "Dilithium Generator F",
+          "name": "dilithium generator f",
           "level": 14
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 61,
-        "bonus2": 355
+        "bonus1": 61.0,
+        "bonus2": 355.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 10200
-          },
-          {
             "type": "tritanium",
             "value": 7500
+          },
+          {
+            "type": "parsteel",
+            "value": 10200
           }
         ]
       },
@@ -512,32 +498,31 @@
       "level": 15,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 15
         },
         {
-          "name": "Dilithium Generator F",
+          "name": "dilithium generator f",
           "level": 15
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 66,
-        "bonus2": 410
+        "bonus1": 66.0,
+        "bonus2": 410.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 13600
-          },
-          {
             "type": "tritanium",
             "value": 10000
+          },
+          {
+            "type": "parsteel",
+            "value": 13600
           }
         ]
       },
@@ -546,20 +531,19 @@
       "level": 16,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 16
         },
         {
-          "name": "Dilithium Generator F",
+          "name": "dilithium generator f",
           "level": 16
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 70,
-        "bonus2": 460
+        "bonus1": 70.0,
+        "bonus2": 460.0
       },
       "build_costs": {
         "materials": [],
@@ -580,32 +564,31 @@
       "level": 17,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 17
         },
         {
-          "name": "Dilithium Generator F",
+          "name": "dilithium generator f",
           "level": 17
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 74,
-        "bonus2": 530
+        "bonus1": 74.0,
+        "bonus2": 530.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 27200
-          },
-          {
             "type": "tritanium",
             "value": 20000
+          },
+          {
+            "type": "parsteel",
+            "value": 27200
           }
         ]
       },
@@ -614,32 +597,31 @@
       "level": 18,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 18
         },
         {
-          "name": "Dilithium Generator F",
+          "name": "dilithium generator f",
           "level": 18
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 78,
-        "bonus2": 590
+        "bonus1": 78.0,
+        "bonus2": 590.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 40800
-          },
-          {
             "type": "tritanium",
             "value": 30000
+          },
+          {
+            "type": "parsteel",
+            "value": 40800
           }
         ]
       },
@@ -648,32 +630,31 @@
       "level": 19,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 19
         },
         {
-          "name": "Dilithium Generator F",
+          "name": "dilithium generator f",
           "level": 19
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 98,
-        "bonus2": 780
+        "bonus1": 98.0,
+        "bonus2": 780.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 57800
-          },
-          {
             "type": "tritanium",
             "value": 42500
+          },
+          {
+            "type": "parsteel",
+            "value": 57800
           }
         ]
       },
@@ -682,32 +663,31 @@
       "level": 20,
       "requirements": [
         {
-          "name": "Dilithium Generator F",
+          "name": "operations",
           "level": 20
         },
         {
-          "name": "Operations",
+          "name": "dilithium generator f",
           "level": 20
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 105,
-        "bonus2": 860
+        "bonus1": 105.0,
+        "bonus2": 860.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 97308
-          },
-          {
             "type": "tritanium",
             "value": 71550
+          },
+          {
+            "type": "parsteel",
+            "value": 97308
           }
         ]
       },
@@ -716,20 +696,19 @@
       "level": 21,
       "requirements": [
         {
-          "name": "Dilithium Generator F",
+          "name": "operations",
           "level": 21
         },
         {
-          "name": "Operations",
+          "name": "dilithium generator f",
           "level": 21
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 110,
-        "bonus2": 900
+        "bonus1": 110.0,
+        "bonus2": 900.0
       },
       "build_costs": {
         "materials": [],
@@ -750,20 +729,19 @@
       "level": 22,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 22
         },
         {
-          "name": "Dilithium Generator F",
+          "name": "dilithium generator f",
           "level": 22
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 115,
-        "bonus2": 970
+        "bonus1": 115.0,
+        "bonus2": 970.0
       },
       "build_costs": {
         "materials": [],
@@ -784,32 +762,31 @@
       "level": 23,
       "requirements": [
         {
-          "name": "Dilithium Generator F",
+          "name": "operations",
           "level": 23
         },
         {
-          "name": "Operations",
+          "name": "dilithium generator f",
           "level": 23
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 120,
-        "bonus2": 1010
+        "bonus1": 120.0,
+        "bonus2": 1010.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 392496
-          },
-          {
             "type": "tritanium",
             "value": 288600
+          },
+          {
+            "type": "parsteel",
+            "value": 392496
           }
         ]
       },
@@ -818,20 +795,19 @@
       "level": 24,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 24
         },
         {
-          "name": "Dilithium Generator F",
+          "name": "dilithium generator f",
           "level": 24
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 145,
-        "bonus2": 1250
+        "bonus1": 145.0,
+        "bonus2": 1250.0
       },
       "build_costs": {
         "materials": [],
@@ -852,20 +828,19 @@
       "level": 25,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 25
         },
         {
-          "name": "Dilithium Generator F",
+          "name": "dilithium generator f",
           "level": 25
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 150,
-        "bonus2": 1290
+        "bonus1": 150.0,
+        "bonus2": 1290.0
       },
       "build_costs": {
         "materials": [],
@@ -886,32 +861,31 @@
       "level": 26,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 26
         },
         {
-          "name": "Dilithium Generator F",
+          "name": "dilithium generator f",
           "level": 26
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 155,
-        "bonus2": 1360
+        "bonus1": 155.0,
+        "bonus2": 1360.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 1517760
-          },
-          {
             "type": "tritanium",
             "value": 1116000
+          },
+          {
+            "type": "parsteel",
+            "value": 1517760
           }
         ]
       },
@@ -920,32 +894,31 @@
       "level": 27,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 27
         },
         {
-          "name": "Dilithium Generator F",
+          "name": "dilithium generator f",
           "level": 27
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 160,
-        "bonus2": 1400
+        "bonus1": 160.0,
+        "bonus2": 1400.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 2276640
-          },
-          {
             "type": "tritanium",
             "value": 1674000
+          },
+          {
+            "type": "parsteel",
+            "value": 2276640
           }
         ]
       },
@@ -954,20 +927,19 @@
       "level": 28,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 28
         },
         {
-          "name": "Dilithium Generator F",
+          "name": "dilithium generator f",
           "level": 28
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 165,
-        "bonus2": 1475
+        "bonus1": 165.0,
+        "bonus2": 1475.0
       },
       "build_costs": {
         "materials": [],
@@ -988,32 +960,31 @@
       "level": 29,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 29
         },
         {
-          "name": "Dilithium Generator F",
+          "name": "dilithium generator f",
           "level": 29
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 195,
-        "bonus2": 1750
+        "bonus1": 195.0,
+        "bonus2": 1750.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 5304000
-          },
-          {
             "type": "tritanium",
             "value": 3900000
+          },
+          {
+            "type": "parsteel",
+            "value": 5304000
           }
         ]
       },
@@ -1022,32 +993,31 @@
       "level": 30,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 30
         },
         {
-          "name": "Dilithium Generator F",
+          "name": "dilithium generator f",
           "level": 30
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 205,
-        "bonus2": 1850
+        "bonus1": 205.0,
+        "bonus2": 1850.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 8384400
-          },
-          {
             "type": "tritanium",
             "value": 6165000
+          },
+          {
+            "type": "parsteel",
+            "value": 8384400
           }
         ]
       },
@@ -1056,20 +1026,19 @@
       "level": 31,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 31
         },
         {
-          "name": "Dilithium Generator F",
+          "name": "dilithium generator f",
           "level": 31
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 210,
-        "bonus2": 2052
+        "bonus1": 210.0,
+        "bonus2": 2052.0
       },
       "build_costs": {
         "materials": [],
@@ -1090,32 +1059,31 @@
       "level": 32,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 32
         },
         {
-          "name": "Dilithium Generator F",
+          "name": "dilithium generator f",
           "level": 32
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 215,
-        "bonus2": 2233
+        "bonus1": 215.0,
+        "bonus2": 2233.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 18734000
-          },
-          {
             "type": "tritanium",
             "value": 13775000
+          },
+          {
+            "type": "parsteel",
+            "value": 18734000
           }
         ]
       },
@@ -1124,32 +1092,31 @@
       "level": 33,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 33
         },
         {
-          "name": "Dilithium Generator F",
+          "name": "dilithium generator f",
           "level": 33
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 225,
-        "bonus2": 2349
+        "bonus1": 225.0,
+        "bonus2": 2349.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 29580000
-          },
-          {
             "type": "tritanium",
             "value": 21750000
+          },
+          {
+            "type": "parsteel",
+            "value": 29580000
           }
         ]
       },
@@ -1158,20 +1125,19 @@
       "level": 34,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 34
         },
         {
-          "name": "Dilithium Generator F",
+          "name": "dilithium generator f",
           "level": 34
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 260,
-        "bonus2": 2914
+        "bonus1": 260.0,
+        "bonus2": 2914.0
       },
       "build_costs": {
         "materials": [],
@@ -1192,32 +1158,31 @@
       "level": 35,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 35
         },
         {
-          "name": "Dilithium Generator F",
+          "name": "dilithium generator f",
           "level": 35
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 265,
-        "bonus2": 3159
+        "bonus1": 265.0,
+        "bonus2": 3159.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 64504800
-          },
-          {
             "type": "tritanium",
             "value": 47430000
+          },
+          {
+            "type": "parsteel",
+            "value": 64504800
           }
         ]
       },
@@ -1226,32 +1191,31 @@
       "level": 36,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 36
         },
         {
-          "name": "Dilithium Generator F",
+          "name": "dilithium generator f",
           "level": 36
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 275,
-        "bonus2": 3292
+        "bonus1": 275.0,
+        "bonus2": 3292.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 99144000
-          },
-          {
             "type": "tritanium",
             "value": 72900000
+          },
+          {
+            "type": "parsteel",
+            "value": 99144000
           }
         ]
       },
@@ -1260,20 +1224,19 @@
       "level": 37,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 37
         },
         {
-          "name": "Dilithium Generator F",
+          "name": "dilithium generator f",
           "level": 37
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 280,
-        "bonus2": 3586
+        "bonus1": 280.0,
+        "bonus2": 3586.0
       },
       "build_costs": {
         "materials": [],
@@ -1294,20 +1257,19 @@
       "level": 38,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 38
         },
         {
-          "name": "Dilithium Generator F",
+          "name": "dilithium generator f",
           "level": 38
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 290,
-        "bonus2": 3978
+        "bonus1": 290.0,
+        "bonus2": 3978.0
       },
       "build_costs": {
         "materials": [],
@@ -1328,32 +1290,31 @@
       "level": 39,
       "requirements": [
         {
-          "name": "Dilithium Generator F",
+          "name": "operations",
           "level": 39
         },
         {
-          "name": "Operations",
+          "name": "dilithium generator f",
           "level": 39
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 365,
-        "bonus2": 5011
+        "bonus1": 365.0,
+        "bonus2": 5011.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 1146208000
-          },
-          {
             "type": "tritanium",
             "value": 301000000
+          },
+          {
+            "type": "parsteel",
+            "value": 1146208000
           }
         ]
       },
@@ -1362,32 +1323,31 @@
       "level": 40,
       "requirements": [
         {
-          "name": "Dilithium Generator F",
+          "name": "operations",
           "level": 40
         },
         {
-          "name": "Operations",
+          "name": "dilithium generator f",
           "level": 40
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 370,
-        "bonus2": 5486
+        "bonus1": 370.0,
+        "bonus2": 5486.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 1169600000
-          },
-          {
             "type": "tritanium",
             "value": 430000000
+          },
+          {
+            "type": "parsteel",
+            "value": 1169600000
           }
         ]
       },
@@ -1396,20 +1356,19 @@
       "level": 41,
       "requirements": [
         {
-          "name": "Dilithium Generator F",
+          "name": "operations",
           "level": 41
         },
         {
-          "name": "Operations",
+          "name": "dilithium generator f",
           "level": 41
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 380,
-        "bonus2": 6199
+        "bonus1": 380.0,
+        "bonus2": 6199.0
       },
       "build_costs": {
         "materials": [],
@@ -1430,32 +1389,31 @@
       "level": 42,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 42
         },
         {
-          "name": "Dilithium Generator F",
+          "name": "dilithium generator f",
           "level": 42
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 390,
-        "bonus2": 6335
+        "bonus1": 390.0,
+        "bonus2": 6335.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 2488800000
-          },
-          {
             "type": "tritanium",
             "value": 915000000
+          },
+          {
+            "type": "parsteel",
+            "value": 2488800000
           }
         ]
       },
@@ -1464,20 +1422,19 @@
       "level": 43,
       "requirements": [
         {
-          "name": "Dilithium Generator F",
+          "name": "operations",
           "level": 43
         },
         {
-          "name": "Operations",
+          "name": "dilithium generator f",
           "level": 43
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 400,
-        "bonus2": 7200
+        "bonus1": 400.0,
+        "bonus2": 7200.0
       },
       "build_costs": {
         "materials": [],
@@ -1498,20 +1455,19 @@
       "level": 44,
       "requirements": [
         {
-          "name": "Dilithium Generator F",
+          "name": "operations",
           "level": 44
         },
         {
-          "name": "Operations",
+          "name": "dilithium generator f",
           "level": 44
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 465,
-        "bonus2": 9394
+        "bonus1": 465.0,
+        "bonus2": 9394.0
       },
       "build_costs": {
         "materials": [],
@@ -1532,20 +1488,19 @@
       "level": 45,
       "requirements": [
         {
-          "name": "Dilithium Generator F",
+          "name": "operations",
           "level": 45
         },
         {
-          "name": "Operations",
+          "name": "dilithium generator f",
           "level": 45
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 475,
-        "bonus2": 9619
+        "bonus1": 475.0,
+        "bonus2": 9619.0
       },
       "build_costs": {
         "materials": [],
@@ -1566,20 +1521,19 @@
       "level": 46,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 46
         },
         {
-          "name": "Dilithium Generator F",
+          "name": "dilithium generator f",
           "level": 46
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 485,
-        "bonus2": 9844
+        "bonus1": 485.0,
+        "bonus2": 9844.0
       },
       "build_costs": {
         "materials": [],
@@ -1600,32 +1554,31 @@
       "level": 47,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 47
         },
         {
-          "name": "Dilithium Generator F",
+          "name": "dilithium generator f",
           "level": 47
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 495,
-        "bonus2": 10013
+        "bonus1": 495.0,
+        "bonus2": 10013.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 17136000000
-          },
-          {
             "type": "tritanium",
             "value": 6300000000
+          },
+          {
+            "type": "parsteel",
+            "value": 17136000000
           }
         ]
       },
@@ -1634,32 +1587,31 @@
       "level": 48,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 48
         },
         {
-          "name": "Dilithium Generator F",
+          "name": "dilithium generator f",
           "level": 48
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 510,
-        "bonus2": 10350
+        "bonus1": 510.0,
+        "bonus2": 10350.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 28560000000
-          },
-          {
             "type": "tritanium",
             "value": 10500000000
+          },
+          {
+            "type": "parsteel",
+            "value": 28560000000
           }
         ]
       },
@@ -1668,32 +1620,31 @@
       "level": 49,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 49
         },
         {
-          "name": "Dilithium Generator F",
+          "name": "dilithium generator f",
           "level": 49
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 620,
-        "bonus2": 12600
+        "bonus1": 620.0,
+        "bonus2": 12600.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 49980000000
-          },
-          {
             "type": "tritanium",
             "value": 18375000000
+          },
+          {
+            "type": "parsteel",
+            "value": 49980000000
           }
         ]
       },
@@ -1702,15 +1653,179 @@
       "level": 50,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 50
         },
         {
-          "name": "Dilithium Generator F",
+          "name": "dilithium generator f",
           "level": 50
         }
-      ],
-      "rewards": []
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 635.0,
+        "bonus2": 12891.0
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 39000000000
+          },
+          {
+            "type": "parsteel",
+            "value": 249288000000
+          }
+        ]
+      },
+      "build_time": 59626080,
+      "increased_power": 2000,
+      "level": 51,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 51
+        },
+        {
+          "name": "dilithium generator f",
+          "level": 51
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 650.0,
+        "bonus2": 13195.0
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 450840000000
+          },
+          {
+            "type": "tritanium",
+            "value": 66300000000
+          }
+        ]
+      },
+      "build_time": 63204480,
+      "increased_power": 1500,
+      "level": 52,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 52
+        },
+        {
+          "name": "dilithium generator f",
+          "level": 52
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 655.0,
+        "bonus2": 13297.0
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 116000000000
+          },
+          {
+            "type": "parsteel",
+            "value": 757248000000
+          }
+        ]
+      },
+      "build_time": 66996000,
+      "increased_power": 2000,
+      "level": 53,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 53
+        },
+        {
+          "name": "dilithium generator f",
+          "level": 53
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 670.0,
+        "bonus2": 13601.0
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 1135872000000
+          },
+          {
+            "type": "tritanium",
+            "value": 174000000000
+          }
+        ]
+      },
+      "build_time": 71016480,
+      "increased_power": 2000,
+      "level": 54,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 54
+        },
+        {
+          "name": "dilithium generator f",
+          "level": 54
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 800.0,
+        "bonus2": 16240.0
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 1930656000000
+          },
+          {
+            "type": "tritanium",
+            "value": 273000000000
+          }
+        ]
+      },
+      "build_time": 75277440,
+      "increased_power": 2000,
+      "level": 55,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 55
+        },
+        {
+          "name": "dilithium generator f",
+          "level": 55
+        }
+      ]
     }
   ]
 }

--- a/buildings/dilithium_vault.json
+++ b/buildings/dilithium_vault.json
@@ -2,7 +2,7 @@
   "description": "Protects the stored Dilithium from enemy attacks. Upgrade the Vault for additional security.",
   "bonuses": {
     "bonus1": {
-      "name": "Dilithium Vault Protection",
+      "name": "dilithium vault protection",
       "percentage": false
     }
   },
@@ -10,7 +10,7 @@
   "levels": [
     {
       "bonuses": {
-        "bonus1": 2000
+        "bonus1": 2000.0
       },
       "build_costs": {
         "materials": [],
@@ -31,27 +31,26 @@
       "level": 1,
       "requirements": [
         {
-          "name": "Unlock Vaults",
+          "name": "unlock vaults",
           "level": 1
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 2050
+        "bonus1": 2050.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 750
-          },
-          {
             "type": "dilithium",
             "value": 50
+          },
+          {
+            "type": "parsteel",
+            "value": 750
           }
         ]
       },
@@ -60,31 +59,30 @@
       "level": 2,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 2
         },
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 11
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 2100
+        "bonus1": 2100.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 1000
-          },
-          {
             "type": "dilithium",
             "value": 50
+          },
+          {
+            "type": "parsteel",
+            "value": 1000
           }
         ]
       },
@@ -93,19 +91,18 @@
       "level": 3,
       "requirements": [
         {
-          "name": "Tritanium Vault",
+          "name": "tritanium vault",
           "level": 3
         },
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 11
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 2200
+        "bonus1": 2200.0
       },
       "build_costs": {
         "materials": [],
@@ -126,31 +123,30 @@
       "level": 4,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 4
         },
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 11
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 2300
+        "bonus1": 2300.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 1600
-          },
-          {
             "type": "dilithium",
             "value": 50
+          },
+          {
+            "type": "parsteel",
+            "value": 1600
           }
         ]
       },
@@ -159,31 +155,30 @@
       "level": 5,
       "requirements": [
         {
-          "name": "Operations",
-          "level": 11
+          "name": "operations",
+          "level": 5
         },
         {
-          "name": "Operations",
-          "level": 5
+          "name": "operations",
+          "level": 11
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 2400
+        "bonus1": 2400.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 2000
-          },
-          {
             "type": "dilithium",
             "value": 50
+          },
+          {
+            "type": "parsteel",
+            "value": 2000
           }
         ]
       },
@@ -192,19 +187,18 @@
       "level": 6,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 6
         },
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 11
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 2500
+        "bonus1": 2500.0
       },
       "build_costs": {
         "materials": [],
@@ -225,19 +219,18 @@
       "level": 7,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 7
         },
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 11
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 2650
+        "bonus1": 2650.0
       },
       "build_costs": {
         "materials": [],
@@ -258,31 +251,30 @@
       "level": 8,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 8
         },
         {
-          "name": "Dilithium Generator B",
+          "name": "dilithium generator b",
           "level": 12
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 2800
+        "bonus1": 2800.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 7000
-          },
-          {
             "type": "dilithium",
             "value": 50
+          },
+          {
+            "type": "parsteel",
+            "value": 7000
           }
         ]
       },
@@ -291,19 +283,18 @@
       "level": 9,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 9
         },
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 11
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 3000
+        "bonus1": 3000.0
       },
       "build_costs": {
         "materials": [],
@@ -324,19 +315,18 @@
       "level": 10,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 10
         },
         {
-          "name": "Tritanium Vault",
+          "name": "tritanium vault",
           "level": 10
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 3300
+        "bonus1": 3300.0
       },
       "build_costs": {
         "materials": [],
@@ -357,19 +347,18 @@
       "level": 11,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 11
         },
         {
-          "name": "Dilithium Generator B",
+          "name": "dilithium generator b",
           "level": 11
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 3600
+        "bonus1": 3600.0
       },
       "build_costs": {
         "materials": [],
@@ -390,31 +379,30 @@
       "level": 12,
       "requirements": [
         {
-          "name": "Dilithium Generator B",
+          "name": "operations",
           "level": 12
         },
         {
-          "name": "Operations",
+          "name": "dilithium generator b",
           "level": 12
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 4200
+        "bonus1": 4200.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 54400
-          },
-          {
             "type": "dilithium",
             "value": 360
+          },
+          {
+            "type": "parsteel",
+            "value": 54400
           }
         ]
       },
@@ -423,19 +411,18 @@
       "level": 13,
       "requirements": [
         {
-          "name": "Dilithium Generator B",
+          "name": "operations",
           "level": 13
         },
         {
-          "name": "Operations",
+          "name": "dilithium generator b",
           "level": 13
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 5000
+        "bonus1": 5000.0
       },
       "build_costs": {
         "materials": [],
@@ -456,19 +443,18 @@
       "level": 14,
       "requirements": [
         {
-          "name": "Dilithium Generator B",
+          "name": "operations",
           "level": 14
         },
         {
-          "name": "Operations",
+          "name": "dilithium generator b",
           "level": 14
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 6000
+        "bonus1": 6000.0
       },
       "build_costs": {
         "materials": [],
@@ -489,31 +475,30 @@
       "level": 15,
       "requirements": [
         {
-          "name": "Dilithium Generator B",
+          "name": "operations",
           "level": 15
         },
         {
-          "name": "Operations",
+          "name": "dilithium generator b",
           "level": 15
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 7000
+        "bonus1": 7000.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 136000
-          },
-          {
             "type": "dilithium",
             "value": 1500
+          },
+          {
+            "type": "parsteel",
+            "value": 136000
           }
         ]
       },
@@ -522,19 +507,18 @@
       "level": 16,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 16
         },
         {
-          "name": "Dilithium Generator B",
+          "name": "dilithium generator b",
           "level": 16
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 8200
+        "bonus1": 8200.0
       },
       "build_costs": {
         "materials": [],
@@ -555,19 +539,18 @@
       "level": 17,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 17
         },
         {
-          "name": "Dilithium Generator B",
+          "name": "dilithium generator b",
           "level": 17
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 9500
+        "bonus1": 9500.0
       },
       "build_costs": {
         "materials": [],
@@ -588,35 +571,34 @@
       "level": 18,
       "requirements": [
         {
-          "name": "Tritanium Vault",
+          "name": "operations",
           "level": 18
         },
         {
-          "name": "Dilithium Generator B",
+          "name": "dilithium generator b",
           "level": 18
         },
         {
-          "name": "Operations",
+          "name": "tritanium vault",
           "level": 18
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 10800
+        "bonus1": 10800.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 408000
-          },
-          {
             "type": "dilithium",
             "value": 4500
+          },
+          {
+            "type": "parsteel",
+            "value": 408000
           }
         ]
       },
@@ -625,19 +607,18 @@
       "level": 19,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 19
         },
         {
-          "name": "Dilithium Generator B",
+          "name": "dilithium generator b",
           "level": 19
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 12300
+        "bonus1": 12300.0
       },
       "build_costs": {
         "materials": [],
@@ -658,31 +639,30 @@
       "level": 20,
       "requirements": [
         {
-          "name": "Dilithium Generator B",
+          "name": "operations",
           "level": 20
         },
         {
-          "name": "Operations",
+          "name": "dilithium generator b",
           "level": 20
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 14500
+        "bonus1": 14500.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 973080
-          },
-          {
             "type": "dilithium",
             "value": 10733
+          },
+          {
+            "type": "parsteel",
+            "value": 973080
           }
         ]
       },
@@ -691,19 +671,18 @@
       "level": 21,
       "requirements": [
         {
-          "name": "Dilithium Generator B",
+          "name": "operations",
           "level": 21
         },
         {
-          "name": "Operations",
+          "name": "dilithium generator b",
           "level": 21
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 16750
+        "bonus1": 16750.0
       },
       "build_costs": {
         "materials": [],
@@ -724,19 +703,18 @@
       "level": 22,
       "requirements": [
         {
-          "name": "Dilithium Generator B",
+          "name": "operations",
           "level": 22
         },
         {
-          "name": "Operations",
+          "name": "dilithium generator b",
           "level": 22
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 19000
+        "bonus1": 19000.0
       },
       "build_costs": {
         "materials": [],
@@ -757,19 +735,18 @@
       "level": 23,
       "requirements": [
         {
-          "name": "Dilithium Generator B",
+          "name": "operations",
           "level": 23
         },
         {
-          "name": "Operations",
+          "name": "dilithium generator b",
           "level": 23
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 21500
+        "bonus1": 21500.0
       },
       "build_costs": {
         "materials": [],
@@ -790,37 +767,36 @@
       "level": 24,
       "requirements": [
         {
-          "name": "Tritanium Vault",
+          "name": "operations",
           "level": 24
         },
         {
-          "name": "Dilithium Generator B",
+          "name": "dilithium generator b",
           "level": 24
         },
         {
-          "name": "Operations",
+          "name": "tritanium vault",
           "level": 24
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 25000
+        "bonus1": 25000.0
       },
       "build_costs": {
         "materials": [
           {
             "type": "ore",
             "grade": 3,
-            "rarity": "common",
-            "value": 190
+            "rarity": "uncommon",
+            "value": 2
           },
           {
             "type": "ore",
             "grade": 3,
-            "rarity": "uncommon",
-            "value": 2
+            "rarity": "common",
+            "value": 190
           }
         ],
         "others": [],
@@ -840,19 +816,18 @@
       "level": 25,
       "requirements": [
         {
-          "name": "Dilithium Generator B",
+          "name": "operations",
           "level": 25
         },
         {
-          "name": "Operations",
+          "name": "dilithium generator b",
           "level": 25
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 29000
+        "bonus1": 29000.0
       },
       "build_costs": {
         "materials": [
@@ -866,12 +841,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 9945000
-          },
-          {
             "type": "dilithium",
             "value": 109688
+          },
+          {
+            "type": "parsteel",
+            "value": 9945000
           }
         ]
       },
@@ -880,33 +855,32 @@
       "level": 26,
       "requirements": [
         {
-          "name": "Dilithium Generator B",
+          "name": "operations",
           "level": 26
         },
         {
-          "name": "Operations",
+          "name": "dilithium generator b",
           "level": 26
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 33000
+        "bonus1": 33000.0
       },
       "build_costs": {
         "materials": [
           {
             "type": "ore",
             "grade": 3,
-            "rarity": "common",
-            "value": 290
+            "rarity": "uncommon",
+            "value": 10
           },
           {
             "type": "ore",
             "grade": 3,
-            "rarity": "uncommon",
-            "value": 10
+            "rarity": "common",
+            "value": 290
           }
         ],
         "others": [],
@@ -926,19 +900,18 @@
       "level": 27,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 27
         },
         {
-          "name": "Dilithium Generator B",
+          "name": "dilithium generator b",
           "level": 27
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 38000
+        "bonus1": 38000.0
       },
       "build_costs": {
         "materials": [
@@ -958,12 +931,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 22766400
-          },
-          {
             "type": "dilithium",
             "value": 251100
+          },
+          {
+            "type": "parsteel",
+            "value": 22766400
           }
         ]
       },
@@ -972,19 +945,18 @@
       "level": 28,
       "requirements": [
         {
-          "name": "Dilithium Generator B",
+          "name": "operations",
           "level": 28
         },
         {
-          "name": "Operations",
+          "name": "dilithium generator b",
           "level": 28
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 44000
+        "bonus1": 44000.0
       },
       "build_costs": {
         "materials": [
@@ -998,12 +970,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 36244000
-          },
-          {
             "type": "dilithium",
             "value": 399750
+          },
+          {
+            "type": "parsteel",
+            "value": 36244000
           }
         ]
       },
@@ -1012,37 +984,36 @@
       "level": 29,
       "requirements": [
         {
-          "name": "Tritanium Vault",
+          "name": "operations",
           "level": 29
         },
         {
-          "name": "Operations",
+          "name": "dilithium generator b",
           "level": 29
         },
         {
-          "name": "Dilithium Generator B",
+          "name": "tritanium vault",
           "level": 29
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 50000
+        "bonus1": 50000.0
       },
       "build_costs": {
         "materials": [
           {
             "type": "ore",
             "grade": 3,
-            "rarity": "common",
-            "value": 550
+            "rarity": "uncommon",
+            "value": 37
           },
           {
             "type": "ore",
             "grade": 3,
-            "rarity": "uncommon",
-            "value": 37
+            "rarity": "common",
+            "value": 550
           }
         ],
         "others": [],
@@ -1062,19 +1033,18 @@
       "level": 30,
       "requirements": [
         {
-          "name": "Dilithium Generator B",
+          "name": "operations",
           "level": 30
         },
         {
-          "name": "Operations",
+          "name": "dilithium generator b",
           "level": 30
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 65000
+        "bonus1": 65000.0
       },
       "build_costs": {
         "materials": [
@@ -1102,19 +1072,18 @@
       "level": 31,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 31
         },
         {
-          "name": "Dilithium Generator B",
+          "name": "dilithium generator b",
           "level": 31
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 82000
+        "bonus1": 82000.0
       },
       "build_costs": {
         "materials": [
@@ -1142,19 +1111,18 @@
       "level": 32,
       "requirements": [
         {
-          "name": "Dilithium Generator B",
+          "name": "operations",
           "level": 32
         },
         {
-          "name": "Operations",
+          "name": "dilithium generator b",
           "level": 32
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 100000
+        "bonus1": 100000.0
       },
       "build_costs": {
         "materials": [
@@ -1174,12 +1142,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 187340000
-          },
-          {
             "type": "dilithium",
             "value": 2066250
+          },
+          {
+            "type": "parsteel",
+            "value": 187340000
           }
         ]
       },
@@ -1188,33 +1156,32 @@
       "level": 33,
       "requirements": [
         {
-          "name": "Dilithium Generator B",
+          "name": "operations",
           "level": 33
         },
         {
-          "name": "Operations",
+          "name": "dilithium generator b",
           "level": 33
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 130000
+        "bonus1": 130000.0
       },
       "build_costs": {
         "materials": [
           {
             "type": "ore",
             "grade": 3,
-            "rarity": "common",
-            "value": 1100
+            "rarity": "uncommon",
+            "value": 100
           },
           {
             "type": "ore",
             "grade": 3,
-            "rarity": "uncommon",
-            "value": 100
+            "rarity": "common",
+            "value": 1100
           }
         ],
         "others": [],
@@ -1234,19 +1201,18 @@
       "level": 34,
       "requirements": [
         {
-          "name": "Dilithium Generator B",
+          "name": "operations",
           "level": 34
         },
         {
-          "name": "Operations",
+          "name": "dilithium generator b",
           "level": 34
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 176000
+        "bonus1": 176000.0
       },
       "build_costs": {
         "materials": [
@@ -1274,19 +1240,18 @@
       "level": 35,
       "requirements": [
         {
-          "name": "Dilithium Generator B",
+          "name": "operations",
           "level": 35
         },
         {
-          "name": "Operations",
+          "name": "dilithium generator b",
           "level": 35
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 223000
+        "bonus1": 223000.0
       },
       "build_costs": {
         "materials": [
@@ -1300,12 +1265,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 645048000
-          },
-          {
             "type": "dilithium",
             "value": 7114500
+          },
+          {
+            "type": "parsteel",
+            "value": 645048000
           }
         ]
       },
@@ -1314,33 +1279,32 @@
       "level": 36,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 36
         },
         {
-          "name": "Dilithium Generator B",
+          "name": "dilithium generator b",
           "level": 36
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 288000
+        "bonus1": 288000.0
       },
       "build_costs": {
         "materials": [
           {
             "type": "ore",
             "grade": 3,
-            "rarity": "common",
-            "value": 1800
+            "rarity": "uncommon",
+            "value": 170
           },
           {
             "type": "ore",
             "grade": 3,
-            "rarity": "uncommon",
-            "value": 170
+            "rarity": "common",
+            "value": 1800
           }
         ],
         "others": [],
@@ -1360,44 +1324,43 @@
       "level": 37,
       "requirements": [
         {
-          "name": "Dilithium Generator B",
+          "name": "operations",
           "level": 37
         },
         {
-          "name": "Operations",
+          "name": "dilithium generator b",
           "level": 37
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 392000
+        "bonus1": 392000.0
       },
       "build_costs": {
         "materials": [
           {
             "type": "ore",
             "grade": 3,
-            "rarity": "common",
-            "value": 2100
+            "rarity": "uncommon",
+            "value": 200
           },
           {
             "type": "ore",
             "grade": 3,
-            "rarity": "uncommon",
-            "value": 200
+            "rarity": "common",
+            "value": 2100
           }
         ],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 1542240000
-          },
-          {
             "type": "dilithium",
             "value": 17010000
+          },
+          {
+            "type": "parsteel",
+            "value": 1542240000
           }
         ]
       },
@@ -1406,23 +1369,22 @@
       "level": 38,
       "requirements": [
         {
-          "name": "Dilithium Generator B",
+          "name": "operations",
           "level": 38
         },
         {
-          "name": "Operations",
+          "name": "dilithium generator b",
           "level": 38
         },
         {
-          "name": "Tritanium Vault",
+          "name": "tritanium vault",
           "level": 38
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 540000
+        "bonus1": 540000.0
       },
       "build_costs": {
         "materials": [],
@@ -1443,19 +1405,18 @@
       "level": 39,
       "requirements": [
         {
-          "name": "Dilithium Generator B",
+          "name": "operations",
           "level": 39
         },
         {
-          "name": "Operations",
+          "name": "dilithium generator b",
           "level": 39
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 700000
+        "bonus1": 700000.0
       },
       "build_costs": {
         "materials": [
@@ -1469,12 +1430,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 11462080000
-          },
-          {
             "type": "dilithium",
             "value": 45150000
+          },
+          {
+            "type": "parsteel",
+            "value": 11462080000
           }
         ]
       },
@@ -1483,33 +1444,32 @@
       "level": 40,
       "requirements": [
         {
-          "name": "Dilithium Generator B",
+          "name": "operations",
           "level": 40
         },
         {
-          "name": "Operations",
+          "name": "dilithium generator b",
           "level": 40
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 950000
+        "bonus1": 950000.0
       },
       "build_costs": {
         "materials": [
           {
             "type": "ore",
             "grade": 4,
-            "rarity": "common",
-            "value": 9000
+            "rarity": "uncommon",
+            "value": 2000
           },
           {
             "type": "ore",
             "grade": 4,
-            "rarity": "uncommon",
-            "value": 2000
+            "rarity": "common",
+            "value": 9000
           }
         ],
         "others": [],
@@ -1529,19 +1489,18 @@
       "level": 41,
       "requirements": [
         {
-          "name": "Dilithium Generator B",
+          "name": "operations",
           "level": 41
         },
         {
-          "name": "Operations",
+          "name": "dilithium generator b",
           "level": 41
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 1260000
+        "bonus1": 1260000.0
       },
       "build_costs": {
         "materials": [
@@ -1561,12 +1520,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 17421600000
-          },
-          {
             "type": "dilithium",
             "value": 96075000
+          },
+          {
+            "type": "parsteel",
+            "value": 17421600000
           }
         ]
       },
@@ -1575,19 +1534,18 @@
       "level": 42,
       "requirements": [
         {
-          "name": "Dilithium Generator B",
+          "name": "operations",
           "level": 42
         },
         {
-          "name": "Operations",
+          "name": "dilithium generator b",
           "level": 42
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 1700000
+        "bonus1": 1700000.0
       },
       "build_costs": {
         "materials": [
@@ -1607,12 +1565,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 24888000000
-          },
-          {
             "type": "dilithium",
             "value": 137250000
+          },
+          {
+            "type": "parsteel",
+            "value": 24888000000
           }
         ]
       },
@@ -1621,19 +1579,18 @@
       "level": 43,
       "requirements": [
         {
-          "name": "Dilithium Generator B",
+          "name": "operations",
           "level": 43
         },
         {
-          "name": "Operations",
+          "name": "dilithium generator b",
           "level": 43
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 2400000
+        "bonus1": 2400000.0
       },
       "build_costs": {
         "materials": [
@@ -1653,12 +1610,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 37332000000
-          },
-          {
             "type": "dilithium",
             "value": 205875000
+          },
+          {
+            "type": "parsteel",
+            "value": 37332000000
           }
         ]
       },
@@ -1667,19 +1624,18 @@
       "level": 44,
       "requirements": [
         {
-          "name": "Dilithium Generator B",
+          "name": "operations",
           "level": 44
         },
         {
-          "name": "Operations",
+          "name": "dilithium generator b",
           "level": 44
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 3000000
+        "bonus1": 3000000.0
       },
       "build_costs": {
         "materials": [
@@ -1693,12 +1649,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 53040000000
-          },
-          {
             "type": "dilithium",
             "value": 292500000
+          },
+          {
+            "type": "parsteel",
+            "value": 53040000000
           }
         ]
       },
@@ -1707,37 +1663,36 @@
       "level": 45,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 45
         },
         {
-          "name": "Dilithium Generator B",
+          "name": "dilithium generator b",
           "level": 45
         },
         {
-          "name": "Dilithium Warehouse",
+          "name": "dilithium warehouse",
           "level": 45
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 3850000
+        "bonus1": 3850000.0
       },
       "build_costs": {
         "materials": [
           {
             "type": "ore",
             "grade": 4,
-            "rarity": "uncommon",
-            "value": 1500
+            "rarity": "rare",
+            "value": 250
           },
           {
             "type": "ore",
             "grade": 4,
-            "rarity": "rare",
-            "value": 250
+            "rarity": "uncommon",
+            "value": 1500
           }
         ],
         "others": [],
@@ -1757,19 +1712,18 @@
       "level": 46,
       "requirements": [
         {
-          "name": "Dilithium Generator B",
+          "name": "operations",
           "level": 46
         },
         {
-          "name": "Operations",
+          "name": "dilithium generator b",
           "level": 46
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 5200000
+        "bonus1": 5200000.0
       },
       "build_costs": {
         "materials": [
@@ -1789,12 +1743,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 106080000000
-          },
-          {
             "type": "dilithium",
             "value": 585000000
+          },
+          {
+            "type": "parsteel",
+            "value": 106080000000
           }
         ]
       },
@@ -1803,37 +1757,36 @@
       "level": 47,
       "requirements": [
         {
-          "name": "Dilithium Generator B",
+          "name": "operations",
           "level": 47
         },
         {
-          "name": "Operations",
+          "name": "dilithium generator b",
           "level": 47
         },
         {
-          "name": "Dilithium Warehouse",
+          "name": "dilithium warehouse",
           "level": 47
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 7200000
+        "bonus1": 7200000.0
       },
       "build_costs": {
         "materials": [
           {
             "type": "ore",
             "grade": 4,
-            "rarity": "common",
-            "value": 50000
+            "rarity": "rare",
+            "value": 1200
           },
           {
             "type": "ore",
             "grade": 4,
-            "rarity": "rare",
-            "value": 1200
+            "rarity": "common",
+            "value": 50000
           }
         ],
         "others": [],
@@ -1853,44 +1806,43 @@
       "level": 48,
       "requirements": [
         {
-          "name": "Dilithium Generator B",
+          "name": "operations",
           "level": 48
         },
         {
-          "name": "Operations",
+          "name": "dilithium generator b",
           "level": 48
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 11000000
+        "bonus1": 11000000.0
       },
       "build_costs": {
         "materials": [
           {
             "type": "ore",
             "grade": 4,
-            "rarity": "common",
-            "value": 70000
+            "rarity": "rare",
+            "value": 4500
           },
           {
             "type": "ore",
             "grade": 4,
-            "rarity": "rare",
-            "value": 4500
+            "rarity": "common",
+            "value": 70000
           }
         ],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 285600000000
-          },
-          {
             "type": "dilithium",
             "value": 1575000000
+          },
+          {
+            "type": "parsteel",
+            "value": 285600000000
           }
         ]
       },
@@ -1899,35 +1851,34 @@
       "level": 49,
       "requirements": [
         {
-          "name": "Dilithium Warehouse",
+          "name": "operations",
           "level": 49
         },
         {
-          "name": "Dilithium Generator B",
+          "name": "dilithium generator b",
           "level": 49
         },
         {
-          "name": "Operations",
+          "name": "dilithium warehouse",
           "level": 49
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 17500000
+        "bonus1": 17500000.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 499800000000
-          },
-          {
             "type": "dilithium",
             "value": 2756250000
+          },
+          {
+            "type": "parsteel",
+            "value": 499800000000
           }
         ]
       },
@@ -1936,15 +1887,235 @@
       "level": 50,
       "requirements": [
         {
-          "name": "Dilithium Generator B",
+          "name": "operations",
           "level": 50
         },
         {
-          "name": "Operations",
+          "name": "dilithium generator b",
           "level": 50
         }
-      ],
-      "rewards": []
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 26000000.0
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "ore",
+            "grade": 5,
+            "rarity": "common",
+            "value": 8500
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "dilithium",
+            "value": 5850000000
+          },
+          {
+            "type": "parsteel",
+            "value": 2492880000000
+          }
+        ]
+      },
+      "build_time": 119252160,
+      "increased_power": 7000,
+      "level": 51,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 51
+        },
+        {
+          "name": "dilithium generator b",
+          "level": 51
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 39000000.0
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "ore",
+            "grade": 5,
+            "rarity": "common",
+            "value": 18800
+          },
+          {
+            "type": "ore",
+            "grade": 5,
+            "rarity": "uncommon",
+            "value": 4300
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 4508400000000
+          },
+          {
+            "type": "dilithium",
+            "value": 9945000000
+          }
+        ]
+      },
+      "build_time": 126407520,
+      "increased_power": 7000,
+      "level": 52,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 52
+        },
+        {
+          "name": "dilithium generator b",
+          "level": 52
+        },
+        {
+          "name": "dilithium warehouse",
+          "level": 52
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 58000000.0
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "ore",
+            "grade": 5,
+            "rarity": "uncommon",
+            "value": 3100
+          },
+          {
+            "type": "ore",
+            "grade": 5,
+            "rarity": "common",
+            "value": 36600
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "dilithium",
+            "value": 17400000000
+          },
+          {
+            "type": "parsteel",
+            "value": 7572480000000
+          }
+        ]
+      },
+      "build_time": 133992000,
+      "increased_power": 8000,
+      "level": 53,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 53
+        },
+        {
+          "name": "dilithium generator b",
+          "level": 53
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 87000000.0
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "ore",
+            "grade": 5,
+            "rarity": "rare",
+            "value": 800
+          },
+          {
+            "type": "ore",
+            "grade": 5,
+            "rarity": "uncommon",
+            "value": 10400
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "dilithium",
+            "value": 26100000000
+          },
+          {
+            "type": "parsteel",
+            "value": 11358720000000
+          }
+        ]
+      },
+      "build_time": 142031520,
+      "increased_power": 7000,
+      "level": 54,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 54
+        },
+        {
+          "name": "dilithium generator b",
+          "level": 54
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 130000000.0
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "ore",
+            "grade": 5,
+            "rarity": "rare",
+            "value": 4800
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "dilithium",
+            "value": 40950000000
+          },
+          {
+            "type": "parsteel",
+            "value": 19306560000000
+          }
+        ]
+      },
+      "build_time": 150553440,
+      "increased_power": 8000,
+      "level": 55,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 55
+        },
+        {
+          "name": "dilithium generator b",
+          "level": 55
+        },
+        {
+          "name": "dilithium warehouse",
+          "level": 55
+        }
+      ]
     }
   ]
 }

--- a/buildings/dilithium_warehouse.json
+++ b/buildings/dilithium_warehouse.json
@@ -2,7 +2,7 @@
   "description": "Stores all collected Dilithium. Upgrade the Warehouse to increase the Dilithium Capacity.",
   "bonuses": {
     "bonus1": {
-      "name": "Dilithium Capacity",
+      "name": "dilithium capacity",
       "percentage": false
     }
   },
@@ -10,7 +10,7 @@
   "levels": [
     {
       "bonuses": {
-        "bonus1": 500
+        "bonus1": 500.0
       },
       "build_costs": {
         "materials": [],
@@ -27,19 +27,18 @@
       "level": 1,
       "requirements": [
         {
-          "name": "Dilithium Generator A",
-          "level": 1
+          "name": "operations",
+          "level": 10
         },
         {
-          "name": "Operations",
-          "level": 10
+          "name": "dilithium generator a",
+          "level": 1
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 675
+        "bonus1": 675.0
       },
       "build_costs": {
         "materials": [],
@@ -56,19 +55,18 @@
       "level": 2,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 10
         },
         {
-          "name": "Dilithium Generator A",
+          "name": "dilithium generator a",
           "level": 2
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 975
+        "bonus1": 975.0
       },
       "build_costs": {
         "materials": [],
@@ -85,19 +83,18 @@
       "level": 3,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 10
         },
         {
-          "name": "Dilithium Generator A",
+          "name": "dilithium generator a",
           "level": 2
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 1350
+        "bonus1": 1350.0
       },
       "build_costs": {
         "materials": [],
@@ -114,19 +111,18 @@
       "level": 4,
       "requirements": [
         {
-          "name": "Dilithium Generator A",
-          "level": 4
+          "name": "operations",
+          "level": 10
         },
         {
-          "name": "Operations",
-          "level": 10
+          "name": "dilithium generator a",
+          "level": 4
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 2100
+        "bonus1": 2100.0
       },
       "build_costs": {
         "materials": [],
@@ -143,19 +139,18 @@
       "level": 5,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 10
         },
         {
-          "name": "Dilithium Generator A",
+          "name": "dilithium generator a",
           "level": 4
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 2600
+        "bonus1": 2600.0
       },
       "build_costs": {
         "materials": [],
@@ -172,19 +167,18 @@
       "level": 6,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 10
         },
         {
-          "name": "Dilithium Generator A",
+          "name": "dilithium generator a",
           "level": 6
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 3300
+        "bonus1": 3300.0
       },
       "build_costs": {
         "materials": [],
@@ -201,19 +195,18 @@
       "level": 7,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 10
         },
         {
-          "name": "Dilithium Generator A",
+          "name": "dilithium generator a",
           "level": 6
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 3600
+        "bonus1": 3600.0
       },
       "build_costs": {
         "materials": [],
@@ -230,19 +223,18 @@
       "level": 8,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 10
         },
         {
-          "name": "Dilithium Generator A",
+          "name": "dilithium generator a",
           "level": 6
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 3800
+        "bonus1": 3800.0
       },
       "build_costs": {
         "materials": [],
@@ -259,19 +251,18 @@
       "level": 9,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 10
         },
         {
-          "name": "Dilithium Generator A",
+          "name": "dilithium generator a",
           "level": 9
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 4000
+        "bonus1": 4000.0
       },
       "build_costs": {
         "materials": [],
@@ -288,31 +279,30 @@
       "level": 10,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 10
         },
         {
-          "name": "Dilithium Generator A",
+          "name": "dilithium generator a",
           "level": 10
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 4200
+        "bonus1": 4200.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 8160
-          },
-          {
             "type": "dilithium",
             "value": 80
+          },
+          {
+            "type": "parsteel",
+            "value": 8160
           }
         ]
       },
@@ -321,19 +311,18 @@
       "level": 11,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 11
         },
         {
-          "name": "Dilithium Generator A",
+          "name": "dilithium generator a",
           "level": 11
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 4400
+        "bonus1": 4400.0
       },
       "build_costs": {
         "materials": [],
@@ -354,19 +343,18 @@
       "level": 12,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 12
         },
         {
-          "name": "Dilithium Generator A",
+          "name": "dilithium generator a",
           "level": 12
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 4600
+        "bonus1": 4600.0
       },
       "build_costs": {
         "materials": [],
@@ -387,19 +375,18 @@
       "level": 13,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 13
         },
         {
-          "name": "Dilithium Generator A",
+          "name": "dilithium generator a",
           "level": 13
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 4800
+        "bonus1": 4800.0
       },
       "build_costs": {
         "materials": [],
@@ -420,19 +407,18 @@
       "level": 14,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 14
         },
         {
-          "name": "Dilithium Generator A",
+          "name": "dilithium generator a",
           "level": 14
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 5000
+        "bonus1": 5000.0
       },
       "build_costs": {
         "materials": [],
@@ -453,19 +439,18 @@
       "level": 15,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 15
         },
         {
-          "name": "Dilithium Generator A",
+          "name": "dilithium generator a",
           "level": 15
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 5250
+        "bonus1": 5250.0
       },
       "build_costs": {
         "materials": [],
@@ -486,19 +471,18 @@
       "level": 16,
       "requirements": [
         {
-          "name": "Dilithium Generator A",
+          "name": "operations",
           "level": 16
         },
         {
-          "name": "Operations",
+          "name": "dilithium generator a",
           "level": 16
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 5500
+        "bonus1": 5500.0
       },
       "build_costs": {
         "materials": [
@@ -526,19 +510,18 @@
       "level": 17,
       "requirements": [
         {
-          "name": "Dilithium Generator A",
+          "name": "operations",
           "level": 17
         },
         {
-          "name": "Operations",
+          "name": "dilithium generator a",
           "level": 17
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 6250
+        "bonus1": 6250.0
       },
       "build_costs": {
         "materials": [
@@ -552,12 +535,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 81600
-          },
-          {
             "type": "dilithium",
             "value": 4000
+          },
+          {
+            "type": "parsteel",
+            "value": 81600
           }
         ]
       },
@@ -566,19 +549,18 @@
       "level": 18,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 18
         },
         {
-          "name": "Dilithium Generator A",
+          "name": "dilithium generator a",
           "level": 18
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 8250
+        "bonus1": 8250.0
       },
       "build_costs": {
         "materials": [
@@ -592,12 +574,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 122400
-          },
-          {
             "type": "dilithium",
             "value": 6000
+          },
+          {
+            "type": "parsteel",
+            "value": 122400
           }
         ]
       },
@@ -606,19 +588,18 @@
       "level": 19,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 19
         },
         {
-          "name": "Dilithium Generator B",
+          "name": "dilithium generator b",
           "level": 19
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 10250
+        "bonus1": 10250.0
       },
       "build_costs": {
         "materials": [],
@@ -639,31 +620,30 @@
       "level": 20,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 20
         },
         {
-          "name": "Dilithium Generator A",
+          "name": "dilithium generator a",
           "level": 20
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 15750
+        "bonus1": 15750.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 291924
-          },
-          {
             "type": "dilithium",
             "value": 14310
+          },
+          {
+            "type": "parsteel",
+            "value": 291924
           }
         ]
       },
@@ -672,19 +652,18 @@
       "level": 21,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 21
         },
         {
-          "name": "Dilithium Generator A",
+          "name": "dilithium generator a",
           "level": 21
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 23500
+        "bonus1": 23500.0
       },
       "build_costs": {
         "materials": [],
@@ -705,31 +684,30 @@
       "level": 22,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 22
         },
         {
-          "name": "Dilithium Generator A",
+          "name": "dilithium generator a",
           "level": 22
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 35500
+        "bonus1": 35500.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 747252
-          },
-          {
             "type": "dilithium",
             "value": 36630
+          },
+          {
+            "type": "parsteel",
+            "value": 747252
           }
         ]
       },
@@ -738,19 +716,18 @@
       "level": 23,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 23
         },
         {
-          "name": "Dilithium Generator A",
+          "name": "dilithium generator a",
           "level": 23
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 54000
+        "bonus1": 54000.0
       },
       "build_costs": {
         "materials": [
@@ -764,12 +741,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 1177488
-          },
-          {
             "type": "dilithium",
             "value": 57720
+          },
+          {
+            "type": "parsteel",
+            "value": 1177488
           }
         ]
       },
@@ -778,19 +755,18 @@
       "level": 24,
       "requirements": [
         {
-          "name": "Dilithium Generator A",
+          "name": "operations",
           "level": 24
         },
         {
-          "name": "Operations",
+          "name": "dilithium generator a",
           "level": 24
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 80000
+        "bonus1": 80000.0
       },
       "build_costs": {
         "materials": [
@@ -804,12 +780,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 1909440
-          },
-          {
             "type": "dilithium",
             "value": 93600
+          },
+          {
+            "type": "parsteel",
+            "value": 1909440
           }
         ]
       },
@@ -818,23 +794,22 @@
       "level": 25,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 25
         },
         {
-          "name": "Dilithium Generator A",
+          "name": "dilithium generator a",
           "level": 25
         },
         {
-          "name": "Tritanium Warehouse",
+          "name": "tritanium warehouse",
           "level": 25
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 120000
+        "bonus1": 120000.0
       },
       "build_costs": {
         "materials": [
@@ -848,12 +823,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 2983500
-          },
-          {
             "type": "dilithium",
             "value": 146250
+          },
+          {
+            "type": "parsteel",
+            "value": 2983500
           }
         ]
       },
@@ -862,33 +837,32 @@
       "level": 26,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 26
         },
         {
-          "name": "Dilithium Generator A",
+          "name": "dilithium generator a",
           "level": 26
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 166000
+        "bonus1": 166000.0
       },
       "build_costs": {
         "materials": [
           {
             "type": "ore",
             "grade": 3,
-            "rarity": "common",
-            "value": 290
+            "rarity": "uncommon",
+            "value": 10
           },
           {
             "type": "ore",
             "grade": 3,
-            "rarity": "uncommon",
-            "value": 10
+            "rarity": "common",
+            "value": 290
           }
         ],
         "others": [],
@@ -908,19 +882,18 @@
       "level": 27,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 27
         },
         {
-          "name": "Dilithium Generator A",
+          "name": "dilithium generator a",
           "level": 27
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 240000
+        "bonus1": 240000.0
       },
       "build_costs": {
         "materials": [
@@ -934,12 +907,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 6829920
-          },
-          {
             "type": "dilithium",
             "value": 334800
+          },
+          {
+            "type": "parsteel",
+            "value": 6829920
           }
         ]
       },
@@ -948,19 +921,18 @@
       "level": 28,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 28
         },
         {
-          "name": "Dilithium Generator A",
+          "name": "dilithium generator a",
           "level": 28
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 345000
+        "bonus1": 345000.0
       },
       "build_costs": {
         "materials": [
@@ -988,44 +960,43 @@
       "level": 29,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 29
         },
         {
-          "name": "Dilithium Generator A",
+          "name": "dilithium generator a",
           "level": 29
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 480000
+        "bonus1": 480000.0
       },
       "build_costs": {
         "materials": [
           {
             "type": "ore",
             "grade": 3,
-            "rarity": "common",
-            "value": 550
+            "rarity": "uncommon",
+            "value": 37
           },
           {
             "type": "ore",
             "grade": 3,
-            "rarity": "uncommon",
-            "value": 37
+            "rarity": "common",
+            "value": 550
           }
         ],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 15912000
-          },
-          {
             "type": "dilithium",
             "value": 780000
+          },
+          {
+            "type": "parsteel",
+            "value": 15912000
           }
         ]
       },
@@ -1034,19 +1005,18 @@
       "level": 30,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 30
         },
         {
-          "name": "Dilithium Generator A",
+          "name": "dilithium generator a",
           "level": 30
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 650000
+        "bonus1": 650000.0
       },
       "build_costs": {
         "materials": [
@@ -1060,12 +1030,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 25153200
-          },
-          {
             "type": "dilithium",
             "value": 1233000
+          },
+          {
+            "type": "parsteel",
+            "value": 25153200
           }
         ]
       },
@@ -1074,19 +1044,18 @@
       "level": 31,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 31
         },
         {
-          "name": "Dilithium Generator A",
+          "name": "dilithium generator a",
           "level": 31
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 850000
+        "bonus1": 850000.0
       },
       "build_costs": {
         "materials": [
@@ -1106,12 +1075,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 36332400
-          },
-          {
             "type": "dilithium",
             "value": 1781000
+          },
+          {
+            "type": "parsteel",
+            "value": 36332400
           }
         ]
       },
@@ -1120,19 +1089,18 @@
       "level": 32,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 32
         },
         {
-          "name": "Dilithium Generator A",
+          "name": "dilithium generator a",
           "level": 32
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 1100000
+        "bonus1": 1100000.0
       },
       "build_costs": {
         "materials": [
@@ -1160,19 +1128,18 @@
       "level": 33,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 33
         },
         {
-          "name": "Dilithium Generator A",
+          "name": "dilithium generator a",
           "level": 33
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 1550000
+        "bonus1": 1550000.0
       },
       "build_costs": {
         "materials": [
@@ -1200,19 +1167,18 @@
       "level": 34,
       "requirements": [
         {
-          "name": "Dilithium Generator A",
+          "name": "operations",
           "level": 34
         },
         {
-          "name": "Operations",
+          "name": "dilithium generator a",
           "level": 34
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 1950000
+        "bonus1": 1950000.0
       },
       "build_costs": {
         "materials": [
@@ -1246,19 +1212,18 @@
       "level": 35,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 35
         },
         {
-          "name": "Dilithium Generator A",
+          "name": "dilithium generator a",
           "level": 35
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 2250000
+        "bonus1": 2250000.0
       },
       "build_costs": {
         "materials": [
@@ -1272,12 +1237,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 193514400
-          },
-          {
             "type": "dilithium",
             "value": 9486000
+          },
+          {
+            "type": "parsteel",
+            "value": 193514400
           }
         ]
       },
@@ -1286,19 +1251,18 @@
       "level": 36,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 36
         },
         {
-          "name": "Dilithium Generator A",
+          "name": "dilithium generator a",
           "level": 36
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 2650000
+        "bonus1": 2650000.0
       },
       "build_costs": {
         "materials": [
@@ -1326,44 +1290,43 @@
       "level": 37,
       "requirements": [
         {
-          "name": "Dilithium Generator A",
+          "name": "operations",
           "level": 37
         },
         {
-          "name": "Operations",
+          "name": "dilithium generator a",
           "level": 37
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 3100000
+        "bonus1": 3100000.0
       },
       "build_costs": {
         "materials": [
           {
             "type": "ore",
             "grade": 3,
-            "rarity": "common",
-            "value": 2100
+            "rarity": "uncommon",
+            "value": 200
           },
           {
             "type": "ore",
             "grade": 3,
-            "rarity": "uncommon",
-            "value": 200
+            "rarity": "common",
+            "value": 2100
           }
         ],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 462672000
-          },
-          {
             "type": "dilithium",
             "value": 22680000
+          },
+          {
+            "type": "parsteel",
+            "value": 462672000
           }
         ]
       },
@@ -1372,23 +1335,22 @@
       "level": 38,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 38
         },
         {
-          "name": "Dilithium Generator A",
+          "name": "dilithium generator a",
           "level": 38
         },
         {
-          "name": "Tritanium Warehouse",
+          "name": "tritanium warehouse",
           "level": 38
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 3300000
+        "bonus1": 3300000.0
       },
       "build_costs": {
         "materials": [],
@@ -1409,19 +1371,18 @@
       "level": 39,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 39
         },
         {
-          "name": "Dilithium Generator A",
+          "name": "dilithium generator a",
           "level": 39
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 3500000
+        "bonus1": 3500000.0
       },
       "build_costs": {
         "materials": [
@@ -1449,19 +1410,18 @@
       "level": 40,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 40
         },
         {
-          "name": "Dilithium Generator A",
+          "name": "dilithium generator a",
           "level": 40
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 3650000
+        "bonus1": 3650000.0
       },
       "build_costs": {
         "materials": [
@@ -1489,19 +1449,18 @@
       "level": 41,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 41
         },
         {
-          "name": "Dilithium Generator A",
+          "name": "dilithium generator a",
           "level": 41
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 4750000
+        "bonus1": 4750000.0
       },
       "build_costs": {
         "materials": [
@@ -1521,12 +1480,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 5226480000
-          },
-          {
             "type": "dilithium",
             "value": 128100000
+          },
+          {
+            "type": "parsteel",
+            "value": 5226480000
           }
         ]
       },
@@ -1535,44 +1494,43 @@
       "level": 42,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 42
         },
         {
-          "name": "Dilithium Generator A",
+          "name": "dilithium generator a",
           "level": 42
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 6450000
+        "bonus1": 6450000.0
       },
       "build_costs": {
         "materials": [
           {
             "type": "ore",
             "grade": 4,
-            "rarity": "uncommon",
-            "value": 1000
+            "rarity": "rare",
+            "value": 600
           },
           {
             "type": "ore",
             "grade": 4,
-            "rarity": "rare",
-            "value": 600
+            "rarity": "uncommon",
+            "value": 1000
           }
         ],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 7466400000
-          },
-          {
             "type": "dilithium",
             "value": 183000000
+          },
+          {
+            "type": "parsteel",
+            "value": 7466400000
           }
         ]
       },
@@ -1581,19 +1539,18 @@
       "level": 43,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 43
         },
         {
-          "name": "Dilithium Generator A",
+          "name": "dilithium generator a",
           "level": 43
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 9150000
+        "bonus1": 9150000.0
       },
       "build_costs": {
         "materials": [
@@ -1613,12 +1570,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 11199600000
-          },
-          {
             "type": "dilithium",
             "value": 274500000
+          },
+          {
+            "type": "parsteel",
+            "value": 11199600000
           }
         ]
       },
@@ -1627,19 +1584,18 @@
       "level": 44,
       "requirements": [
         {
-          "name": "Dilithium Generator A",
+          "name": "operations",
           "level": 44
         },
         {
-          "name": "Operations",
+          "name": "dilithium generator a",
           "level": 44
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 11500000
+        "bonus1": 11500000.0
       },
       "build_costs": {
         "materials": [
@@ -1667,23 +1623,22 @@
       "level": 45,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 45
         },
         {
-          "name": "Dilithium Generator A",
+          "name": "dilithium generator a",
           "level": 45
         },
         {
-          "name": "Tritanium Vault",
+          "name": "tritanium vault",
           "level": 45
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 15000000
+        "bonus1": 15000000.0
       },
       "build_costs": {
         "materials": [
@@ -1717,33 +1672,32 @@
       "level": 46,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 46
         },
         {
-          "name": "Dilithium Generator A",
+          "name": "dilithium generator a",
           "level": 46
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 20000000
+        "bonus1": 20000000.0
       },
       "build_costs": {
         "materials": [
           {
             "type": "ore",
             "grade": 4,
-            "rarity": "uncommon",
-            "value": 3000
+            "rarity": "rare",
+            "value": 500
           },
           {
             "type": "ore",
             "grade": 4,
-            "rarity": "rare",
-            "value": 500
+            "rarity": "uncommon",
+            "value": 3000
           }
         ],
         "others": [],
@@ -1763,37 +1717,36 @@
       "level": 47,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 47
         },
         {
-          "name": "Dilithium Generator A",
+          "name": "dilithium generator a",
           "level": 47
         },
         {
-          "name": "Tritanium Vault",
+          "name": "tritanium vault",
           "level": 47
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 28000000
+        "bonus1": 28000000.0
       },
       "build_costs": {
         "materials": [
           {
             "type": "ore",
             "grade": 4,
-            "rarity": "common",
-            "value": 50000
+            "rarity": "rare",
+            "value": 1200
           },
           {
             "type": "ore",
             "grade": 4,
-            "rarity": "rare",
-            "value": 1200
+            "rarity": "common",
+            "value": 50000
           }
         ],
         "others": [],
@@ -1813,19 +1766,18 @@
       "level": 48,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 48
         },
         {
-          "name": "Dilithium Generator A",
+          "name": "dilithium generator a",
           "level": 48
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 43500000
+        "bonus1": 43500000.0
       },
       "build_costs": {
         "materials": [
@@ -1845,12 +1797,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 85680000000
-          },
-          {
             "type": "dilithium",
             "value": 2100000000
+          },
+          {
+            "type": "parsteel",
+            "value": 85680000000
           }
         ]
       },
@@ -1859,35 +1811,34 @@
       "level": 49,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 49
         },
         {
-          "name": "Dilithium Generator A",
+          "name": "dilithium generator a",
           "level": 49
         },
         {
-          "name": "Tritanium Vault",
+          "name": "tritanium vault",
           "level": 49
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 70000000
+        "bonus1": 70000000.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 149940000000
-          },
-          {
             "type": "dilithium",
             "value": 3675000000
+          },
+          {
+            "type": "parsteel",
+            "value": 149940000000
           }
         ]
       },
@@ -1896,15 +1847,235 @@
       "level": 50,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 50
         },
         {
-          "name": "Dilithium Generator A",
+          "name": "dilithium generator a",
           "level": 50
         }
-      ],
-      "rewards": []
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 105000000.0
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "ore",
+            "grade": 5,
+            "rarity": "common",
+            "value": 8500
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 747864000000
+          },
+          {
+            "type": "dilithium",
+            "value": 7800000000
+          }
+        ]
+      },
+      "build_time": 89439840,
+      "increased_power": 3500,
+      "level": 51,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 51
+        },
+        {
+          "name": "dilithium generator a",
+          "level": 51
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 155000000.0
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "ore",
+            "grade": 5,
+            "rarity": "uncommon",
+            "value": 4300
+          },
+          {
+            "type": "ore",
+            "grade": 5,
+            "rarity": "common",
+            "value": 18800
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 1352520000000
+          },
+          {
+            "type": "dilithium",
+            "value": 13260000000
+          }
+        ]
+      },
+      "build_time": 94805280,
+      "increased_power": 3500,
+      "level": 52,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 52
+        },
+        {
+          "name": "dilithium generator a",
+          "level": 52
+        },
+        {
+          "name": "tritanium vault",
+          "level": 52
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 230000000.0
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "ore",
+            "grade": 5,
+            "rarity": "common",
+            "value": 37500
+          },
+          {
+            "type": "ore",
+            "grade": 5,
+            "rarity": "uncommon",
+            "value": 3100
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "dilithium",
+            "value": 23200000000
+          },
+          {
+            "type": "parsteel",
+            "value": 2271744000000
+          }
+        ]
+      },
+      "build_time": 100494720,
+      "increased_power": 4000,
+      "level": 53,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 53
+        },
+        {
+          "name": "dilithium generator a",
+          "level": 53
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 350000000.0
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "ore",
+            "grade": 5,
+            "rarity": "uncommon",
+            "value": 10400
+          },
+          {
+            "type": "ore",
+            "grade": 5,
+            "rarity": "rare",
+            "value": 800
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 3407616000000
+          },
+          {
+            "type": "dilithium",
+            "value": 34800000000
+          }
+        ]
+      },
+      "build_time": 106524000,
+      "increased_power": 4000,
+      "level": 54,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 54
+        },
+        {
+          "name": "dilithium generator a",
+          "level": 54
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 520000000.0
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "ore",
+            "grade": 5,
+            "rarity": "rare",
+            "value": 4800
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 5791968000000
+          },
+          {
+            "type": "dilithium",
+            "value": 54600000000
+          }
+        ]
+      },
+      "build_time": 112914720,
+      "increased_power": 4000,
+      "level": 55,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 55
+        },
+        {
+          "name": "dilithium generator a",
+          "level": 55
+        },
+        {
+          "name": "tritanium vault",
+          "level": 55
+        }
+      ]
     }
   ]
 }

--- a/buildings/drydock_a.json
+++ b/buildings/drydock_a.json
@@ -2,11 +2,11 @@
   "description": "Ship A. Ships can be assigned, managed and upgraded via Ship Management. Every additional Drydock increases the amounts of Ships that can be deployed.",
   "bonuses": {
     "bonus1": {
-      "name": "Repair Cost Efficiency",
+      "name": "repair speed bonus",
       "percentage": true
     },
     "bonus2": {
-      "name": "Repair Speed Bonus",
+      "name": "repair cost efficiency",
       "percentage": true
     }
   },
@@ -14,8 +14,8 @@
   "levels": [
     {
       "bonuses": {
-        "bonus1": 0,
-        "bonus2": 0
+        "bonus1": 0.0,
+        "bonus2": 0.0
       },
       "build_costs": {
         "materials": [],
@@ -25,13 +25,12 @@
       "build_time": 0,
       "increased_power": 0,
       "level": 1,
-      "requirements": [],
-      "rewards": []
+      "requirements": []
     },
     {
       "bonuses": {
-        "bonus1": 3,
-        "bonus2": 0
+        "bonus1": 0.0,
+        "bonus2": 0.03
       },
       "build_costs": {
         "materials": [],
@@ -48,16 +47,15 @@
       "level": 2,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 7
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 5,
-        "bonus2": 0
+        "bonus1": 0.0,
+        "bonus2": 0.05
       },
       "build_costs": {
         "materials": [],
@@ -74,16 +72,15 @@
       "level": 3,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 7
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 6,
-        "bonus2": 0
+        "bonus1": 0.0,
+        "bonus2": 0.06
       },
       "build_costs": {
         "materials": [],
@@ -100,16 +97,15 @@
       "level": 4,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 7
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 8,
-        "bonus2": 10
+        "bonus1": 0.1,
+        "bonus2": 0.08
       },
       "build_costs": {
         "materials": [],
@@ -126,20 +122,19 @@
       "level": 5,
       "requirements": [
         {
-          "name": "Drydock B",
-          "level": 4
+          "name": "operations",
+          "level": 5
         },
         {
-          "name": "Operations",
-          "level": 5
+          "name": "drydock b",
+          "level": 4
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 9,
-        "bonus2": 10
+        "bonus1": 0.1,
+        "bonus2": 0.09
       },
       "build_costs": {
         "materials": [],
@@ -156,28 +151,27 @@
       "level": 6,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 6
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 11,
-        "bonus2": 14
+        "bonus1": 0.14,
+        "bonus2": 0.11
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 4500
-          },
-          {
             "type": "tritanium",
             "value": 50
+          },
+          {
+            "type": "parsteel",
+            "value": 4500
           }
         ]
       },
@@ -186,28 +180,27 @@
       "level": 7,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 7
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 12,
-        "bonus2": 14
+        "bonus1": 0.14,
+        "bonus2": 0.12
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 4750
-          },
-          {
             "type": "tritanium",
             "value": 100
+          },
+          {
+            "type": "parsteel",
+            "value": 4750
           }
         ]
       },
@@ -216,28 +209,27 @@
       "level": 8,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 8
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 14,
-        "bonus2": 14
+        "bonus1": 0.14,
+        "bonus2": 0.14
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 5000
-          },
-          {
             "type": "tritanium",
             "value": 200
+          },
+          {
+            "type": "parsteel",
+            "value": 5000
           }
         ]
       },
@@ -246,28 +238,27 @@
       "level": 9,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 9
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 15,
-        "bonus2": 20
+        "bonus1": 0.2,
+        "bonus2": 0.15
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 7500
-          },
-          {
             "type": "tritanium",
             "value": 225
+          },
+          {
+            "type": "parsteel",
+            "value": 7500
           }
         ]
       },
@@ -276,16 +267,15 @@
       "level": 10,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 10
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 17,
-        "bonus2": 20
+        "bonus1": 0.2,
+        "bonus2": 0.17
       },
       "build_costs": {
         "materials": [],
@@ -306,28 +296,27 @@
       "level": 11,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 11
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 19,
-        "bonus2": 25
+        "bonus1": 0.25,
+        "bonus2": 0.19
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 14960
-          },
-          {
             "type": "tritanium",
             "value": 413
+          },
+          {
+            "type": "parsteel",
+            "value": 14960
           }
         ]
       },
@@ -336,28 +325,27 @@
       "level": 12,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 12
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 21,
-        "bonus2": 25
+        "bonus1": 0.25,
+        "bonus2": 0.21
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 21760
-          },
-          {
             "type": "tritanium",
             "value": 600
+          },
+          {
+            "type": "parsteel",
+            "value": 21760
           }
         ]
       },
@@ -366,16 +354,15 @@
       "level": 13,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 13
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 23,
-        "bonus2": 25
+        "bonus1": 0.25,
+        "bonus2": 0.23
       },
       "build_costs": {
         "materials": [],
@@ -396,16 +383,15 @@
       "level": 14,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 14
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 25,
-        "bonus2": 35
+        "bonus1": 0.35,
+        "bonus2": 0.25
       },
       "build_costs": {
         "materials": [],
@@ -426,16 +412,15 @@
       "level": 15,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 15
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 28,
-        "bonus2": 35
+        "bonus1": 0.35,
+        "bonus2": 0.28
       },
       "build_costs": {
         "materials": [],
@@ -456,16 +441,15 @@
       "level": 16,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 16
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 31,
-        "bonus2": 42
+        "bonus1": 0.42,
+        "bonus2": 0.31
       },
       "build_costs": {
         "materials": [
@@ -493,16 +477,15 @@
       "level": 17,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 17
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 34,
-        "bonus2": 42
+        "bonus1": 0.42,
+        "bonus2": 0.34
       },
       "build_costs": {
         "materials": [
@@ -516,12 +499,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 108800
-          },
-          {
             "type": "tritanium",
             "value": 3000
+          },
+          {
+            "type": "parsteel",
+            "value": 108800
           }
         ]
       },
@@ -530,16 +513,15 @@
       "level": 18,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 18
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 37,
-        "bonus2": 42
+        "bonus1": 0.42,
+        "bonus2": 0.37
       },
       "build_costs": {
         "materials": [
@@ -567,28 +549,27 @@
       "level": 19,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 19
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 40,
-        "bonus2": 55
+        "bonus1": 0.55,
+        "bonus2": 0.4
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 231200
-          },
-          {
             "type": "tritanium",
             "value": 6375
+          },
+          {
+            "type": "parsteel",
+            "value": 231200
           }
         ]
       },
@@ -597,16 +578,15 @@
       "level": 20,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 20
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 44,
-        "bonus2": 55
+        "bonus1": 0.55,
+        "bonus2": 0.44
       },
       "build_costs": {
         "materials": [],
@@ -627,28 +607,27 @@
       "level": 21,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 21
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 48,
-        "bonus2": 62
+        "bonus1": 0.62,
+        "bonus2": 0.48
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 605472
-          },
-          {
             "type": "tritanium",
             "value": 16695
+          },
+          {
+            "type": "parsteel",
+            "value": 605472
           }
         ]
       },
@@ -657,28 +636,27 @@
       "level": 22,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 22
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 52,
-        "bonus2": 62
+        "bonus1": 0.62,
+        "bonus2": 0.52
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 996336
-          },
-          {
             "type": "tritanium",
             "value": 27473
+          },
+          {
+            "type": "parsteel",
+            "value": 996336
           }
         ]
       },
@@ -687,16 +665,15 @@
       "level": 23,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 23
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 56,
-        "bonus2": 62
+        "bonus1": 0.62,
+        "bonus2": 0.56
       },
       "build_costs": {
         "materials": [
@@ -724,16 +701,15 @@
       "level": 24,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 24
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 60,
-        "bonus2": 75
+        "bonus1": 0.75,
+        "bonus2": 0.6
       },
       "build_costs": {
         "materials": [
@@ -767,34 +743,33 @@
       "level": 25,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 25
         },
         {
-          "name": "R&D Department",
+          "name": "r&d department",
           "level": 25
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 64,
-        "bonus2": 75
+        "bonus1": 0.75,
+        "bonus2": 0.64
       },
       "build_costs": {
         "materials": [
           {
             "type": "crystal",
             "grade": 3,
-            "rarity": "common",
-            "value": 230
+            "rarity": "uncommon",
+            "value": 4
           },
           {
             "type": "crystal",
             "grade": 3,
-            "rarity": "uncommon",
-            "value": 4
+            "rarity": "common",
+            "value": 230
           }
         ],
         "others": [],
@@ -814,16 +789,15 @@
       "level": 26,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 26
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 68,
-        "bonus2": 85
+        "bonus1": 0.85,
+        "bonus2": 0.68
       },
       "build_costs": {
         "materials": [
@@ -843,12 +817,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 6071040
-          },
-          {
             "type": "tritanium",
             "value": 167400
+          },
+          {
+            "type": "parsteel",
+            "value": 6071040
           }
         ]
       },
@@ -857,16 +831,15 @@
       "level": 27,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 27
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 72,
-        "bonus2": 85
+        "bonus1": 0.85,
+        "bonus2": 0.72
       },
       "build_costs": {
         "materials": [
@@ -880,12 +853,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 9106560
-          },
-          {
             "type": "tritanium",
             "value": 251100
+          },
+          {
+            "type": "parsteel",
+            "value": 9106560
           }
         ]
       },
@@ -894,30 +867,29 @@
       "level": 28,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 28
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 76,
-        "bonus2": 85
+        "bonus1": 0.85,
+        "bonus2": 0.76
       },
       "build_costs": {
         "materials": [
           {
             "type": "crystal",
             "grade": 3,
-            "rarity": "common",
-            "value": 450
+            "rarity": "uncommon",
+            "value": 30
           },
           {
             "type": "crystal",
             "grade": 3,
-            "rarity": "uncommon",
-            "value": 30
+            "rarity": "common",
+            "value": 450
           }
         ],
         "others": [],
@@ -937,16 +909,15 @@
       "level": 29,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 29
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 80,
-        "bonus2": 100
+        "bonus1": 1.0,
+        "bonus2": 0.8
       },
       "build_costs": {
         "materials": [
@@ -966,12 +937,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 21216000
-          },
-          {
             "type": "tritanium",
             "value": 585000
+          },
+          {
+            "type": "parsteel",
+            "value": 21216000
           }
         ]
       },
@@ -980,16 +951,15 @@
       "level": 30,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 30
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 84,
-        "bonus2": 100
+        "bonus1": 1.0,
+        "bonus2": 0.84
       },
       "build_costs": {
         "materials": [
@@ -1023,16 +993,15 @@
       "level": 31,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 31
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 88,
-        "bonus2": 110
+        "bonus1": 1.1,
+        "bonus2": 0.88
       },
       "build_costs": {
         "materials": [
@@ -1046,12 +1015,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 48443200
-          },
-          {
             "type": "tritanium",
             "value": 1335750
+          },
+          {
+            "type": "parsteel",
+            "value": 48443200
           }
         ]
       },
@@ -1060,16 +1029,15 @@
       "level": 32,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 32
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 92,
-        "bonus2": 110
+        "bonus1": 1.1,
+        "bonus2": 0.92
       },
       "build_costs": {
         "materials": [
@@ -1083,12 +1051,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 74936000
-          },
-          {
             "type": "tritanium",
             "value": 2066250
+          },
+          {
+            "type": "parsteel",
+            "value": 74936000
           }
         ]
       },
@@ -1097,16 +1065,15 @@
       "level": 33,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 33
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 96,
-        "bonus2": 110
+        "bonus1": 1.1,
+        "bonus2": 0.96
       },
       "build_costs": {
         "materials": [
@@ -1126,12 +1093,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 118320000
-          },
-          {
             "type": "tritanium",
             "value": 3262500
+          },
+          {
+            "type": "parsteel",
+            "value": 118320000
           }
         ]
       },
@@ -1140,16 +1107,15 @@
       "level": 34,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 34
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 100,
-        "bonus2": 130
+        "bonus1": 1.3,
+        "bonus2": 1.0
       },
       "build_costs": {
         "materials": [
@@ -1169,12 +1135,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 183110400
-          },
-          {
             "type": "tritanium",
             "value": 5049000
+          },
+          {
+            "type": "parsteel",
+            "value": 183110400
           }
         ]
       },
@@ -1183,16 +1149,15 @@
       "level": 35,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 35
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 105,
-        "bonus2": 130
+        "bonus1": 1.3,
+        "bonus2": 1.05
       },
       "build_costs": {
         "materials": [
@@ -1212,12 +1177,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 258019200
-          },
-          {
             "type": "tritanium",
             "value": 7114500
+          },
+          {
+            "type": "parsteel",
+            "value": 258019200
           }
         ]
       },
@@ -1226,16 +1191,15 @@
       "level": 36,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 36
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 110,
-        "bonus2": 140
+        "bonus1": 1.4,
+        "bonus2": 1.1
       },
       "build_costs": {
         "materials": [
@@ -1249,12 +1213,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 396576000
-          },
-          {
             "type": "tritanium",
             "value": 10935000
+          },
+          {
+            "type": "parsteel",
+            "value": 396576000
           }
         ]
       },
@@ -1263,30 +1227,29 @@
       "level": 37,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 37
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 115,
-        "bonus2": 140
+        "bonus1": 1.4,
+        "bonus2": 1.15
       },
       "build_costs": {
         "materials": [
           {
             "type": "crystal",
             "grade": 3,
-            "rarity": "common",
-            "value": 2100
+            "rarity": "uncommon",
+            "value": 310
           },
           {
             "type": "crystal",
             "grade": 3,
-            "rarity": "uncommon",
-            "value": 310
+            "rarity": "common",
+            "value": 2100
           }
         ],
         "others": [],
@@ -1306,16 +1269,15 @@
       "level": 38,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 38
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 120,
-        "bonus2": 140
+        "bonus1": 1.4,
+        "bonus2": 1.2
       },
       "build_costs": {
         "materials": [],
@@ -1336,41 +1298,40 @@
       "level": 39,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 39
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 125,
-        "bonus2": 160
+        "bonus1": 1.6,
+        "bonus2": 1.25
       },
       "build_costs": {
         "materials": [
           {
             "type": "crystal",
             "grade": 4,
-            "rarity": "common",
-            "value": 12000
+            "rarity": "uncommon",
+            "value": 2500
           },
           {
             "type": "crystal",
             "grade": 4,
-            "rarity": "uncommon",
-            "value": 2500
+            "rarity": "common",
+            "value": 12000
           }
         ],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 4584832000
-          },
-          {
             "type": "tritanium",
             "value": 45150000
+          },
+          {
+            "type": "parsteel",
+            "value": 4584832000
           }
         ]
       },
@@ -1379,16 +1340,15 @@
       "level": 40,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 40
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 130,
-        "bonus2": 160
+        "bonus1": 1.6,
+        "bonus2": 1.3
       },
       "build_costs": {
         "materials": [
@@ -1422,16 +1382,15 @@
       "level": 41,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 41
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 135,
-        "bonus2": 170
+        "bonus1": 1.7,
+        "bonus2": 1.35
       },
       "build_costs": {
         "materials": [
@@ -1451,12 +1410,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 6968640000
-          },
-          {
             "type": "tritanium",
             "value": 96075000
+          },
+          {
+            "type": "parsteel",
+            "value": 6968640000
           }
         ]
       },
@@ -1465,16 +1424,15 @@
       "level": 42,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 42
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 140,
-        "bonus2": 170
+        "bonus1": 1.7,
+        "bonus2": 1.4
       },
       "build_costs": {
         "materials": [
@@ -1502,41 +1460,40 @@
       "level": 43,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 43
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 145,
-        "bonus2": 170
+        "bonus1": 1.7,
+        "bonus2": 1.45
       },
       "build_costs": {
         "materials": [
           {
             "type": "crystal",
             "grade": 4,
-            "rarity": "common",
-            "value": 6500
+            "rarity": "rare",
+            "value": 3000
           },
           {
             "type": "crystal",
             "grade": 4,
-            "rarity": "rare",
-            "value": 3000
+            "rarity": "common",
+            "value": 6500
           }
         ],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 14932800000
-          },
-          {
             "type": "tritanium",
             "value": 205875000
+          },
+          {
+            "type": "parsteel",
+            "value": 14932800000
           }
         ]
       },
@@ -1545,16 +1502,15 @@
       "level": 44,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 44
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 150,
-        "bonus2": 200
+        "bonus1": 2.0,
+        "bonus2": 1.5
       },
       "build_costs": {
         "materials": [
@@ -1574,12 +1530,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 21216000000
-          },
-          {
             "type": "tritanium",
             "value": 292500000
+          },
+          {
+            "type": "parsteel",
+            "value": 21216000000
           }
         ]
       },
@@ -1588,41 +1544,40 @@
       "level": 45,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 45
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 155,
-        "bonus2": 200
+        "bonus1": 2.0,
+        "bonus2": 1.55
       },
       "build_costs": {
         "materials": [
           {
             "type": "crystal",
             "grade": 4,
-            "rarity": "common",
-            "value": 50000
+            "rarity": "uncommon",
+            "value": 6000
           },
           {
             "type": "crystal",
             "grade": 4,
-            "rarity": "uncommon",
-            "value": 6000
+            "rarity": "common",
+            "value": 50000
           }
         ],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 29172000000
-          },
-          {
             "type": "tritanium",
             "value": 402187500
+          },
+          {
+            "type": "parsteel",
+            "value": 29172000000
           }
         ]
       },
@@ -1631,16 +1586,15 @@
       "level": 46,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 46
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 160,
-        "bonus2": 215
+        "bonus1": 2.15,
+        "bonus2": 1.6
       },
       "build_costs": {
         "materials": [
@@ -1660,12 +1614,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 42432000000
-          },
-          {
             "type": "tritanium",
             "value": 585000000
+          },
+          {
+            "type": "parsteel",
+            "value": 42432000000
           }
         ]
       },
@@ -1674,16 +1628,15 @@
       "level": 47,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 47
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 165,
-        "bonus2": 215
+        "bonus1": 2.15,
+        "bonus2": 1.65
       },
       "build_costs": {
         "materials": [
@@ -1703,12 +1656,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 68544000000
-          },
-          {
             "type": "tritanium",
             "value": 945000000
+          },
+          {
+            "type": "parsteel",
+            "value": 68544000000
           }
         ]
       },
@@ -1717,16 +1670,15 @@
       "level": 48,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 48
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 170,
-        "bonus2": 215
+        "bonus1": 2.15,
+        "bonus2": 1.7
       },
       "build_costs": {
         "materials": [
@@ -1746,12 +1698,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 114240000000
-          },
-          {
             "type": "tritanium",
             "value": 1575000000
+          },
+          {
+            "type": "parsteel",
+            "value": 114240000000
           }
         ]
       },
@@ -1760,32 +1712,31 @@
       "level": 49,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 49
         },
         {
-          "name": "Scrapyard",
+          "name": "scrapyard",
           "level": 49
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 175,
-        "bonus2": 250
+        "bonus1": 2.5,
+        "bonus2": 1.75
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 199920000000
-          },
-          {
             "type": "tritanium",
             "value": 2756250000
+          },
+          {
+            "type": "parsteel",
+            "value": 199920000000
           }
         ]
       },
@@ -1794,11 +1745,224 @@
       "level": 50,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 50
         }
-      ],
-      "rewards": []
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 2.5,
+        "bonus2": 1.8
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "crystal",
+            "grade": 5,
+            "rarity": "uncommon",
+            "value": 2600
+          },
+          {
+            "type": "crystal",
+            "grade": 5,
+            "rarity": "common",
+            "value": 27100
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 5850000000
+          },
+          {
+            "type": "parsteel",
+            "value": 997152000000
+          }
+        ]
+      },
+      "build_time": 74532960,
+      "increased_power": 11000,
+      "level": 51,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 51
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 2.6,
+        "bonus2": 1.85
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "crystal",
+            "grade": 5,
+            "rarity": "uncommon",
+            "value": 5700
+          },
+          {
+            "type": "crystal",
+            "grade": 5,
+            "rarity": "common",
+            "value": 46900
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 9945000000
+          },
+          {
+            "type": "parsteel",
+            "value": 1803360000000
+          }
+        ]
+      },
+      "build_time": 79005600,
+      "increased_power": 10000,
+      "level": 52,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 52
+        },
+        {
+          "name": "scrapyard",
+          "level": 52
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 2.6,
+        "bonus2": 1.9
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "crystal",
+            "grade": 5,
+            "rarity": "uncommon",
+            "value": 20600
+          },
+          {
+            "type": "crystal",
+            "grade": 5,
+            "rarity": "common",
+            "value": 61900
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 17400000000
+          },
+          {
+            "type": "parsteel",
+            "value": 3028992000000
+          }
+        ]
+      },
+      "build_time": 83744640,
+      "increased_power": 11000,
+      "level": 53,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 53
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 2.6,
+        "bonus2": 1.95
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "crystal",
+            "grade": 5,
+            "rarity": "uncommon",
+            "value": 27400
+          },
+          {
+            "type": "crystal",
+            "grade": 5,
+            "rarity": "common",
+            "value": 98600
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 4543488000000
+          },
+          {
+            "type": "tritanium",
+            "value": 26100000000
+          }
+        ]
+      },
+      "build_time": 88770240,
+      "increased_power": 12000,
+      "level": 54,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 54
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 2.9,
+        "bonus2": 2.0
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "crystal",
+            "grade": 5,
+            "rarity": "rare",
+            "value": 8800
+          },
+          {
+            "type": "crystal",
+            "grade": 5,
+            "rarity": "common",
+            "value": 127600
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 40950000000
+          },
+          {
+            "type": "parsteel",
+            "value": 7722624000000
+          }
+        ]
+      },
+      "build_time": 94096800,
+      "increased_power": 11000,
+      "level": 55,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 55
+        }
+      ]
     }
   ]
 }

--- a/buildings/drydock_b.json
+++ b/buildings/drydock_b.json
@@ -2,11 +2,11 @@
   "description": "Ship B. Ships can be assigned, managed and upgraded via Ship Management. Every additional Drydock increases the amounts of Ships that can be deployed.",
   "bonuses": {
     "bonus1": {
-      "name": "Repair Cost Efficiency",
+      "name": "repair speed bonus",
       "percentage": true
     },
     "bonus2": {
-      "name": "Repair Speed Bonus",
+      "name": "repair cost efficiency",
       "percentage": true
     }
   },
@@ -14,8 +14,8 @@
   "levels": [
     {
       "bonuses": {
-        "bonus1": 0,
-        "bonus2": 0
+        "bonus1": 0.0,
+        "bonus2": 0.0
       },
       "build_costs": {
         "materials": [],
@@ -32,16 +32,15 @@
       "level": 1,
       "requirements": [
         {
-          "name": "Fleet Commander",
+          "name": "fleet commander",
           "level": 1
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 3,
-        "bonus2": 0
+        "bonus1": 0.0,
+        "bonus2": 0.03
       },
       "build_costs": {
         "materials": [],
@@ -58,16 +57,15 @@
       "level": 2,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 7
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 5,
-        "bonus2": 0
+        "bonus1": 0.0,
+        "bonus2": 0.05
       },
       "build_costs": {
         "materials": [],
@@ -84,16 +82,15 @@
       "level": 3,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 7
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 6,
-        "bonus2": 0
+        "bonus1": 0.0,
+        "bonus2": 0.06
       },
       "build_costs": {
         "materials": [],
@@ -110,16 +107,15 @@
       "level": 4,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 7
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 8,
-        "bonus2": 10
+        "bonus1": 0.1,
+        "bonus2": 0.08
       },
       "build_costs": {
         "materials": [],
@@ -136,16 +132,15 @@
       "level": 5,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 5
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 9,
-        "bonus2": 10
+        "bonus1": 0.1,
+        "bonus2": 0.09
       },
       "build_costs": {
         "materials": [],
@@ -162,16 +157,15 @@
       "level": 6,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 6
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 11,
-        "bonus2": 14
+        "bonus1": 0.14,
+        "bonus2": 0.11
       },
       "build_costs": {
         "materials": [],
@@ -192,16 +186,15 @@
       "level": 7,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 7
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 12,
-        "bonus2": 14
+        "bonus1": 0.14,
+        "bonus2": 0.12
       },
       "build_costs": {
         "materials": [],
@@ -222,28 +215,27 @@
       "level": 8,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 8
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 14,
-        "bonus2": 14
+        "bonus1": 0.14,
+        "bonus2": 0.14
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 5000
-          },
-          {
             "type": "tritanium",
             "value": 200
+          },
+          {
+            "type": "parsteel",
+            "value": 5000
           }
         ]
       },
@@ -252,28 +244,27 @@
       "level": 9,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 9
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 15,
-        "bonus2": 20
+        "bonus1": 0.2,
+        "bonus2": 0.15
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 7500
-          },
-          {
             "type": "tritanium",
             "value": 225
+          },
+          {
+            "type": "parsteel",
+            "value": 7500
           }
         ]
       },
@@ -282,28 +273,27 @@
       "level": 10,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 10
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 17,
-        "bonus2": 20
+        "bonus1": 0.2,
+        "bonus2": 0.17
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 10880
-          },
-          {
             "type": "tritanium",
             "value": 300
+          },
+          {
+            "type": "parsteel",
+            "value": 10880
           }
         ]
       },
@@ -312,28 +302,27 @@
       "level": 11,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 11
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 19,
-        "bonus2": 25
+        "bonus1": 0.25,
+        "bonus2": 0.19
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 14960
-          },
-          {
             "type": "tritanium",
             "value": 413
+          },
+          {
+            "type": "parsteel",
+            "value": 14960
           }
         ]
       },
@@ -342,16 +331,15 @@
       "level": 12,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 12
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 21,
-        "bonus2": 25
+        "bonus1": 0.25,
+        "bonus2": 0.21
       },
       "build_costs": {
         "materials": [],
@@ -372,28 +360,27 @@
       "level": 13,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 13
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 23,
-        "bonus2": 25
+        "bonus1": 0.25,
+        "bonus2": 0.23
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 29920
-          },
-          {
             "type": "tritanium",
             "value": 825
+          },
+          {
+            "type": "parsteel",
+            "value": 29920
           }
         ]
       },
@@ -402,28 +389,27 @@
       "level": 14,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 14
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 25,
-        "bonus2": 35
+        "bonus1": 0.35,
+        "bonus2": 0.25
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 40800
-          },
-          {
             "type": "tritanium",
             "value": 1125
+          },
+          {
+            "type": "parsteel",
+            "value": 40800
           }
         ]
       },
@@ -432,16 +418,15 @@
       "level": 15,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 15
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 28,
-        "bonus2": 35
+        "bonus1": 0.35,
+        "bonus2": 0.28
       },
       "build_costs": {
         "materials": [],
@@ -462,16 +447,15 @@
       "level": 16,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 16
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 31,
-        "bonus2": 42
+        "bonus1": 0.42,
+        "bonus2": 0.31
       },
       "build_costs": {
         "materials": [
@@ -485,12 +469,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 76160
-          },
-          {
             "type": "tritanium",
             "value": 2100
+          },
+          {
+            "type": "parsteel",
+            "value": 76160
           }
         ]
       },
@@ -499,16 +483,15 @@
       "level": 17,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 17
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 34,
-        "bonus2": 42
+        "bonus1": 0.42,
+        "bonus2": 0.34
       },
       "build_costs": {
         "materials": [
@@ -522,12 +505,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 108800
-          },
-          {
             "type": "tritanium",
             "value": 3000
+          },
+          {
+            "type": "parsteel",
+            "value": 108800
           }
         ]
       },
@@ -536,16 +519,15 @@
       "level": 18,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 18
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 37,
-        "bonus2": 42
+        "bonus1": 0.42,
+        "bonus2": 0.37
       },
       "build_costs": {
         "materials": [
@@ -559,12 +541,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 163200
-          },
-          {
             "type": "tritanium",
             "value": 4500
+          },
+          {
+            "type": "parsteel",
+            "value": 163200
           }
         ]
       },
@@ -573,16 +555,15 @@
       "level": 19,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 19
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 40,
-        "bonus2": 55
+        "bonus1": 0.55,
+        "bonus2": 0.4
       },
       "build_costs": {
         "materials": [],
@@ -603,16 +584,15 @@
       "level": 20,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 20
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 44,
-        "bonus2": 55
+        "bonus1": 0.55,
+        "bonus2": 0.44
       },
       "build_costs": {
         "materials": [],
@@ -633,28 +613,27 @@
       "level": 21,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 21
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 48,
-        "bonus2": 62
+        "bonus1": 0.62,
+        "bonus2": 0.48
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 605472
-          },
-          {
             "type": "tritanium",
             "value": 16695
+          },
+          {
+            "type": "parsteel",
+            "value": 605472
           }
         ]
       },
@@ -663,16 +642,15 @@
       "level": 22,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 22
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 52,
-        "bonus2": 62
+        "bonus1": 0.62,
+        "bonus2": 0.52
       },
       "build_costs": {
         "materials": [],
@@ -693,16 +671,15 @@
       "level": 23,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 23
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 56,
-        "bonus2": 62
+        "bonus1": 0.62,
+        "bonus2": 0.56
       },
       "build_costs": {
         "materials": [
@@ -730,16 +707,15 @@
       "level": 24,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 24
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 60,
-        "bonus2": 75
+        "bonus1": 0.75,
+        "bonus2": 0.6
       },
       "build_costs": {
         "materials": [
@@ -753,12 +729,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 2545920
-          },
-          {
             "type": "tritanium",
             "value": 70200
+          },
+          {
+            "type": "parsteel",
+            "value": 2545920
           }
         ]
       },
@@ -767,45 +743,44 @@
       "level": 25,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 25
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 25
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 64,
-        "bonus2": 75
+        "bonus1": 0.75,
+        "bonus2": 0.64
       },
       "build_costs": {
         "materials": [
           {
             "type": "crystal",
             "grade": 3,
-            "rarity": "common",
-            "value": 230
+            "rarity": "uncommon",
+            "value": 4
           },
           {
             "type": "crystal",
             "grade": 3,
-            "rarity": "uncommon",
-            "value": 4
+            "rarity": "common",
+            "value": 230
           }
         ],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 3978000
-          },
-          {
             "type": "tritanium",
             "value": 109688
+          },
+          {
+            "type": "parsteel",
+            "value": 3978000
           }
         ]
       },
@@ -814,16 +789,15 @@
       "level": 26,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 26
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 68,
-        "bonus2": 85
+        "bonus1": 0.85,
+        "bonus2": 0.68
       },
       "build_costs": {
         "materials": [
@@ -843,12 +817,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 6071040
-          },
-          {
             "type": "tritanium",
             "value": 167400
+          },
+          {
+            "type": "parsteel",
+            "value": 6071040
           }
         ]
       },
@@ -857,16 +831,15 @@
       "level": 27,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 27
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 72,
-        "bonus2": 85
+        "bonus1": 0.85,
+        "bonus2": 0.72
       },
       "build_costs": {
         "materials": [
@@ -900,16 +873,15 @@
       "level": 28,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 28
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 76,
-        "bonus2": 85
+        "bonus1": 0.85,
+        "bonus2": 0.76
       },
       "build_costs": {
         "materials": [
@@ -923,12 +895,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 14497600
-          },
-          {
             "type": "tritanium",
             "value": 399750
+          },
+          {
+            "type": "parsteel",
+            "value": 14497600
           }
         ]
       },
@@ -937,16 +909,15 @@
       "level": 29,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 29
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 80,
-        "bonus2": 100
+        "bonus1": 1.0,
+        "bonus2": 0.8
       },
       "build_costs": {
         "materials": [
@@ -966,12 +937,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 21216000
-          },
-          {
             "type": "tritanium",
             "value": 585000
+          },
+          {
+            "type": "parsteel",
+            "value": 21216000
           }
         ]
       },
@@ -980,16 +951,15 @@
       "level": 30,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 30
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 84,
-        "bonus2": 100
+        "bonus1": 1.0,
+        "bonus2": 0.84
       },
       "build_costs": {
         "materials": [
@@ -1017,16 +987,15 @@
       "level": 31,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 31
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 88,
-        "bonus2": 110
+        "bonus1": 1.1,
+        "bonus2": 0.88
       },
       "build_costs": {
         "materials": [
@@ -1054,30 +1023,29 @@
       "level": 32,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 32
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 92,
-        "bonus2": 110
+        "bonus1": 1.1,
+        "bonus2": 0.92
       },
       "build_costs": {
         "materials": [
           {
             "type": "crystal",
             "grade": 3,
-            "rarity": "common",
-            "value": 1000
+            "rarity": "uncommon",
+            "value": 110
           },
           {
             "type": "crystal",
             "grade": 3,
-            "rarity": "uncommon",
-            "value": 110
+            "rarity": "common",
+            "value": 1000
           }
         ],
         "others": [],
@@ -1097,16 +1065,15 @@
       "level": 33,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 33
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 96,
-        "bonus2": 110
+        "bonus1": 1.1,
+        "bonus2": 0.96
       },
       "build_costs": {
         "materials": [
@@ -1126,12 +1093,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 118320000
-          },
-          {
             "type": "tritanium",
             "value": 3262500
+          },
+          {
+            "type": "parsteel",
+            "value": 118320000
           }
         ]
       },
@@ -1140,16 +1107,15 @@
       "level": 34,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 34
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 100,
-        "bonus2": 130
+        "bonus1": 1.3,
+        "bonus2": 1.0
       },
       "build_costs": {
         "materials": [
@@ -1169,12 +1135,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 183110400
-          },
-          {
             "type": "tritanium",
             "value": 5049000
+          },
+          {
+            "type": "parsteel",
+            "value": 183110400
           }
         ]
       },
@@ -1183,30 +1149,29 @@
       "level": 35,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 35
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 105,
-        "bonus2": 130
+        "bonus1": 1.3,
+        "bonus2": 1.05
       },
       "build_costs": {
         "materials": [
           {
             "type": "crystal",
             "grade": 3,
-            "rarity": "common",
-            "value": 1600
+            "rarity": "uncommon",
+            "value": 220
           },
           {
             "type": "crystal",
             "grade": 3,
-            "rarity": "uncommon",
-            "value": 220
+            "rarity": "common",
+            "value": 1600
           }
         ],
         "others": [],
@@ -1226,41 +1191,40 @@
       "level": 36,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 36
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 110,
-        "bonus2": 140
+        "bonus1": 1.4,
+        "bonus2": 1.1
       },
       "build_costs": {
         "materials": [
           {
             "type": "crystal",
             "grade": 3,
-            "rarity": "common",
-            "value": 1800
+            "rarity": "uncommon",
+            "value": 260
           },
           {
             "type": "crystal",
             "grade": 3,
-            "rarity": "uncommon",
-            "value": 260
+            "rarity": "common",
+            "value": 1800
           }
         ],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 396576000
-          },
-          {
             "type": "tritanium",
             "value": 10935000
+          },
+          {
+            "type": "parsteel",
+            "value": 396576000
           }
         ]
       },
@@ -1269,41 +1233,40 @@
       "level": 37,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 37
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 115,
-        "bonus2": 140
+        "bonus1": 1.4,
+        "bonus2": 1.15
       },
       "build_costs": {
         "materials": [
           {
             "type": "crystal",
             "grade": 3,
-            "rarity": "common",
-            "value": 2100
+            "rarity": "uncommon",
+            "value": 310
           },
           {
             "type": "crystal",
             "grade": 3,
-            "rarity": "uncommon",
-            "value": 310
+            "rarity": "common",
+            "value": 2100
           }
         ],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 616896000
-          },
-          {
             "type": "tritanium",
             "value": 17010000
+          },
+          {
+            "type": "parsteel",
+            "value": 616896000
           }
         ]
       },
@@ -1312,28 +1275,27 @@
       "level": 38,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 38
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 120,
-        "bonus2": 140
+        "bonus1": 1.4,
+        "bonus2": 1.2
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 1052640000
-          },
-          {
             "type": "tritanium",
             "value": 29025000
+          },
+          {
+            "type": "parsteel",
+            "value": 1052640000
           }
         ]
       },
@@ -1342,41 +1304,40 @@
       "level": 39,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 39
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 125,
-        "bonus2": 160
+        "bonus1": 1.6,
+        "bonus2": 1.25
       },
       "build_costs": {
         "materials": [
           {
             "type": "crystal",
             "grade": 4,
-            "rarity": "common",
-            "value": 10000
+            "rarity": "uncommon",
+            "value": 2500
           },
           {
             "type": "crystal",
             "grade": 4,
-            "rarity": "uncommon",
-            "value": 2500
+            "rarity": "common",
+            "value": 10000
           }
         ],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 4584832000
-          },
-          {
             "type": "tritanium",
             "value": 45150000
+          },
+          {
+            "type": "parsteel",
+            "value": 4584832000
           }
         ]
       },
@@ -1385,30 +1346,29 @@
       "level": 40,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 40
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 130,
-        "bonus2": 160
+        "bonus1": 1.6,
+        "bonus2": 1.3
       },
       "build_costs": {
         "materials": [
           {
             "type": "crystal",
             "grade": 4,
-            "rarity": "common",
-            "value": 14000
+            "rarity": "uncommon",
+            "value": 3200
           },
           {
             "type": "crystal",
             "grade": 4,
-            "rarity": "uncommon",
-            "value": 3200
+            "rarity": "common",
+            "value": 14000
           }
         ],
         "others": [],
@@ -1428,41 +1388,40 @@
       "level": 41,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 41
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 135,
-        "bonus2": 170
+        "bonus1": 1.7,
+        "bonus2": 1.35
       },
       "build_costs": {
         "materials": [
           {
             "type": "crystal",
             "grade": 4,
-            "rarity": "common",
-            "value": 24000
+            "rarity": "uncommon",
+            "value": 6000
           },
           {
             "type": "crystal",
             "grade": 4,
-            "rarity": "uncommon",
-            "value": 6000
+            "rarity": "common",
+            "value": 24000
           }
         ],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 6968640000
-          },
-          {
             "type": "tritanium",
             "value": 96075000
+          },
+          {
+            "type": "parsteel",
+            "value": 6968640000
           }
         ]
       },
@@ -1471,20 +1430,19 @@
       "level": 42,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 42
         },
         {
-          "name": "Drydock A",
+          "name": "drydock a",
           "level": 42
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 140,
-        "bonus2": 170
+        "bonus1": 1.7,
+        "bonus2": 1.4
       },
       "build_costs": {
         "materials": [
@@ -1498,12 +1456,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 9955200000
-          },
-          {
             "type": "tritanium",
             "value": 137250000
+          },
+          {
+            "type": "parsteel",
+            "value": 9955200000
           }
         ]
       },
@@ -1512,16 +1470,15 @@
       "level": 43,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 43
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 145,
-        "bonus2": 170
+        "bonus1": 1.7,
+        "bonus2": 1.45
       },
       "build_costs": {
         "materials": [
@@ -1541,12 +1498,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 14932800000
-          },
-          {
             "type": "tritanium",
             "value": 205875000
+          },
+          {
+            "type": "parsteel",
+            "value": 14932800000
           }
         ]
       },
@@ -1555,16 +1512,15 @@
       "level": 44,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 44
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 150,
-        "bonus2": 200
+        "bonus1": 2.0,
+        "bonus2": 1.5
       },
       "build_costs": {
         "materials": [
@@ -1584,12 +1540,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 21216000000
-          },
-          {
             "type": "tritanium",
             "value": 292500000
+          },
+          {
+            "type": "parsteel",
+            "value": 21216000000
           }
         ]
       },
@@ -1598,30 +1554,29 @@
       "level": 45,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 45
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 155,
-        "bonus2": 200
+        "bonus1": 2.0,
+        "bonus2": 1.55
       },
       "build_costs": {
         "materials": [
           {
             "type": "crystal",
             "grade": 4,
-            "rarity": "common",
-            "value": 50000
+            "rarity": "uncommon",
+            "value": 6000
           },
           {
             "type": "crystal",
             "grade": 4,
-            "rarity": "uncommon",
-            "value": 6000
+            "rarity": "common",
+            "value": 50000
           }
         ],
         "others": [],
@@ -1641,20 +1596,19 @@
       "level": 46,
       "requirements": [
         {
-          "name": "Drydock A",
+          "name": "operations",
           "level": 46
         },
         {
-          "name": "Operations",
+          "name": "drydock a",
           "level": 46
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 160,
-        "bonus2": 215
+        "bonus1": 2.15,
+        "bonus2": 1.6
       },
       "build_costs": {
         "materials": [
@@ -1674,12 +1628,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 42432000000
-          },
-          {
             "type": "tritanium",
             "value": 585000000
+          },
+          {
+            "type": "parsteel",
+            "value": 42432000000
           }
         ]
       },
@@ -1688,16 +1642,15 @@
       "level": 47,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 47
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 165,
-        "bonus2": 215
+        "bonus1": 2.15,
+        "bonus2": 1.65
       },
       "build_costs": {
         "materials": [
@@ -1717,12 +1670,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 68544000000
-          },
-          {
             "type": "tritanium",
             "value": 945000000
+          },
+          {
+            "type": "parsteel",
+            "value": 68544000000
           }
         ]
       },
@@ -1731,16 +1684,15 @@
       "level": 48,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 48
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 170,
-        "bonus2": 215
+        "bonus1": 2.15,
+        "bonus2": 1.7
       },
       "build_costs": {
         "materials": [
@@ -1760,12 +1712,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 114240000000
-          },
-          {
             "type": "tritanium",
             "value": 1575000000
+          },
+          {
+            "type": "parsteel",
+            "value": 114240000000
           }
         ]
       },
@@ -1774,32 +1726,31 @@
       "level": 49,
       "requirements": [
         {
-          "name": "Drydock A",
+          "name": "operations",
           "level": 49
         },
         {
-          "name": "Operations",
+          "name": "drydock a",
           "level": 49
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 175,
-        "bonus2": 250
+        "bonus1": 2.5,
+        "bonus2": 1.75
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 199920000000
-          },
-          {
             "type": "tritanium",
             "value": 2756250000
+          },
+          {
+            "type": "parsteel",
+            "value": 199920000000
           }
         ]
       },
@@ -1808,11 +1759,224 @@
       "level": 50,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 50
         }
-      ],
-      "rewards": []
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 2.5,
+        "bonus2": 1.8
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "crystal",
+            "grade": 5,
+            "rarity": "common",
+            "value": 27100
+          },
+          {
+            "type": "crystal",
+            "grade": 5,
+            "rarity": "uncommon",
+            "value": 2600
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 5850000000
+          },
+          {
+            "type": "parsteel",
+            "value": 997152000000
+          }
+        ]
+      },
+      "build_time": 74532960,
+      "increased_power": 11000,
+      "level": 51,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 51
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 2.6,
+        "bonus2": 1.85
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "crystal",
+            "grade": 5,
+            "rarity": "uncommon",
+            "value": 5700
+          },
+          {
+            "type": "crystal",
+            "grade": 5,
+            "rarity": "common",
+            "value": 46900
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 9945000000
+          },
+          {
+            "type": "parsteel",
+            "value": 1803360000000
+          }
+        ]
+      },
+      "build_time": 79005600,
+      "increased_power": 10000,
+      "level": 52,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 52
+        },
+        {
+          "name": "drydock a",
+          "level": 52
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 2.6,
+        "bonus2": 1.9
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "crystal",
+            "grade": 5,
+            "rarity": "uncommon",
+            "value": 20600
+          },
+          {
+            "type": "crystal",
+            "grade": 5,
+            "rarity": "common",
+            "value": 61900
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 3028992000000
+          },
+          {
+            "type": "tritanium",
+            "value": 17400000000
+          }
+        ]
+      },
+      "build_time": 83744640,
+      "increased_power": 11000,
+      "level": 53,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 53
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 2.6,
+        "bonus2": 1.95
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "crystal",
+            "grade": 5,
+            "rarity": "uncommon",
+            "value": 27400
+          },
+          {
+            "type": "crystal",
+            "grade": 5,
+            "rarity": "common",
+            "value": 98600
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 26100000000
+          },
+          {
+            "type": "parsteel",
+            "value": 4543488000000
+          }
+        ]
+      },
+      "build_time": 88770240,
+      "increased_power": 12000,
+      "level": 54,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 54
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 2.9,
+        "bonus2": 2.0
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "crystal",
+            "grade": 5,
+            "rarity": "common",
+            "value": 127600
+          },
+          {
+            "type": "crystal",
+            "grade": 5,
+            "rarity": "rare",
+            "value": 8800
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 40950000000
+          },
+          {
+            "type": "parsteel",
+            "value": 7722624000000
+          }
+        ]
+      },
+      "build_time": 94096800,
+      "increased_power": 11000,
+      "level": 55,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 55
+        }
+      ]
     }
   ]
 }

--- a/buildings/drydock_c.json
+++ b/buildings/drydock_c.json
@@ -2,11 +2,11 @@
   "description": "Ship C. Ships can be assigned, managed and upgraded via Ship Management. Every additional Drydock increases the amounts of Ships that can be deployed.",
   "bonuses": {
     "bonus1": {
-      "name": "Repair Cost Efficiency",
+      "name": "repair speed bonus",
       "percentage": true
     },
     "bonus2": {
-      "name": "Repair Speed Bonus",
+      "name": "repair cost efficiency",
       "percentage": true
     }
   },
@@ -14,8 +14,8 @@
   "levels": [
     {
       "bonuses": {
-        "bonus1": 0,
-        "bonus2": 0
+        "bonus1": 0.0,
+        "bonus2": 0.0
       },
       "build_costs": {
         "materials": [],
@@ -32,16 +32,15 @@
       "level": 1,
       "requirements": [
         {
-          "name": "Fleet Commander",
+          "name": "fleet commander",
           "level": 2
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 3,
-        "bonus2": 0
+        "bonus1": 0.0,
+        "bonus2": 0.03
       },
       "build_costs": {
         "materials": [],
@@ -58,16 +57,15 @@
       "level": 2,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 2
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 5,
-        "bonus2": 0
+        "bonus1": 0.0,
+        "bonus2": 0.05
       },
       "build_costs": {
         "materials": [],
@@ -84,16 +82,15 @@
       "level": 3,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 3
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 6,
-        "bonus2": 0
+        "bonus1": 0.0,
+        "bonus2": 0.06
       },
       "build_costs": {
         "materials": [],
@@ -110,16 +107,15 @@
       "level": 4,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 4
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 8,
-        "bonus2": 10
+        "bonus1": 0.1,
+        "bonus2": 0.08
       },
       "build_costs": {
         "materials": [],
@@ -136,16 +132,15 @@
       "level": 5,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 5
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 9,
-        "bonus2": 10
+        "bonus1": 0.1,
+        "bonus2": 0.09
       },
       "build_costs": {
         "materials": [],
@@ -162,28 +157,27 @@
       "level": 6,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 6
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 11,
-        "bonus2": 14
+        "bonus1": 0.14,
+        "bonus2": 0.11
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 4500
-          },
-          {
             "type": "tritanium",
             "value": 50
+          },
+          {
+            "type": "parsteel",
+            "value": 4500
           }
         ]
       },
@@ -192,16 +186,15 @@
       "level": 7,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 7
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 12,
-        "bonus2": 14
+        "bonus1": 0.14,
+        "bonus2": 0.12
       },
       "build_costs": {
         "materials": [],
@@ -222,16 +215,15 @@
       "level": 8,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 8
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 14,
-        "bonus2": 14
+        "bonus1": 0.14,
+        "bonus2": 0.14
       },
       "build_costs": {
         "materials": [],
@@ -252,16 +244,15 @@
       "level": 9,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 9
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 15,
-        "bonus2": 20
+        "bonus1": 0.2,
+        "bonus2": 0.15
       },
       "build_costs": {
         "materials": [],
@@ -282,16 +273,15 @@
       "level": 10,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 10
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 17,
-        "bonus2": 20
+        "bonus1": 0.2,
+        "bonus2": 0.17
       },
       "build_costs": {
         "materials": [],
@@ -312,28 +302,27 @@
       "level": 11,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 11
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 19,
-        "bonus2": 25
+        "bonus1": 0.25,
+        "bonus2": 0.19
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 14960
-          },
-          {
             "type": "tritanium",
             "value": 413
+          },
+          {
+            "type": "parsteel",
+            "value": 14960
           }
         ]
       },
@@ -342,28 +331,27 @@
       "level": 12,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 12
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 21,
-        "bonus2": 25
+        "bonus1": 0.25,
+        "bonus2": 0.21
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 21760
-          },
-          {
             "type": "tritanium",
             "value": 600
+          },
+          {
+            "type": "parsteel",
+            "value": 21760
           }
         ]
       },
@@ -372,28 +360,27 @@
       "level": 13,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 13
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 23,
-        "bonus2": 25
+        "bonus1": 0.25,
+        "bonus2": 0.23
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 29920
-          },
-          {
             "type": "tritanium",
             "value": 825
+          },
+          {
+            "type": "parsteel",
+            "value": 29920
           }
         ]
       },
@@ -402,16 +389,15 @@
       "level": 14,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 14
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 25,
-        "bonus2": 35
+        "bonus1": 0.35,
+        "bonus2": 0.25
       },
       "build_costs": {
         "materials": [],
@@ -432,16 +418,15 @@
       "level": 15,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 15
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 28,
-        "bonus2": 35
+        "bonus1": 0.35,
+        "bonus2": 0.28
       },
       "build_costs": {
         "materials": [],
@@ -462,28 +447,27 @@
       "level": 16,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 16
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 31,
-        "bonus2": 42
+        "bonus1": 0.42,
+        "bonus2": 0.31
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 76160
-          },
-          {
             "type": "tritanium",
             "value": 2100
+          },
+          {
+            "type": "parsteel",
+            "value": 76160
           }
         ]
       },
@@ -492,28 +476,27 @@
       "level": 17,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 17
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 34,
-        "bonus2": 42
+        "bonus1": 0.42,
+        "bonus2": 0.34
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 108800
-          },
-          {
             "type": "tritanium",
             "value": 3000
+          },
+          {
+            "type": "parsteel",
+            "value": 108800
           }
         ]
       },
@@ -522,28 +505,27 @@
       "level": 18,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 18
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 37,
-        "bonus2": 42
+        "bonus1": 0.42,
+        "bonus2": 0.37
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 163200
-          },
-          {
             "type": "tritanium",
             "value": 4500
+          },
+          {
+            "type": "parsteel",
+            "value": 163200
           }
         ]
       },
@@ -552,28 +534,27 @@
       "level": 19,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 19
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 40,
-        "bonus2": 55
+        "bonus1": 0.55,
+        "bonus2": 0.4
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 231200
-          },
-          {
             "type": "tritanium",
             "value": 6375
+          },
+          {
+            "type": "parsteel",
+            "value": 231200
           }
         ]
       },
@@ -582,16 +563,15 @@
       "level": 20,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 20
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 44,
-        "bonus2": 55
+        "bonus1": 0.55,
+        "bonus2": 0.44
       },
       "build_costs": {
         "materials": [],
@@ -612,28 +592,27 @@
       "level": 21,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 21
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 48,
-        "bonus2": 62
+        "bonus1": 0.62,
+        "bonus2": 0.48
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 605472
-          },
-          {
             "type": "tritanium",
             "value": 16695
+          },
+          {
+            "type": "parsteel",
+            "value": 605472
           }
         ]
       },
@@ -642,16 +621,15 @@
       "level": 22,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 22
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 52,
-        "bonus2": 62
+        "bonus1": 0.62,
+        "bonus2": 0.52
       },
       "build_costs": {
         "materials": [],
@@ -672,28 +650,27 @@
       "level": 23,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 23
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 56,
-        "bonus2": 62
+        "bonus1": 0.62,
+        "bonus2": 0.56
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 1569984
-          },
-          {
             "type": "tritanium",
             "value": 43290
+          },
+          {
+            "type": "parsteel",
+            "value": 1569984
           }
         ]
       },
@@ -702,41 +679,40 @@
       "level": 24,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 24
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 60,
-        "bonus2": 75
+        "bonus1": 0.75,
+        "bonus2": 0.6
       },
       "build_costs": {
         "materials": [
           {
             "type": "crystal",
             "grade": 3,
-            "rarity": "common",
-            "value": 190
+            "rarity": "uncommon",
+            "value": 1
           },
           {
             "type": "crystal",
             "grade": 3,
-            "rarity": "uncommon",
-            "value": 1
+            "rarity": "common",
+            "value": 190
           }
         ],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 2545920
-          },
-          {
             "type": "tritanium",
             "value": 70200
+          },
+          {
+            "type": "parsteel",
+            "value": 2545920
           }
         ]
       },
@@ -745,20 +721,19 @@
       "level": 25,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 25
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 25
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 64,
-        "bonus2": 75
+        "bonus1": 0.75,
+        "bonus2": 0.64
       },
       "build_costs": {
         "materials": [
@@ -792,16 +767,15 @@
       "level": 26,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 26
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 68,
-        "bonus2": 85
+        "bonus1": 0.85,
+        "bonus2": 0.68
       },
       "build_costs": {
         "materials": [
@@ -829,41 +803,40 @@
       "level": 27,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 27
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 72,
-        "bonus2": 85
+        "bonus1": 0.85,
+        "bonus2": 0.72
       },
       "build_costs": {
         "materials": [
           {
             "type": "crystal",
             "grade": 3,
-            "rarity": "common",
-            "value": 360
+            "rarity": "uncommon",
+            "value": 18
           },
           {
             "type": "crystal",
             "grade": 3,
-            "rarity": "uncommon",
-            "value": 18
+            "rarity": "common",
+            "value": 360
           }
         ],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 9106560
-          },
-          {
             "type": "tritanium",
             "value": 251100
+          },
+          {
+            "type": "parsteel",
+            "value": 9106560
           }
         ]
       },
@@ -872,16 +845,15 @@
       "level": 28,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 28
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 76,
-        "bonus2": 85
+        "bonus1": 0.85,
+        "bonus2": 0.76
       },
       "build_costs": {
         "materials": [
@@ -895,12 +867,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 14497600
-          },
-          {
             "type": "tritanium",
             "value": 399750
+          },
+          {
+            "type": "parsteel",
+            "value": 14497600
           }
         ]
       },
@@ -909,41 +881,40 @@
       "level": 29,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 29
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 80,
-        "bonus2": 100
+        "bonus1": 1.0,
+        "bonus2": 0.8
       },
       "build_costs": {
         "materials": [
           {
             "type": "crystal",
             "grade": 3,
-            "rarity": "common",
-            "value": 500
+            "rarity": "uncommon",
+            "value": 45
           },
           {
             "type": "crystal",
             "grade": 3,
-            "rarity": "uncommon",
-            "value": 45
+            "rarity": "common",
+            "value": 500
           }
         ],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 21216000
-          },
-          {
             "type": "tritanium",
             "value": 585000
+          },
+          {
+            "type": "parsteel",
+            "value": 21216000
           }
         ]
       },
@@ -952,16 +923,15 @@
       "level": 30,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 30
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 84,
-        "bonus2": 100
+        "bonus1": 1.0,
+        "bonus2": 0.84
       },
       "build_costs": {
         "materials": [
@@ -981,12 +951,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 33537600
-          },
-          {
             "type": "tritanium",
             "value": 924750
+          },
+          {
+            "type": "parsteel",
+            "value": 33537600
           }
         ]
       },
@@ -995,30 +965,29 @@
       "level": 31,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 31
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 88,
-        "bonus2": 110
+        "bonus1": 1.1,
+        "bonus2": 0.88
       },
       "build_costs": {
         "materials": [
           {
             "type": "crystal",
             "grade": 3,
-            "rarity": "common",
-            "value": 800
+            "rarity": "uncommon",
+            "value": 87
           },
           {
             "type": "crystal",
             "grade": 3,
-            "rarity": "uncommon",
-            "value": 87
+            "rarity": "common",
+            "value": 800
           }
         ],
         "others": [],
@@ -1038,16 +1007,15 @@
       "level": 32,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 32
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 92,
-        "bonus2": 110
+        "bonus1": 1.1,
+        "bonus2": 0.92
       },
       "build_costs": {
         "materials": [
@@ -1067,12 +1035,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 74936000
-          },
-          {
             "type": "tritanium",
             "value": 2066250
+          },
+          {
+            "type": "parsteel",
+            "value": 74936000
           }
         ]
       },
@@ -1081,30 +1049,29 @@
       "level": 33,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 33
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 96,
-        "bonus2": 110
+        "bonus1": 1.1,
+        "bonus2": 0.96
       },
       "build_costs": {
         "materials": [
           {
             "type": "crystal",
             "grade": 3,
-            "rarity": "common",
-            "value": 1100
+            "rarity": "uncommon",
+            "value": 140
           },
           {
             "type": "crystal",
             "grade": 3,
-            "rarity": "uncommon",
-            "value": 140
+            "rarity": "common",
+            "value": 1100
           }
         ],
         "others": [],
@@ -1124,16 +1091,15 @@
       "level": 34,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 34
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 100,
-        "bonus2": 130
+        "bonus1": 1.3,
+        "bonus2": 1.0
       },
       "build_costs": {
         "materials": [
@@ -1161,30 +1127,29 @@
       "level": 35,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 35
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 105,
-        "bonus2": 130
+        "bonus1": 1.3,
+        "bonus2": 1.05
       },
       "build_costs": {
         "materials": [
           {
             "type": "crystal",
             "grade": 3,
-            "rarity": "common",
-            "value": 1600
+            "rarity": "uncommon",
+            "value": 220
           },
           {
             "type": "crystal",
             "grade": 3,
-            "rarity": "uncommon",
-            "value": 220
+            "rarity": "common",
+            "value": 1600
           }
         ],
         "others": [],
@@ -1204,16 +1169,15 @@
       "level": 36,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 36
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 110,
-        "bonus2": 140
+        "bonus1": 1.4,
+        "bonus2": 1.1
       },
       "build_costs": {
         "materials": [
@@ -1233,12 +1197,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 396576000
-          },
-          {
             "type": "tritanium",
             "value": 10935000
+          },
+          {
+            "type": "parsteel",
+            "value": 396576000
           }
         ]
       },
@@ -1247,30 +1211,29 @@
       "level": 37,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 37
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 115,
-        "bonus2": 140
+        "bonus1": 1.4,
+        "bonus2": 1.15
       },
       "build_costs": {
         "materials": [
           {
             "type": "crystal",
             "grade": 3,
-            "rarity": "common",
-            "value": 2100
+            "rarity": "uncommon",
+            "value": 310
           },
           {
             "type": "crystal",
             "grade": 3,
-            "rarity": "uncommon",
-            "value": 310
+            "rarity": "common",
+            "value": 2100
           }
         ],
         "others": [],
@@ -1290,28 +1253,27 @@
       "level": 38,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 38
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 120,
-        "bonus2": 140
+        "bonus1": 1.4,
+        "bonus2": 1.2
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 1052640000
-          },
-          {
             "type": "tritanium",
             "value": 29025000
+          },
+          {
+            "type": "parsteel",
+            "value": 1052640000
           }
         ]
       },
@@ -1320,16 +1282,15 @@
       "level": 39,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 39
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 125,
-        "bonus2": 160
+        "bonus1": 1.6,
+        "bonus2": 1.25
       },
       "build_costs": {
         "materials": [
@@ -1349,12 +1310,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 4584832000
-          },
-          {
             "type": "tritanium",
             "value": 45150000
+          },
+          {
+            "type": "parsteel",
+            "value": 4584832000
           }
         ]
       },
@@ -1363,30 +1324,29 @@
       "level": 40,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 40
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 130,
-        "bonus2": 160
+        "bonus1": 1.6,
+        "bonus2": 1.3
       },
       "build_costs": {
         "materials": [
           {
             "type": "crystal",
             "grade": 4,
-            "rarity": "common",
-            "value": 12000
+            "rarity": "uncommon",
+            "value": 3200
           },
           {
             "type": "crystal",
             "grade": 4,
-            "rarity": "uncommon",
-            "value": 3200
+            "rarity": "common",
+            "value": 12000
           }
         ],
         "others": [],
@@ -1406,30 +1366,29 @@
       "level": 41,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 41
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 135,
-        "bonus2": 170
+        "bonus1": 1.7,
+        "bonus2": 1.35
       },
       "build_costs": {
         "materials": [
           {
             "type": "crystal",
             "grade": 4,
-            "rarity": "common",
-            "value": 24000
+            "rarity": "uncommon",
+            "value": 5000
           },
           {
             "type": "crystal",
             "grade": 4,
-            "rarity": "uncommon",
-            "value": 5000
+            "rarity": "common",
+            "value": 24000
           }
         ],
         "others": [],
@@ -1449,20 +1408,19 @@
       "level": 42,
       "requirements": [
         {
-          "name": "Drydock B",
+          "name": "operations",
           "level": 42
         },
         {
-          "name": "Operations",
+          "name": "drydock b",
           "level": 42
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 140,
-        "bonus2": 170
+        "bonus1": 1.7,
+        "bonus2": 1.4
       },
       "build_costs": {
         "materials": [
@@ -1490,30 +1448,29 @@
       "level": 43,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 43
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 145,
-        "bonus2": 170
+        "bonus1": 1.7,
+        "bonus2": 1.45
       },
       "build_costs": {
         "materials": [
           {
             "type": "crystal",
             "grade": 4,
-            "rarity": "common",
-            "value": 6500
+            "rarity": "rare",
+            "value": 2000
           },
           {
             "type": "crystal",
             "grade": 4,
-            "rarity": "rare",
-            "value": 2000
+            "rarity": "common",
+            "value": 6500
           }
         ],
         "others": [],
@@ -1533,16 +1490,15 @@
       "level": 44,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 44
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 150,
-        "bonus2": 200
+        "bonus1": 2.0,
+        "bonus2": 1.5
       },
       "build_costs": {
         "materials": [
@@ -1562,12 +1518,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 21216000000
-          },
-          {
             "type": "tritanium",
             "value": 292500000
+          },
+          {
+            "type": "parsteel",
+            "value": 21216000000
           }
         ]
       },
@@ -1576,16 +1532,15 @@
       "level": 45,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 45
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 155,
-        "bonus2": 200
+        "bonus1": 2.0,
+        "bonus2": 1.55
       },
       "build_costs": {
         "materials": [
@@ -1605,12 +1560,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 29172000000
-          },
-          {
             "type": "tritanium",
             "value": 402187500
+          },
+          {
+            "type": "parsteel",
+            "value": 29172000000
           }
         ]
       },
@@ -1619,45 +1574,44 @@
       "level": 46,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 46
         },
         {
-          "name": "Drydock B",
+          "name": "drydock b",
           "level": 46
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 160,
-        "bonus2": 215
+        "bonus1": 2.15,
+        "bonus2": 1.6
       },
       "build_costs": {
         "materials": [
           {
             "type": "crystal",
             "grade": 4,
-            "rarity": "common",
-            "value": 35000
+            "rarity": "uncommon",
+            "value": 6000
           },
           {
             "type": "crystal",
             "grade": 4,
-            "rarity": "uncommon",
-            "value": 6000
+            "rarity": "common",
+            "value": 35000
           }
         ],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 42432000000
-          },
-          {
             "type": "tritanium",
             "value": 585000000
+          },
+          {
+            "type": "parsteel",
+            "value": 42432000000
           }
         ]
       },
@@ -1666,16 +1620,15 @@
       "level": 47,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 47
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 165,
-        "bonus2": 215
+        "bonus1": 2.15,
+        "bonus2": 1.65
       },
       "build_costs": {
         "materials": [
@@ -1695,12 +1648,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 68544000000
-          },
-          {
             "type": "tritanium",
             "value": 945000000
+          },
+          {
+            "type": "parsteel",
+            "value": 68544000000
           }
         ]
       },
@@ -1709,30 +1662,29 @@
       "level": 48,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 48
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 170,
-        "bonus2": 215
+        "bonus1": 2.15,
+        "bonus2": 1.7
       },
       "build_costs": {
         "materials": [
           {
             "type": "crystal",
             "grade": 4,
-            "rarity": "uncommon",
-            "value": 14000
+            "rarity": "rare",
+            "value": 4500
           },
           {
             "type": "crystal",
             "grade": 4,
-            "rarity": "rare",
-            "value": 4500
+            "rarity": "uncommon",
+            "value": 14000
           }
         ],
         "others": [],
@@ -1752,20 +1704,19 @@
       "level": 49,
       "requirements": [
         {
-          "name": "Drydock B",
+          "name": "operations",
           "level": 49
         },
         {
-          "name": "Operations",
+          "name": "drydock b",
           "level": 49
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 175,
-        "bonus2": 250
+        "bonus1": 2.5,
+        "bonus2": 1.75
       },
       "build_costs": {
         "materials": [],
@@ -1786,11 +1737,224 @@
       "level": 50,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 50
         }
-      ],
-      "rewards": []
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 2.5,
+        "bonus2": 1.8
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "crystal",
+            "grade": 5,
+            "rarity": "uncommon",
+            "value": 2600
+          },
+          {
+            "type": "crystal",
+            "grade": 5,
+            "rarity": "common",
+            "value": 27100
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 997152000000
+          },
+          {
+            "type": "tritanium",
+            "value": 5850000000
+          }
+        ]
+      },
+      "build_time": 74532960,
+      "increased_power": 11000,
+      "level": 51,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 51
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 2.6,
+        "bonus2": 1.85
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "crystal",
+            "grade": 5,
+            "rarity": "uncommon",
+            "value": 5700
+          },
+          {
+            "type": "crystal",
+            "grade": 5,
+            "rarity": "common",
+            "value": 46900
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 9945000000
+          },
+          {
+            "type": "parsteel",
+            "value": 1803360000000
+          }
+        ]
+      },
+      "build_time": 79005600,
+      "increased_power": 10000,
+      "level": 52,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 52
+        },
+        {
+          "name": "drydock b",
+          "level": 52
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 2.6,
+        "bonus2": 1.9
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "crystal",
+            "grade": 5,
+            "rarity": "common",
+            "value": 61900
+          },
+          {
+            "type": "crystal",
+            "grade": 5,
+            "rarity": "uncommon",
+            "value": 20600
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 3028992000000
+          },
+          {
+            "type": "tritanium",
+            "value": 17400000000
+          }
+        ]
+      },
+      "build_time": 83744640,
+      "increased_power": 11000,
+      "level": 53,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 53
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 2.6,
+        "bonus2": 1.95
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "crystal",
+            "grade": 5,
+            "rarity": "uncommon",
+            "value": 27400
+          },
+          {
+            "type": "crystal",
+            "grade": 5,
+            "rarity": "common",
+            "value": 98600
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 4543488000000
+          },
+          {
+            "type": "tritanium",
+            "value": 26100000000
+          }
+        ]
+      },
+      "build_time": 88770240,
+      "increased_power": 12000,
+      "level": 54,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 54
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 2.9,
+        "bonus2": 2.0
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "crystal",
+            "grade": 5,
+            "rarity": "common",
+            "value": 127600
+          },
+          {
+            "type": "crystal",
+            "grade": 5,
+            "rarity": "rare",
+            "value": 8800
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 40950000000
+          },
+          {
+            "type": "parsteel",
+            "value": 7722624000000
+          }
+        ]
+      },
+      "build_time": 94096800,
+      "increased_power": 11000,
+      "level": 55,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 55
+        }
+      ]
     }
   ]
 }

--- a/buildings/drydock_d.json
+++ b/buildings/drydock_d.json
@@ -2,11 +2,11 @@
   "description": "Ship D. Ships can be assigned, managed and upgraded via Ship Management. Every additional Drydock increases the amounts of Ships that can be deployed.",
   "bonuses": {
     "bonus1": {
-      "name": "Repair Cost Efficiency",
+      "name": "repair speed bonus",
       "percentage": true
     },
     "bonus2": {
-      "name": "Repair Speed Bonus",
+      "name": "repair cost efficiency",
       "percentage": true
     }
   },
@@ -14,8 +14,8 @@
   "levels": [
     {
       "bonuses": {
-        "bonus1": 0,
-        "bonus2": 0
+        "bonus1": 0.0,
+        "bonus2": 0.0
       },
       "build_costs": {
         "materials": [
@@ -39,16 +39,15 @@
       "level": 1,
       "requirements": [
         {
-          "name": "Fleet Commander",
+          "name": "fleet commander",
           "level": 3
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 3,
-        "bonus2": 0
+        "bonus1": 0.0,
+        "bonus2": 0.03
       },
       "build_costs": {
         "materials": [],
@@ -65,16 +64,15 @@
       "level": 2,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 2
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 5,
-        "bonus2": 0
+        "bonus1": 0.0,
+        "bonus2": 0.05
       },
       "build_costs": {
         "materials": [],
@@ -91,16 +89,15 @@
       "level": 3,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 3
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 6,
-        "bonus2": 0
+        "bonus1": 0.0,
+        "bonus2": 0.06
       },
       "build_costs": {
         "materials": [],
@@ -117,16 +114,15 @@
       "level": 4,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 4
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 8,
-        "bonus2": 10
+        "bonus1": 0.1,
+        "bonus2": 0.08
       },
       "build_costs": {
         "materials": [],
@@ -143,16 +139,15 @@
       "level": 5,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 5
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 9,
-        "bonus2": 10
+        "bonus1": 0.1,
+        "bonus2": 0.09
       },
       "build_costs": {
         "materials": [],
@@ -169,28 +164,27 @@
       "level": 6,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 6
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 11,
-        "bonus2": 14
+        "bonus1": 0.14,
+        "bonus2": 0.11
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 4500
-          },
-          {
             "type": "tritanium",
             "value": 50
+          },
+          {
+            "type": "parsteel",
+            "value": 4500
           }
         ]
       },
@@ -199,16 +193,15 @@
       "level": 7,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 7
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 12,
-        "bonus2": 14
+        "bonus1": 0.14,
+        "bonus2": 0.12
       },
       "build_costs": {
         "materials": [],
@@ -229,16 +222,15 @@
       "level": 8,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 8
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 14,
-        "bonus2": 14
+        "bonus1": 0.14,
+        "bonus2": 0.14
       },
       "build_costs": {
         "materials": [],
@@ -259,28 +251,27 @@
       "level": 9,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 9
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 15,
-        "bonus2": 20
+        "bonus1": 0.2,
+        "bonus2": 0.15
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 7500
-          },
-          {
             "type": "tritanium",
             "value": 225
+          },
+          {
+            "type": "parsteel",
+            "value": 7500
           }
         ]
       },
@@ -289,28 +280,27 @@
       "level": 10,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 10
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 17,
-        "bonus2": 20
+        "bonus1": 0.2,
+        "bonus2": 0.17
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 10880
-          },
-          {
             "type": "tritanium",
             "value": 300
+          },
+          {
+            "type": "parsteel",
+            "value": 10880
           }
         ]
       },
@@ -319,16 +309,15 @@
       "level": 11,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 11
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 19,
-        "bonus2": 25
+        "bonus1": 0.25,
+        "bonus2": 0.19
       },
       "build_costs": {
         "materials": [],
@@ -349,16 +338,15 @@
       "level": 12,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 12
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 21,
-        "bonus2": 25
+        "bonus1": 0.25,
+        "bonus2": 0.21
       },
       "build_costs": {
         "materials": [],
@@ -379,28 +367,27 @@
       "level": 13,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 13
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 23,
-        "bonus2": 25
+        "bonus1": 0.25,
+        "bonus2": 0.23
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 29920
-          },
-          {
             "type": "tritanium",
             "value": 825
+          },
+          {
+            "type": "parsteel",
+            "value": 29920
           }
         ]
       },
@@ -409,28 +396,27 @@
       "level": 14,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 14
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 25,
-        "bonus2": 35
+        "bonus1": 0.35,
+        "bonus2": 0.25
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 40800
-          },
-          {
             "type": "tritanium",
             "value": 1125
+          },
+          {
+            "type": "parsteel",
+            "value": 40800
           }
         ]
       },
@@ -439,16 +425,15 @@
       "level": 15,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 15
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 28,
-        "bonus2": 35
+        "bonus1": 0.35,
+        "bonus2": 0.28
       },
       "build_costs": {
         "materials": [],
@@ -469,28 +454,27 @@
       "level": 16,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 16
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 31,
-        "bonus2": 42
+        "bonus1": 0.42,
+        "bonus2": 0.31
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 76160
-          },
-          {
             "type": "tritanium",
             "value": 2100
+          },
+          {
+            "type": "parsteel",
+            "value": 76160
           }
         ]
       },
@@ -499,28 +483,27 @@
       "level": 17,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 17
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 34,
-        "bonus2": 42
+        "bonus1": 0.42,
+        "bonus2": 0.34
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 108800
-          },
-          {
             "type": "tritanium",
             "value": 3000
+          },
+          {
+            "type": "parsteel",
+            "value": 108800
           }
         ]
       },
@@ -529,28 +512,27 @@
       "level": 18,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 18
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 37,
-        "bonus2": 42
+        "bonus1": 0.42,
+        "bonus2": 0.37
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 163200
-          },
-          {
             "type": "tritanium",
             "value": 4500
+          },
+          {
+            "type": "parsteel",
+            "value": 163200
           }
         ]
       },
@@ -559,16 +541,15 @@
       "level": 19,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 19
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 40,
-        "bonus2": 55
+        "bonus1": 0.55,
+        "bonus2": 0.4
       },
       "build_costs": {
         "materials": [],
@@ -589,28 +570,27 @@
       "level": 20,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 20
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 44,
-        "bonus2": 55
+        "bonus1": 0.55,
+        "bonus2": 0.44
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 389232
-          },
-          {
             "type": "tritanium",
             "value": 10733
+          },
+          {
+            "type": "parsteel",
+            "value": 389232
           }
         ]
       },
@@ -619,16 +599,15 @@
       "level": 21,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 21
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 48,
-        "bonus2": 62
+        "bonus1": 0.62,
+        "bonus2": 0.48
       },
       "build_costs": {
         "materials": [],
@@ -649,16 +628,15 @@
       "level": 22,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 22
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 52,
-        "bonus2": 62
+        "bonus1": 0.62,
+        "bonus2": 0.52
       },
       "build_costs": {
         "materials": [],
@@ -679,28 +657,27 @@
       "level": 23,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 23
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 56,
-        "bonus2": 62
+        "bonus1": 0.62,
+        "bonus2": 0.56
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 1569984
-          },
-          {
             "type": "tritanium",
             "value": 43290
+          },
+          {
+            "type": "parsteel",
+            "value": 1569984
           }
         ]
       },
@@ -709,16 +686,15 @@
       "level": 24,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 24
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 60,
-        "bonus2": 75
+        "bonus1": 0.75,
+        "bonus2": 0.6
       },
       "build_costs": {
         "materials": [
@@ -746,16 +722,15 @@
       "level": 25,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 25
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 64,
-        "bonus2": 75
+        "bonus1": 0.75,
+        "bonus2": 0.64
       },
       "build_costs": {
         "materials": [
@@ -769,12 +744,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 3978000
-          },
-          {
             "type": "tritanium",
             "value": 109688
+          },
+          {
+            "type": "parsteel",
+            "value": 3978000
           }
         ]
       },
@@ -783,16 +758,15 @@
       "level": 26,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 26
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 68,
-        "bonus2": 85
+        "bonus1": 0.85,
+        "bonus2": 0.68
       },
       "build_costs": {
         "materials": [
@@ -806,12 +780,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 6071040
-          },
-          {
             "type": "tritanium",
             "value": 167400
+          },
+          {
+            "type": "parsteel",
+            "value": 6071040
           }
         ]
       },
@@ -820,16 +794,15 @@
       "level": 27,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 27
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 72,
-        "bonus2": 85
+        "bonus1": 0.85,
+        "bonus2": 0.72
       },
       "build_costs": {
         "materials": [
@@ -857,16 +830,15 @@
       "level": 28,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 28
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 76,
-        "bonus2": 85
+        "bonus1": 0.85,
+        "bonus2": 0.76
       },
       "build_costs": {
         "materials": [
@@ -900,16 +872,15 @@
       "level": 29,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 29
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 80,
-        "bonus2": 100
+        "bonus1": 1.0,
+        "bonus2": 0.8
       },
       "build_costs": {
         "materials": [
@@ -923,12 +894,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 21216000
-          },
-          {
             "type": "tritanium",
             "value": 585000
+          },
+          {
+            "type": "parsteel",
+            "value": 21216000
           }
         ]
       },
@@ -937,41 +908,40 @@
       "level": 30,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 30
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 84,
-        "bonus2": 100
+        "bonus1": 1.0,
+        "bonus2": 0.84
       },
       "build_costs": {
         "materials": [
           {
             "type": "crystal",
             "grade": 3,
-            "rarity": "common",
-            "value": 700
+            "rarity": "uncommon",
+            "value": 65
           },
           {
             "type": "crystal",
             "grade": 3,
-            "rarity": "uncommon",
-            "value": 65
+            "rarity": "common",
+            "value": 700
           }
         ],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 33537600
-          },
-          {
             "type": "tritanium",
             "value": 924750
+          },
+          {
+            "type": "parsteel",
+            "value": 33537600
           }
         ]
       },
@@ -980,16 +950,15 @@
       "level": 31,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 31
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 88,
-        "bonus2": 110
+        "bonus1": 1.1,
+        "bonus2": 0.88
       },
       "build_costs": {
         "materials": [
@@ -1009,12 +978,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 48443200
-          },
-          {
             "type": "tritanium",
             "value": 1335750
+          },
+          {
+            "type": "parsteel",
+            "value": 48443200
           }
         ]
       },
@@ -1023,16 +992,15 @@
       "level": 32,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 32
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 92,
-        "bonus2": 110
+        "bonus1": 1.1,
+        "bonus2": 0.92
       },
       "build_costs": {
         "materials": [
@@ -1052,12 +1020,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 74936000
-          },
-          {
             "type": "tritanium",
             "value": 2066250
+          },
+          {
+            "type": "parsteel",
+            "value": 74936000
           }
         ]
       },
@@ -1066,16 +1034,15 @@
       "level": 33,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 33
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 96,
-        "bonus2": 110
+        "bonus1": 1.1,
+        "bonus2": 0.96
       },
       "build_costs": {
         "materials": [
@@ -1089,12 +1056,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 118320000
-          },
-          {
             "type": "tritanium",
             "value": 3262500
+          },
+          {
+            "type": "parsteel",
+            "value": 118320000
           }
         ]
       },
@@ -1103,16 +1070,15 @@
       "level": 34,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 34
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 100,
-        "bonus2": 130
+        "bonus1": 1.3,
+        "bonus2": 1.0
       },
       "build_costs": {
         "materials": [
@@ -1146,16 +1112,15 @@
       "level": 35,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 35
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 105,
-        "bonus2": 130
+        "bonus1": 1.3,
+        "bonus2": 1.05
       },
       "build_costs": {
         "materials": [
@@ -1175,12 +1140,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 258019200
-          },
-          {
             "type": "tritanium",
             "value": 7114500
+          },
+          {
+            "type": "parsteel",
+            "value": 258019200
           }
         ]
       },
@@ -1189,16 +1154,15 @@
       "level": 36,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 36
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 110,
-        "bonus2": 140
+        "bonus1": 1.4,
+        "bonus2": 1.1
       },
       "build_costs": {
         "materials": [
@@ -1212,12 +1176,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 396576000
-          },
-          {
             "type": "tritanium",
             "value": 10935000
+          },
+          {
+            "type": "parsteel",
+            "value": 396576000
           }
         ]
       },
@@ -1226,16 +1190,15 @@
       "level": 37,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 37
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 115,
-        "bonus2": 140
+        "bonus1": 1.4,
+        "bonus2": 1.15
       },
       "build_costs": {
         "materials": [
@@ -1255,12 +1218,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 616896000
-          },
-          {
             "type": "tritanium",
             "value": 17010000
+          },
+          {
+            "type": "parsteel",
+            "value": 616896000
           }
         ]
       },
@@ -1269,28 +1232,27 @@
       "level": 38,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 38
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 120,
-        "bonus2": 140
+        "bonus1": 1.4,
+        "bonus2": 1.2
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 1052640000
-          },
-          {
             "type": "tritanium",
             "value": 29025000
+          },
+          {
+            "type": "parsteel",
+            "value": 1052640000
           }
         ]
       },
@@ -1299,30 +1261,29 @@
       "level": 39,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 39
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 125,
-        "bonus2": 160
+        "bonus1": 1.6,
+        "bonus2": 1.25
       },
       "build_costs": {
         "materials": [
           {
             "type": "crystal",
             "grade": 4,
-            "rarity": "common",
-            "value": 6000
+            "rarity": "uncommon",
+            "value": 2500
           },
           {
             "type": "crystal",
             "grade": 4,
-            "rarity": "uncommon",
-            "value": 2500
+            "rarity": "common",
+            "value": 6000
           }
         ],
         "others": [],
@@ -1342,41 +1303,40 @@
       "level": 40,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 40
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 130,
-        "bonus2": 160
+        "bonus1": 1.6,
+        "bonus2": 1.3
       },
       "build_costs": {
         "materials": [
           {
             "type": "crystal",
             "grade": 4,
-            "rarity": "common",
-            "value": 10000
+            "rarity": "uncommon",
+            "value": 3200
           },
           {
             "type": "crystal",
             "grade": 4,
-            "rarity": "uncommon",
-            "value": 3200
+            "rarity": "common",
+            "value": 10000
           }
         ],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 4678400000
-          },
-          {
             "type": "tritanium",
             "value": 64500000
+          },
+          {
+            "type": "parsteel",
+            "value": 4678400000
           }
         ]
       },
@@ -1385,41 +1345,40 @@
       "level": 41,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 41
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 135,
-        "bonus2": 170
+        "bonus1": 1.7,
+        "bonus2": 1.35
       },
       "build_costs": {
         "materials": [
           {
             "type": "crystal",
             "grade": 4,
-            "rarity": "common",
-            "value": 24000
+            "rarity": "uncommon",
+            "value": 4000
           },
           {
             "type": "crystal",
             "grade": 4,
-            "rarity": "uncommon",
-            "value": 4000
+            "rarity": "common",
+            "value": 24000
           }
         ],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 6968640000
-          },
-          {
             "type": "tritanium",
             "value": 96075000
+          },
+          {
+            "type": "parsteel",
+            "value": 6968640000
           }
         ]
       },
@@ -1428,20 +1387,19 @@
       "level": 42,
       "requirements": [
         {
-          "name": "Drydock C",
+          "name": "operations",
           "level": 42
         },
         {
-          "name": "Operations",
+          "name": "drydock c",
           "level": 42
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 140,
-        "bonus2": 170
+        "bonus1": 1.7,
+        "bonus2": 1.4
       },
       "build_costs": {
         "materials": [
@@ -1469,16 +1427,15 @@
       "level": 43,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 43
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 145,
-        "bonus2": 170
+        "bonus1": 1.7,
+        "bonus2": 1.45
       },
       "build_costs": {
         "materials": [
@@ -1498,12 +1455,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 14932800000
-          },
-          {
             "type": "tritanium",
             "value": 205875000
+          },
+          {
+            "type": "parsteel",
+            "value": 14932800000
           }
         ]
       },
@@ -1512,41 +1469,40 @@
       "level": 44,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 44
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 150,
-        "bonus2": 200
+        "bonus1": 2.0,
+        "bonus2": 1.5
       },
       "build_costs": {
         "materials": [
           {
             "type": "crystal",
             "grade": 4,
-            "rarity": "common",
-            "value": 40000
+            "rarity": "rare",
+            "value": 5000
           },
           {
             "type": "crystal",
             "grade": 4,
-            "rarity": "rare",
-            "value": 5000
+            "rarity": "common",
+            "value": 40000
           }
         ],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 21216000000
-          },
-          {
             "type": "tritanium",
             "value": 292500000
+          },
+          {
+            "type": "parsteel",
+            "value": 21216000000
           }
         ]
       },
@@ -1555,16 +1511,15 @@
       "level": 45,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 45
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 155,
-        "bonus2": 200
+        "bonus1": 2.0,
+        "bonus2": 1.55
       },
       "build_costs": {
         "materials": [
@@ -1598,34 +1553,33 @@
       "level": 46,
       "requirements": [
         {
-          "name": "Drydock C",
+          "name": "operations",
           "level": 46
         },
         {
-          "name": "Operations",
+          "name": "drydock c",
           "level": 46
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 160,
-        "bonus2": 215
+        "bonus1": 2.15,
+        "bonus2": 1.6
       },
       "build_costs": {
         "materials": [
           {
             "type": "crystal",
             "grade": 4,
-            "rarity": "common",
-            "value": 35000
+            "rarity": "uncommon",
+            "value": 6000
           },
           {
             "type": "crystal",
             "grade": 4,
-            "rarity": "uncommon",
-            "value": 6000
+            "rarity": "common",
+            "value": 35000
           }
         ],
         "others": [],
@@ -1645,16 +1599,15 @@
       "level": 47,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 47
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 165,
-        "bonus2": 215
+        "bonus1": 2.15,
+        "bonus2": 1.65
       },
       "build_costs": {
         "materials": [
@@ -1674,12 +1627,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 68544000000
-          },
-          {
             "type": "tritanium",
             "value": 945000000
+          },
+          {
+            "type": "parsteel",
+            "value": 68544000000
           }
         ]
       },
@@ -1688,16 +1641,15 @@
       "level": 48,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 48
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 170,
-        "bonus2": 215
+        "bonus1": 2.15,
+        "bonus2": 1.7
       },
       "build_costs": {
         "materials": [
@@ -1731,32 +1683,31 @@
       "level": 49,
       "requirements": [
         {
-          "name": "Drydock C",
+          "name": "operations",
           "level": 49
         },
         {
-          "name": "Operations",
+          "name": "drydock c",
           "level": 49
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 175,
-        "bonus2": 250
+        "bonus1": 2.5,
+        "bonus2": 1.75
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 199920000000
-          },
-          {
             "type": "tritanium",
             "value": 2756250000
+          },
+          {
+            "type": "parsteel",
+            "value": 199920000000
           }
         ]
       },
@@ -1765,11 +1716,224 @@
       "level": 50,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 50
         }
-      ],
-      "rewards": []
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 2.5,
+        "bonus2": 1.8
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "crystal",
+            "grade": 5,
+            "rarity": "uncommon",
+            "value": 2600
+          },
+          {
+            "type": "crystal",
+            "grade": 5,
+            "rarity": "common",
+            "value": 27100
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 997152000000
+          },
+          {
+            "type": "tritanium",
+            "value": 5850000000
+          }
+        ]
+      },
+      "build_time": 74532960,
+      "increased_power": 11000,
+      "level": 51,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 51
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 2.6,
+        "bonus2": 1.85
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "crystal",
+            "grade": 5,
+            "rarity": "uncommon",
+            "value": 5700
+          },
+          {
+            "type": "crystal",
+            "grade": 5,
+            "rarity": "common",
+            "value": 46900
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 1803360000000
+          },
+          {
+            "type": "tritanium",
+            "value": 9945000000
+          }
+        ]
+      },
+      "build_time": 79005600,
+      "increased_power": 10000,
+      "level": 52,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 52
+        },
+        {
+          "name": "drydock c",
+          "level": 52
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 2.6,
+        "bonus2": 1.9
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "crystal",
+            "grade": 5,
+            "rarity": "common",
+            "value": 61900
+          },
+          {
+            "type": "crystal",
+            "grade": 5,
+            "rarity": "uncommon",
+            "value": 20600
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 3028992000000
+          },
+          {
+            "type": "tritanium",
+            "value": 17400000000
+          }
+        ]
+      },
+      "build_time": 83744640,
+      "increased_power": 11000,
+      "level": 53,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 53
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 2.6,
+        "bonus2": 1.95
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "crystal",
+            "grade": 5,
+            "rarity": "uncommon",
+            "value": 27400
+          },
+          {
+            "type": "crystal",
+            "grade": 5,
+            "rarity": "common",
+            "value": 98600
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 26100000000
+          },
+          {
+            "type": "parsteel",
+            "value": 4543488000000
+          }
+        ]
+      },
+      "build_time": 88770240,
+      "increased_power": 12000,
+      "level": 54,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 54
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 2.9,
+        "bonus2": 2.0
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "crystal",
+            "grade": 5,
+            "rarity": "rare",
+            "value": 8800
+          },
+          {
+            "type": "crystal",
+            "grade": 5,
+            "rarity": "common",
+            "value": 127600
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 40950000000
+          },
+          {
+            "type": "parsteel",
+            "value": 7722624000000
+          }
+        ]
+      },
+      "build_time": 94096800,
+      "increased_power": 11000,
+      "level": 55,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 55
+        }
+      ]
     }
   ]
 }

--- a/buildings/drydock_e.json
+++ b/buildings/drydock_e.json
@@ -2,11 +2,11 @@
   "description": "Ship E. Ships can be assigned, managed and upgraded via Ship Management. Every additional Drydock increases the amounts of Ships that can be deployed.",
   "bonuses": {
     "bonus1": {
-      "name": "Repair Cost Efficiency",
+      "name": "repair speed bonus",
       "percentage": true
     },
     "bonus2": {
-      "name": "Repair Speed Bonus",
+      "name": "repair cost efficiency",
       "percentage": true
     }
   },
@@ -14,8 +14,8 @@
   "levels": [
     {
       "bonuses": {
-        "bonus1": 0,
-        "bonus2": 0
+        "bonus1": 0.0,
+        "bonus2": 0.0
       },
       "build_costs": {
         "materials": [
@@ -39,16 +39,15 @@
       "level": 1,
       "requirements": [
         {
-          "name": "Fleet Commander",
+          "name": "fleet commander",
           "level": 4
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 3,
-        "bonus2": 0
+        "bonus1": 0.0,
+        "bonus2": 0.03
       },
       "build_costs": {
         "materials": [],
@@ -65,16 +64,15 @@
       "level": 2,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 2
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 5,
-        "bonus2": 0
+        "bonus1": 0.0,
+        "bonus2": 0.05
       },
       "build_costs": {
         "materials": [],
@@ -91,16 +89,15 @@
       "level": 3,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 3
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 6,
-        "bonus2": 0
+        "bonus1": 0.0,
+        "bonus2": 0.06
       },
       "build_costs": {
         "materials": [],
@@ -117,16 +114,15 @@
       "level": 4,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 4
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 8,
-        "bonus2": 10
+        "bonus1": 0.1,
+        "bonus2": 0.08
       },
       "build_costs": {
         "materials": [],
@@ -143,16 +139,15 @@
       "level": 5,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 5
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 9,
-        "bonus2": 10
+        "bonus1": 0.1,
+        "bonus2": 0.09
       },
       "build_costs": {
         "materials": [],
@@ -169,16 +164,15 @@
       "level": 6,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 6
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 11,
-        "bonus2": 14
+        "bonus1": 0.14,
+        "bonus2": 0.11
       },
       "build_costs": {
         "materials": [],
@@ -199,16 +193,15 @@
       "level": 7,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 7
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 12,
-        "bonus2": 14
+        "bonus1": 0.14,
+        "bonus2": 0.12
       },
       "build_costs": {
         "materials": [],
@@ -229,16 +222,15 @@
       "level": 8,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 8
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 14,
-        "bonus2": 14
+        "bonus1": 0.14,
+        "bonus2": 0.14
       },
       "build_costs": {
         "materials": [],
@@ -259,16 +251,15 @@
       "level": 9,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 9
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 15,
-        "bonus2": 20
+        "bonus1": 0.2,
+        "bonus2": 0.15
       },
       "build_costs": {
         "materials": [],
@@ -289,16 +280,15 @@
       "level": 10,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 10
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 17,
-        "bonus2": 20
+        "bonus1": 0.2,
+        "bonus2": 0.17
       },
       "build_costs": {
         "materials": [],
@@ -319,28 +309,27 @@
       "level": 11,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 11
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 19,
-        "bonus2": 25
+        "bonus1": 0.25,
+        "bonus2": 0.19
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 14960
-          },
-          {
             "type": "tritanium",
             "value": 413
+          },
+          {
+            "type": "parsteel",
+            "value": 14960
           }
         ]
       },
@@ -349,16 +338,15 @@
       "level": 12,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 12
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 21,
-        "bonus2": 25
+        "bonus1": 0.25,
+        "bonus2": 0.21
       },
       "build_costs": {
         "materials": [],
@@ -379,16 +367,15 @@
       "level": 13,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 13
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 23,
-        "bonus2": 25
+        "bonus1": 0.25,
+        "bonus2": 0.23
       },
       "build_costs": {
         "materials": [],
@@ -409,28 +396,27 @@
       "level": 14,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 14
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 25,
-        "bonus2": 35
+        "bonus1": 0.35,
+        "bonus2": 0.25
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 40800
-          },
-          {
             "type": "tritanium",
             "value": 1125
+          },
+          {
+            "type": "parsteel",
+            "value": 40800
           }
         ]
       },
@@ -439,28 +425,27 @@
       "level": 15,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 15
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 28,
-        "bonus2": 35
+        "bonus1": 0.35,
+        "bonus2": 0.28
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 54400
-          },
-          {
             "type": "tritanium",
             "value": 1500
+          },
+          {
+            "type": "parsteel",
+            "value": 54400
           }
         ]
       },
@@ -469,28 +454,27 @@
       "level": 16,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 16
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 31,
-        "bonus2": 42
+        "bonus1": 0.42,
+        "bonus2": 0.31
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 76160
-          },
-          {
             "type": "tritanium",
             "value": 2100
+          },
+          {
+            "type": "parsteel",
+            "value": 76160
           }
         ]
       },
@@ -499,28 +483,27 @@
       "level": 17,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 17
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 34,
-        "bonus2": 42
+        "bonus1": 0.42,
+        "bonus2": 0.34
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 108800
-          },
-          {
             "type": "tritanium",
             "value": 3000
+          },
+          {
+            "type": "parsteel",
+            "value": 108800
           }
         ]
       },
@@ -529,28 +512,27 @@
       "level": 18,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 18
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 37,
-        "bonus2": 42
+        "bonus1": 0.42,
+        "bonus2": 0.37
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 163200
-          },
-          {
             "type": "tritanium",
             "value": 4500
+          },
+          {
+            "type": "parsteel",
+            "value": 163200
           }
         ]
       },
@@ -559,28 +541,27 @@
       "level": 19,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 19
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 40,
-        "bonus2": 55
+        "bonus1": 0.55,
+        "bonus2": 0.4
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 231200
-          },
-          {
             "type": "tritanium",
             "value": 6375
+          },
+          {
+            "type": "parsteel",
+            "value": 231200
           }
         ]
       },
@@ -589,28 +570,27 @@
       "level": 20,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 20
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 44,
-        "bonus2": 55
+        "bonus1": 0.55,
+        "bonus2": 0.44
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 389232
-          },
-          {
             "type": "tritanium",
             "value": 10733
+          },
+          {
+            "type": "parsteel",
+            "value": 389232
           }
         ]
       },
@@ -619,28 +599,27 @@
       "level": 21,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 21
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 48,
-        "bonus2": 62
+        "bonus1": 0.62,
+        "bonus2": 0.48
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 605472
-          },
-          {
             "type": "tritanium",
             "value": 16695
+          },
+          {
+            "type": "parsteel",
+            "value": 605472
           }
         ]
       },
@@ -649,16 +628,15 @@
       "level": 22,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 22
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 52,
-        "bonus2": 62
+        "bonus1": 0.62,
+        "bonus2": 0.52
       },
       "build_costs": {
         "materials": [],
@@ -679,28 +657,27 @@
       "level": 23,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 23
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 56,
-        "bonus2": 62
+        "bonus1": 0.62,
+        "bonus2": 0.56
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 1569984
-          },
-          {
             "type": "tritanium",
             "value": 43290
+          },
+          {
+            "type": "parsteel",
+            "value": 1569984
           }
         ]
       },
@@ -709,16 +686,15 @@
       "level": 24,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 24
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 60,
-        "bonus2": 75
+        "bonus1": 0.75,
+        "bonus2": 0.6
       },
       "build_costs": {
         "materials": [],
@@ -739,16 +715,15 @@
       "level": 25,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 25
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 64,
-        "bonus2": 75
+        "bonus1": 0.75,
+        "bonus2": 0.64
       },
       "build_costs": {
         "materials": [],
@@ -769,28 +744,27 @@
       "level": 26,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 26
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 68,
-        "bonus2": 85
+        "bonus1": 0.85,
+        "bonus2": 0.68
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 6071040
-          },
-          {
             "type": "tritanium",
             "value": 167400
+          },
+          {
+            "type": "parsteel",
+            "value": 6071040
           }
         ]
       },
@@ -799,16 +773,15 @@
       "level": 27,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 27
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 72,
-        "bonus2": 85
+        "bonus1": 0.85,
+        "bonus2": 0.72
       },
       "build_costs": {
         "materials": [],
@@ -829,28 +802,27 @@
       "level": 28,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 28
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 76,
-        "bonus2": 85
+        "bonus1": 0.85,
+        "bonus2": 0.76
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 14497600
-          },
-          {
             "type": "tritanium",
             "value": 399750
+          },
+          {
+            "type": "parsteel",
+            "value": 14497600
           }
         ]
       },
@@ -859,16 +831,15 @@
       "level": 29,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 29
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 80,
-        "bonus2": 100
+        "bonus1": 1.0,
+        "bonus2": 0.8
       },
       "build_costs": {
         "materials": [],
@@ -889,16 +860,15 @@
       "level": 30,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 30
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 84,
-        "bonus2": 100
+        "bonus1": 1.0,
+        "bonus2": 0.84
       },
       "build_costs": {
         "materials": [],
@@ -919,16 +889,15 @@
       "level": 31,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 31
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 88,
-        "bonus2": 110
+        "bonus1": 1.1,
+        "bonus2": 0.88
       },
       "build_costs": {
         "materials": [],
@@ -949,16 +918,15 @@
       "level": 32,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 32
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 92,
-        "bonus2": 110
+        "bonus1": 1.1,
+        "bonus2": 0.92
       },
       "build_costs": {
         "materials": [],
@@ -979,28 +947,27 @@
       "level": 33,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 33
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 96,
-        "bonus2": 110
+        "bonus1": 1.1,
+        "bonus2": 0.96
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 118320000
-          },
-          {
             "type": "tritanium",
             "value": 3262500
+          },
+          {
+            "type": "parsteel",
+            "value": 118320000
           }
         ]
       },
@@ -1009,16 +976,15 @@
       "level": 34,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 34
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 100,
-        "bonus2": 130
+        "bonus1": 1.3,
+        "bonus2": 1.0
       },
       "build_costs": {
         "materials": [],
@@ -1039,28 +1005,27 @@
       "level": 35,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 35
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 105,
-        "bonus2": 130
+        "bonus1": 1.3,
+        "bonus2": 1.05
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 258019200
-          },
-          {
             "type": "tritanium",
             "value": 7114500
+          },
+          {
+            "type": "parsteel",
+            "value": 258019200
           }
         ]
       },
@@ -1069,28 +1034,27 @@
       "level": 36,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 36
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 110,
-        "bonus2": 140
+        "bonus1": 1.4,
+        "bonus2": 1.1
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 396576000
-          },
-          {
             "type": "tritanium",
             "value": 10935000
+          },
+          {
+            "type": "parsteel",
+            "value": 396576000
           }
         ]
       },
@@ -1099,16 +1063,15 @@
       "level": 37,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 37
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 115,
-        "bonus2": 140
+        "bonus1": 1.4,
+        "bonus2": 1.15
       },
       "build_costs": {
         "materials": [],
@@ -1129,28 +1092,27 @@
       "level": 38,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 38
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 120,
-        "bonus2": 140
+        "bonus1": 1.4,
+        "bonus2": 1.2
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 1052640000
-          },
-          {
             "type": "tritanium",
             "value": 29025000
+          },
+          {
+            "type": "parsteel",
+            "value": 1052640000
           }
         ]
       },
@@ -1159,16 +1121,15 @@
       "level": 39,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 39
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 125,
-        "bonus2": 160
+        "bonus1": 1.6,
+        "bonus2": 1.25
       },
       "build_costs": {
         "materials": [
@@ -1196,16 +1157,15 @@
       "level": 40,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 40
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 130,
-        "bonus2": 160
+        "bonus1": 1.6,
+        "bonus2": 1.3
       },
       "build_costs": {
         "materials": [
@@ -1233,16 +1193,15 @@
       "level": 41,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 41
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 135,
-        "bonus2": 170
+        "bonus1": 1.7,
+        "bonus2": 1.35
       },
       "build_costs": {
         "materials": [
@@ -1270,20 +1229,19 @@
       "level": 42,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 42
         },
         {
-          "name": "Drydock D",
+          "name": "drydock d",
           "level": 42
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 140,
-        "bonus2": 170
+        "bonus1": 1.7,
+        "bonus2": 1.4
       },
       "build_costs": {
         "materials": [
@@ -1297,12 +1255,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 9955200000
-          },
-          {
             "type": "tritanium",
             "value": 137250000
+          },
+          {
+            "type": "parsteel",
+            "value": 9955200000
           }
         ]
       },
@@ -1311,16 +1269,15 @@
       "level": 43,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 43
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 145,
-        "bonus2": 170
+        "bonus1": 1.7,
+        "bonus2": 1.45
       },
       "build_costs": {
         "materials": [
@@ -1340,12 +1297,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 14932800000
-          },
-          {
             "type": "tritanium",
             "value": 205875000
+          },
+          {
+            "type": "parsteel",
+            "value": 14932800000
           }
         ]
       },
@@ -1354,16 +1311,15 @@
       "level": 44,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 44
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 150,
-        "bonus2": 200
+        "bonus1": 2.0,
+        "bonus2": 1.5
       },
       "build_costs": {
         "materials": [
@@ -1383,12 +1339,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 21216000000
-          },
-          {
             "type": "tritanium",
             "value": 292500000
+          },
+          {
+            "type": "parsteel",
+            "value": 21216000000
           }
         ]
       },
@@ -1397,16 +1353,15 @@
       "level": 45,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 45
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 155,
-        "bonus2": 200
+        "bonus1": 2.0,
+        "bonus2": 1.55
       },
       "build_costs": {
         "materials": [
@@ -1420,12 +1375,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 29172000000
-          },
-          {
             "type": "tritanium",
             "value": 402187500
+          },
+          {
+            "type": "parsteel",
+            "value": 29172000000
           }
         ]
       },
@@ -1434,45 +1389,44 @@
       "level": 46,
       "requirements": [
         {
-          "name": "Drydock D",
+          "name": "operations",
           "level": 46
         },
         {
-          "name": "Operations",
+          "name": "drydock d",
           "level": 46
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 160,
-        "bonus2": 215
+        "bonus1": 2.15,
+        "bonus2": 1.6
       },
       "build_costs": {
         "materials": [
           {
             "type": "crystal",
             "grade": 4,
-            "rarity": "common",
-            "value": 35000
+            "rarity": "uncommon",
+            "value": 6000
           },
           {
             "type": "crystal",
             "grade": 4,
-            "rarity": "uncommon",
-            "value": 6000
+            "rarity": "common",
+            "value": 35000
           }
         ],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 42432000000
-          },
-          {
             "type": "tritanium",
             "value": 585000000
+          },
+          {
+            "type": "parsteel",
+            "value": 42432000000
           }
         ]
       },
@@ -1481,30 +1435,29 @@
       "level": 47,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 47
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 165,
-        "bonus2": 215
+        "bonus1": 2.15,
+        "bonus2": 1.65
       },
       "build_costs": {
         "materials": [
           {
             "type": "crystal",
             "grade": 4,
-            "rarity": "common",
-            "value": 65000
+            "rarity": "uncommon",
+            "value": 13000
           },
           {
             "type": "crystal",
             "grade": 4,
-            "rarity": "uncommon",
-            "value": 13000
+            "rarity": "common",
+            "value": 65000
           }
         ],
         "others": [],
@@ -1524,16 +1477,15 @@
       "level": 48,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 48
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 170,
-        "bonus2": 215
+        "bonus1": 2.15,
+        "bonus2": 1.7
       },
       "build_costs": {
         "materials": [
@@ -1567,32 +1519,31 @@
       "level": 49,
       "requirements": [
         {
-          "name": "Drydock D",
+          "name": "operations",
           "level": 49
         },
         {
-          "name": "Operations",
+          "name": "drydock d",
           "level": 49
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 175,
-        "bonus2": 250
+        "bonus1": 2.5,
+        "bonus2": 1.75
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 199920000000
-          },
-          {
             "type": "tritanium",
             "value": 2756250000
+          },
+          {
+            "type": "parsteel",
+            "value": 199920000000
           }
         ]
       },
@@ -1601,11 +1552,224 @@
       "level": 50,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 50
         }
-      ],
-      "rewards": []
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 2.5,
+        "bonus2": 1.8
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "crystal",
+            "grade": 5,
+            "rarity": "uncommon",
+            "value": 2600
+          },
+          {
+            "type": "crystal",
+            "grade": 5,
+            "rarity": "common",
+            "value": 27100
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 5850000000
+          },
+          {
+            "type": "parsteel",
+            "value": 997152000000
+          }
+        ]
+      },
+      "build_time": 74532960,
+      "increased_power": 11000,
+      "level": 51,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 51
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 2.6,
+        "bonus2": 1.85
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "crystal",
+            "grade": 5,
+            "rarity": "common",
+            "value": 46900
+          },
+          {
+            "type": "crystal",
+            "grade": 5,
+            "rarity": "uncommon",
+            "value": 5700
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 9945000000
+          },
+          {
+            "type": "parsteel",
+            "value": 1803360000000
+          }
+        ]
+      },
+      "build_time": 79005600,
+      "increased_power": 10000,
+      "level": 52,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 52
+        },
+        {
+          "name": "drydock d",
+          "level": 52
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 2.6,
+        "bonus2": 1.9
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "crystal",
+            "grade": 5,
+            "rarity": "uncommon",
+            "value": 20600
+          },
+          {
+            "type": "crystal",
+            "grade": 5,
+            "rarity": "common",
+            "value": 61900
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 17400000000
+          },
+          {
+            "type": "parsteel",
+            "value": 3028992000000
+          }
+        ]
+      },
+      "build_time": 83744640,
+      "increased_power": 11000,
+      "level": 53,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 53
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 2.6,
+        "bonus2": 1.95
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "crystal",
+            "grade": 5,
+            "rarity": "uncommon",
+            "value": 27400
+          },
+          {
+            "type": "crystal",
+            "grade": 5,
+            "rarity": "common",
+            "value": 98600
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 26100000000
+          },
+          {
+            "type": "parsteel",
+            "value": 4543488000000
+          }
+        ]
+      },
+      "build_time": 88770240,
+      "increased_power": 12000,
+      "level": 54,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 54
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 2.9,
+        "bonus2": 2.0
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "crystal",
+            "grade": 5,
+            "rarity": "rare",
+            "value": 8800
+          },
+          {
+            "type": "crystal",
+            "grade": 5,
+            "rarity": "common",
+            "value": 127600
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 40950000000
+          },
+          {
+            "type": "parsteel",
+            "value": 7722624000000
+          }
+        ]
+      },
+      "build_time": 94096800,
+      "increased_power": 11000,
+      "level": 55,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 55
+        }
+      ]
     }
   ]
 }

--- a/buildings/drydock_f.json
+++ b/buildings/drydock_f.json
@@ -2,11 +2,11 @@
   "description": "Ship F. Ships can be assigned, managed and upgraded via Ship Management. Every additional Drydock increases the amounts of Ships that can be deployed.",
   "bonuses": {
     "bonus1": {
-      "name": "Repair Cost Efficiency",
+      "name": "repair speed bonus",
       "percentage": true
     },
     "bonus2": {
-      "name": "Repair Speed Bonus",
+      "name": "repair cost efficiency",
       "percentage": true
     }
   },
@@ -14,8 +14,8 @@
   "levels": [
     {
       "bonuses": {
-        "bonus1": 0,
-        "bonus2": 0
+        "bonus1": 0.0,
+        "bonus2": 0.0
       },
       "build_costs": {
         "materials": [],
@@ -32,16 +32,15 @@
       "level": 1,
       "requirements": [
         {
-          "name": "Fleet Commander",
+          "name": "fleet commander",
           "level": 5
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 3,
-        "bonus2": 0
+        "bonus1": 0.0,
+        "bonus2": 0.03
       },
       "build_costs": {
         "materials": [],
@@ -58,16 +57,15 @@
       "level": 2,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 2
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 5,
-        "bonus2": 0
+        "bonus1": 0.0,
+        "bonus2": 0.05
       },
       "build_costs": {
         "materials": [],
@@ -84,16 +82,15 @@
       "level": 3,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 3
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 6,
-        "bonus2": 0
+        "bonus1": 0.0,
+        "bonus2": 0.06
       },
       "build_costs": {
         "materials": [],
@@ -110,16 +107,15 @@
       "level": 4,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 4
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 8,
-        "bonus2": 10
+        "bonus1": 0.1,
+        "bonus2": 0.08
       },
       "build_costs": {
         "materials": [],
@@ -136,16 +132,15 @@
       "level": 5,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 5
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 9,
-        "bonus2": 10
+        "bonus1": 0.1,
+        "bonus2": 0.09
       },
       "build_costs": {
         "materials": [],
@@ -162,28 +157,27 @@
       "level": 6,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 6
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 11,
-        "bonus2": 14
+        "bonus1": 0.14,
+        "bonus2": 0.11
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 4500
-          },
-          {
             "type": "tritanium",
             "value": 50
+          },
+          {
+            "type": "parsteel",
+            "value": 4500
           }
         ]
       },
@@ -192,28 +186,27 @@
       "level": 7,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 7
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 12,
-        "bonus2": 14
+        "bonus1": 0.14,
+        "bonus2": 0.12
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 4750
-          },
-          {
             "type": "tritanium",
             "value": 100
+          },
+          {
+            "type": "parsteel",
+            "value": 4750
           }
         ]
       },
@@ -222,16 +215,15 @@
       "level": 8,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 8
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 14,
-        "bonus2": 14
+        "bonus1": 0.14,
+        "bonus2": 0.14
       },
       "build_costs": {
         "materials": [],
@@ -252,16 +244,15 @@
       "level": 9,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 9
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 15,
-        "bonus2": 20
+        "bonus1": 0.2,
+        "bonus2": 0.15
       },
       "build_costs": {
         "materials": [],
@@ -282,16 +273,15 @@
       "level": 10,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 10
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 17,
-        "bonus2": 20
+        "bonus1": 0.2,
+        "bonus2": 0.17
       },
       "build_costs": {
         "materials": [],
@@ -312,28 +302,27 @@
       "level": 11,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 11
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 19,
-        "bonus2": 25
+        "bonus1": 0.25,
+        "bonus2": 0.19
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 14960
-          },
-          {
             "type": "tritanium",
             "value": 413
+          },
+          {
+            "type": "parsteel",
+            "value": 14960
           }
         ]
       },
@@ -342,28 +331,27 @@
       "level": 12,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 12
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 21,
-        "bonus2": 25
+        "bonus1": 0.25,
+        "bonus2": 0.21
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 21760
-          },
-          {
             "type": "tritanium",
             "value": 600
+          },
+          {
+            "type": "parsteel",
+            "value": 21760
           }
         ]
       },
@@ -372,16 +360,15 @@
       "level": 13,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 13
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 23,
-        "bonus2": 25
+        "bonus1": 0.25,
+        "bonus2": 0.23
       },
       "build_costs": {
         "materials": [],
@@ -402,16 +389,15 @@
       "level": 14,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 14
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 25,
-        "bonus2": 35
+        "bonus1": 0.35,
+        "bonus2": 0.25
       },
       "build_costs": {
         "materials": [],
@@ -432,28 +418,27 @@
       "level": 15,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 15
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 28,
-        "bonus2": 35
+        "bonus1": 0.35,
+        "bonus2": 0.28
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 54400
-          },
-          {
             "type": "tritanium",
             "value": 1500
+          },
+          {
+            "type": "parsteel",
+            "value": 54400
           }
         ]
       },
@@ -462,28 +447,27 @@
       "level": 16,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 16
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 31,
-        "bonus2": 42
+        "bonus1": 0.42,
+        "bonus2": 0.31
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 76160
-          },
-          {
             "type": "tritanium",
             "value": 2100
+          },
+          {
+            "type": "parsteel",
+            "value": 76160
           }
         ]
       },
@@ -492,16 +476,15 @@
       "level": 17,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 17
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 34,
-        "bonus2": 42
+        "bonus1": 0.42,
+        "bonus2": 0.34
       },
       "build_costs": {
         "materials": [],
@@ -522,16 +505,15 @@
       "level": 18,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 18
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 37,
-        "bonus2": 42
+        "bonus1": 0.42,
+        "bonus2": 0.37
       },
       "build_costs": {
         "materials": [],
@@ -552,28 +534,27 @@
       "level": 19,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 19
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 40,
-        "bonus2": 55
+        "bonus1": 0.55,
+        "bonus2": 0.4
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 231200
-          },
-          {
             "type": "tritanium",
             "value": 6375
+          },
+          {
+            "type": "parsteel",
+            "value": 231200
           }
         ]
       },
@@ -582,28 +563,27 @@
       "level": 20,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 20
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 44,
-        "bonus2": 55
+        "bonus1": 0.55,
+        "bonus2": 0.44
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 389232
-          },
-          {
             "type": "tritanium",
             "value": 10733
+          },
+          {
+            "type": "parsteel",
+            "value": 389232
           }
         ]
       },
@@ -612,28 +592,27 @@
       "level": 21,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 21
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 48,
-        "bonus2": 62
+        "bonus1": 0.62,
+        "bonus2": 0.48
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 605472
-          },
-          {
             "type": "tritanium",
             "value": 16695
+          },
+          {
+            "type": "parsteel",
+            "value": 605472
           }
         ]
       },
@@ -642,28 +621,27 @@
       "level": 22,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 22
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 52,
-        "bonus2": 62
+        "bonus1": 0.62,
+        "bonus2": 0.52
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 996336
-          },
-          {
             "type": "tritanium",
             "value": 27473
+          },
+          {
+            "type": "parsteel",
+            "value": 996336
           }
         ]
       },
@@ -672,28 +650,27 @@
       "level": 23,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 23
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 56,
-        "bonus2": 62
+        "bonus1": 0.62,
+        "bonus2": 0.56
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 1569984
-          },
-          {
             "type": "tritanium",
             "value": 43290
+          },
+          {
+            "type": "parsteel",
+            "value": 1569984
           }
         ]
       },
@@ -702,16 +679,15 @@
       "level": 24,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 24
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 60,
-        "bonus2": 75
+        "bonus1": 0.75,
+        "bonus2": 0.6
       },
       "build_costs": {
         "materials": [],
@@ -732,16 +708,15 @@
       "level": 25,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 25
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 64,
-        "bonus2": 75
+        "bonus1": 0.75,
+        "bonus2": 0.64
       },
       "build_costs": {
         "materials": [],
@@ -762,28 +737,27 @@
       "level": 26,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 26
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 68,
-        "bonus2": 85
+        "bonus1": 0.85,
+        "bonus2": 0.68
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 6071040
-          },
-          {
             "type": "tritanium",
             "value": 167400
+          },
+          {
+            "type": "parsteel",
+            "value": 6071040
           }
         ]
       },
@@ -792,16 +766,15 @@
       "level": 27,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 27
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 72,
-        "bonus2": 85
+        "bonus1": 0.85,
+        "bonus2": 0.72
       },
       "build_costs": {
         "materials": [],
@@ -822,16 +795,15 @@
       "level": 28,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 28
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 76,
-        "bonus2": 85
+        "bonus1": 0.85,
+        "bonus2": 0.76
       },
       "build_costs": {
         "materials": [],
@@ -852,16 +824,15 @@
       "level": 29,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 29
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 80,
-        "bonus2": 100
+        "bonus1": 1.0,
+        "bonus2": 0.8
       },
       "build_costs": {
         "materials": [],
@@ -882,28 +853,27 @@
       "level": 30,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 30
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 84,
-        "bonus2": 100
+        "bonus1": 1.0,
+        "bonus2": 0.84
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 33537600
-          },
-          {
             "type": "tritanium",
             "value": 924750
+          },
+          {
+            "type": "parsteel",
+            "value": 33537600
           }
         ]
       },
@@ -912,16 +882,15 @@
       "level": 31,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 31
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 88,
-        "bonus2": 110
+        "bonus1": 1.1,
+        "bonus2": 0.88
       },
       "build_costs": {
         "materials": [],
@@ -942,16 +911,15 @@
       "level": 32,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 32
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 92,
-        "bonus2": 110
+        "bonus1": 1.1,
+        "bonus2": 0.92
       },
       "build_costs": {
         "materials": [],
@@ -972,28 +940,27 @@
       "level": 33,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 33
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 96,
-        "bonus2": 110
+        "bonus1": 1.1,
+        "bonus2": 0.96
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 118320000
-          },
-          {
             "type": "tritanium",
             "value": 3262500
+          },
+          {
+            "type": "parsteel",
+            "value": 118320000
           }
         ]
       },
@@ -1002,16 +969,15 @@
       "level": 34,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 34
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 100,
-        "bonus2": 130
+        "bonus1": 1.3,
+        "bonus2": 1.0
       },
       "build_costs": {
         "materials": [],
@@ -1032,16 +998,15 @@
       "level": 35,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 35
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 105,
-        "bonus2": 130
+        "bonus1": 1.3,
+        "bonus2": 1.05
       },
       "build_costs": {
         "materials": [],
@@ -1062,16 +1027,15 @@
       "level": 36,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 36
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 110,
-        "bonus2": 140
+        "bonus1": 1.4,
+        "bonus2": 1.1
       },
       "build_costs": {
         "materials": [],
@@ -1092,28 +1056,27 @@
       "level": 37,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 37
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 115,
-        "bonus2": 140
+        "bonus1": 1.4,
+        "bonus2": 1.15
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 616896000
-          },
-          {
             "type": "tritanium",
             "value": 17010000
+          },
+          {
+            "type": "parsteel",
+            "value": 616896000
           }
         ]
       },
@@ -1122,28 +1085,27 @@
       "level": 38,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 38
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 120,
-        "bonus2": 140
+        "bonus1": 1.4,
+        "bonus2": 1.2
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 1052640000
-          },
-          {
             "type": "tritanium",
             "value": 29025000
+          },
+          {
+            "type": "parsteel",
+            "value": 1052640000
           }
         ]
       },
@@ -1152,16 +1114,15 @@
       "level": 39,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 39
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 125,
-        "bonus2": 160
+        "bonus1": 1.6,
+        "bonus2": 1.25
       },
       "build_costs": {
         "materials": [
@@ -1181,12 +1142,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 4584832000
-          },
-          {
             "type": "tritanium",
             "value": 45150000
+          },
+          {
+            "type": "parsteel",
+            "value": 4584832000
           }
         ]
       },
@@ -1195,16 +1156,15 @@
       "level": 40,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 40
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 130,
-        "bonus2": 160
+        "bonus1": 1.6,
+        "bonus2": 1.3
       },
       "build_costs": {
         "materials": [
@@ -1224,12 +1184,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 4678400000
-          },
-          {
             "type": "tritanium",
             "value": 64500000
+          },
+          {
+            "type": "parsteel",
+            "value": 4678400000
           }
         ]
       },
@@ -1238,30 +1198,29 @@
       "level": 41,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 41
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 135,
-        "bonus2": 170
+        "bonus1": 1.7,
+        "bonus2": 1.35
       },
       "build_costs": {
         "materials": [
           {
             "type": "crystal",
             "grade": 4,
-            "rarity": "common",
-            "value": 24000
+            "rarity": "uncommon",
+            "value": 7000
           },
           {
             "type": "crystal",
             "grade": 4,
-            "rarity": "uncommon",
-            "value": 7000
+            "rarity": "common",
+            "value": 24000
           }
         ],
         "others": [],
@@ -1281,16 +1240,15 @@
       "level": 42,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 42
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 140,
-        "bonus2": 170
+        "bonus1": 1.7,
+        "bonus2": 1.4
       },
       "build_costs": {
         "materials": [
@@ -1318,41 +1276,40 @@
       "level": 43,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 43
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 145,
-        "bonus2": 170
+        "bonus1": 1.7,
+        "bonus2": 1.45
       },
       "build_costs": {
         "materials": [
           {
             "type": "crystal",
             "grade": 4,
-            "rarity": "common",
-            "value": 6500
+            "rarity": "rare",
+            "value": 3000
           },
           {
             "type": "crystal",
             "grade": 4,
-            "rarity": "rare",
-            "value": 3000
+            "rarity": "common",
+            "value": 6500
           }
         ],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 14932800000
-          },
-          {
             "type": "tritanium",
             "value": 205875000
+          },
+          {
+            "type": "parsteel",
+            "value": 14932800000
           }
         ]
       },
@@ -1361,16 +1318,15 @@
       "level": 44,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 44
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 150,
-        "bonus2": 200
+        "bonus1": 2.0,
+        "bonus2": 1.5
       },
       "build_costs": {
         "materials": [
@@ -1404,41 +1360,40 @@
       "level": 45,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 45
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 155,
-        "bonus2": 200
+        "bonus1": 2.0,
+        "bonus2": 1.55
       },
       "build_costs": {
         "materials": [
           {
             "type": "crystal",
             "grade": 4,
-            "rarity": "common",
-            "value": 50000
+            "rarity": "uncommon",
+            "value": 6000
           },
           {
             "type": "crystal",
             "grade": 4,
-            "rarity": "uncommon",
-            "value": 6000
+            "rarity": "common",
+            "value": 50000
           }
         ],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 29172000000
-          },
-          {
             "type": "tritanium",
             "value": 402187500
+          },
+          {
+            "type": "parsteel",
+            "value": 29172000000
           }
         ]
       },
@@ -1447,41 +1402,40 @@
       "level": 46,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 46
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 160,
-        "bonus2": 215
+        "bonus1": 2.15,
+        "bonus2": 1.6
       },
       "build_costs": {
         "materials": [
           {
             "type": "crystal",
             "grade": 4,
-            "rarity": "common",
-            "value": 35000
+            "rarity": "uncommon",
+            "value": 6000
           },
           {
             "type": "crystal",
             "grade": 4,
-            "rarity": "uncommon",
-            "value": 6000
+            "rarity": "common",
+            "value": 35000
           }
         ],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 42432000000
-          },
-          {
             "type": "tritanium",
             "value": 585000000
+          },
+          {
+            "type": "parsteel",
+            "value": 42432000000
           }
         ]
       },
@@ -1490,16 +1444,15 @@
       "level": 47,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 47
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 165,
-        "bonus2": 215
+        "bonus1": 2.15,
+        "bonus2": 1.65
       },
       "build_costs": {
         "materials": [
@@ -1533,30 +1486,29 @@
       "level": 48,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 48
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 170,
-        "bonus2": 215
+        "bonus1": 2.15,
+        "bonus2": 1.7
       },
       "build_costs": {
         "materials": [
           {
             "type": "crystal",
             "grade": 4,
-            "rarity": "uncommon",
-            "value": 22500
+            "rarity": "rare",
+            "value": 4500
           },
           {
             "type": "crystal",
             "grade": 4,
-            "rarity": "rare",
-            "value": 4500
+            "rarity": "uncommon",
+            "value": 22500
           }
         ],
         "others": [],
@@ -1576,16 +1528,15 @@
       "level": 49,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 49
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 175,
-        "bonus2": 250
+        "bonus1": 2.5,
+        "bonus2": 1.75
       },
       "build_costs": {
         "materials": [],
@@ -1606,11 +1557,220 @@
       "level": 50,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 50
         }
-      ],
-      "rewards": []
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 2.5,
+        "bonus2": 1.8
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "crystal",
+            "grade": 5,
+            "rarity": "common",
+            "value": 29300
+          },
+          {
+            "type": "crystal",
+            "grade": 5,
+            "rarity": "uncommon",
+            "value": 2800
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 5850000000
+          },
+          {
+            "type": "parsteel",
+            "value": 997152000000
+          }
+        ]
+      },
+      "build_time": 74532960,
+      "increased_power": 11000,
+      "level": 51,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 51
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 2.6,
+        "bonus2": 1.85
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "crystal",
+            "grade": 5,
+            "rarity": "common",
+            "value": 50700
+          },
+          {
+            "type": "crystal",
+            "grade": 5,
+            "rarity": "uncommon",
+            "value": 6100
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 9945000000
+          },
+          {
+            "type": "parsteel",
+            "value": 1803360000000
+          }
+        ]
+      },
+      "build_time": 79005600,
+      "increased_power": 10000,
+      "level": 52,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 52
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 2.6,
+        "bonus2": 1.9
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "crystal",
+            "grade": 5,
+            "rarity": "uncommon",
+            "value": 21700
+          },
+          {
+            "type": "crystal",
+            "grade": 5,
+            "rarity": "common",
+            "value": 65200
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 3028992000000
+          },
+          {
+            "type": "tritanium",
+            "value": 17400000000
+          }
+        ]
+      },
+      "build_time": 83744640,
+      "increased_power": 11000,
+      "level": 53,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 53
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 2.6,
+        "bonus2": 1.95
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "crystal",
+            "grade": 5,
+            "rarity": "common",
+            "value": 102500
+          },
+          {
+            "type": "crystal",
+            "grade": 5,
+            "rarity": "uncommon",
+            "value": 28500
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 26100000000
+          },
+          {
+            "type": "parsteel",
+            "value": 4543488000000
+          }
+        ]
+      },
+      "build_time": 88770240,
+      "increased_power": 12000,
+      "level": 54,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 54
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 2.9,
+        "bonus2": 2.0
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "crystal",
+            "grade": 5,
+            "rarity": "common",
+            "value": 129300
+          },
+          {
+            "type": "crystal",
+            "grade": 5,
+            "rarity": "rare",
+            "value": 8900
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 7722624000000
+          },
+          {
+            "type": "tritanium",
+            "value": 40950000000
+          }
+        ]
+      },
+      "build_time": 94096800,
+      "increased_power": 11000,
+      "level": 55,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 55
+        }
+      ]
     }
   ]
 }

--- a/buildings/engine_technology_lab.json
+++ b/buildings/engine_technology_lab.json
@@ -2,11 +2,11 @@
   "description": "Engine Tech Research facility.",
   "bonuses": {
     "bonus1": {
-      "name": "Interceptor Shield Health Bonus",
+      "name": "dodge bonus",
       "percentage": true
     },
     "bonus2": {
-      "name": "Dodge Bonus",
+      "name": "interceptor shield health bonus",
       "percentage": true
     }
   },
@@ -14,8 +14,8 @@
   "levels": [
     {
       "bonuses": {
-        "bonus1": 3,
-        "bonus2": 1
+        "bonus1": 0.01,
+        "bonus2": 0.03
       },
       "build_costs": {
         "materials": [
@@ -39,16 +39,15 @@
       "level": 1,
       "requirements": [
         {
-          "name": "Unlock Technology Lab",
+          "name": "unlock technology lab",
           "level": 1
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 6,
-        "bonus2": 2
+        "bonus1": 0.02,
+        "bonus2": 0.06
       },
       "build_costs": {
         "materials": [],
@@ -65,20 +64,19 @@
       "level": 2,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 2
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 2
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 9,
-        "bonus2": 3
+        "bonus1": 0.03,
+        "bonus2": 0.09
       },
       "build_costs": {
         "materials": [],
@@ -95,20 +93,19 @@
       "level": 3,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 3
         },
         {
-          "name": "R&D Department",
+          "name": "r&d department",
           "level": 3
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 12,
-        "bonus2": 4
+        "bonus1": 0.04,
+        "bonus2": 0.12
       },
       "build_costs": {
         "materials": [],
@@ -125,20 +122,19 @@
       "level": 4,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 4
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 4
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 15,
-        "bonus2": 5
+        "bonus1": 0.05,
+        "bonus2": 0.15
       },
       "build_costs": {
         "materials": [],
@@ -155,20 +151,19 @@
       "level": 5,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 5
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 5
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 18,
-        "bonus2": 6
+        "bonus1": 0.06,
+        "bonus2": 0.18
       },
       "build_costs": {
         "materials": [],
@@ -185,20 +180,19 @@
       "level": 6,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 6
         },
         {
-          "name": "R&D Department",
+          "name": "r&d department",
           "level": 6
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 21,
-        "bonus2": 7
+        "bonus1": 0.07,
+        "bonus2": 0.21
       },
       "build_costs": {
         "materials": [],
@@ -215,20 +209,19 @@
       "level": 7,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 7
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 7
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 24,
-        "bonus2": 8
+        "bonus1": 0.08,
+        "bonus2": 0.24
       },
       "build_costs": {
         "materials": [],
@@ -245,20 +238,19 @@
       "level": 8,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 8
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 8
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 27,
-        "bonus2": 9
+        "bonus1": 0.09,
+        "bonus2": 0.27
       },
       "build_costs": {
         "materials": [],
@@ -275,20 +267,19 @@
       "level": 9,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 9
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 9
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 30,
-        "bonus2": 10
+        "bonus1": 0.1,
+        "bonus2": 0.3
       },
       "build_costs": {
         "materials": [],
@@ -305,20 +296,19 @@
       "level": 10,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 10
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 10
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 33,
-        "bonus2": 11
+        "bonus1": 0.11,
+        "bonus2": 0.33
       },
       "build_costs": {
         "materials": [],
@@ -339,20 +329,19 @@
       "level": 11,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 11
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 11
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 36,
-        "bonus2": 12
+        "bonus1": 0.12,
+        "bonus2": 0.36
       },
       "build_costs": {
         "materials": [],
@@ -373,20 +362,19 @@
       "level": 12,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 12
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 12
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 39,
-        "bonus2": 13
+        "bonus1": 0.13,
+        "bonus2": 0.39
       },
       "build_costs": {
         "materials": [],
@@ -407,20 +395,19 @@
       "level": 13,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 13
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 13
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 42,
-        "bonus2": 14
+        "bonus1": 0.14,
+        "bonus2": 0.42
       },
       "build_costs": {
         "materials": [],
@@ -441,32 +428,31 @@
       "level": 14,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 14
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 14
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 45,
-        "bonus2": 15
+        "bonus1": 0.15,
+        "bonus2": 0.45
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 215016
-          },
-          {
             "type": "dilithium",
             "value": 375
+          },
+          {
+            "type": "parsteel",
+            "value": 215016
           }
         ]
       },
@@ -475,20 +461,19 @@
       "level": 15,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 15
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 15
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 48,
-        "bonus2": 16
+        "bonus1": 0.16,
+        "bonus2": 0.48
       },
       "build_costs": {
         "materials": [],
@@ -509,32 +494,31 @@
       "level": 16,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 16
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 16
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 51,
-        "bonus2": 17
+        "bonus1": 0.17,
+        "bonus2": 0.51
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 232696
-          },
-          {
             "type": "dilithium",
             "value": 700
+          },
+          {
+            "type": "parsteel",
+            "value": 232696
           }
         ]
       },
@@ -543,20 +527,19 @@
       "level": 17,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 17
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 17
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 54,
-        "bonus2": 18
+        "bonus1": 0.18,
+        "bonus2": 0.54
       },
       "build_costs": {
         "materials": [],
@@ -577,20 +560,19 @@
       "level": 18,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 18
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 18
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 57,
-        "bonus2": 19
+        "bonus1": 0.19,
+        "bonus2": 0.57
       },
       "build_costs": {
         "materials": [],
@@ -611,32 +593,31 @@
       "level": 19,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 19
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 19
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 60,
-        "bonus2": 20
+        "bonus1": 0.2,
+        "bonus2": 0.6
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 310216
-          },
-          {
             "type": "dilithium",
             "value": 2125
+          },
+          {
+            "type": "parsteel",
+            "value": 310216
           }
         ]
       },
@@ -645,32 +626,31 @@
       "level": 20,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 20
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 20
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 63,
-        "bonus2": 21
+        "bonus1": 0.21,
+        "bonus2": 0.63
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 389232
-          },
-          {
             "type": "dilithium",
             "value": 3578
+          },
+          {
+            "type": "parsteel",
+            "value": 389232
           }
         ]
       },
@@ -679,32 +659,31 @@
       "level": 21,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 21
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 21
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 66,
-        "bonus2": 22
+        "bonus1": 0.22,
+        "bonus2": 0.66
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 497352
-          },
-          {
             "type": "dilithium",
             "value": 5565
+          },
+          {
+            "type": "parsteel",
+            "value": 497352
           }
         ]
       },
@@ -713,20 +692,19 @@
       "level": 22,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 22
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 22
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 69,
-        "bonus2": 23
+        "bonus1": 0.23,
+        "bonus2": 0.69
       },
       "build_costs": {
         "materials": [],
@@ -747,20 +725,19 @@
       "level": 23,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 23
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 23
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 72,
-        "bonus2": 24
+        "bonus1": 0.24,
+        "bonus2": 0.72
       },
       "build_costs": {
         "materials": [],
@@ -781,20 +758,19 @@
       "level": 24,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 24
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 24
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 75,
-        "bonus2": 25
+        "bonus1": 0.25,
+        "bonus2": 0.75
       },
       "build_costs": {
         "materials": [
@@ -808,12 +784,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 1272960
-          },
-          {
             "type": "dilithium",
             "value": 23400
+          },
+          {
+            "type": "parsteel",
+            "value": 1272960
           }
         ]
       },
@@ -822,20 +798,19 @@
       "level": 25,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 25
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 25
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 78,
-        "bonus2": 26
+        "bonus1": 0.26,
+        "bonus2": 0.78
       },
       "build_costs": {
         "materials": [
@@ -863,20 +838,19 @@
       "level": 26,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 26
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 26
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 81,
-        "bonus2": 27
+        "bonus1": 0.27,
+        "bonus2": 0.81
       },
       "build_costs": {
         "materials": [
@@ -910,20 +884,19 @@
       "level": 27,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 27
         },
         {
-          "name": "R&D Department",
+          "name": "r&d department",
           "level": 27
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 84,
-        "bonus2": 28
+        "bonus1": 0.28,
+        "bonus2": 0.84
       },
       "build_costs": {
         "materials": [
@@ -943,12 +916,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 4553280
-          },
-          {
             "type": "dilithium",
             "value": 83700
+          },
+          {
+            "type": "parsteel",
+            "value": 4553280
           }
         ]
       },
@@ -957,20 +930,19 @@
       "level": 28,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 28
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 28
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 87,
-        "bonus2": 29
+        "bonus1": 0.29,
+        "bonus2": 0.87
       },
       "build_costs": {
         "materials": [
@@ -984,12 +956,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 7248800
-          },
-          {
             "type": "dilithium",
             "value": 133250
+          },
+          {
+            "type": "parsteel",
+            "value": 7248800
           }
         ]
       },
@@ -998,20 +970,19 @@
       "level": 29,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 29
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 29
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 90,
-        "bonus2": 37
+        "bonus1": 0.37,
+        "bonus2": 0.9
       },
       "build_costs": {
         "materials": [
@@ -1039,34 +1010,33 @@
       "level": 30,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 30
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 30
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 93,
-        "bonus2": 38
+        "bonus1": 0.38,
+        "bonus2": 0.93
       },
       "build_costs": {
         "materials": [
           {
             "type": "gas",
             "grade": 3,
-            "rarity": "common",
-            "value": 700
+            "rarity": "uncommon",
+            "value": 65
           },
           {
             "type": "gas",
             "grade": 3,
-            "rarity": "uncommon",
-            "value": 65
+            "rarity": "common",
+            "value": 700
           }
         ],
         "others": [],
@@ -1086,38 +1056,37 @@
       "level": 31,
       "requirements": [
         {
-          "name": "Science Lab",
+          "name": "operations",
           "level": 31
         },
         {
-          "name": "R&D Department",
+          "name": "r&d department",
           "level": 31
         },
         {
-          "name": "Operations",
+          "name": "science lab",
           "level": 31
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 96,
-        "bonus2": 39
+        "bonus1": 0.39,
+        "bonus2": 0.96
       },
       "build_costs": {
         "materials": [
           {
             "type": "gas",
             "grade": 3,
-            "rarity": "common",
-            "value": 800
+            "rarity": "uncommon",
+            "value": 87
           },
           {
             "type": "gas",
             "grade": 3,
-            "rarity": "uncommon",
-            "value": 87
+            "rarity": "common",
+            "value": 800
           }
         ],
         "others": [],
@@ -1137,20 +1106,19 @@
       "level": 32,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 32
         },
         {
-          "name": "R&D Department",
+          "name": "r&d department",
           "level": 32
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 99,
-        "bonus2": 40
+        "bonus1": 0.4,
+        "bonus2": 0.99
       },
       "build_costs": {
         "materials": [
@@ -1184,20 +1152,19 @@
       "level": 33,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 33
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 33
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 102,
-        "bonus2": 42
+        "bonus1": 0.42,
+        "bonus2": 1.02
       },
       "build_costs": {
         "materials": [
@@ -1225,20 +1192,19 @@
       "level": 34,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 34
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 34
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 105,
-        "bonus2": 44
+        "bonus1": 0.44,
+        "bonus2": 1.05
       },
       "build_costs": {
         "materials": [
@@ -1252,12 +1218,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 91555200
-          },
-          {
             "type": "dilithium",
             "value": 1683000
+          },
+          {
+            "type": "parsteel",
+            "value": 91555200
           }
         ]
       },
@@ -1266,20 +1232,19 @@
       "level": 35,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 35
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 35
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 108,
-        "bonus2": 46
+        "bonus1": 0.46,
+        "bonus2": 1.08
       },
       "build_costs": {
         "materials": [
@@ -1313,20 +1278,19 @@
       "level": 36,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 36
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 36
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 111,
-        "bonus2": 48
+        "bonus1": 0.48,
+        "bonus2": 1.11
       },
       "build_costs": {
         "materials": [
@@ -1340,12 +1304,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 198288000
-          },
-          {
             "type": "dilithium",
             "value": 3645000
+          },
+          {
+            "type": "parsteel",
+            "value": 198288000
           }
         ]
       },
@@ -1354,20 +1318,19 @@
       "level": 37,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 37
         },
         {
-          "name": "R&D Department",
+          "name": "r&d department",
           "level": 37
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 114,
-        "bonus2": 50
+        "bonus1": 0.5,
+        "bonus2": 1.14
       },
       "build_costs": {
         "materials": [
@@ -1401,20 +1364,19 @@
       "level": 38,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 38
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 38
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 117,
-        "bonus2": 52
+        "bonus1": 0.52,
+        "bonus2": 1.17
       },
       "build_costs": {
         "materials": [
@@ -1442,24 +1404,23 @@
       "level": 39,
       "requirements": [
         {
-          "name": "Science Lab",
+          "name": "operations",
           "level": 39
         },
         {
-          "name": "R&D Department",
+          "name": "r&d department",
           "level": 39
         },
         {
-          "name": "Operations",
+          "name": "science lab",
           "level": 39
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 120,
-        "bonus2": 54
+        "bonus1": 0.54,
+        "bonus2": 1.2
       },
       "build_costs": {
         "materials": [
@@ -1479,12 +1440,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 2292416000
-          },
-          {
             "type": "dilithium",
             "value": 15050000
+          },
+          {
+            "type": "parsteel",
+            "value": 2292416000
           }
         ]
       },
@@ -1493,20 +1454,19 @@
       "level": 40,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 40
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 40
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 123,
-        "bonus2": 56
+        "bonus1": 0.56,
+        "bonus2": 1.23
       },
       "build_costs": {
         "materials": [
@@ -1526,12 +1486,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 2339200000
-          },
-          {
             "type": "dilithium",
             "value": 21500000
+          },
+          {
+            "type": "parsteel",
+            "value": 2339200000
           }
         ]
       },
@@ -1540,45 +1500,44 @@
       "level": 41,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 41
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 41
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 126,
-        "bonus2": 58
+        "bonus1": 0.58,
+        "bonus2": 1.26
       },
       "build_costs": {
         "materials": [
           {
             "type": "gas",
             "grade": 4,
-            "rarity": "common",
-            "value": 10000
+            "rarity": "uncommon",
+            "value": 3000
           },
           {
             "type": "gas",
             "grade": 4,
-            "rarity": "uncommon",
-            "value": 3000
+            "rarity": "common",
+            "value": 10000
           }
         ],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 3484320000
-          },
-          {
             "type": "dilithium",
             "value": 32025000
+          },
+          {
+            "type": "parsteel",
+            "value": 3484320000
           }
         ]
       },
@@ -1587,20 +1546,19 @@
       "level": 42,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 42
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 42
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 129,
-        "bonus2": 74
+        "bonus1": 0.74,
+        "bonus2": 1.29
       },
       "build_costs": {
         "materials": [
@@ -1620,12 +1578,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 4977600000
-          },
-          {
             "type": "dilithium",
             "value": 45750000
+          },
+          {
+            "type": "parsteel",
+            "value": 4977600000
           }
         ]
       },
@@ -1634,45 +1592,44 @@
       "level": 43,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 43
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 43
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 132,
-        "bonus2": 76
+        "bonus1": 0.76,
+        "bonus2": 1.32
       },
       "build_costs": {
         "materials": [
           {
             "type": "gas",
             "grade": 4,
-            "rarity": "common",
-            "value": 10000
+            "rarity": "uncommon",
+            "value": 3000
           },
           {
             "type": "gas",
             "grade": 4,
-            "rarity": "uncommon",
-            "value": 3000
+            "rarity": "common",
+            "value": 10000
           }
         ],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 7466400000
-          },
-          {
             "type": "dilithium",
             "value": 68625000
+          },
+          {
+            "type": "parsteel",
+            "value": 7466400000
           }
         ]
       },
@@ -1681,20 +1638,19 @@
       "level": 44,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 44
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 44
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 135,
-        "bonus2": 80
+        "bonus1": 0.8,
+        "bonus2": 1.35
       },
       "build_costs": {
         "materials": [
@@ -1728,49 +1684,48 @@
       "level": 45,
       "requirements": [
         {
-          "name": "4\u2605 Interceptor Armor Piercing",
+          "name": "operations",
+          "level": 45
+        },
+        {
+          "name": "r&d department",
+          "level": 45
+        },
+        {
+          "name": "4\u2605 interceptor armor piercing",
           "level": 1
-        },
-        {
-          "name": "R&D Department",
-          "level": 45
-        },
-        {
-          "name": "Operations",
-          "level": 45
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 138,
-        "bonus2": 84
+        "bonus1": 0.84,
+        "bonus2": 1.38
       },
       "build_costs": {
         "materials": [
           {
             "type": "gas",
             "grade": 4,
-            "rarity": "common",
-            "value": 15000
+            "rarity": "uncommon",
+            "value": 1000
           },
           {
             "type": "gas",
             "grade": 4,
-            "rarity": "uncommon",
-            "value": 1000
+            "rarity": "common",
+            "value": 15000
           }
         ],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 14586000000
-          },
-          {
             "type": "dilithium",
             "value": 134062500
+          },
+          {
+            "type": "parsteel",
+            "value": 14586000000
           }
         ]
       },
@@ -1779,45 +1734,44 @@
       "level": 46,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 46
         },
         {
-          "name": "R&D Department",
+          "name": "r&d department",
           "level": 46
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 141,
-        "bonus2": 88
+        "bonus1": 0.88,
+        "bonus2": 1.41
       },
       "build_costs": {
         "materials": [
           {
             "type": "gas",
             "grade": 4,
-            "rarity": "common",
-            "value": 45000
+            "rarity": "uncommon",
+            "value": 2500
           },
           {
             "type": "gas",
             "grade": 4,
-            "rarity": "uncommon",
-            "value": 2500
+            "rarity": "common",
+            "value": 45000
           }
         ],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 21216000000
-          },
-          {
             "type": "dilithium",
             "value": 195000000
+          },
+          {
+            "type": "parsteel",
+            "value": 21216000000
           }
         ]
       },
@@ -1826,45 +1780,44 @@
       "level": 47,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 47
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 47
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 144,
-        "bonus2": 92
+        "bonus1": 0.92,
+        "bonus2": 1.44
       },
       "build_costs": {
         "materials": [
           {
             "type": "gas",
             "grade": 4,
-            "rarity": "uncommon",
-            "value": 10000
+            "rarity": "rare",
+            "value": 2000
           },
           {
             "type": "gas",
             "grade": 4,
-            "rarity": "rare",
-            "value": 2000
+            "rarity": "uncommon",
+            "value": 10000
           }
         ],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 34272000000
-          },
-          {
             "type": "dilithium",
             "value": 315000000
+          },
+          {
+            "type": "parsteel",
+            "value": 34272000000
           }
         ]
       },
@@ -1873,20 +1826,19 @@
       "level": 48,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 48
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 48
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 147,
-        "bonus2": 96
+        "bonus1": 0.96,
+        "bonus2": 1.47
       },
       "build_costs": {
         "materials": [
@@ -1920,20 +1872,19 @@
       "level": 49,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 49
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 49
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 150,
-        "bonus2": 100
+        "bonus1": 1.0,
+        "bonus2": 1.5
       },
       "build_costs": {
         "materials": [],
@@ -1954,15 +1905,244 @@
       "level": 50,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 50
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 50
         }
-      ],
-      "rewards": []
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 1.04,
+        "bonus2": 1.53
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "gas",
+            "grade": 5,
+            "rarity": "common",
+            "value": 24700
+          },
+          {
+            "type": "gas",
+            "grade": 5,
+            "rarity": "uncommon",
+            "value": 3900
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 498576000000
+          },
+          {
+            "type": "dilithium",
+            "value": 1950000000
+          }
+        ]
+      },
+      "build_time": 44719200,
+      "increased_power": 5000,
+      "level": 51,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 51
+        },
+        {
+          "name": "r&d department",
+          "level": 51
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 1.08,
+        "bonus2": 1.56
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "gas",
+            "grade": 5,
+            "rarity": "uncommon",
+            "value": 8600
+          },
+          {
+            "type": "gas",
+            "grade": 5,
+            "rarity": "common",
+            "value": 42800
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "dilithium",
+            "value": 3315000000
+          },
+          {
+            "type": "parsteel",
+            "value": 901680000000
+          }
+        ]
+      },
+      "build_time": 47403360,
+      "increased_power": 6000,
+      "level": 52,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 52
+        },
+        {
+          "name": "r&d department",
+          "level": 52
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 1.12,
+        "bonus2": 1.59
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "gas",
+            "grade": 5,
+            "rarity": "uncommon",
+            "value": 14900
+          },
+          {
+            "type": "gas",
+            "grade": 5,
+            "rarity": "common",
+            "value": 102600
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 1514496000000
+          },
+          {
+            "type": "dilithium",
+            "value": 5800000000
+          }
+        ]
+      },
+      "build_time": 50247360,
+      "increased_power": 5000,
+      "level": 53,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 53
+        },
+        {
+          "name": "r&d department",
+          "level": 53
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 1.16,
+        "bonus2": 1.62
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "gas",
+            "grade": 5,
+            "rarity": "common",
+            "value": 87200
+          },
+          {
+            "type": "gas",
+            "grade": 5,
+            "rarity": "uncommon",
+            "value": 18200
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "dilithium",
+            "value": 8700000000
+          },
+          {
+            "type": "parsteel",
+            "value": 2271744000000
+          }
+        ]
+      },
+      "build_time": 53261280,
+      "increased_power": 6000,
+      "level": 54,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 54
+        },
+        {
+          "name": "r&d department",
+          "level": 54
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 1.2,
+        "bonus2": 1.65
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "gas",
+            "grade": 5,
+            "rarity": "rare",
+            "value": 4300
+          },
+          {
+            "type": "gas",
+            "grade": 5,
+            "rarity": "common",
+            "value": 140000
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "dilithium",
+            "value": 13650000000
+          },
+          {
+            "type": "parsteel",
+            "value": 3861312000000
+          }
+        ]
+      },
+      "build_time": 56458080,
+      "increased_power": 6000,
+      "level": 55,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 55
+        },
+        {
+          "name": "r&d department",
+          "level": 55
+        }
+      ]
     }
   ]
 }

--- a/buildings/exocomp_factory.json
+++ b/buildings/exocomp_factory.json
@@ -2,15 +2,15 @@
   "description": "The Exocomp Factory grants the ability to activate and improve Consumables, unlock additional Exocomps, and earn Axionic Chips.",
   "bonuses": {
     "bonus1": {
-      "name": "Axionic Chips Daily Bundle Amount",
+      "name": "axionic chips daily bundle amount",
       "percentage": false
     },
     "bonus2": {
-      "name": "Exocomp Consumable Grade",
+      "name": "exocomp consumable grade",
       "percentage": false
     },
     "bonus3": {
-      "name": "Exocomps Unlocked",
+      "name": "exocomps unlocked",
       "percentage": false
     }
   },
@@ -26,7 +26,7 @@
         "materials": [],
         "others": [
           {
-            "type": "Exocomp Factory Key",
+            "type": "exocomp factory key",
             "value": 1
           }
         ],
@@ -42,14 +42,18 @@
       "level": 1,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 16
         }
       ],
       "rewards": [
         {
-          "type": "Axionic Chips",
+          "type": "axionic chip",
           "value": 120
+        },
+        {
+          "type": "galaxy exocomp",
+          "value": 1
         }
       ]
     },
@@ -63,7 +67,7 @@
         "materials": [],
         "others": [
           {
-            "type": "Axionic Servo",
+            "type": "axionic servo",
             "value": 2
           }
         ],
@@ -79,11 +83,10 @@
       "level": 2,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 16
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
@@ -95,7 +98,7 @@
         "materials": [],
         "others": [
           {
-            "type": "Axionic Servo",
+            "type": "axionic servo",
             "value": 3
           }
         ],
@@ -111,11 +114,10 @@
       "level": 3,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 16
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
@@ -127,7 +129,7 @@
         "materials": [],
         "others": [
           {
-            "type": "Axionic Servo",
+            "type": "axionic servo",
             "value": 5
           }
         ],
@@ -143,11 +145,10 @@
       "level": 4,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 16
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
@@ -159,7 +160,7 @@
         "materials": [],
         "others": [
           {
-            "type": "Axionic Servo",
+            "type": "axionic servo",
             "value": 6
           }
         ],
@@ -175,11 +176,16 @@
       "level": 5,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 16
         }
       ],
-      "rewards": []
+      "rewards": [
+        {
+          "type": "station exocomp",
+          "value": 1
+        }
+      ]
     },
     {
       "bonuses": {
@@ -191,7 +197,7 @@
         "materials": [],
         "others": [
           {
-            "type": "Axionic Servo",
+            "type": "axionic servo",
             "value": 8
           }
         ],
@@ -207,11 +213,10 @@
       "level": 6,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 16
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
@@ -223,7 +228,7 @@
         "materials": [],
         "others": [
           {
-            "type": "Axionic Servo",
+            "type": "axionic servo",
             "value": 10
           }
         ],
@@ -243,11 +248,10 @@
       "level": 7,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 16
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
@@ -259,7 +263,7 @@
         "materials": [],
         "others": [
           {
-            "type": "Axionic Servo",
+            "type": "axionic servo",
             "value": 12
           }
         ],
@@ -279,11 +283,10 @@
       "level": 8,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 16
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
@@ -295,7 +298,7 @@
         "materials": [],
         "others": [
           {
-            "type": "Axionic Servo",
+            "type": "axionic servo",
             "value": 14
           }
         ],
@@ -315,11 +318,10 @@
       "level": 9,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 16
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
@@ -331,18 +333,18 @@
         "materials": [],
         "others": [
           {
-            "type": "Axionic Servo",
+            "type": "axionic servo",
             "value": 34
           }
         ],
         "resources": [
           {
-            "type": "tritanium",
-            "value": 150
-          },
-          {
             "type": "parsteel",
             "value": 7000
+          },
+          {
+            "type": "tritanium",
+            "value": 150
           }
         ]
       },
@@ -351,11 +353,10 @@
       "level": 10,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 16
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
@@ -367,7 +368,7 @@
         "materials": [],
         "others": [
           {
-            "type": "Axionic Servo",
+            "type": "axionic servo",
             "value": 15
           }
         ],
@@ -387,11 +388,10 @@
       "level": 11,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 16
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
@@ -403,7 +403,7 @@
         "materials": [],
         "others": [
           {
-            "type": "Axionic Servo",
+            "type": "axionic servo",
             "value": 17
           }
         ],
@@ -423,11 +423,10 @@
       "level": 12,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 16
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
@@ -439,7 +438,7 @@
         "materials": [],
         "others": [
           {
-            "type": "Axionic Servo",
+            "type": "axionic servo",
             "value": 19
           }
         ],
@@ -459,11 +458,10 @@
       "level": 13,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 16
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
@@ -475,7 +473,7 @@
         "materials": [],
         "others": [
           {
-            "type": "Axionic Servo",
+            "type": "axionic servo",
             "value": 22
           }
         ],
@@ -495,11 +493,10 @@
       "level": 14,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 16
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
@@ -511,7 +508,7 @@
         "materials": [],
         "others": [
           {
-            "type": "Axionic Servo",
+            "type": "axionic servo",
             "value": 43
           }
         ],
@@ -531,11 +528,16 @@
       "level": 15,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 16
         }
       ],
-      "rewards": []
+      "rewards": [
+        {
+          "type": "combat exocomp",
+          "value": 1
+        }
+      ]
     },
     {
       "bonuses": {
@@ -547,18 +549,18 @@
         "materials": [],
         "others": [
           {
-            "type": "Axionic Servo",
+            "type": "axionic servo",
             "value": 26
           }
         ],
         "resources": [
           {
-            "type": "tritanium",
-            "value": 1000
-          },
-          {
             "type": "parsteel",
             "value": 34000
+          },
+          {
+            "type": "tritanium",
+            "value": 1000
           }
         ]
       },
@@ -567,11 +569,10 @@
       "level": 16,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 16
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
@@ -583,18 +584,18 @@
         "materials": [],
         "others": [
           {
-            "type": "Axionic Servo",
+            "type": "axionic servo",
             "value": 31
           }
         ],
         "resources": [
           {
-            "type": "tritanium",
-            "value": 1400
-          },
-          {
             "type": "parsteel",
             "value": 47600
+          },
+          {
+            "type": "tritanium",
+            "value": 1400
           }
         ]
       },
@@ -603,11 +604,10 @@
       "level": 17,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 17
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
@@ -619,7 +619,7 @@
         "materials": [],
         "others": [
           {
-            "type": "Axionic Servo",
+            "type": "axionic servo",
             "value": 37
           }
         ],
@@ -639,11 +639,10 @@
       "level": 18,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 18
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
@@ -655,18 +654,18 @@
         "materials": [],
         "others": [
           {
-            "type": "Axionic Servo",
+            "type": "axionic servo",
             "value": 42
           }
         ],
         "resources": [
           {
-            "type": "tritanium",
-            "value": 3000
-          },
-          {
             "type": "parsteel",
             "value": 102000
+          },
+          {
+            "type": "tritanium",
+            "value": 3000
           }
         ]
       },
@@ -675,11 +674,10 @@
       "level": 19,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 19
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
@@ -691,18 +689,18 @@
         "materials": [],
         "others": [
           {
-            "type": "Axionic Servo",
+            "type": "axionic servo",
             "value": 47
           }
         ],
         "resources": [
           {
-            "type": "tritanium",
-            "value": 4250
-          },
-          {
             "type": "parsteel",
             "value": 144500
+          },
+          {
+            "type": "tritanium",
+            "value": 4250
           }
         ]
       },
@@ -711,11 +709,10 @@
       "level": 20,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 20
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
@@ -727,18 +724,18 @@
         "materials": [],
         "others": [
           {
-            "type": "Axionic Servo",
+            "type": "axionic servo",
             "value": 51
           }
         ],
         "resources": [
           {
-            "type": "tritanium",
-            "value": 7155
-          },
-          {
             "type": "parsteel",
             "value": 243270
+          },
+          {
+            "type": "tritanium",
+            "value": 7155
           }
         ]
       },
@@ -747,11 +744,10 @@
       "level": 21,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 21
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
@@ -763,7 +759,7 @@
         "materials": [],
         "others": [
           {
-            "type": "Axionic Servo",
+            "type": "axionic servo",
             "value": 59
           }
         ],
@@ -783,11 +779,10 @@
       "level": 22,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 22
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
@@ -799,7 +794,7 @@
         "materials": [],
         "others": [
           {
-            "type": "Axionic Servo",
+            "type": "axionic servo",
             "value": 64
           }
         ],
@@ -819,11 +814,10 @@
       "level": 23,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 23
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
@@ -835,7 +829,7 @@
         "materials": [],
         "others": [
           {
-            "type": "Axionic Servo",
+            "type": "axionic servo",
             "value": 69
           }
         ],
@@ -855,11 +849,10 @@
       "level": 24,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 24
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
@@ -871,7 +864,7 @@
         "materials": [],
         "others": [
           {
-            "type": "Axionic Servo",
+            "type": "axionic servo",
             "value": 150
           }
         ],
@@ -891,11 +884,10 @@
       "level": 25,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 25
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
@@ -907,7 +899,7 @@
         "materials": [],
         "others": [
           {
-            "type": "Axionic Servo",
+            "type": "axionic servo",
             "value": 120
           }
         ],
@@ -927,11 +919,10 @@
       "level": 26,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 26
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
@@ -943,7 +934,7 @@
         "materials": [],
         "others": [
           {
-            "type": "Axionic Servo",
+            "type": "axionic servo",
             "value": 140
           }
         ],
@@ -963,11 +954,10 @@
       "level": 27,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 27
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
@@ -979,7 +969,7 @@
         "materials": [],
         "others": [
           {
-            "type": "Axionic Servo",
+            "type": "axionic servo",
             "value": 160
           }
         ],
@@ -999,11 +989,10 @@
       "level": 28,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 28
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
@@ -1015,18 +1004,18 @@
         "materials": [],
         "others": [
           {
-            "type": "Axionic Servo",
+            "type": "axionic servo",
             "value": 170
           }
         ],
         "resources": [
           {
-            "type": "tritanium",
-            "value": 266500
-          },
-          {
             "type": "parsteel",
             "value": 9061000
+          },
+          {
+            "type": "tritanium",
+            "value": 266500
           }
         ]
       },
@@ -1035,11 +1024,10 @@
       "level": 29,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 29
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
@@ -1051,7 +1039,7 @@
         "materials": [],
         "others": [
           {
-            "type": "Axionic Servo",
+            "type": "axionic servo",
             "value": 200
           }
         ],
@@ -1071,11 +1059,10 @@
       "level": 30,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 30
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
@@ -1087,7 +1074,7 @@
         "materials": [],
         "others": [
           {
-            "type": "Axionic Servo",
+            "type": "axionic servo",
             "value": 210
           }
         ],
@@ -1107,11 +1094,10 @@
       "level": 31,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 31
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
@@ -1123,7 +1109,7 @@
         "materials": [],
         "others": [
           {
-            "type": "Axionic Servo",
+            "type": "axionic servo",
             "value": 240
           }
         ],
@@ -1143,11 +1129,10 @@
       "level": 32,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 32
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
@@ -1159,7 +1144,7 @@
         "materials": [],
         "others": [
           {
-            "type": "Axionic Servo",
+            "type": "axionic servo",
             "value": 270
           }
         ],
@@ -1179,11 +1164,10 @@
       "level": 33,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 33
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
@@ -1195,7 +1179,7 @@
         "materials": [],
         "others": [
           {
-            "type": "Axionic Servo",
+            "type": "axionic servo",
             "value": 300
           }
         ],
@@ -1215,11 +1199,10 @@
       "level": 34,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 34
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
@@ -1231,7 +1214,7 @@
         "materials": [],
         "others": [
           {
-            "type": "Axionic Servo",
+            "type": "axionic servo",
             "value": 840
           }
         ],
@@ -1251,11 +1234,16 @@
       "level": 35,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 35
         }
       ],
-      "rewards": []
+      "rewards": [
+        {
+          "type": "multi-purpose exocomp",
+          "value": 1
+        }
+      ]
     },
     {
       "bonuses": {
@@ -1267,18 +1255,18 @@
         "materials": [],
         "others": [
           {
-            "type": "Axionic Servo",
+            "type": "axionic servo",
             "value": 350
           }
         ],
         "resources": [
           {
-            "type": "tritanium",
-            "value": 4743000
-          },
-          {
             "type": "parsteel",
             "value": 161262000
+          },
+          {
+            "type": "tritanium",
+            "value": 4743000
           }
         ]
       },
@@ -1287,11 +1275,10 @@
       "level": 36,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 36
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
@@ -1303,7 +1290,7 @@
         "materials": [],
         "others": [
           {
-            "type": "Axionic Servo",
+            "type": "axionic servo",
             "value": 380
           }
         ],
@@ -1323,11 +1310,10 @@
       "level": 37,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 37
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
@@ -1339,7 +1325,7 @@
         "materials": [],
         "others": [
           {
-            "type": "Axionic Servo",
+            "type": "axionic servo",
             "value": 430
           }
         ],
@@ -1359,11 +1345,10 @@
       "level": 38,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 38
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
@@ -1375,7 +1360,7 @@
         "materials": [],
         "others": [
           {
-            "type": "Axionic Servo",
+            "type": "axionic servo",
             "value": 460
           }
         ],
@@ -1395,11 +1380,10 @@
       "level": 39,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 39
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
@@ -1411,18 +1395,18 @@
         "materials": [],
         "others": [
           {
-            "type": "Axionic Servo",
+            "type": "axionic servo",
             "value": 1400
           }
         ],
         "resources": [
           {
-            "type": "tritanium",
-            "value": 30100000
-          },
-          {
             "type": "parsteel",
             "value": 2865520000
+          },
+          {
+            "type": "tritanium",
+            "value": 30100000
           }
         ]
       },
@@ -1431,11 +1415,10 @@
       "level": 40,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 40
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
@@ -1447,11 +1430,11 @@
         "materials": [],
         "others": [
           {
-            "type": "Advanced Exocomp Factory Key",
+            "type": "advanced exocomp factory key",
             "value": 1
           },
           {
-            "type": "Axionic Servo",
+            "type": "axionic servo",
             "value": 820
           }
         ],
@@ -1471,11 +1454,10 @@
       "level": 41,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 41
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
@@ -1487,7 +1469,7 @@
         "materials": [],
         "others": [
           {
-            "type": "Axionic Servo",
+            "type": "axionic servo",
             "value": 930
           }
         ],
@@ -1507,11 +1489,10 @@
       "level": 42,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 42
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
@@ -1523,7 +1504,7 @@
         "materials": [],
         "others": [
           {
-            "type": "Axionic Servo",
+            "type": "axionic servo",
             "value": 1000
           }
         ],
@@ -1543,11 +1524,10 @@
       "level": 43,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 43
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
@@ -1559,18 +1539,18 @@
         "materials": [],
         "others": [
           {
-            "type": "Axionic Servo",
+            "type": "axionic servo",
             "value": 1150
           }
         ],
         "resources": [
           {
-            "type": "tritanium",
-            "value": 103852700
-          },
-          {
             "type": "parsteel",
             "value": 9333000000
+          },
+          {
+            "type": "tritanium",
+            "value": 103852700
           }
         ]
       },
@@ -1579,11 +1559,10 @@
       "level": 44,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 44
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
@@ -1595,18 +1574,18 @@
         "materials": [],
         "others": [
           {
-            "type": "Axionic Servo",
+            "type": "axionic servo",
             "value": 1200
           }
         ],
         "resources": [
           {
-            "type": "tritanium",
-            "value": 147550300
-          },
-          {
             "type": "parsteel",
             "value": 13260000000
+          },
+          {
+            "type": "tritanium",
+            "value": 147550300
           }
         ]
       },
@@ -1615,11 +1594,10 @@
       "level": 45,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 45
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
@@ -1631,7 +1609,7 @@
         "materials": [],
         "others": [
           {
-            "type": "Axionic Servo",
+            "type": "axionic servo",
             "value": 1350
           }
         ],
@@ -1651,11 +1629,10 @@
       "level": 46,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 46
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
@@ -1667,7 +1644,7 @@
         "materials": [],
         "others": [
           {
-            "type": "Axionic Servo",
+            "type": "axionic servo",
             "value": 1450
           }
         ],
@@ -1687,11 +1664,10 @@
       "level": 47,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 47
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
@@ -1703,18 +1679,18 @@
         "materials": [],
         "others": [
           {
-            "type": "Axionic Servo",
+            "type": "axionic servo",
             "value": 1650
           }
         ],
         "resources": [
           {
-            "type": "tritanium",
-            "value": 476701000
-          },
-          {
             "type": "parsteel",
             "value": 42840000000
+          },
+          {
+            "type": "tritanium",
+            "value": 476701000
           }
         ]
       },
@@ -1723,11 +1699,10 @@
       "level": 48,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 48
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
@@ -1739,7 +1714,7 @@
         "materials": [],
         "others": [
           {
-            "type": "Axionic Servo",
+            "type": "axionic servo",
             "value": 1750
           }
         ],
@@ -1759,11 +1734,10 @@
       "level": 49,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 49
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
@@ -1775,18 +1749,18 @@
         "materials": [],
         "others": [
           {
-            "type": "Axionic Servo",
+            "type": "axionic servo",
             "value": 2100
           }
         ],
         "resources": [
           {
-            "type": "tritanium",
-            "value": 1390378000
-          },
-          {
             "type": "parsteel",
             "value": 124950000000
+          },
+          {
+            "type": "tritanium",
+            "value": 1390378000
           }
         ]
       },
@@ -1795,11 +1769,189 @@
       "level": 50,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 50
         }
-      ],
-      "rewards": []
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 156.0,
+        "bonus2": 5.0,
+        "bonus3": 4.0
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [
+          {
+            "type": "axionic servo",
+            "value": 2200
+          }
+        ],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 3900000000
+          },
+          {
+            "type": "parsteel",
+            "value": 623220000000
+          }
+        ]
+      },
+      "build_time": 149065920,
+      "increased_power": 6500,
+      "level": 51,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 51
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 174.0,
+        "bonus2": 5.0,
+        "bonus3": 4.0
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [
+          {
+            "type": "advanced exocomp factory key ii",
+            "value": 1
+          },
+          {
+            "type": "axionic servo",
+            "value": 3600
+          }
+        ],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 6630000000
+          },
+          {
+            "type": "parsteel",
+            "value": 1127100000000
+          }
+        ]
+      },
+      "build_time": 158009760,
+      "increased_power": 3500,
+      "level": 52,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 52
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 174.0,
+        "bonus2": 5.0,
+        "bonus3": 4.0
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [
+          {
+            "type": "axionic servo",
+            "value": 3800
+          }
+        ],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 1893120000000
+          },
+          {
+            "type": "tritanium",
+            "value": 11600000000
+          }
+        ]
+      },
+      "build_time": 167490720,
+      "increased_power": 4000,
+      "level": 53,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 53
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 194.0,
+        "bonus2": 5.0,
+        "bonus3": 4.0
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [
+          {
+            "type": "axionic servo",
+            "value": 4250
+          }
+        ],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 2839680000000
+          },
+          {
+            "type": "tritanium",
+            "value": 17400000000
+          }
+        ]
+      },
+      "build_time": 177540480,
+      "increased_power": 4000,
+      "level": 54,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 54
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 194.0,
+        "bonus2": 5.0,
+        "bonus3": 4.0
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [
+          {
+            "type": "axionic servo",
+            "value": 4450
+          }
+        ],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 4826640000000
+          },
+          {
+            "type": "tritanium",
+            "value": 27300000000
+          }
+        ]
+      },
+      "build_time": 188192160,
+      "increased_power": 4000,
+      "level": 55,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 55
+        }
+      ]
     }
   ]
 }

--- a/buildings/foundry.json
+++ b/buildings/foundry.json
@@ -2,11 +2,11 @@
   "description": "Armor Tech Research facility.",
   "bonuses": {
     "bonus1": {
-      "name": "Battleships Shield Health Bonus",
+      "name": "armor bonus",
       "percentage": true
     },
     "bonus2": {
-      "name": "Armor Bonus",
+      "name": "battleship shield health bonus",
       "percentage": true
     }
   },
@@ -14,8 +14,8 @@
   "levels": [
     {
       "bonuses": {
-        "bonus1": 3,
-        "bonus2": 1
+        "bonus1": 0.01,
+        "bonus2": 0.03
       },
       "build_costs": {
         "materials": [
@@ -39,16 +39,15 @@
       "level": 1,
       "requirements": [
         {
-          "name": "Unlock Foundry",
+          "name": "unlock foundry",
           "level": 1
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 6,
-        "bonus2": 2
+        "bonus1": 0.02,
+        "bonus2": 0.06
       },
       "build_costs": {
         "materials": [],
@@ -65,20 +64,19 @@
       "level": 2,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 2
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 2
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 9,
-        "bonus2": 3
+        "bonus1": 0.03,
+        "bonus2": 0.09
       },
       "build_costs": {
         "materials": [],
@@ -95,20 +93,19 @@
       "level": 3,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 3
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 3
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 12,
-        "bonus2": 4
+        "bonus1": 0.04,
+        "bonus2": 0.12
       },
       "build_costs": {
         "materials": [],
@@ -125,20 +122,19 @@
       "level": 4,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 4
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 4
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 15,
-        "bonus2": 5
+        "bonus1": 0.05,
+        "bonus2": 0.15
       },
       "build_costs": {
         "materials": [],
@@ -155,20 +151,19 @@
       "level": 5,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 5
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 5
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 18,
-        "bonus2": 6
+        "bonus1": 0.06,
+        "bonus2": 0.18
       },
       "build_costs": {
         "materials": [],
@@ -185,20 +180,19 @@
       "level": 6,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 6
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 6
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 21,
-        "bonus2": 7
+        "bonus1": 0.07,
+        "bonus2": 0.21
       },
       "build_costs": {
         "materials": [],
@@ -219,32 +213,31 @@
       "level": 7,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 7
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 7
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 24,
-        "bonus2": 8
+        "bonus1": 0.08,
+        "bonus2": 0.24
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 245310
-          },
-          {
             "type": "tritanium",
             "value": 45
+          },
+          {
+            "type": "parsteel",
+            "value": 245310
           }
         ]
       },
@@ -253,20 +246,19 @@
       "level": 8,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 8
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 8
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 27,
-        "bonus2": 9
+        "bonus1": 0.09,
+        "bonus2": 0.27
       },
       "build_costs": {
         "materials": [],
@@ -287,32 +279,31 @@
       "level": 9,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 9
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 9
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 30,
-        "bonus2": 10
+        "bonus1": 0.1,
+        "bonus2": 0.3
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 248370
-          },
-          {
             "type": "tritanium",
             "value": 225
+          },
+          {
+            "type": "parsteel",
+            "value": 248370
           }
         ]
       },
@@ -321,32 +312,31 @@
       "level": 10,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 10
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 10
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 33,
-        "bonus2": 11
+        "bonus1": 0.11,
+        "bonus2": 0.33
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 250070
-          },
-          {
             "type": "tritanium",
             "value": 300
+          },
+          {
+            "type": "parsteel",
+            "value": 250070
           }
         ]
       },
@@ -355,32 +345,31 @@
       "level": 11,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 11
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 11
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 36,
-        "bonus2": 12
+        "bonus1": 0.12,
+        "bonus2": 0.36
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 252620
-          },
-          {
             "type": "tritanium",
             "value": 413
+          },
+          {
+            "type": "parsteel",
+            "value": 252620
           }
         ]
       },
@@ -389,20 +378,19 @@
       "level": 12,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 12
         },
         {
-          "name": "R&D Department",
+          "name": "r&d department",
           "level": 12
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 39,
-        "bonus2": 13
+        "bonus1": 0.13,
+        "bonus2": 0.39
       },
       "build_costs": {
         "materials": [],
@@ -423,32 +411,31 @@
       "level": 13,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 13
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 13
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 42,
-        "bonus2": 14
+        "bonus1": 0.14,
+        "bonus2": 0.42
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 261970
-          },
-          {
             "type": "tritanium",
             "value": 825
+          },
+          {
+            "type": "parsteel",
+            "value": 261970
           }
         ]
       },
@@ -457,32 +444,31 @@
       "level": 14,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 14
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 14
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 45,
-        "bonus2": 15
+        "bonus1": 0.15,
+        "bonus2": 0.45
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 268770
-          },
-          {
             "type": "tritanium",
             "value": 1125
+          },
+          {
+            "type": "parsteel",
+            "value": 268770
           }
         ]
       },
@@ -491,32 +477,31 @@
       "level": 15,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 15
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 15
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 48,
-        "bonus2": 16
+        "bonus1": 0.16,
+        "bonus2": 0.48
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 277270
-          },
-          {
             "type": "tritanium",
             "value": 1500
+          },
+          {
+            "type": "parsteel",
+            "value": 277270
           }
         ]
       },
@@ -525,20 +510,19 @@
       "level": 16,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 16
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 16
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 51,
-        "bonus2": 17
+        "bonus1": 0.17,
+        "bonus2": 0.51
       },
       "build_costs": {
         "materials": [],
@@ -559,32 +543,31 @@
       "level": 17,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 17
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 17
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 54,
-        "bonus2": 18
+        "bonus1": 0.18,
+        "bonus2": 0.54
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 311270
-          },
-          {
             "type": "tritanium",
             "value": 3000
+          },
+          {
+            "type": "parsteel",
+            "value": 311270
           }
         ]
       },
@@ -593,20 +576,19 @@
       "level": 18,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 18
         },
         {
-          "name": "R&D Department",
+          "name": "r&d department",
           "level": 18
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 57,
-        "bonus2": 19
+        "bonus1": 0.19,
+        "bonus2": 0.57
       },
       "build_costs": {
         "materials": [],
@@ -627,32 +609,31 @@
       "level": 19,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 19
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 19
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 60,
-        "bonus2": 20
+        "bonus1": 0.2,
+        "bonus2": 0.6
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 387770
-          },
-          {
             "type": "tritanium",
             "value": 6375
+          },
+          {
+            "type": "parsteel",
+            "value": 387770
           }
         ]
       },
@@ -661,32 +642,31 @@
       "level": 20,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 20
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 20
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 63,
-        "bonus2": 21
+        "bonus1": 0.21,
+        "bonus2": 0.63
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 486540
-          },
-          {
             "type": "tritanium",
             "value": 10733
+          },
+          {
+            "type": "parsteel",
+            "value": 486540
           }
         ]
       },
@@ -695,20 +675,19 @@
       "level": 21,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 21
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 21
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 66,
-        "bonus2": 22
+        "bonus1": 0.22,
+        "bonus2": 0.66
       },
       "build_costs": {
         "materials": [],
@@ -729,20 +708,19 @@
       "level": 22,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 22
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 22
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 69,
-        "bonus2": 23
+        "bonus1": 0.23,
+        "bonus2": 0.69
       },
       "build_costs": {
         "materials": [],
@@ -763,32 +741,31 @@
       "level": 23,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 23
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 23
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 72,
-        "bonus2": 24
+        "bonus1": 0.24,
+        "bonus2": 0.72
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 981240
-          },
-          {
             "type": "tritanium",
             "value": 43290
+          },
+          {
+            "type": "parsteel",
+            "value": 981240
           }
         ]
       },
@@ -797,24 +774,23 @@
       "level": 24,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 24
         },
         {
-          "name": "Science Lab",
+          "name": "r&d department",
+          "level": 24
+        },
+        {
+          "name": "science lab",
           "level": 2
-        },
-        {
-          "name": "R&D Department",
-          "level": 24
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 75,
-        "bonus2": 25
+        "bonus1": 0.25,
+        "bonus2": 0.75
       },
       "build_costs": {
         "materials": [
@@ -842,20 +818,19 @@
       "level": 25,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 25
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 25
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 78,
-        "bonus2": 26
+        "bonus1": 0.26,
+        "bonus2": 0.78
       },
       "build_costs": {
         "materials": [
@@ -869,12 +844,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 2486250
-          },
-          {
             "type": "tritanium",
             "value": 109688
+          },
+          {
+            "type": "parsteel",
+            "value": 2486250
           }
         ]
       },
@@ -883,45 +858,44 @@
       "level": 26,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 26
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 26
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 81,
-        "bonus2": 27
+        "bonus1": 0.27,
+        "bonus2": 0.81
       },
       "build_costs": {
         "materials": [
           {
             "type": "gas",
             "grade": 3,
-            "rarity": "common",
-            "value": 290
+            "rarity": "uncommon",
+            "value": 10
           },
           {
             "type": "gas",
             "grade": 3,
-            "rarity": "uncommon",
-            "value": 10
+            "rarity": "common",
+            "value": 290
           }
         ],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 3794400
-          },
-          {
             "type": "tritanium",
             "value": 167400
+          },
+          {
+            "type": "parsteel",
+            "value": 3794400
           }
         ]
       },
@@ -930,45 +904,44 @@
       "level": 27,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 27
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 27
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 84,
-        "bonus2": 28
+        "bonus1": 0.28,
+        "bonus2": 0.84
       },
       "build_costs": {
         "materials": [
           {
             "type": "gas",
             "grade": 3,
-            "rarity": "common",
-            "value": 360
+            "rarity": "uncommon",
+            "value": 18
           },
           {
             "type": "gas",
             "grade": 3,
-            "rarity": "uncommon",
-            "value": 18
+            "rarity": "common",
+            "value": 360
           }
         ],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 5691600
-          },
-          {
             "type": "tritanium",
             "value": 251100
+          },
+          {
+            "type": "parsteel",
+            "value": 5691600
           }
         ]
       },
@@ -977,20 +950,19 @@
       "level": 28,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 28
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 28
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 87,
-        "bonus2": 29
+        "bonus1": 0.29,
+        "bonus2": 0.87
       },
       "build_costs": {
         "materials": [
@@ -1018,20 +990,19 @@
       "level": 29,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 29
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 29
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 90,
-        "bonus2": 37
+        "bonus1": 0.37,
+        "bonus2": 0.9
       },
       "build_costs": {
         "materials": [
@@ -1065,20 +1036,19 @@
       "level": 30,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 30
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 30
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 93,
-        "bonus2": 38
+        "bonus1": 0.38,
+        "bonus2": 0.93
       },
       "build_costs": {
         "materials": [
@@ -1106,24 +1076,23 @@
       "level": 31,
       "requirements": [
         {
-          "name": "Engine Technology Lab",
+          "name": "operations",
           "level": 31
         },
         {
-          "name": "R&D Department",
+          "name": "r&d department",
           "level": 31
         },
         {
-          "name": "Operations",
+          "name": "engine technology lab",
           "level": 31
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 96,
-        "bonus2": 39
+        "bonus1": 0.39,
+        "bonus2": 0.96
       },
       "build_costs": {
         "materials": [
@@ -1143,12 +1112,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 30277000
-          },
-          {
             "type": "tritanium",
             "value": 1335750
+          },
+          {
+            "type": "parsteel",
+            "value": 30277000
           }
         ]
       },
@@ -1157,49 +1126,48 @@
       "level": 32,
       "requirements": [
         {
-          "name": "Ship Hangar",
+          "name": "operations",
           "level": 32
         },
         {
-          "name": "R&D Department",
+          "name": "r&d department",
           "level": 32
         },
         {
-          "name": "Operations",
+          "name": "ship hangar",
           "level": 32
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 99,
-        "bonus2": 40
+        "bonus1": 0.4,
+        "bonus2": 0.99
       },
       "build_costs": {
         "materials": [
           {
             "type": "gas",
             "grade": 3,
-            "rarity": "common",
-            "value": 1000
+            "rarity": "uncommon",
+            "value": 110
           },
           {
             "type": "gas",
             "grade": 3,
-            "rarity": "uncommon",
-            "value": 110
+            "rarity": "common",
+            "value": 1000
           }
         ],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 46835000
-          },
-          {
             "type": "tritanium",
             "value": 2066250
+          },
+          {
+            "type": "parsteel",
+            "value": 46835000
           }
         ]
       },
@@ -1208,20 +1176,19 @@
       "level": 33,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 33
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 33
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 102,
-        "bonus2": 42
+        "bonus1": 0.42,
+        "bonus2": 1.02
       },
       "build_costs": {
         "materials": [
@@ -1235,12 +1202,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 73950000
-          },
-          {
             "type": "tritanium",
             "value": 3262500
+          },
+          {
+            "type": "parsteel",
+            "value": 73950000
           }
         ]
       },
@@ -1249,20 +1216,19 @@
       "level": 34,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 34
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 34
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 105,
-        "bonus2": 44
+        "bonus1": 0.44,
+        "bonus2": 1.05
       },
       "build_costs": {
         "materials": [
@@ -1296,20 +1262,19 @@
       "level": 35,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 35
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 35
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 108,
-        "bonus2": 46
+        "bonus1": 0.46,
+        "bonus2": 1.08
       },
       "build_costs": {
         "materials": [
@@ -1337,20 +1302,19 @@
       "level": 36,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 36
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 36
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 111,
-        "bonus2": 48
+        "bonus1": 0.48,
+        "bonus2": 1.11
       },
       "build_costs": {
         "materials": [
@@ -1364,12 +1328,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 247860000
-          },
-          {
             "type": "tritanium",
             "value": 10935000
+          },
+          {
+            "type": "parsteel",
+            "value": 247860000
           }
         ]
       },
@@ -1378,20 +1342,19 @@
       "level": 37,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 37
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 37
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 114,
-        "bonus2": 50
+        "bonus1": 0.5,
+        "bonus2": 1.14
       },
       "build_costs": {
         "materials": [
@@ -1411,12 +1374,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 385560000
-          },
-          {
             "type": "tritanium",
             "value": 17010000
+          },
+          {
+            "type": "parsteel",
+            "value": 385560000
           }
         ]
       },
@@ -1425,20 +1388,19 @@
       "level": 38,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 38
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 38
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 117,
-        "bonus2": 52
+        "bonus1": 0.52,
+        "bonus2": 1.17
       },
       "build_costs": {
         "materials": [
@@ -1472,24 +1434,23 @@
       "level": 39,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 39
         },
         {
-          "name": "Engine Technology Lab",
+          "name": "r&d department",
           "level": 39
         },
         {
-          "name": "Operations",
+          "name": "engine technology lab",
           "level": 39
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 120,
-        "bonus2": 54
+        "bonus1": 0.54,
+        "bonus2": 1.2
       },
       "build_costs": {
         "materials": [
@@ -1523,34 +1484,33 @@
       "level": 40,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 40
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 40
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 123,
-        "bonus2": 56
+        "bonus1": 0.56,
+        "bonus2": 1.23
       },
       "build_costs": {
         "materials": [
           {
             "type": "gas",
             "grade": 4,
-            "rarity": "common",
-            "value": 25000
+            "rarity": "uncommon",
+            "value": 5000
           },
           {
             "type": "gas",
             "grade": 4,
-            "rarity": "uncommon",
-            "value": 5000
+            "rarity": "common",
+            "value": 25000
           }
         ],
         "others": [],
@@ -1570,20 +1530,19 @@
       "level": 41,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 41
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 41
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 126,
-        "bonus2": 58
+        "bonus1": 0.58,
+        "bonus2": 1.26
       },
       "build_costs": {
         "materials": [
@@ -1617,20 +1576,19 @@
       "level": 42,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 42
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 42
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 129,
-        "bonus2": 74
+        "bonus1": 0.74,
+        "bonus2": 1.29
       },
       "build_costs": {
         "materials": [
@@ -1650,12 +1608,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 6222000000
-          },
-          {
             "type": "tritanium",
             "value": 137250000
+          },
+          {
+            "type": "parsteel",
+            "value": 6222000000
           }
         ]
       },
@@ -1664,45 +1622,44 @@
       "level": 43,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 43
         },
         {
-          "name": "R&D Department",
+          "name": "r&d department",
           "level": 43
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 132,
-        "bonus2": 76
+        "bonus1": 0.76,
+        "bonus2": 1.32
       },
       "build_costs": {
         "materials": [
           {
             "type": "gas",
             "grade": 4,
-            "rarity": "common",
-            "value": 10000
+            "rarity": "uncommon",
+            "value": 3000
           },
           {
             "type": "gas",
             "grade": 4,
-            "rarity": "uncommon",
-            "value": 3000
+            "rarity": "common",
+            "value": 10000
           }
         ],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 9333000000
-          },
-          {
             "type": "tritanium",
             "value": 205875000
+          },
+          {
+            "type": "parsteel",
+            "value": 9333000000
           }
         ]
       },
@@ -1711,34 +1668,33 @@
       "level": 44,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 44
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 44
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 135,
-        "bonus2": 80
+        "bonus1": 0.8,
+        "bonus2": 1.35
       },
       "build_costs": {
         "materials": [
           {
             "type": "gas",
             "grade": 4,
-            "rarity": "common",
-            "value": 10000
+            "rarity": "uncommon",
+            "value": 3000
           },
           {
             "type": "gas",
             "grade": 4,
-            "rarity": "uncommon",
-            "value": 3000
+            "rarity": "common",
+            "value": 10000
           }
         ],
         "others": [],
@@ -1758,20 +1714,19 @@
       "level": 45,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 45
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 45
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 138,
-        "bonus2": 84
+        "bonus1": 0.84,
+        "bonus2": 1.38
       },
       "build_costs": {
         "materials": [
@@ -1805,45 +1760,44 @@
       "level": 46,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 46
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 46
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 141,
-        "bonus2": 88
+        "bonus1": 0.88,
+        "bonus2": 1.41
       },
       "build_costs": {
         "materials": [
           {
             "type": "gas",
             "grade": 4,
-            "rarity": "common",
-            "value": 45000
+            "rarity": "uncommon",
+            "value": 2500
           },
           {
             "type": "gas",
             "grade": 4,
-            "rarity": "uncommon",
-            "value": 2500
+            "rarity": "common",
+            "value": 45000
           }
         ],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 26520000000
-          },
-          {
             "type": "tritanium",
             "value": 585000000
+          },
+          {
+            "type": "parsteel",
+            "value": 26520000000
           }
         ]
       },
@@ -1852,45 +1806,44 @@
       "level": 47,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 47
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 47
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 144,
-        "bonus2": 92
+        "bonus1": 0.92,
+        "bonus2": 1.44
       },
       "build_costs": {
         "materials": [
           {
             "type": "gas",
             "grade": 4,
-            "rarity": "uncommon",
-            "value": 10000
+            "rarity": "rare",
+            "value": 2000
           },
           {
             "type": "gas",
             "grade": 4,
-            "rarity": "rare",
-            "value": 2000
+            "rarity": "uncommon",
+            "value": 10000
           }
         ],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 42840000000
-          },
-          {
             "type": "tritanium",
             "value": 945000000
+          },
+          {
+            "type": "parsteel",
+            "value": 42840000000
           }
         ]
       },
@@ -1899,34 +1852,33 @@
       "level": 48,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 48
         },
         {
-          "name": "R&D Department",
+          "name": "r&d department",
           "level": 48
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 147,
-        "bonus2": 96
+        "bonus1": 0.96,
+        "bonus2": 1.47
       },
       "build_costs": {
         "materials": [
           {
             "type": "gas",
             "grade": 4,
-            "rarity": "uncommon",
-            "value": 15000
+            "rarity": "rare",
+            "value": 4000
           },
           {
             "type": "gas",
             "grade": 4,
-            "rarity": "rare",
-            "value": 4000
+            "rarity": "uncommon",
+            "value": 15000
           }
         ],
         "others": [],
@@ -1946,36 +1898,35 @@
       "level": 49,
       "requirements": [
         {
-          "name": "Science Lab",
+          "name": "operations",
           "level": 49
         },
         {
-          "name": "R&D Department",
+          "name": "r&d department",
           "level": 49
         },
         {
-          "name": "Operations",
+          "name": "science lab",
           "level": 49
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 150,
-        "bonus2": 100
+        "bonus1": 1.0,
+        "bonus2": 1.5
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 124950000000
-          },
-          {
             "type": "tritanium",
             "value": 2756250000
+          },
+          {
+            "type": "parsteel",
+            "value": 124950000000
           }
         ]
       },
@@ -1984,15 +1935,244 @@
       "level": 50,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 50
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 50
         }
-      ],
-      "rewards": []
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 1.04,
+        "bonus2": 1.53
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "gas",
+            "grade": 5,
+            "rarity": "uncommon",
+            "value": 3900
+          },
+          {
+            "type": "gas",
+            "grade": 5,
+            "rarity": "common",
+            "value": 24700
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 5850000000
+          },
+          {
+            "type": "parsteel",
+            "value": 623220000000
+          }
+        ]
+      },
+      "build_time": 44719200,
+      "increased_power": 5000,
+      "level": 51,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 51
+        },
+        {
+          "name": "r&d department",
+          "level": 51
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 1.08,
+        "bonus2": 1.56
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "gas",
+            "grade": 5,
+            "rarity": "uncommon",
+            "value": 8600
+          },
+          {
+            "type": "gas",
+            "grade": 5,
+            "rarity": "common",
+            "value": 42800
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 9945000000
+          },
+          {
+            "type": "parsteel",
+            "value": 1127100000000
+          }
+        ]
+      },
+      "build_time": 47403360,
+      "increased_power": 6000,
+      "level": 52,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 52
+        },
+        {
+          "name": "r&d department",
+          "level": 52
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 1.12,
+        "bonus2": 1.59
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "gas",
+            "grade": 5,
+            "rarity": "common",
+            "value": 102600
+          },
+          {
+            "type": "gas",
+            "grade": 5,
+            "rarity": "uncommon",
+            "value": 14900
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 1893120000000
+          },
+          {
+            "type": "tritanium",
+            "value": 17400000000
+          }
+        ]
+      },
+      "build_time": 50247360,
+      "increased_power": 5000,
+      "level": 53,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 53
+        },
+        {
+          "name": "r&d department",
+          "level": 53
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 1.16,
+        "bonus2": 1.62
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "gas",
+            "grade": 5,
+            "rarity": "common",
+            "value": 87200
+          },
+          {
+            "type": "gas",
+            "grade": 5,
+            "rarity": "uncommon",
+            "value": 18200
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 26100000000
+          },
+          {
+            "type": "parsteel",
+            "value": 2839680000000
+          }
+        ]
+      },
+      "build_time": 53261280,
+      "increased_power": 6000,
+      "level": 54,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 54
+        },
+        {
+          "name": "r&d department",
+          "level": 54
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 1.2,
+        "bonus2": 1.65
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "gas",
+            "grade": 5,
+            "rarity": "rare",
+            "value": 4300
+          },
+          {
+            "type": "gas",
+            "grade": 5,
+            "rarity": "common",
+            "value": 140000
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 40950000000
+          },
+          {
+            "type": "parsteel",
+            "value": 4826640000000
+          }
+        ]
+      },
+      "build_time": 56458080,
+      "increased_power": 6000,
+      "level": 55,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 55
+        },
+        {
+          "name": "r&d department",
+          "level": 55
+        }
+      ]
     }
   ]
 }

--- a/buildings/operations.json
+++ b/buildings/operations.json
@@ -2,7 +2,7 @@
   "description": "Operations houses the command center and the main computer. Upgrading Operations increases the overall capability of the Station by unlocking more buildings for construction.",
   "bonuses": {
     "bonus1": {
-      "name": "Weapon Damage Bonus",
+      "name": "weapon damage bonus",
       "percentage": true
     }
   },
@@ -10,7 +10,7 @@
   "levels": [
     {
       "bonuses": {
-        "bonus1": 1
+        "bonus1": 0.01
       },
       "build_costs": {
         "materials": [],
@@ -20,12 +20,11 @@
       "build_time": 0,
       "increased_power": 0,
       "level": 1,
-      "requirements": [],
-      "rewards": []
+      "requirements": []
     },
     {
       "bonuses": {
-        "bonus1": 2
+        "bonus1": 0.02
       },
       "build_costs": {
         "materials": [],
@@ -42,15 +41,14 @@
       "level": 2,
       "requirements": [
         {
-          "name": "Parsteel Warehouse",
+          "name": "parsteel warehouse",
           "level": 1
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 3
+        "bonus1": 0.03
       },
       "build_costs": {
         "materials": [],
@@ -67,24 +65,24 @@
       "level": 3,
       "requirements": [
         {
-          "name": "Parsteel Warehouse",
+          "name": "parsteel warehouse",
           "level": 2
         }
       ],
       "rewards": [
         {
-          "type": "Latinum",
+          "type": "latinum",
           "value": 5
         },
         {
-          "type": "3\u00a0Minute\u00a0Speed\u00a0Up",
+          "type": "3 minute speed up",
           "value": 1
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 4
+        "bonus1": 0.04
       },
       "build_costs": {
         "materials": [],
@@ -101,28 +99,28 @@
       "level": 4,
       "requirements": [
         {
-          "name": "Parsteel Warehouse",
+          "name": "parsteel warehouse",
           "level": 3
         },
         {
-          "name": "Parsteel Generator B",
+          "name": "parsteel generator b",
           "level": 2
         }
       ],
       "rewards": [
         {
-          "type": "Latinum",
+          "type": "latinum",
           "value": 5
         },
         {
-          "type": "5\u00a0Minute\u00a0Speed\u00a0Up",
+          "type": "5 minute speed up",
           "value": 5
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 5
+        "bonus1": 0.05
       },
       "build_costs": {
         "materials": [],
@@ -139,28 +137,28 @@
       "level": 5,
       "requirements": [
         {
-          "name": "Parsteel Warehouse",
+          "name": "parsteel warehouse",
           "level": 4
         }
       ],
       "rewards": [
         {
-          "type": "10\u00a0Minute\u00a0Speed\u00a0Up",
-          "value": 3
-        },
-        {
-          "type": "1\u00a0Minute\u00a0Repair\u00a0Speed\u00a0Up",
-          "value": 3
-        },
-        {
-          "type": "Latinum",
+          "type": "latinum",
           "value": 10
+        },
+        {
+          "type": "10 minute speed up",
+          "value": 3
+        },
+        {
+          "type": "1 minute repair speed up",
+          "value": 3
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 6
+        "bonus1": 0.06
       },
       "build_costs": {
         "materials": [],
@@ -177,40 +175,40 @@
       "level": 6,
       "requirements": [
         {
-          "name": "Drydock B",
+          "name": "drydock b",
           "level": 1
         }
       ],
       "rewards": [
         {
-          "type": "Latinum",
+          "type": "latinum",
           "value": 10
         },
         {
-          "type": "15\u00a0Minute\u00a0Speed\u00a0Up",
+          "type": "15 minute speed up",
           "value": 5
         },
         {
-          "type": "1\u00a0Minute\u00a0Repair\u00a0Speed\u00a0Up",
+          "type": "1 minute repair speed up",
           "value": 3
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 7
+        "bonus1": 0.07
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 2000
-          },
-          {
             "type": "tritanium",
             "value": 70
+          },
+          {
+            "type": "parsteel",
+            "value": 2000
           }
         ]
       },
@@ -219,44 +217,44 @@
       "level": 7,
       "requirements": [
         {
-          "name": "Shipyard",
+          "name": "shipyard",
           "level": 6
         },
         {
-          "name": "Tritanium Warehouse",
+          "name": "tritanium warehouse",
           "level": 3
         }
       ],
       "rewards": [
         {
-          "type": "Latinum",
+          "type": "latinum",
           "value": 10
         },
         {
-          "type": "30\u00a0Minute\u00a0Speed\u00a0Up",
+          "type": "30 minute speed up",
           "value": 3
         },
         {
-          "type": "1\u00a0Minute\u00a0Repair\u00a0Speed\u00a0Up",
+          "type": "1 minute repair speed up",
           "value": 3
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 8
+        "bonus1": 0.08
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 6000
-          },
-          {
             "type": "tritanium",
             "value": 100
+          },
+          {
+            "type": "parsteel",
+            "value": 6000
           }
         ]
       },
@@ -265,48 +263,48 @@
       "level": 8,
       "requirements": [
         {
-          "name": "Shipyard",
+          "name": "shipyard",
           "level": 7
         },
         {
-          "name": "Drydock B",
+          "name": "drydock b",
           "level": 4
         },
         {
-          "name": "Tritanium Generator B",
+          "name": "tritanium generator b",
           "level": 4
         }
       ],
       "rewards": [
         {
-          "type": "1\u00a0Minute\u00a0Repair\u00a0Speed\u00a0Up",
-          "value": 5
+          "type": "latinum",
+          "value": 10
         },
         {
-          "type": "1\u00a0Hour\u00a0Speed\u00a0Up",
+          "type": "1 hour speed up",
           "value": 2
         },
         {
-          "type": "Latinum",
-          "value": 10
+          "type": "1 minute repair speed up",
+          "value": 5
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 9
+        "bonus1": 0.09
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 10000
-          },
-          {
             "type": "tritanium",
             "value": 250
+          },
+          {
+            "type": "parsteel",
+            "value": 10000
           }
         ]
       },
@@ -315,36 +313,36 @@
       "level": 9,
       "requirements": [
         {
-          "name": "Parsteel Warehouse",
+          "name": "shipyard",
           "level": 8
         },
         {
-          "name": "Shipyard",
+          "name": "tritanium warehouse",
           "level": 8
         },
         {
-          "name": "Tritanium Warehouse",
+          "name": "parsteel warehouse",
           "level": 8
         }
       ],
       "rewards": [
         {
-          "type": "Latinum",
+          "type": "latinum",
           "value": 10
         },
         {
-          "type": "1\u00a0Hour\u00a0Speed\u00a0Up",
+          "type": "1 hour speed up",
           "value": 3
         },
         {
-          "type": "1\u00a0Minute\u00a0Repair\u00a0Speed\u00a0Up",
+          "type": "1 minute repair speed up",
           "value": 5
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 10
+        "bonus1": 0.1
       },
       "build_costs": {
         "materials": [],
@@ -365,41 +363,45 @@
       "level": 10,
       "requirements": [
         {
-          "name": "Shipyard",
+          "name": "shipyard",
           "level": 9
         },
         {
-          "name": "Astronautics Studio",
+          "name": "astronautics studio",
           "level": 5
         },
         {
-          "name": "Drydock B",
+          "name": "drydock b",
           "level": 9
         }
       ],
       "rewards": [
         {
-          "type": "1\u00a0Minute\u00a0Repair\u00a0Speed\u00a0Up",
-          "value": 5
-        },
-        {
-          "type": "Latinum",
+          "type": "latinum",
           "value": 15
         },
         {
-          "type": "1\u00a0Hour\u00a0Speed\u00a0Up",
+          "type": "1 hour speed up",
           "value": 4
+        },
+        {
+          "type": "1 minute repair speed up",
+          "value": 5
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 11
+        "bonus1": 0.11
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
+          {
+            "type": "dilithium",
+            "value": 20
+          },
           {
             "type": "parsteel",
             "value": 16320
@@ -407,10 +409,6 @@
           {
             "type": "tritanium",
             "value": 300
-          },
-          {
-            "type": "dilithium",
-            "value": 20
           }
         ]
       },
@@ -419,40 +417,40 @@
       "level": 11,
       "requirements": [
         {
-          "name": "Shipyard",
+          "name": "shipyard",
           "level": 10
         }
       ],
       "rewards": [
         {
-          "type": "1\u00a0Minute\u00a0Repair\u00a0Speed\u00a0Up",
-          "value": 7
+          "type": "latinum",
+          "value": 15
         },
         {
-          "type": "1\u00a0Hour\u00a0Speed\u00a0Up",
+          "type": "1 hour speed up",
           "value": 5
         },
         {
-          "type": "Latinum",
-          "value": 15
+          "type": "1 minute repair speed up",
+          "value": 7
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 12
+        "bonus1": 0.12
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 22440
-          },
-          {
             "type": "tritanium",
             "value": 413
+          },
+          {
+            "type": "parsteel",
+            "value": 22440
           },
           {
             "type": "dilithium",
@@ -465,41 +463,37 @@
       "level": 12,
       "requirements": [
         {
-          "name": "Shipyard",
+          "name": "shipyard",
           "level": 11
         },
         {
-          "name": "Refinery",
+          "name": "refinery",
           "level": 3
         }
       ],
       "rewards": [
         {
-          "type": "Latinum",
+          "type": "latinum",
           "value": 15
         },
         {
-          "type": "1\u00a0Minute\u00a0Repair\u00a0Speed\u00a0Up",
-          "value": 9
+          "type": "3 hour speed up",
+          "value": 2
         },
         {
-          "type": "3\u00a0Hour\u00a0Speed\u00a0Up",
-          "value": 2
+          "type": "1 minute repair speed up",
+          "value": 9
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 13
+        "bonus1": 0.13
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
-          {
-            "type": "parsteel",
-            "value": 32640
-          },
           {
             "type": "tritanium",
             "value": 600
@@ -507,6 +501,10 @@
           {
             "type": "dilithium",
             "value": 120
+          },
+          {
+            "type": "parsteel",
+            "value": 32640
           }
         ]
       },
@@ -515,32 +513,32 @@
       "level": 13,
       "requirements": [
         {
-          "name": "Shipyard",
+          "name": "shipyard",
           "level": 12
         },
         {
-          "name": "Refinery",
+          "name": "refinery",
           "level": 6
         }
       ],
       "rewards": [
         {
-          "type": "1\u00a0Minute\u00a0Repair\u00a0Speed\u00a0Up",
-          "value": 11
+          "type": "latinum",
+          "value": 15
         },
         {
-          "type": "3\u00a0Hour\u00a0Speed\u00a0Up",
+          "type": "3 hour speed up",
           "value": 3
         },
         {
-          "type": "Latinum",
-          "value": 15
+          "type": "1 minute repair speed up",
+          "value": 11
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 14
+        "bonus1": 0.14
       },
       "build_costs": {
         "materials": [
@@ -554,12 +552,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 44880
-          },
-          {
             "type": "tritanium",
             "value": 825
+          },
+          {
+            "type": "parsteel",
+            "value": 44880
           },
           {
             "type": "dilithium",
@@ -572,36 +570,36 @@
       "level": 14,
       "requirements": [
         {
-          "name": "Shipyard",
+          "name": "shipyard",
           "level": 13
         },
         {
-          "name": "Parsteel Warehouse",
+          "name": "parsteel warehouse",
           "level": 12
         },
         {
-          "name": "Defense Platform A",
+          "name": "defense platform a",
           "level": 6
         }
       ],
       "rewards": [
         {
-          "type": "3\u00a0Hour\u00a0Speed\u00a0Up",
+          "type": "latinum",
+          "value": 15
+        },
+        {
+          "type": "3 hour speed up",
           "value": 3
         },
         {
-          "type": "3\u00a0Minute\u00a0Repair\u00a0Speed\u00a0Up",
+          "type": "3 minute repair speed up",
           "value": 4
-        },
-        {
-          "type": "Latinum",
-          "value": 15
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 15
+        "bonus1": 0.15
       },
       "build_costs": {
         "materials": [
@@ -619,12 +617,12 @@
             "value": 61200
           },
           {
-            "type": "tritanium",
-            "value": 1125
-          },
-          {
             "type": "dilithium",
             "value": 375
+          },
+          {
+            "type": "tritanium",
+            "value": 1125
           }
         ]
       },
@@ -633,61 +631,61 @@
       "level": 15,
       "requirements": [
         {
-          "name": "Shipyard",
+          "name": "shipyard",
           "level": 14
         },
         {
-          "name": "Defense Platform A",
+          "name": "defense platform a",
           "level": 10
         },
         {
-          "name": "Defense Platform B",
+          "name": "defense platform b",
           "level": 10
         }
       ],
       "rewards": [
         {
-          "type": "Latinum",
+          "type": "latinum",
           "value": 25
         },
         {
-          "type": "8\u00a0Hr\u00a0Peace\u00a0Shield",
+          "type": "8 hour peace shield",
           "value": 15
         },
         {
-          "type": "3\u00a0Minute\u00a0Repair\u00a0Speed\u00a0Up",
+          "type": "3 minute repair speed up",
           "value": 4
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 16
+        "bonus1": 0.16
       },
       "build_costs": {
         "materials": [
           {
             "type": "ore",
             "grade": 2,
-            "rarity": "common",
-            "value": 100
+            "rarity": "uncommon",
+            "value": 5
           },
           {
             "type": "ore",
             "grade": 2,
-            "rarity": "uncommon",
-            "value": 5
+            "rarity": "common",
+            "value": 100
           }
         ],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 81600
-          },
-          {
             "type": "tritanium",
             "value": 1500
+          },
+          {
+            "type": "parsteel",
+            "value": 81600
           },
           {
             "type": "dilithium",
@@ -700,46 +698,46 @@
       "level": 16,
       "requirements": [
         {
-          "name": "Shipyard",
+          "name": "shipyard",
           "level": 15
         },
         {
-          "name": "Defense Technologies",
+          "name": "defense technologies",
           "level": 5
         }
       ],
       "rewards": [
         {
-          "type": "Latinum",
+          "type": "latinum",
           "value": 25
         },
         {
-          "type": "1\u00a0Day\u00a0Peace\u00a0Shield",
+          "type": "1 day peace shield",
           "value": 1
         },
         {
-          "type": "5\u00a0Hour\u00a0Speed\u00a0Up",
+          "type": "5 hour speed up",
           "value": 2
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 17
+        "bonus1": 0.17
       },
       "build_costs": {
         "materials": [
           {
             "type": "ore",
             "grade": 2,
-            "rarity": "common",
-            "value": 200
+            "rarity": "uncommon",
+            "value": 10
           },
           {
             "type": "ore",
             "grade": 2,
-            "rarity": "uncommon",
-            "value": 10
+            "rarity": "common",
+            "value": 200
           }
         ],
         "others": [],
@@ -763,61 +761,61 @@
       "level": 17,
       "requirements": [
         {
-          "name": "Shipyard",
+          "name": "shipyard",
           "level": 16
         },
         {
-          "name": "Dilithium Vault",
+          "name": "dilithium vault",
           "level": 3
         }
       ],
       "rewards": [
         {
-          "type": "Latinum",
+          "type": "latinum",
           "value": 25
         },
         {
-          "type": "1\u00a0Day\u00a0Peace\u00a0Shield",
+          "type": "1 day peace shield",
           "value": 1
         },
         {
-          "type": "5\u00a0Hour\u00a0Speed\u00a0Up",
+          "type": "5 hour speed up",
           "value": 3
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 18
+        "bonus1": 0.18
       },
       "build_costs": {
         "materials": [
           {
             "type": "ore",
             "grade": 2,
-            "rarity": "common",
-            "value": 500
+            "rarity": "uncommon",
+            "value": 25
           },
           {
             "type": "ore",
             "grade": 2,
-            "rarity": "uncommon",
-            "value": 25
+            "rarity": "common",
+            "value": 500
           }
         ],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 163200
+            "type": "dilithium",
+            "value": 1000
           },
           {
             "type": "tritanium",
             "value": 3000
           },
           {
-            "type": "dilithium",
-            "value": 1000
+            "type": "parsteel",
+            "value": 163200
           }
         ]
       },
@@ -826,36 +824,36 @@
       "level": 18,
       "requirements": [
         {
-          "name": "Shipyard",
+          "name": "shipyard",
           "level": 17
         },
         {
-          "name": "Parsteel Warehouse",
+          "name": "parsteel warehouse",
           "level": 15
         },
         {
-          "name": "Refinery",
+          "name": "refinery",
           "level": 17
         }
       ],
       "rewards": [
         {
-          "type": "5\u00a0Hour\u00a0Speed\u00a0Up",
-          "value": 4
+          "type": "latinum",
+          "value": 25
         },
         {
-          "type": "1\u00a0Day\u00a0Peace\u00a0Shield",
+          "type": "1 day peace shield",
           "value": 1
         },
         {
-          "type": "Latinum",
-          "value": 25
+          "type": "5 hour speed up",
+          "value": 4
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 19
+        "bonus1": 0.19
       },
       "build_costs": {
         "materials": [
@@ -875,12 +873,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 244800
-          },
-          {
             "type": "tritanium",
             "value": 4500
+          },
+          {
+            "type": "parsteel",
+            "value": 244800
           },
           {
             "type": "dilithium",
@@ -893,32 +891,32 @@
       "level": 19,
       "requirements": [
         {
-          "name": "Shipyard",
+          "name": "shipyard",
           "level": 18
         },
         {
-          "name": "Ship Hangar",
+          "name": "ship hangar",
           "level": 5
         }
       ],
       "rewards": [
         {
-          "type": "Latinum",
+          "type": "latinum",
           "value": 25
         },
         {
-          "type": "1\u00a0Day\u00a0Peace\u00a0Shield",
+          "type": "1 day peace shield",
           "value": 1
         },
         {
-          "type": "8\u00a0Hour\u00a0Speed\u00a0Up",
+          "type": "8 hour speed up",
           "value": 2
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 20
+        "bonus1": 0.2
       },
       "build_costs": {
         "materials": [
@@ -938,16 +936,16 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 346800
-          },
-          {
             "type": "tritanium",
             "value": 6375
           },
           {
             "type": "dilithium",
             "value": 2125
+          },
+          {
+            "type": "parsteel",
+            "value": 346800
           }
         ]
       },
@@ -956,36 +954,36 @@
       "level": 20,
       "requirements": [
         {
-          "name": "Shipyard",
+          "name": "shipyard",
           "level": 19
         },
         {
-          "name": "Refinery",
+          "name": "refinery",
           "level": 19
         },
         {
-          "name": "Defense Technologies",
+          "name": "defense technologies",
           "level": 19
         }
       ],
       "rewards": [
         {
-          "type": "8\u00a0Hour\u00a0Speed\u00a0Up",
-          "value": 3
+          "type": "latinum",
+          "value": 50
         },
         {
-          "type": "3\u00a0Day\u00a0Peace\u00a0Shield",
+          "type": "3 day peace shield",
           "value": 1
         },
         {
-          "type": "Latinum",
-          "value": 50
+          "type": "8 hour speed up",
+          "value": 3
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 21
+        "bonus1": 0.21
       },
       "build_costs": {
         "materials": [],
@@ -1010,36 +1008,36 @@
       "level": 21,
       "requirements": [
         {
-          "name": "Defense Platform A",
+          "name": "shipyard",
           "level": 20
         },
         {
-          "name": "Shipyard",
+          "name": "drydock a",
           "level": 20
         },
         {
-          "name": "Drydock A",
+          "name": "defense platform a",
           "level": 20
         }
       ],
       "rewards": [
         {
-          "type": "8\u00a0Hour\u00a0Speed\u00a0Up",
-          "value": 4
+          "type": "latinum",
+          "value": 50
         },
         {
-          "type": "1\u00a0Day\u00a0Peace\u00a0Shield",
+          "type": "1 day peace shield",
           "value": 2
         },
         {
-          "type": "Latinum",
-          "value": 50
+          "type": "8 hour speed up",
+          "value": 4
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 22
+        "bonus1": 0.22
       },
       "build_costs": {
         "materials": [
@@ -1053,16 +1051,16 @@
         "others": [],
         "resources": [
           {
+            "type": "dilithium",
+            "value": 5565
+          },
+          {
             "type": "parsteel",
             "value": 908208
           },
           {
             "type": "tritanium",
             "value": 16695
-          },
-          {
-            "type": "dilithium",
-            "value": 5565
           }
         ]
       },
@@ -1071,36 +1069,36 @@
       "level": 22,
       "requirements": [
         {
-          "name": "Shipyard",
+          "name": "shipyard",
           "level": 21
         },
         {
-          "name": "Parsteel Warehouse",
+          "name": "parsteel warehouse",
           "level": 21
         },
         {
-          "name": "Dilithium Vault",
+          "name": "dilithium vault",
           "level": 18
         }
       ],
       "rewards": [
         {
-          "type": "8\u00a0Hour\u00a0Speed\u00a0Up",
-          "value": 5
+          "type": "latinum",
+          "value": 50
         },
         {
-          "type": "1\u00a0Day\u00a0Peace\u00a0Shield",
+          "type": "1 day peace shield",
           "value": 2
         },
         {
-          "type": "Latinum",
-          "value": 50
+          "type": "8 hour speed up",
+          "value": 5
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 23
+        "bonus1": 0.23
       },
       "build_costs": {
         "materials": [
@@ -1114,16 +1112,16 @@
         "others": [],
         "resources": [
           {
+            "type": "dilithium",
+            "value": 9158
+          },
+          {
             "type": "parsteel",
             "value": 1494504
           },
           {
             "type": "tritanium",
             "value": 27473
-          },
-          {
-            "type": "dilithium",
-            "value": 9158
           }
         ]
       },
@@ -1132,36 +1130,36 @@
       "level": 23,
       "requirements": [
         {
-          "name": "Shipyard",
+          "name": "shipyard",
           "level": 22
         },
         {
-          "name": "Defense Platform B",
+          "name": "defense platform b",
           "level": 22
         },
         {
-          "name": "Defense Platform C",
+          "name": "defense platform c",
           "level": 22
         }
       ],
       "rewards": [
         {
-          "type": "1\u00a0Day\u00a0Peace\u00a0Shield",
-          "value": 2
-        },
-        {
-          "type": "Latinum",
+          "type": "latinum",
           "value": 50
         },
         {
-          "type": "12\u00a0Hour\u00a0Speed\u00a0Up",
+          "type": "1 day peace shield",
+          "value": 2
+        },
+        {
+          "type": "12 hour speed up",
           "value": 2
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 24
+        "bonus1": 0.24
       },
       "build_costs": {
         "materials": [
@@ -1199,36 +1197,36 @@
       "level": 24,
       "requirements": [
         {
-          "name": "Science Lab",
+          "name": "science lab",
           "level": 5
         },
         {
-          "name": "Foundry",
+          "name": "foundry",
           "level": 5
         },
         {
-          "name": "Engine Technology Lab",
+          "name": "engine technology lab",
           "level": 5
         }
       ],
       "rewards": [
         {
-          "type": "Latinum",
+          "type": "latinum",
           "value": 50
         },
         {
-          "type": "1\u00a0Day\u00a0Peace\u00a0Shield",
+          "type": "1 day peace shield",
           "value": 2
         },
         {
-          "type": "12\u00a0Hour\u00a0Speed\u00a0Up",
+          "type": "12 hour speed up",
           "value": 3
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 25
+        "bonus1": 0.25
       },
       "build_costs": {
         "materials": [
@@ -1248,16 +1246,16 @@
         "others": [],
         "resources": [
           {
+            "type": "dilithium",
+            "value": 23400
+          },
+          {
             "type": "parsteel",
             "value": 3818880
           },
           {
             "type": "tritanium",
             "value": 70200
-          },
-          {
-            "type": "dilithium",
-            "value": 23400
           }
         ]
       },
@@ -1266,32 +1264,32 @@
       "level": 25,
       "requirements": [
         {
-          "name": "Shipyard",
+          "name": "shipyard",
           "level": 24
         },
         {
-          "name": "Ship Hangar",
+          "name": "ship hangar",
           "level": 24
         }
       ],
       "rewards": [
         {
-          "type": "Latinum",
+          "type": "latinum",
           "value": 100
         },
         {
-          "type": "1\u00a0Day\u00a0Peace\u00a0Shield",
+          "type": "1 day peace shield",
           "value": 2
         },
         {
-          "type": "15\u00a0Hour\u00a0Speed\u00a0Up",
+          "type": "15 hour speed up",
           "value": 2
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 26
+        "bonus1": 0.26
       },
       "build_costs": {
         "materials": [
@@ -1311,16 +1309,16 @@
         "others": [],
         "resources": [
           {
+            "type": "dilithium",
+            "value": 36563
+          },
+          {
             "type": "parsteel",
             "value": 5967000
           },
           {
             "type": "tritanium",
             "value": 109688
-          },
-          {
-            "type": "dilithium",
-            "value": 36563
           }
         ]
       },
@@ -1329,32 +1327,32 @@
       "level": 26,
       "requirements": [
         {
-          "name": "Shipyard",
+          "name": "shipyard",
           "level": 25
         },
         {
-          "name": "Defense Platform C",
+          "name": "defense platform c",
           "level": 25
         }
       ],
       "rewards": [
         {
-          "type": "Latinum",
+          "type": "latinum",
           "value": 100
         },
         {
-          "type": "1\u00a0Day\u00a0Peace\u00a0Shield",
+          "type": "1 day peace shield",
           "value": 2
         },
         {
-          "type": "15\u00a0Hour\u00a0Speed\u00a0Up",
+          "type": "15 hour speed up",
           "value": 3
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 27
+        "bonus1": 0.27
       },
       "build_costs": {
         "materials": [
@@ -1374,12 +1372,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 9106560
-          },
-          {
             "type": "tritanium",
             "value": 167400
+          },
+          {
+            "type": "parsteel",
+            "value": 9106560
           },
           {
             "type": "dilithium",
@@ -1392,61 +1390,61 @@
       "level": 27,
       "requirements": [
         {
-          "name": "Foundry",
+          "name": "shipyard",
           "level": 26
         },
         {
-          "name": "Shipyard",
+          "name": "foundry",
           "level": 26
         }
       ],
       "rewards": [
         {
-          "type": "1\u00a0Day\u00a0Peace\u00a0Shield",
+          "type": "latinum",
+          "value": 100
+        },
+        {
+          "type": "1 day peace shield",
           "value": 2
         },
         {
-          "type": "15\u00a0Hour\u00a0Speed\u00a0Up",
+          "type": "15 hour speed up",
           "value": 3
-        },
-        {
-          "type": "Latinum",
-          "value": 100
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 28
+        "bonus1": 0.28
       },
       "build_costs": {
         "materials": [
           {
             "type": "ore",
             "grade": 3,
-            "rarity": "common",
-            "value": 1210
+            "rarity": "uncommon",
+            "value": 230
           },
           {
             "type": "ore",
             "grade": 3,
-            "rarity": "uncommon",
-            "value": 230
+            "rarity": "common",
+            "value": 1210
           }
         ],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 13659840
+            "type": "dilithium",
+            "value": 83700
           },
           {
             "type": "tritanium",
             "value": 251100
           },
           {
-            "type": "dilithium",
-            "value": 83700
+            "type": "parsteel",
+            "value": 13659840
           }
         ]
       },
@@ -1455,32 +1453,32 @@
       "level": 28,
       "requirements": [
         {
-          "name": "Shipyard",
+          "name": "shipyard",
           "level": 27
         },
         {
-          "name": "Engine Technology Lab",
+          "name": "engine technology lab",
           "level": 27
         }
       ],
       "rewards": [
         {
-          "type": "15\u00a0Hour\u00a0Speed\u00a0Up",
-          "value": 4
+          "type": "latinum",
+          "value": 100
         },
         {
-          "type": "1\u00a0Day\u00a0Peace\u00a0Shield",
+          "type": "1 day peace shield",
           "value": 2
         },
         {
-          "type": "Latinum",
-          "value": 100
+          "type": "15 hour speed up",
+          "value": 4
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 29
+        "bonus1": 0.29
       },
       "build_costs": {
         "materials": [
@@ -1500,12 +1498,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 21746400
-          },
-          {
             "type": "tritanium",
             "value": 399750
+          },
+          {
+            "type": "parsteel",
+            "value": 21746400
           },
           {
             "type": "dilithium",
@@ -1518,36 +1516,36 @@
       "level": 29,
       "requirements": [
         {
-          "name": "Shipyard",
+          "name": "shipyard",
           "level": 28
         },
         {
-          "name": "Parsteel Warehouse",
+          "name": "parsteel warehouse",
           "level": 27
         },
         {
-          "name": "Science Lab",
+          "name": "science lab",
           "level": 28
         }
       ],
       "rewards": [
         {
-          "type": "1\u00a0Day\u00a0Peace\u00a0Shield",
-          "value": 2
-        },
-        {
-          "type": "Latinum",
+          "type": "latinum",
           "value": 100
         },
         {
-          "type": "1\u00a0Day\u00a0Speed\u00a0Up",
+          "type": "1 day peace shield",
+          "value": 2
+        },
+        {
+          "type": "1 day speed up",
           "value": 2
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 30
+        "bonus1": 0.3
       },
       "build_costs": {
         "materials": [
@@ -1585,36 +1583,36 @@
       "level": 30,
       "requirements": [
         {
-          "name": "Shipyard",
+          "name": "shipyard",
           "level": 29
         },
         {
-          "name": "Defense Platform D",
+          "name": "defense platform d",
           "level": 10
         },
         {
-          "name": "Ship Hangar",
+          "name": "ship hangar",
           "level": 29
         }
       ],
       "rewards": [
         {
-          "type": "3\u00a0Day\u00a0Peace\u00a0Shield",
+          "type": "latinum",
+          "value": 150
+        },
+        {
+          "type": "3 day peace shield",
           "value": 1
         },
         {
-          "type": "1\u00a0Day\u00a0Speed\u00a0Up",
+          "type": "1 day speed up",
           "value": 2
-        },
-        {
-          "type": "Latinum",
-          "value": 150
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 31
+        "bonus1": 0.31
       },
       "build_costs": {
         "materials": [
@@ -1634,12 +1632,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 50306400
-          },
-          {
             "type": "tritanium",
             "value": 924750
+          },
+          {
+            "type": "parsteel",
+            "value": 50306400
           },
           {
             "type": "dilithium",
@@ -1652,36 +1650,36 @@
       "level": 31,
       "requirements": [
         {
-          "name": "Shipyard",
+          "name": "shipyard",
           "level": 30
         },
         {
-          "name": "Defense Platform A",
+          "name": "defense platform a",
           "level": 30
         },
         {
-          "name": "Defense Platform B",
+          "name": "defense platform b",
           "level": 30
         }
       ],
       "rewards": [
         {
-          "type": "Latinum",
+          "type": "latinum",
           "value": 150
         },
         {
-          "type": "1\u00a0Day\u00a0Peace\u00a0Shield",
+          "type": "1 day peace shield",
           "value": 3
         },
         {
-          "type": "1\u00a0Day\u00a0Speed\u00a0Up",
+          "type": "1 day speed up",
           "value": 3
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 32
+        "bonus1": 0.32
       },
       "build_costs": {
         "materials": [
@@ -1701,16 +1699,16 @@
         "others": [],
         "resources": [
           {
+            "type": "dilithium",
+            "value": 445250
+          },
+          {
             "type": "parsteel",
             "value": 72664800
           },
           {
             "type": "tritanium",
             "value": 1335750
-          },
-          {
-            "type": "dilithium",
-            "value": 445250
           }
         ]
       },
@@ -1719,54 +1717,58 @@
       "level": 32,
       "requirements": [
         {
-          "name": "Defense Platform D",
+          "name": "shipyard",
           "level": 31
         },
         {
-          "name": "Defense Platform C",
+          "name": "defense platform c",
           "level": 31
         },
         {
-          "name": "Shipyard",
+          "name": "defense platform d",
           "level": 31
         }
       ],
       "rewards": [
         {
-          "type": "1\u00a0Day\u00a0Speed\u00a0Up",
-          "value": 3
-        },
-        {
-          "type": "1\u00a0Day\u00a0Peace\u00a0Shield",
-          "value": 3
-        },
-        {
-          "type": "Latinum",
+          "type": "latinum",
           "value": 150
+        },
+        {
+          "type": "1 day peace shield",
+          "value": 3
+        },
+        {
+          "type": "1 day speed up",
+          "value": 3
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 33
+        "bonus1": 0.33
       },
       "build_costs": {
         "materials": [
           {
             "type": "ore",
             "grade": 3,
-            "rarity": "common",
-            "value": 2400
+            "rarity": "uncommon",
+            "value": 780
           },
           {
             "type": "ore",
             "grade": 3,
-            "rarity": "uncommon",
-            "value": 780
+            "rarity": "common",
+            "value": 2400
           }
         ],
         "others": [],
         "resources": [
+          {
+            "type": "dilithium",
+            "value": 688750
+          },
           {
             "type": "parsteel",
             "value": 112404000
@@ -1774,10 +1776,6 @@
           {
             "type": "tritanium",
             "value": 2066250
-          },
-          {
-            "type": "dilithium",
-            "value": 688750
           }
         ]
       },
@@ -1786,36 +1784,36 @@
       "level": 33,
       "requirements": [
         {
-          "name": "Parsteel Warehouse",
+          "name": "shipyard",
           "level": 32
         },
         {
-          "name": "Parsteel Vault",
+          "name": "parsteel warehouse",
           "level": 32
         },
         {
-          "name": "Shipyard",
+          "name": "parsteel vault",
           "level": 32
         }
       ],
       "rewards": [
         {
-          "type": "1\u00a0Day\u00a0Speed\u00a0Up",
-          "value": 3
-        },
-        {
-          "type": "1\u00a0Day\u00a0Peace\u00a0Shield",
-          "value": 3
-        },
-        {
-          "type": "Latinum",
+          "type": "latinum",
           "value": 150
+        },
+        {
+          "type": "1 day peace shield",
+          "value": 3
+        },
+        {
+          "type": "1 day speed up",
+          "value": 3
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 34
+        "bonus1": 0.34
       },
       "build_costs": {
         "materials": [
@@ -1835,16 +1833,16 @@
         "others": [],
         "resources": [
           {
+            "type": "dilithium",
+            "value": 1087500
+          },
+          {
             "type": "parsteel",
             "value": 177480000
           },
           {
             "type": "tritanium",
             "value": 3262500
-          },
-          {
-            "type": "dilithium",
-            "value": 1087500
           }
         ]
       },
@@ -1853,46 +1851,46 @@
       "level": 34,
       "requirements": [
         {
-          "name": "Shipyard",
+          "name": "shipyard",
           "level": 33
         },
         {
-          "name": "Defense Platform D",
+          "name": "defense platform d",
           "level": 33
         }
       ],
       "rewards": [
         {
-          "type": "2\u00a0Day\u00a0Speed\u00a0Up",
-          "value": 2
+          "type": "latinum",
+          "value": 150
         },
         {
-          "type": "1\u00a0Day\u00a0Peace\u00a0Shield",
+          "type": "1 day peace shield",
           "value": 3
         },
         {
-          "type": "Latinum",
-          "value": 150
+          "type": "2 day speed up",
+          "value": 2
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 35
+        "bonus1": 0.35
       },
       "build_costs": {
         "materials": [
           {
             "type": "ore",
             "grade": 3,
-            "rarity": "common",
-            "value": 3100
+            "rarity": "rare",
+            "value": 100
           },
           {
             "type": "ore",
             "grade": 3,
-            "rarity": "rare",
-            "value": 100
+            "rarity": "common",
+            "value": 3100
           }
         ],
         "others": [],
@@ -1902,12 +1900,12 @@
             "value": 274665600
           },
           {
-            "type": "tritanium",
-            "value": 5049000
-          },
-          {
             "type": "dilithium",
             "value": 1683000
+          },
+          {
+            "type": "tritanium",
+            "value": 5049000
           }
         ]
       },
@@ -1916,58 +1914,54 @@
       "level": 35,
       "requirements": [
         {
-          "name": "Parsteel Warehouse",
+          "name": "parsteel warehouse",
           "level": 34
         },
         {
-          "name": "Dilithium Warehouse",
+          "name": "tritanium warehouse",
           "level": 34
         },
         {
-          "name": "Tritanium Warehouse",
+          "name": "dilithium warehouse",
           "level": 34
         }
       ],
       "rewards": [
         {
-          "type": "2\u00a0Day\u00a0Speed\u00a0Up",
-          "value": 2
+          "type": "latinum",
+          "value": 250
         },
         {
-          "type": "1\u00a0Day\u00a0Peace\u00a0Shield",
+          "type": "1 day peace shield",
           "value": 3
         },
         {
-          "type": "Latinum",
-          "value": 250
+          "type": "2 day speed up",
+          "value": 2
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 36
+        "bonus1": 0.36
       },
       "build_costs": {
         "materials": [
           {
             "type": "ore",
             "grade": 3,
-            "rarity": "common",
-            "value": 3500
+            "rarity": "uncommon",
+            "value": 1370
           },
           {
             "type": "ore",
             "grade": 3,
-            "rarity": "uncommon",
-            "value": 1370
+            "rarity": "common",
+            "value": 3500
           }
         ],
         "others": [],
         "resources": [
-          {
-            "type": "parsteel",
-            "value": 387028800
-          },
           {
             "type": "tritanium",
             "value": 7114500
@@ -1975,6 +1969,10 @@
           {
             "type": "dilithium",
             "value": 2371500
+          },
+          {
+            "type": "parsteel",
+            "value": 387028800
           }
         ]
       },
@@ -1983,32 +1981,32 @@
       "level": 36,
       "requirements": [
         {
-          "name": "Shipyard",
+          "name": "shipyard",
           "level": 35
         },
         {
-          "name": "Parsteel Warehouse",
+          "name": "parsteel warehouse",
           "level": 31
         }
       ],
       "rewards": [
         {
-          "type": "2\u00a0Day\u00a0Speed\u00a0Up",
-          "value": 2
+          "type": "latinum",
+          "value": 250
         },
         {
-          "type": "1\u00a0Day\u00a0Peace\u00a0Shield",
+          "type": "1 day peace shield",
           "value": 3
         },
         {
-          "type": "Latinum",
-          "value": 250
+          "type": "2 day speed up",
+          "value": 2
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 37
+        "bonus1": 0.37
       },
       "build_costs": {
         "materials": [
@@ -2046,53 +2044,53 @@
       "level": 37,
       "requirements": [
         {
-          "name": "Shipyard",
+          "name": "shipyard",
           "level": 36
         }
       ],
       "rewards": [
         {
-          "type": "2\u00a0Day\u00a0Speed\u00a0Up",
-          "value": 2
-        },
-        {
-          "type": "Latinum",
+          "type": "latinum",
           "value": 250
         },
         {
-          "type": "1\u00a0Day\u00a0Peace\u00a0Shield",
+          "type": "1 day peace shield",
           "value": 3
+        },
+        {
+          "type": "2 day speed up",
+          "value": 2
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 38
+        "bonus1": 0.38
       },
       "build_costs": {
         "materials": [
           {
             "type": "ore",
             "grade": 3,
-            "rarity": "common",
-            "value": 4300
+            "rarity": "uncommon",
+            "value": 1900
           },
           {
             "type": "ore",
             "grade": 3,
-            "rarity": "uncommon",
-            "value": 1900
+            "rarity": "common",
+            "value": 4300
           }
         ],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 925344000
-          },
-          {
             "type": "tritanium",
             "value": 17010000
+          },
+          {
+            "type": "parsteel",
+            "value": 925344000
           },
           {
             "type": "dilithium",
@@ -2105,50 +2103,46 @@
       "level": 38,
       "requirements": [
         {
-          "name": "Shipyard",
+          "name": "shipyard",
           "level": 37
         }
       ],
       "rewards": [
         {
-          "type": "2\u00a0Day\u00a0Speed\u00a0Up",
-          "value": 3
-        },
-        {
-          "type": "1\u00a0Day\u00a0Peace\u00a0Shield",
-          "value": 3
-        },
-        {
-          "type": "Latinum",
+          "type": "latinum",
           "value": 250
+        },
+        {
+          "type": "1 day peace shield",
+          "value": 3
+        },
+        {
+          "type": "2 day speed up",
+          "value": 3
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 39
+        "bonus1": 0.39
       },
       "build_costs": {
         "materials": [
           {
             "type": "ore",
             "grade": 3,
-            "rarity": "common",
-            "value": 4800
+            "rarity": "rare",
+            "value": 500
           },
           {
             "type": "ore",
             "grade": 3,
-            "rarity": "rare",
-            "value": 500
+            "rarity": "common",
+            "value": 4800
           }
         ],
         "others": [],
         "resources": [
-          {
-            "type": "parsteel",
-            "value": 1578960000
-          },
           {
             "type": "tritanium",
             "value": 29025000
@@ -2156,6 +2150,10 @@
           {
             "type": "dilithium",
             "value": 9675000
+          },
+          {
+            "type": "parsteel",
+            "value": 1578960000
           }
         ]
       },
@@ -2164,49 +2162,49 @@
       "level": 39,
       "requirements": [
         {
-          "name": "Shipyard",
+          "name": "shipyard",
           "level": 38
         },
         {
-          "name": "Ship Hangar",
+          "name": "ship hangar",
           "level": 38
         }
       ],
       "rewards": [
         {
-          "type": "1\u00a0Day\u00a0Peace\u00a0Shield",
+          "type": "latinum",
+          "value": 250
+        },
+        {
+          "type": "1 day peace shield",
           "value": 3
         },
         {
-          "type": "2\u00a0Day\u00a0Speed\u00a0Up",
+          "type": "2 day speed up",
           "value": 4
-        },
-        {
-          "type": "Latinum",
-          "value": 250
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 40
+        "bonus1": 0.4
       },
       "build_costs": {
         "materials": [],
         "others": [
           {
-            "type": "Ascend\u00a0Key",
+            "type": "ascend key",
             "value": 400
           }
         ],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 6877248000
-          },
-          {
             "type": "tritanium",
             "value": 45150000
+          },
+          {
+            "type": "parsteel",
+            "value": 6877248000
           },
           {
             "type": "dilithium",
@@ -2219,32 +2217,32 @@
       "level": 40,
       "requirements": [
         {
-          "name": "Shipyard",
+          "name": "shipyard",
           "level": 39
         },
         {
-          "name": "Astronautics Studio",
+          "name": "astronautics studio",
           "level": 39
         }
       ],
       "rewards": [
         {
-          "type": "Latinum",
-          "value": 400
+          "type": "latinum",
+          "value": 2000
         },
         {
-          "type": "1\u00a0Day\u00a0Peace\u00a0Shield",
+          "type": "1 day peace shield",
           "value": 3
         },
         {
-          "type": "2\u00a0Day\u00a0Speed\u00a0Up",
+          "type": "2 day speed up",
           "value": 6
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 41
+        "bonus1": 0.41
       },
       "build_costs": {
         "materials": [
@@ -2276,32 +2274,32 @@
       "level": 41,
       "requirements": [
         {
-          "name": "Shipyard",
+          "name": "shipyard",
           "level": 40
         },
         {
-          "name": "Parsteel Vault",
+          "name": "parsteel vault",
           "level": 40
         }
       ],
       "rewards": [
         {
-          "type": "Latinum",
-          "value": 400
+          "type": "latinum",
+          "value": 3000
         },
         {
-          "type": "1\u00a0Day\u00a0Peace\u00a0Shield",
+          "type": "1 day peace shield",
           "value": 3
         },
         {
-          "type": "3\u00a0Day\u00a0Speed\u00a0Up",
+          "type": "3 day speed up",
           "value": 4
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 42
+        "bonus1": 0.42
       },
       "build_costs": {
         "materials": [
@@ -2325,12 +2323,12 @@
             "value": 10452960000
           },
           {
-            "type": "tritanium",
-            "value": 96075000
-          },
-          {
             "type": "dilithium",
             "value": 32025000
+          },
+          {
+            "type": "tritanium",
+            "value": 96075000
           }
         ]
       },
@@ -2339,61 +2337,61 @@
       "level": 42,
       "requirements": [
         {
-          "name": "Shipyard",
+          "name": "shipyard",
           "level": 41
         },
         {
-          "name": "Dilithium Vault",
+          "name": "dilithium vault",
           "level": 41
         },
         {
-          "name": "Defense Platform D",
+          "name": "defense platform d",
           "level": 41
         }
       ],
       "rewards": [
         {
-          "type": "Latinum",
-          "value": 400
+          "type": "latinum",
+          "value": 4000
         },
         {
-          "type": "1\u00a0Day\u00a0Peace\u00a0Shield",
+          "type": "1 day peace shield",
           "value": 3
         },
         {
-          "type": "3\u00a0Day\u00a0Speed\u00a0Up",
-          "value": 4
+          "type": "3 day speed up",
+          "value": 5
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 43
+        "bonus1": 0.43
       },
       "build_costs": {
         "materials": [
           {
             "type": "ore",
             "grade": 4,
-            "rarity": "common",
-            "value": 50000
+            "rarity": "rare",
+            "value": 2500
           },
           {
             "type": "ore",
             "grade": 4,
-            "rarity": "rare",
-            "value": 2500
+            "rarity": "common",
+            "value": 50000
           }
         ],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 14932800000
-          },
-          {
             "type": "tritanium",
             "value": 137250000
+          },
+          {
+            "type": "parsteel",
+            "value": 14932800000
           },
           {
             "type": "dilithium",
@@ -2406,36 +2404,36 @@
       "level": 43,
       "requirements": [
         {
-          "name": "Ship Hangar",
+          "name": "shipyard",
           "level": 42
         },
         {
-          "name": "Defense Platform E",
+          "name": "defense platform e",
           "level": 10
         },
         {
-          "name": "Shipyard",
+          "name": "ship hangar",
           "level": 42
         }
       ],
       "rewards": [
         {
-          "type": "Latinum",
-          "value": 400
+          "type": "latinum",
+          "value": 6000
         },
         {
-          "type": "1\u00a0Day\u00a0Peace\u00a0Shield",
+          "type": "1 day peace shield",
           "value": 3
         },
         {
-          "type": "3\u00a0Day\u00a0Speed\u00a0Up",
-          "value": 5
+          "type": "3 day speed up",
+          "value": 6
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 44
+        "bonus1": 0.44
       },
       "build_costs": {
         "materials": [
@@ -2455,16 +2453,16 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 22399200000
-          },
-          {
             "type": "tritanium",
             "value": 205875000
           },
           {
             "type": "dilithium",
             "value": 68625000
+          },
+          {
+            "type": "parsteel",
+            "value": 22399200000
           }
         ]
       },
@@ -2473,36 +2471,36 @@
       "level": 44,
       "requirements": [
         {
-          "name": "Shipyard",
+          "name": "shipyard",
           "level": 43
         },
         {
-          "name": "Drydock D",
+          "name": "drydock d",
           "level": 43
         },
         {
-          "name": "Defense Platform E",
+          "name": "defense platform e",
           "level": 20
         }
       ],
       "rewards": [
         {
-          "type": "Latinum",
-          "value": 400
+          "type": "latinum",
+          "value": 8000
         },
         {
-          "type": "3\u00a0Day\u00a0Speed\u00a0Up",
-          "value": 6
-        },
-        {
-          "type": "1\u00a0Day\u00a0Peace\u00a0Shield",
+          "type": "1 day peace shield",
           "value": 3
+        },
+        {
+          "type": "3 day speed up",
+          "value": 7
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 45
+        "bonus1": 0.45
       },
       "build_costs": {
         "materials": [
@@ -2540,36 +2538,36 @@
       "level": 45,
       "requirements": [
         {
-          "name": "Shipyard",
+          "name": "shipyard",
           "level": 44
         },
         {
-          "name": "Defense Platform E",
+          "name": "defense platform e",
           "level": 30
         },
         {
-          "name": "Defense Platform D",
+          "name": "defense platform d",
           "level": 44
         }
       ],
       "rewards": [
         {
-          "type": "Latinum",
-          "value": 400
+          "type": "latinum",
+          "value": 10000
         },
         {
-          "type": "1\u00a0Day\u00a0Peace\u00a0Shield",
+          "type": "1 day peace shield",
           "value": 3
         },
         {
-          "type": "3\u00a0Day\u00a0Speed\u00a0Up",
-          "value": 7
+          "type": "3 day speed up",
+          "value": 9
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 46
+        "bonus1": 0.46
       },
       "build_costs": {
         "materials": [
@@ -2589,12 +2587,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 43758000000
-          },
-          {
             "type": "tritanium",
             "value": 402187500
+          },
+          {
+            "type": "parsteel",
+            "value": 43758000000
           },
           {
             "type": "dilithium",
@@ -2607,61 +2605,61 @@
       "level": 46,
       "requirements": [
         {
-          "name": "Shipyard",
+          "name": "shipyard",
           "level": 45
         },
         {
-          "name": "Defense Platform E",
+          "name": "defense platform e",
           "level": 40
         },
         {
-          "name": "Refinery",
+          "name": "refinery",
           "level": 45
         }
       ],
       "rewards": [
         {
-          "type": "Latinum",
-          "value": 400
+          "type": "latinum",
+          "value": 12000
         },
         {
-          "type": "1\u00a0Day\u00a0Peace\u00a0Shield",
+          "type": "1 day peace shield",
           "value": 3
         },
         {
-          "type": "3\u00a0Day\u00a0Speed\u00a0Up",
-          "value": 8
+          "type": "3 day speed up",
+          "value": 11
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 47
+        "bonus1": 0.47
       },
       "build_costs": {
         "materials": [
           {
             "type": "ore",
             "grade": 4,
-            "rarity": "uncommon",
-            "value": 30000
+            "rarity": "rare",
+            "value": 12000
           },
           {
             "type": "ore",
             "grade": 4,
-            "rarity": "rare",
-            "value": 12000
+            "rarity": "uncommon",
+            "value": 30000
           }
         ],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 63648000000
-          },
-          {
             "type": "tritanium",
             "value": 585000000
+          },
+          {
+            "type": "parsteel",
+            "value": 63648000000
           },
           {
             "type": "dilithium",
@@ -2674,46 +2672,46 @@
       "level": 47,
       "requirements": [
         {
-          "name": "Shipyard",
+          "name": "shipyard",
           "level": 46
         },
         {
-          "name": "Defense Platform E",
+          "name": "defense platform e",
           "level": 46
         }
       ],
       "rewards": [
         {
-          "type": "Latinum",
-          "value": 400
+          "type": "latinum",
+          "value": 14000
         },
         {
-          "type": "1\u00a0Day\u00a0Peace\u00a0Shield",
+          "type": "1 day peace shield",
           "value": 3
         },
         {
-          "type": "3\u00a0Day\u00a0Speed\u00a0Up",
-          "value": 9
+          "type": "3 day speed up",
+          "value": 13
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 48
+        "bonus1": 0.48
       },
       "build_costs": {
         "materials": [
           {
             "type": "ore",
             "grade": 4,
-            "rarity": "uncommon",
-            "value": 30000
+            "rarity": "rare",
+            "value": 8000
           },
           {
             "type": "ore",
             "grade": 4,
-            "rarity": "rare",
-            "value": 8000
+            "rarity": "uncommon",
+            "value": 30000
           }
         ],
         "others": [],
@@ -2723,12 +2721,12 @@
             "value": 102816000000
           },
           {
-            "type": "tritanium",
-            "value": 945000000
-          },
-          {
             "type": "dilithium",
             "value": 315000000
+          },
+          {
+            "type": "tritanium",
+            "value": 945000000
           }
         ]
       },
@@ -2737,61 +2735,61 @@
       "level": 48,
       "requirements": [
         {
-          "name": "Shipyard",
+          "name": "shipyard",
           "level": 47
         },
         {
-          "name": "Dilithium Vault",
+          "name": "dilithium vault",
           "level": 47
         },
         {
-          "name": "Ship Hangar",
+          "name": "ship hangar",
           "level": 47
         }
       ],
       "rewards": [
         {
-          "type": "3\u00a0Day\u00a0Speed\u00a0Up",
-          "value": 10
+          "type": "latinum",
+          "value": 16000
         },
         {
-          "type": "Latinum",
-          "value": 400
-        },
-        {
-          "type": "1\u00a0Day\u00a0Peace\u00a0Shield",
+          "type": "1 day peace shield",
           "value": 3
+        },
+        {
+          "type": "3 day speed up",
+          "value": 16
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 49
+        "bonus1": 0.49
       },
       "build_costs": {
         "materials": [
           {
             "type": "ore",
             "grade": 4,
-            "rarity": "uncommon",
-            "value": 12500
+            "rarity": "rare",
+            "value": 3400
           },
           {
             "type": "ore",
             "grade": 4,
-            "rarity": "rare",
-            "value": 3400
+            "rarity": "uncommon",
+            "value": 12500
           }
         ],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 171360000000
-          },
-          {
             "type": "tritanium",
             "value": 1575000000
+          },
+          {
+            "type": "parsteel",
+            "value": 171360000000
           },
           {
             "type": "dilithium",
@@ -2804,46 +2802,50 @@
       "level": 49,
       "requirements": [
         {
-          "name": "Shipyard",
+          "name": "shipyard",
           "level": 48
         }
       ],
       "rewards": [
         {
-          "type": "Latinum",
-          "value": 400
+          "type": "latinum",
+          "value": 18000
         },
         {
-          "type": "1\u00a0Day\u00a0Peace\u00a0Shield",
+          "type": "1 day peace shield",
           "value": 3
         },
         {
-          "type": "3\u00a0Day\u00a0Speed\u00a0Up",
-          "value": 11
+          "type": "3 day speed up",
+          "value": 20
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 50
+        "bonus1": 0.5
       },
       "build_costs": {
         "materials": [
           {
             "type": "ore",
             "grade": 4,
-            "rarity": "uncommon",
-            "value": 60000
+            "rarity": "rare",
+            "value": 20000
           },
           {
             "type": "ore",
             "grade": 4,
-            "rarity": "rare",
-            "value": 20000
+            "rarity": "uncommon",
+            "value": 60000
           }
         ],
         "others": [],
         "resources": [
+          {
+            "type": "dilithium",
+            "value": 918750000
+          },
           {
             "type": "parsteel",
             "value": 299880000000
@@ -2851,10 +2853,6 @@
           {
             "type": "tritanium",
             "value": 2756250000
-          },
-          {
-            "type": "dilithium",
-            "value": 918750000
           }
         ]
       },
@@ -2863,30 +2861,343 @@
       "level": 50,
       "requirements": [
         {
-          "name": "Ship Hangar",
+          "name": "ship hangar",
           "level": 49
         },
         {
-          "name": "Refinery",
+          "name": "refinery",
           "level": 49
         },
         {
-          "name": "Defense Platform E",
+          "name": "defense platform e",
           "level": 49
         }
       ],
       "rewards": [
         {
-          "type": "Latinum",
-          "value": 400
+          "type": "latinum",
+          "value": 20000
         },
         {
-          "type": "1\u00a0Day\u00a0Peace\u00a0Shield",
+          "type": "1 day peace shield",
           "value": 3
         },
         {
-          "type": "3\u00a0Day\u00a0Speed\u00a0Up",
-          "value": 12
+          "type": "3 day speed up",
+          "value": 24
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 0.51
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [
+          {
+            "type": "ascend key 2",
+            "value": 400
+          }
+        ],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 1495728000000
+          },
+          {
+            "type": "dilithium",
+            "value": 1950000000
+          },
+          {
+            "type": "tritanium",
+            "value": 5850000000
+          }
+        ]
+      },
+      "build_time": 372664800,
+      "increased_power": 11000,
+      "level": 51,
+      "requirements": [
+        {
+          "name": "shipyard",
+          "level": 50
+        },
+        {
+          "name": "armada control center",
+          "level": 45
+        },
+        {
+          "name": "shuttle bay",
+          "level": 5
+        }
+      ],
+      "rewards": [
+        {
+          "type": "5\u21f5 alliance galaxy consumable - 3 hour mining",
+          "value": 2
+        },
+        {
+          "type": "latinum",
+          "value": 32000
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 0.52
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "ore",
+            "grade": 5,
+            "rarity": "common",
+            "value": 42200
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 9945000000
+          },
+          {
+            "type": "parsteel",
+            "value": 2705040000000
+          },
+          {
+            "type": "dilithium",
+            "value": 3315000000
+          }
+        ]
+      },
+      "build_time": 395025120,
+      "increased_power": 10000,
+      "level": 52,
+      "requirements": [
+        {
+          "name": "shipyard",
+          "level": 51
+        },
+        {
+          "name": "parsteel vault",
+          "level": 51
+        }
+      ],
+      "rewards": [
+        {
+          "type": "latinum",
+          "value": 36000
+        },
+        {
+          "type": "7 day peace shield",
+          "value": 1
+        },
+        {
+          "type": "10 day speed up",
+          "value": 13
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 0.53
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "ore",
+            "grade": 5,
+            "rarity": "common",
+            "value": 55900
+          },
+          {
+            "type": "ore",
+            "grade": 5,
+            "rarity": "uncommon",
+            "value": 36700
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 4543488000000
+          },
+          {
+            "type": "tritanium",
+            "value": 17400000000
+          },
+          {
+            "type": "dilithium",
+            "value": 5800000000
+          }
+        ]
+      },
+      "build_time": 418726080,
+      "increased_power": 11000,
+      "level": 53,
+      "requirements": [
+        {
+          "name": "dilithium vault",
+          "level": 52
+        },
+        {
+          "name": "defense platform e",
+          "level": 52
+        },
+        {
+          "name": "ship hangar",
+          "level": 52
+        }
+      ],
+      "rewards": [
+        {
+          "type": "latinum",
+          "value": 40000
+        },
+        {
+          "type": "7 day peace shield",
+          "value": 1
+        },
+        {
+          "type": "10 day speed up",
+          "value": 14
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 0.54
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "ore",
+            "grade": 5,
+            "rarity": "uncommon",
+            "value": 46200
+          },
+          {
+            "type": "ore",
+            "grade": 5,
+            "rarity": "rare",
+            "value": 9600
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 26100000000
+          },
+          {
+            "type": "parsteel",
+            "value": 6815232000000
+          },
+          {
+            "type": "dilithium",
+            "value": 8700000000
+          }
+        ]
+      },
+      "build_time": 443849760,
+      "increased_power": 12000,
+      "level": 54,
+      "requirements": [
+        {
+          "name": "shipyard",
+          "level": 53
+        },
+        {
+          "name": "defense platform f",
+          "level": 10
+        },
+        {
+          "name": "astronautics studio",
+          "level": 53
+        }
+      ],
+      "rewards": [
+        {
+          "type": "latinum",
+          "value": 45000
+        },
+        {
+          "type": "10 day speed up",
+          "value": 15
+        },
+        {
+          "type": "5\u21f5 alliance station consumable - 1 hour repair cost efficiency",
+          "value": 2
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 0.55
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "ore",
+            "grade": 5,
+            "rarity": "rare",
+            "value": 12600
+          },
+          {
+            "type": "ore",
+            "grade": 5,
+            "rarity": "uncommon",
+            "value": 74000
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "dilithium",
+            "value": 13650000000
+          },
+          {
+            "type": "tritanium",
+            "value": 40950000000
+          },
+          {
+            "type": "parsteel",
+            "value": 11583936000000
+          }
+        ]
+      },
+      "build_time": 470481120,
+      "increased_power": 11000,
+      "level": 55,
+      "requirements": [
+        {
+          "name": "shipyard",
+          "level": 54
+        },
+        {
+          "name": "defense platform f",
+          "level": 20
+        },
+        {
+          "name": "defense technologies",
+          "level": 54
+        }
+      ],
+      "rewards": [
+        {
+          "type": "latinum",
+          "value": 51000
+        },
+        {
+          "type": "7 day peace shield",
+          "value": 1
+        },
+        {
+          "type": "10 day speed up",
+          "value": 16
         }
       ]
     }

--- a/buildings/parsteel_generator_a.json
+++ b/buildings/parsteel_generator_a.json
@@ -2,11 +2,11 @@
   "description": "Produces Parsteel, an alloy with immense tensile strength used to build Station buildings. Upgrading Parsteel Generators increases the amount of Parsteel that is produced.",
   "bonuses": {
     "bonus1": {
-      "name": "Parsteel Production",
+      "name": "parsteel production",
       "percentage": false
     },
     "bonus2": {
-      "name": "Parsteel Storage",
+      "name": "parsteel storage",
       "percentage": false
     }
   },
@@ -14,8 +14,8 @@
   "levels": [
     {
       "bonuses": {
-        "bonus1": 90,
-        "bonus2": 45
+        "bonus1": 90.0,
+        "bonus2": 45.0
       },
       "build_costs": {
         "materials": [],
@@ -32,16 +32,15 @@
       "level": 1,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 1
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 190,
-        "bonus2": 285
+        "bonus1": 190.0,
+        "bonus2": 285.0
       },
       "build_costs": {
         "materials": [],
@@ -58,16 +57,15 @@
       "level": 2,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 2
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 290,
-        "bonus2": 580
+        "bonus1": 290.0,
+        "bonus2": 580.0
       },
       "build_costs": {
         "materials": [],
@@ -84,16 +82,15 @@
       "level": 3,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 3
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 395,
-        "bonus2": 1190
+        "bonus1": 395.0,
+        "bonus2": 1190.0
       },
       "build_costs": {
         "materials": [],
@@ -110,16 +107,15 @@
       "level": 4,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 4
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 495,
-        "bonus2": 1975
+        "bonus1": 495.0,
+        "bonus2": 1975.0
       },
       "build_costs": {
         "materials": [],
@@ -136,16 +132,15 @@
       "level": 5,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 5
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 600,
-        "bonus2": 2700
+        "bonus1": 600.0,
+        "bonus2": 2700.0
       },
       "build_costs": {
         "materials": [],
@@ -162,28 +157,27 @@
       "level": 6,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 6
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 700,
-        "bonus2": 3850
+        "bonus1": 700.0,
+        "bonus2": 3850.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 700
-          },
-          {
             "type": "tritanium",
             "value": 5
+          },
+          {
+            "type": "parsteel",
+            "value": 700
           }
         ]
       },
@@ -192,16 +186,15 @@
       "level": 7,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 7
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 800,
-        "bonus2": 5200
+        "bonus1": 800.0,
+        "bonus2": 5200.0
       },
       "build_costs": {
         "materials": [],
@@ -222,28 +215,27 @@
       "level": 8,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 8
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 900,
-        "bonus2": 6300
+        "bonus1": 900.0,
+        "bonus2": 6300.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 2500
-          },
-          {
             "type": "tritanium",
             "value": 38
+          },
+          {
+            "type": "parsteel",
+            "value": 2500
           }
         ]
       },
@@ -252,28 +244,27 @@
       "level": 9,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 9
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 1200,
-        "bonus2": 9600
+        "bonus1": 1200.0,
+        "bonus2": 9600.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 2800
-          },
-          {
             "type": "tritanium",
             "value": 75
+          },
+          {
+            "type": "parsteel",
+            "value": 2800
           }
         ]
       },
@@ -282,28 +273,27 @@
       "level": 10,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 10
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 1320,
-        "bonus2": 11900
+        "bonus1": 1320.0,
+        "bonus2": 11900.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "tritanium",
-            "value": 100
-          },
-          {
             "type": "dilithium",
             "value": 20
+          },
+          {
+            "type": "tritanium",
+            "value": 100
           }
         ]
       },
@@ -312,16 +302,15 @@
       "level": 11,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 11
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 1450,
-        "bonus2": 15200
+        "bonus1": 1450.0,
+        "bonus2": 15200.0
       },
       "build_costs": {
         "materials": [],
@@ -342,16 +331,15 @@
       "level": 12,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 12
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 1550,
-        "bonus2": 17800
+        "bonus1": 1550.0,
+        "bonus2": 17800.0
       },
       "build_costs": {
         "materials": [],
@@ -372,28 +360,27 @@
       "level": 13,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 13
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 1675,
-        "bonus2": 21750
+        "bonus1": 1675.0,
+        "bonus2": 21750.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "tritanium",
-            "value": 275
-          },
-          {
             "type": "dilithium",
             "value": 220
+          },
+          {
+            "type": "tritanium",
+            "value": 275
           }
         ]
       },
@@ -402,27 +389,26 @@
       "level": 14,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 14
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 1800,
-        "bonus2": 25250
+        "bonus1": 1800.0,
+        "bonus2": 25250.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "tritanium",
+            "type": "dilithium",
             "value": 375
           },
           {
-            "type": "dilithium",
+            "type": "tritanium",
             "value": 375
           }
         ]
@@ -432,16 +418,15 @@
       "level": 15,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 15
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 1925,
-        "bonus2": 29000
+        "bonus1": 1925.0,
+        "bonus2": 29000.0
       },
       "build_costs": {
         "materials": [],
@@ -462,16 +447,15 @@
       "level": 16,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 16
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 2050,
-        "bonus2": 33750
+        "bonus1": 2050.0,
+        "bonus2": 33750.0
       },
       "build_costs": {
         "materials": [],
@@ -492,16 +476,15 @@
       "level": 17,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 17
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 2175,
-        "bonus2": 38000
+        "bonus1": 2175.0,
+        "bonus2": 38000.0
       },
       "build_costs": {
         "materials": [],
@@ -522,27 +505,26 @@
       "level": 18,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 18
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 2300,
-        "bonus2": 43750
+        "bonus1": 2300.0,
+        "bonus2": 43750.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "tritanium",
+            "type": "dilithium",
             "value": 1500
           },
           {
-            "type": "dilithium",
+            "type": "tritanium",
             "value": 1500
           }
         ]
@@ -552,16 +534,15 @@
       "level": 19,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 19
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 2825,
-        "bonus2": 56500
+        "bonus1": 2825.0,
+        "bonus2": 56500.0
       },
       "build_costs": {
         "materials": [],
@@ -582,16 +563,15 @@
       "level": 20,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 20
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 2950,
-        "bonus2": 59000
+        "bonus1": 2950.0,
+        "bonus2": 59000.0
       },
       "build_costs": {
         "materials": [],
@@ -612,27 +592,26 @@
       "level": 21,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 21
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 3100,
-        "bonus2": 62000
+        "bonus1": 3100.0,
+        "bonus2": 62000.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "tritanium",
+            "type": "dilithium",
             "value": 5565
           },
           {
-            "type": "dilithium",
+            "type": "tritanium",
             "value": 5565
           }
         ]
@@ -642,27 +621,26 @@
       "level": 22,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 22
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 3225,
-        "bonus2": 64500
+        "bonus1": 3225.0,
+        "bonus2": 64500.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "tritanium",
+            "type": "dilithium",
             "value": 9158
           },
           {
-            "type": "dilithium",
+            "type": "tritanium",
             "value": 9158
           }
         ]
@@ -672,27 +650,26 @@
       "level": 23,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 23
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 3375,
-        "bonus2": 67500
+        "bonus1": 3375.0,
+        "bonus2": 67500.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "tritanium",
+            "type": "dilithium",
             "value": 14430
           },
           {
-            "type": "dilithium",
+            "type": "tritanium",
             "value": 14430
           }
         ]
@@ -702,16 +679,15 @@
       "level": 24,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 24
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 4025,
-        "bonus2": 80500
+        "bonus1": 4025.0,
+        "bonus2": 80500.0
       },
       "build_costs": {
         "materials": [],
@@ -732,16 +708,15 @@
       "level": 25,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 25
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 4175,
-        "bonus2": 83500
+        "bonus1": 4175.0,
+        "bonus2": 83500.0
       },
       "build_costs": {
         "materials": [],
@@ -762,16 +737,15 @@
       "level": 26,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 26
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 4350,
-        "bonus2": 87000
+        "bonus1": 4350.0,
+        "bonus2": 87000.0
       },
       "build_costs": {
         "materials": [],
@@ -792,27 +766,26 @@
       "level": 27,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 27
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 4500,
-        "bonus2": 90000
+        "bonus1": 4500.0,
+        "bonus2": 90000.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "tritanium",
+            "type": "dilithium",
             "value": 83700
           },
           {
-            "type": "dilithium",
+            "type": "tritanium",
             "value": 83700
           }
         ]
@@ -822,27 +795,26 @@
       "level": 28,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 28
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 4675,
-        "bonus2": 93500
+        "bonus1": 4675.0,
+        "bonus2": 93500.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "tritanium",
+            "type": "dilithium",
             "value": 133250
           },
           {
-            "type": "dilithium",
+            "type": "tritanium",
             "value": 133250
           }
         ]
@@ -852,27 +824,26 @@
       "level": 29,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 29
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 5400,
-        "bonus2": 108000
+        "bonus1": 5400.0,
+        "bonus2": 108000.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "tritanium",
+            "type": "dilithium",
             "value": 195000
           },
           {
-            "type": "dilithium",
+            "type": "tritanium",
             "value": 195000
           }
         ]
@@ -882,16 +853,15 @@
       "level": 30,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 30
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 5600,
-        "bonus2": 112000
+        "bonus1": 5600.0,
+        "bonus2": 112000.0
       },
       "build_costs": {
         "materials": [],
@@ -912,27 +882,26 @@
       "level": 31,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 31
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 5800,
-        "bonus2": 125280
+        "bonus1": 5800.0,
+        "bonus2": 125280.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "tritanium",
+            "type": "dilithium",
             "value": 445250
           },
           {
-            "type": "dilithium",
+            "type": "tritanium",
             "value": 445250
           }
         ]
@@ -942,16 +911,15 @@
       "level": 32,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 32
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 6000,
-        "bonus2": 139200
+        "bonus1": 6000.0,
+        "bonus2": 139200.0
       },
       "build_costs": {
         "materials": [],
@@ -972,16 +940,15 @@
       "level": 33,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 33
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 6200,
-        "bonus2": 143840
+        "bonus1": 6200.0,
+        "bonus2": 143840.0
       },
       "build_costs": {
         "materials": [],
@@ -1002,27 +969,26 @@
       "level": 34,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 34
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 7000,
-        "bonus2": 173600
+        "bonus1": 7000.0,
+        "bonus2": 173600.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "tritanium",
+            "type": "dilithium",
             "value": 1683000
           },
           {
-            "type": "dilithium",
+            "type": "tritanium",
             "value": 1683000
           }
         ]
@@ -1032,16 +998,15 @@
       "level": 35,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 35
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 7300,
-        "bonus2": 194180
+        "bonus1": 7300.0,
+        "bonus2": 194180.0
       },
       "build_costs": {
         "materials": [],
@@ -1062,16 +1027,15 @@
       "level": 36,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 36
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 7500,
-        "bonus2": 199500
+        "bonus1": 7500.0,
+        "bonus2": 199500.0
       },
       "build_costs": {
         "materials": [],
@@ -1092,27 +1056,26 @@
       "level": 37,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 37
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 7700,
-        "bonus2": 218680
+        "bonus1": 7700.0,
+        "bonus2": 218680.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "tritanium",
+            "type": "dilithium",
             "value": 5670000
           },
           {
-            "type": "dilithium",
+            "type": "tritanium",
             "value": 5670000
           }
         ]
@@ -1122,16 +1085,15 @@
       "level": 38,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 38
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 7900,
-        "bonus2": 241740
+        "bonus1": 7900.0,
+        "bonus2": 241740.0
       },
       "build_costs": {
         "materials": [],
@@ -1152,16 +1114,15 @@
       "level": 39,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 39
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 8900,
-        "bonus2": 272340
+        "bonus1": 8900.0,
+        "bonus2": 272340.0
       },
       "build_costs": {
         "materials": [
@@ -1175,11 +1136,11 @@
         "others": [],
         "resources": [
           {
-            "type": "tritanium",
+            "type": "dilithium",
             "value": 15050000
           },
           {
-            "type": "dilithium",
+            "type": "tritanium",
             "value": 15050000
           }
         ]
@@ -1189,16 +1150,15 @@
       "level": 40,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 40
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 9100,
-        "bonus2": 300300
+        "bonus1": 9100.0,
+        "bonus2": 300300.0
       },
       "build_costs": {
         "materials": [
@@ -1226,16 +1186,15 @@
       "level": 41,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 41
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 9300,
-        "bonus2": 336660
+        "bonus1": 9300.0,
+        "bonus2": 336660.0
       },
       "build_costs": {
         "materials": [
@@ -1249,11 +1208,11 @@
         "others": [],
         "resources": [
           {
-            "type": "tritanium",
+            "type": "dilithium",
             "value": 32025000
           },
           {
-            "type": "dilithium",
+            "type": "tritanium",
             "value": 32025000
           }
         ]
@@ -1263,16 +1222,15 @@
       "level": 42,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 42
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 9500,
-        "bonus2": 343900
+        "bonus1": 9500.0,
+        "bonus2": 343900.0
       },
       "build_costs": {
         "materials": [
@@ -1300,16 +1258,15 @@
       "level": 43,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 43
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 9800,
-        "bonus2": 392000
+        "bonus1": 9800.0,
+        "bonus2": 392000.0
       },
       "build_costs": {
         "materials": [
@@ -1323,11 +1280,11 @@
         "others": [],
         "resources": [
           {
-            "type": "tritanium",
+            "type": "dilithium",
             "value": 68625000
           },
           {
-            "type": "dilithium",
+            "type": "tritanium",
             "value": 68625000
           }
         ]
@@ -1337,16 +1294,15 @@
       "level": 44,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 44
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 11300,
-        "bonus2": 508500
+        "bonus1": 11300.0,
+        "bonus2": 508500.0
       },
       "build_costs": {
         "materials": [
@@ -1374,30 +1330,29 @@
       "level": 45,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 45
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 11600,
-        "bonus2": 522000
+        "bonus1": 11600.0,
+        "bonus2": 522000.0
       },
       "build_costs": {
         "materials": [
           {
             "type": "ore",
             "grade": 4,
-            "rarity": "common",
-            "value": 15000
+            "rarity": "uncommon",
+            "value": 500
           },
           {
             "type": "ore",
             "grade": 4,
-            "rarity": "uncommon",
-            "value": 500
+            "rarity": "common",
+            "value": 15000
           }
         ],
         "others": [],
@@ -1417,16 +1372,15 @@
       "level": 46,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 46
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 11800,
-        "bonus2": 531000
+        "bonus1": 11800.0,
+        "bonus2": 531000.0
       },
       "build_costs": {
         "materials": [
@@ -1446,11 +1400,11 @@
         "others": [],
         "resources": [
           {
-            "type": "tritanium",
+            "type": "dilithium",
             "value": 195000000
           },
           {
-            "type": "dilithium",
+            "type": "tritanium",
             "value": 195000000
           }
         ]
@@ -1460,16 +1414,15 @@
       "level": 47,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 47
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 12100,
-        "bonus2": 544500
+        "bonus1": 12100.0,
+        "bonus2": 544500.0
       },
       "build_costs": {
         "materials": [
@@ -1503,16 +1456,15 @@
       "level": 48,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 48
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 12300,
-        "bonus2": 553500
+        "bonus1": 12300.0,
+        "bonus2": 553500.0
       },
       "build_costs": {
         "materials": [
@@ -1532,11 +1484,11 @@
         "others": [],
         "resources": [
           {
-            "type": "tritanium",
+            "type": "dilithium",
             "value": 525000000
           },
           {
-            "type": "dilithium",
+            "type": "tritanium",
             "value": 525000000
           }
         ]
@@ -1546,16 +1498,15 @@
       "level": 49,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 49
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 15100,
-        "bonus2": 679500
+        "bonus1": 15100.0,
+        "bonus2": 679500.0
       },
       "build_costs": {
         "materials": [],
@@ -1576,11 +1527,190 @@
       "level": 50,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 50
         }
-      ],
-      "rewards": []
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 15400.0,
+        "bonus2": 693000.0
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "ore",
+            "grade": 5,
+            "rarity": "common",
+            "value": 8800
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 1950000000
+          },
+          {
+            "type": "dilithium",
+            "value": 1950000000
+          }
+        ]
+      },
+      "build_time": 14906880,
+      "increased_power": 2000,
+      "level": 51,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 51
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 15700.0,
+        "bonus2": 706500.0
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "ore",
+            "grade": 5,
+            "rarity": "common",
+            "value": 21900
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 3315000000
+          },
+          {
+            "type": "dilithium",
+            "value": 3315000000
+          }
+        ]
+      },
+      "build_time": 15801120,
+      "increased_power": 1500,
+      "level": 52,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 52
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 16000.0,
+        "bonus2": 720000.0
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "ore",
+            "grade": 5,
+            "rarity": "common",
+            "value": 42200
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "dilithium",
+            "value": 5800000000
+          },
+          {
+            "type": "tritanium",
+            "value": 5800000000
+          }
+        ]
+      },
+      "build_time": 16748640,
+      "increased_power": 2000,
+      "level": 53,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 53
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 16300.0,
+        "bonus2": 733500.0
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "ore",
+            "grade": 5,
+            "rarity": "common",
+            "value": 43100
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "dilithium",
+            "value": 8700000000
+          },
+          {
+            "type": "tritanium",
+            "value": 8700000000
+          }
+        ]
+      },
+      "build_time": 17753760,
+      "increased_power": 2000,
+      "level": 54,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 54
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 19400.0,
+        "bonus2": 873000.0
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "ore",
+            "grade": 5,
+            "rarity": "common",
+            "value": 74800
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 13650000000
+          },
+          {
+            "type": "dilithium",
+            "value": 13650000000
+          }
+        ]
+      },
+      "build_time": 18819360,
+      "increased_power": 2000,
+      "level": 55,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 55
+        }
+      ]
     }
   ]
 }

--- a/buildings/parsteel_generator_b.json
+++ b/buildings/parsteel_generator_b.json
@@ -2,11 +2,11 @@
   "description": "Produces Parsteel, an alloy with immense tensile strength used to build Station buildings. Upgrading Parsteel Generators increases the amount of Parsteel that is produced.",
   "bonuses": {
     "bonus1": {
-      "name": "Parsteel Production",
+      "name": "parsteel production",
       "percentage": false
     },
     "bonus2": {
-      "name": "Parsteel Storage",
+      "name": "parsteel storage",
       "percentage": false
     }
   },
@@ -14,8 +14,8 @@
   "levels": [
     {
       "bonuses": {
-        "bonus1": 90,
-        "bonus2": 45
+        "bonus1": 90.0,
+        "bonus2": 45.0
       },
       "build_costs": {
         "materials": [],
@@ -32,20 +32,19 @@
       "level": 1,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 2
         },
         {
-          "name": "Parsteel Generator A",
+          "name": "parsteel generator a",
           "level": 1
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 190,
-        "bonus2": 285
+        "bonus1": 190.0,
+        "bonus2": 285.0
       },
       "build_costs": {
         "materials": [],
@@ -62,20 +61,19 @@
       "level": 2,
       "requirements": [
         {
-          "name": "Parsteel Generator A",
-          "level": 2
+          "name": "operations",
+          "level": 3
         },
         {
-          "name": "Operations",
-          "level": 3
+          "name": "parsteel generator a",
+          "level": 2
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 290,
-        "bonus2": 580
+        "bonus1": 290.0,
+        "bonus2": 580.0
       },
       "build_costs": {
         "materials": [],
@@ -92,20 +90,19 @@
       "level": 3,
       "requirements": [
         {
-          "name": "Parsteel Generator A",
+          "name": "operations",
           "level": 3
         },
         {
-          "name": "Operations",
+          "name": "parsteel generator a",
           "level": 3
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 395,
-        "bonus2": 1190
+        "bonus1": 395.0,
+        "bonus2": 1190.0
       },
       "build_costs": {
         "materials": [],
@@ -122,20 +119,19 @@
       "level": 4,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 4
         },
         {
-          "name": "Parsteel Generator A",
+          "name": "parsteel generator a",
           "level": 4
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 495,
-        "bonus2": 1975
+        "bonus1": 495.0,
+        "bonus2": 1975.0
       },
       "build_costs": {
         "materials": [],
@@ -152,20 +148,19 @@
       "level": 5,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 5
         },
         {
-          "name": "Parsteel Generator A",
+          "name": "parsteel generator a",
           "level": 5
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 600,
-        "bonus2": 2700
+        "bonus1": 600.0,
+        "bonus2": 2700.0
       },
       "build_costs": {
         "materials": [],
@@ -182,32 +177,31 @@
       "level": 6,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 6
         },
         {
-          "name": "Parsteel Generator A",
+          "name": "parsteel generator a",
           "level": 6
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 700,
-        "bonus2": 3850
+        "bonus1": 700.0,
+        "bonus2": 3850.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 700
-          },
-          {
             "type": "tritanium",
             "value": 5
+          },
+          {
+            "type": "parsteel",
+            "value": 700
           }
         ]
       },
@@ -216,20 +210,19 @@
       "level": 7,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 7
         },
         {
-          "name": "Parsteel Generator A",
+          "name": "parsteel generator a",
           "level": 7
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 800,
-        "bonus2": 5200
+        "bonus1": 800.0,
+        "bonus2": 5200.0
       },
       "build_costs": {
         "materials": [],
@@ -250,20 +243,19 @@
       "level": 8,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 8
         },
         {
-          "name": "Parsteel Generator A",
+          "name": "parsteel generator a",
           "level": 8
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 900,
-        "bonus2": 6300
+        "bonus1": 900.0,
+        "bonus2": 6300.0
       },
       "build_costs": {
         "materials": [],
@@ -284,32 +276,31 @@
       "level": 9,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 9
         },
         {
-          "name": "Parsteel Generator A",
+          "name": "parsteel generator a",
           "level": 9
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 1200,
-        "bonus2": 9600
+        "bonus1": 1200.0,
+        "bonus2": 9600.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 2800
-          },
-          {
             "type": "tritanium",
             "value": 75
+          },
+          {
+            "type": "parsteel",
+            "value": 2800
           }
         ]
       },
@@ -318,32 +309,31 @@
       "level": 10,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 10
         },
         {
-          "name": "Parsteel Generator A",
+          "name": "parsteel generator a",
           "level": 10
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 1320,
-        "bonus2": 11900
+        "bonus1": 1320.0,
+        "bonus2": 11900.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "tritanium",
-            "value": 100
-          },
-          {
             "type": "dilithium",
             "value": 20
+          },
+          {
+            "type": "tritanium",
+            "value": 100
           }
         ]
       },
@@ -352,32 +342,31 @@
       "level": 11,
       "requirements": [
         {
-          "name": "Parsteel Generator A",
+          "name": "operations",
           "level": 11
         },
         {
-          "name": "Operations",
+          "name": "parsteel generator a",
           "level": 11
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 1450,
-        "bonus2": 15200
+        "bonus1": 1450.0,
+        "bonus2": 15200.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "tritanium",
-            "value": 138
-          },
-          {
             "type": "dilithium",
             "value": 55
+          },
+          {
+            "type": "tritanium",
+            "value": 138
           }
         ]
       },
@@ -386,20 +375,19 @@
       "level": 12,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 12
         },
         {
-          "name": "Parsteel Generator A",
+          "name": "parsteel generator a",
           "level": 12
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 1550,
-        "bonus2": 17800
+        "bonus1": 1550.0,
+        "bonus2": 17800.0
       },
       "build_costs": {
         "materials": [],
@@ -420,20 +408,19 @@
       "level": 13,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 13
         },
         {
-          "name": "Parsteel Generator A",
+          "name": "parsteel generator a",
           "level": 13
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 1675,
-        "bonus2": 21750
+        "bonus1": 1675.0,
+        "bonus2": 21750.0
       },
       "build_costs": {
         "materials": [],
@@ -454,31 +441,30 @@
       "level": 14,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 14
         },
         {
-          "name": "Parsteel Generator A",
+          "name": "parsteel generator a",
           "level": 14
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 1800,
-        "bonus2": 25250
+        "bonus1": 1800.0,
+        "bonus2": 25250.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "tritanium",
+            "type": "dilithium",
             "value": 375
           },
           {
-            "type": "dilithium",
+            "type": "tritanium",
             "value": 375
           }
         ]
@@ -488,20 +474,19 @@
       "level": 15,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 15
         },
         {
-          "name": "Parsteel Generator A",
+          "name": "parsteel generator a",
           "level": 15
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 1925,
-        "bonus2": 29000
+        "bonus1": 1925.0,
+        "bonus2": 29000.0
       },
       "build_costs": {
         "materials": [],
@@ -522,31 +507,30 @@
       "level": 16,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 16
         },
         {
-          "name": "Parsteel Generator A",
+          "name": "parsteel generator a",
           "level": 16
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 2050,
-        "bonus2": 33750
+        "bonus1": 2050.0,
+        "bonus2": 33750.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "tritanium",
+            "type": "dilithium",
             "value": 700
           },
           {
-            "type": "dilithium",
+            "type": "tritanium",
             "value": 700
           }
         ]
@@ -556,31 +540,30 @@
       "level": 17,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 17
         },
         {
-          "name": "Parsteel Generator A",
+          "name": "parsteel generator a",
           "level": 17
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 2175,
-        "bonus2": 38000
+        "bonus1": 2175.0,
+        "bonus2": 38000.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "tritanium",
+            "type": "dilithium",
             "value": 1000
           },
           {
-            "type": "dilithium",
+            "type": "tritanium",
             "value": 1000
           }
         ]
@@ -590,20 +573,19 @@
       "level": 18,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 18
         },
         {
-          "name": "Parsteel Generator A",
+          "name": "parsteel generator a",
           "level": 18
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 2300,
-        "bonus2": 43750
+        "bonus1": 2300.0,
+        "bonus2": 43750.0
       },
       "build_costs": {
         "materials": [],
@@ -624,31 +606,30 @@
       "level": 19,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 19
         },
         {
-          "name": "Parsteel Generator A",
+          "name": "parsteel generator a",
           "level": 19
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 2825,
-        "bonus2": 56500
+        "bonus1": 2825.0,
+        "bonus2": 56500.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "tritanium",
+            "type": "dilithium",
             "value": 2125
           },
           {
-            "type": "dilithium",
+            "type": "tritanium",
             "value": 2125
           }
         ]
@@ -658,31 +639,30 @@
       "level": 20,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 20
         },
         {
-          "name": "Parsteel Generator A",
+          "name": "parsteel generator a",
           "level": 20
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 2950,
-        "bonus2": 59000
+        "bonus1": 2950.0,
+        "bonus2": 59000.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "tritanium",
+            "type": "dilithium",
             "value": 3578
           },
           {
-            "type": "dilithium",
+            "type": "tritanium",
             "value": 3578
           }
         ]
@@ -692,20 +672,19 @@
       "level": 21,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 21
         },
         {
-          "name": "Parsteel Generator A",
+          "name": "parsteel generator a",
           "level": 21
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 3100,
-        "bonus2": 62000
+        "bonus1": 3100.0,
+        "bonus2": 62000.0
       },
       "build_costs": {
         "materials": [],
@@ -726,31 +705,30 @@
       "level": 22,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 22
         },
         {
-          "name": "Parsteel Generator A",
+          "name": "parsteel generator a",
           "level": 22
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 3225,
-        "bonus2": 64500
+        "bonus1": 3225.0,
+        "bonus2": 64500.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "tritanium",
+            "type": "dilithium",
             "value": 9158
           },
           {
-            "type": "dilithium",
+            "type": "tritanium",
             "value": 9158
           }
         ]
@@ -760,20 +738,19 @@
       "level": 23,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 23
         },
         {
-          "name": "Parsteel Generator A",
+          "name": "parsteel generator a",
           "level": 23
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 3375,
-        "bonus2": 67500
+        "bonus1": 3375.0,
+        "bonus2": 67500.0
       },
       "build_costs": {
         "materials": [],
@@ -794,20 +771,19 @@
       "level": 24,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 24
         },
         {
-          "name": "Parsteel Generator A",
+          "name": "parsteel generator a",
           "level": 24
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 4025,
-        "bonus2": 80500
+        "bonus1": 4025.0,
+        "bonus2": 80500.0
       },
       "build_costs": {
         "materials": [],
@@ -828,31 +804,30 @@
       "level": 25,
       "requirements": [
         {
-          "name": "Parsteel Generator A",
+          "name": "operations",
           "level": 25
         },
         {
-          "name": "Operations",
+          "name": "parsteel generator a",
           "level": 25
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 4175,
-        "bonus2": 83500
+        "bonus1": 4175.0,
+        "bonus2": 83500.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "tritanium",
+            "type": "dilithium",
             "value": 36563
           },
           {
-            "type": "dilithium",
+            "type": "tritanium",
             "value": 36563
           }
         ]
@@ -862,31 +837,30 @@
       "level": 26,
       "requirements": [
         {
-          "name": "Parsteel Generator A",
+          "name": "operations",
           "level": 26
         },
         {
-          "name": "Operations",
+          "name": "parsteel generator a",
           "level": 26
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 4350,
-        "bonus2": 87000
+        "bonus1": 4350.0,
+        "bonus2": 87000.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "tritanium",
+            "type": "dilithium",
             "value": 55800
           },
           {
-            "type": "dilithium",
+            "type": "tritanium",
             "value": 55800
           }
         ]
@@ -896,31 +870,30 @@
       "level": 27,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 27
         },
         {
-          "name": "Parsteel Generator A",
+          "name": "parsteel generator a",
           "level": 27
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 4500,
-        "bonus2": 90000
+        "bonus1": 4500.0,
+        "bonus2": 90000.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "tritanium",
+            "type": "dilithium",
             "value": 83700
           },
           {
-            "type": "dilithium",
+            "type": "tritanium",
             "value": 83700
           }
         ]
@@ -930,20 +903,19 @@
       "level": 28,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 28
         },
         {
-          "name": "Parsteel Generator A",
+          "name": "parsteel generator a",
           "level": 28
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 4675,
-        "bonus2": 93500
+        "bonus1": 4675.0,
+        "bonus2": 93500.0
       },
       "build_costs": {
         "materials": [],
@@ -964,20 +936,19 @@
       "level": 29,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 29
         },
         {
-          "name": "Parsteel Generator A",
+          "name": "parsteel generator a",
           "level": 29
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 5400,
-        "bonus2": 108000
+        "bonus1": 5400.0,
+        "bonus2": 108000.0
       },
       "build_costs": {
         "materials": [],
@@ -998,31 +969,30 @@
       "level": 30,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 30
         },
         {
-          "name": "Parsteel Generator A",
+          "name": "parsteel generator a",
           "level": 30
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 5600,
-        "bonus2": 112000
+        "bonus1": 5600.0,
+        "bonus2": 112000.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "tritanium",
+            "type": "dilithium",
             "value": 308250
           },
           {
-            "type": "dilithium",
+            "type": "tritanium",
             "value": 308250
           }
         ]
@@ -1032,20 +1002,19 @@
       "level": 31,
       "requirements": [
         {
-          "name": "Parsteel Generator A",
+          "name": "operations",
           "level": 31
         },
         {
-          "name": "Operations",
+          "name": "parsteel generator a",
           "level": 31
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 5800,
-        "bonus2": 125280
+        "bonus1": 5800.0,
+        "bonus2": 125280.0
       },
       "build_costs": {
         "materials": [],
@@ -1066,20 +1035,19 @@
       "level": 32,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 32
         },
         {
-          "name": "Parsteel Generator A",
+          "name": "parsteel generator a",
           "level": 32
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 6000,
-        "bonus2": 139200
+        "bonus1": 6000.0,
+        "bonus2": 139200.0
       },
       "build_costs": {
         "materials": [],
@@ -1100,20 +1068,19 @@
       "level": 33,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 33
         },
         {
-          "name": "Parsteel Generator A",
+          "name": "parsteel generator a",
           "level": 33
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 6200,
-        "bonus2": 143840
+        "bonus1": 6200.0,
+        "bonus2": 143840.0
       },
       "build_costs": {
         "materials": [],
@@ -1134,31 +1101,30 @@
       "level": 34,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 34
         },
         {
-          "name": "Parsteel Generator A",
+          "name": "parsteel generator a",
           "level": 34
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 7000,
-        "bonus2": 173600
+        "bonus1": 7000.0,
+        "bonus2": 173600.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "tritanium",
+            "type": "dilithium",
             "value": 1683000
           },
           {
-            "type": "dilithium",
+            "type": "tritanium",
             "value": 1683000
           }
         ]
@@ -1168,31 +1134,30 @@
       "level": 35,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 35
         },
         {
-          "name": "Parsteel Generator A",
+          "name": "parsteel generator a",
           "level": 35
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 7300,
-        "bonus2": 194180
+        "bonus1": 7300.0,
+        "bonus2": 194180.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "tritanium",
+            "type": "dilithium",
             "value": 2371500
           },
           {
-            "type": "dilithium",
+            "type": "tritanium",
             "value": 2371500
           }
         ]
@@ -1202,20 +1167,19 @@
       "level": 36,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 36
         },
         {
-          "name": "Parsteel Generator A",
+          "name": "parsteel generator a",
           "level": 36
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 7500,
-        "bonus2": 199500
+        "bonus1": 7500.0,
+        "bonus2": 199500.0
       },
       "build_costs": {
         "materials": [],
@@ -1236,20 +1200,19 @@
       "level": 37,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 37
         },
         {
-          "name": "Parsteel Generator A",
+          "name": "parsteel generator a",
           "level": 37
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 7700,
-        "bonus2": 218680
+        "bonus1": 7700.0,
+        "bonus2": 218680.0
       },
       "build_costs": {
         "materials": [],
@@ -1270,31 +1233,30 @@
       "level": 38,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 38
         },
         {
-          "name": "Parsteel Generator A",
+          "name": "parsteel generator a",
           "level": 38
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 7900,
-        "bonus2": 241740
+        "bonus1": 7900.0,
+        "bonus2": 241740.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "tritanium",
+            "type": "dilithium",
             "value": 9675000
           },
           {
-            "type": "dilithium",
+            "type": "tritanium",
             "value": 9675000
           }
         ]
@@ -1304,20 +1266,19 @@
       "level": 39,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 39
         },
         {
-          "name": "Parsteel Generator A",
+          "name": "parsteel generator a",
           "level": 39
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 8900,
-        "bonus2": 272340
+        "bonus1": 8900.0,
+        "bonus2": 272340.0
       },
       "build_costs": {
         "materials": [
@@ -1345,20 +1306,19 @@
       "level": 40,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 40
         },
         {
-          "name": "Parsteel Generator A",
+          "name": "parsteel generator a",
           "level": 40
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 9100,
-        "bonus2": 300300
+        "bonus1": 9100.0,
+        "bonus2": 300300.0
       },
       "build_costs": {
         "materials": [
@@ -1386,20 +1346,19 @@
       "level": 41,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 41
         },
         {
-          "name": "Parsteel Generator A",
+          "name": "parsteel generator a",
           "level": 41
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 9300,
-        "bonus2": 336660
+        "bonus1": 9300.0,
+        "bonus2": 336660.0
       },
       "build_costs": {
         "materials": [
@@ -1427,20 +1386,19 @@
       "level": 42,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 42
         },
         {
-          "name": "Parsteel Generator A",
+          "name": "parsteel generator a",
           "level": 42
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 9500,
-        "bonus2": 343900
+        "bonus1": 9500.0,
+        "bonus2": 343900.0
       },
       "build_costs": {
         "materials": [
@@ -1454,11 +1412,11 @@
         "others": [],
         "resources": [
           {
-            "type": "tritanium",
+            "type": "dilithium",
             "value": 45750000
           },
           {
-            "type": "dilithium",
+            "type": "tritanium",
             "value": 45750000
           }
         ]
@@ -1468,20 +1426,19 @@
       "level": 43,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 43
         },
         {
-          "name": "Parsteel Generator A",
+          "name": "parsteel generator a",
           "level": 43
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 9800,
-        "bonus2": 392000
+        "bonus1": 9800.0,
+        "bonus2": 392000.0
       },
       "build_costs": {
         "materials": [
@@ -1509,20 +1466,19 @@
       "level": 44,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 44
         },
         {
-          "name": "Parsteel Generator A",
+          "name": "parsteel generator a",
           "level": 44
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 11300,
-        "bonus2": 508500
+        "bonus1": 11300.0,
+        "bonus2": 508500.0
       },
       "build_costs": {
         "materials": [
@@ -1536,11 +1492,11 @@
         "others": [],
         "resources": [
           {
-            "type": "tritanium",
+            "type": "dilithium",
             "value": 97500000
           },
           {
-            "type": "dilithium",
+            "type": "tritanium",
             "value": 97500000
           }
         ]
@@ -1550,34 +1506,33 @@
       "level": 45,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 45
         },
         {
-          "name": "Parsteel Generator A",
+          "name": "parsteel generator a",
           "level": 45
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 11600,
-        "bonus2": 522000
+        "bonus1": 11600.0,
+        "bonus2": 522000.0
       },
       "build_costs": {
         "materials": [
           {
             "type": "ore",
             "grade": 4,
-            "rarity": "common",
-            "value": 15000
+            "rarity": "uncommon",
+            "value": 500
           },
           {
             "type": "ore",
             "grade": 4,
-            "rarity": "uncommon",
-            "value": 500
+            "rarity": "common",
+            "value": 15000
           }
         ],
         "others": [],
@@ -1597,34 +1552,33 @@
       "level": 46,
       "requirements": [
         {
-          "name": "Parsteel Generator A",
+          "name": "operations",
           "level": 46
         },
         {
-          "name": "Operations",
+          "name": "parsteel generator a",
           "level": 46
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 11800,
-        "bonus2": 531000
+        "bonus1": 11800.0,
+        "bonus2": 531000.0
       },
       "build_costs": {
         "materials": [
           {
             "type": "ore",
             "grade": 4,
-            "rarity": "common",
-            "value": 30000
+            "rarity": "uncommon",
+            "value": 1000
           },
           {
             "type": "ore",
             "grade": 4,
-            "rarity": "uncommon",
-            "value": 1000
+            "rarity": "common",
+            "value": 30000
           }
         ],
         "others": [],
@@ -1644,34 +1598,33 @@
       "level": 47,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 47
         },
         {
-          "name": "Parsteel Generator A",
+          "name": "parsteel generator a",
           "level": 47
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 12100,
-        "bonus2": 544500
+        "bonus1": 12100.0,
+        "bonus2": 544500.0
       },
       "build_costs": {
         "materials": [
           {
             "type": "ore",
             "grade": 4,
-            "rarity": "common",
-            "value": 15000
+            "rarity": "uncommon",
+            "value": 6000
           },
           {
             "type": "ore",
             "grade": 4,
-            "rarity": "uncommon",
-            "value": 6000
+            "rarity": "common",
+            "value": 15000
           }
         ],
         "others": [],
@@ -1691,44 +1644,43 @@
       "level": 48,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 48
         },
         {
-          "name": "Parsteel Generator A",
+          "name": "parsteel generator a",
           "level": 48
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 12300,
-        "bonus2": 553500
+        "bonus1": 12300.0,
+        "bonus2": 553500.0
       },
       "build_costs": {
         "materials": [
           {
             "type": "ore",
             "grade": 4,
-            "rarity": "common",
-            "value": 20000
+            "rarity": "uncommon",
+            "value": 13250
           },
           {
             "type": "ore",
             "grade": 4,
-            "rarity": "uncommon",
-            "value": 13250
+            "rarity": "common",
+            "value": 20000
           }
         ],
         "others": [],
         "resources": [
           {
-            "type": "tritanium",
+            "type": "dilithium",
             "value": 525000000
           },
           {
-            "type": "dilithium",
+            "type": "tritanium",
             "value": 525000000
           }
         ]
@@ -1738,20 +1690,19 @@
       "level": 49,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 49
         },
         {
-          "name": "Parsteel Generator A",
+          "name": "parsteel generator a",
           "level": 49
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 15100,
-        "bonus2": 679500
+        "bonus1": 15100.0,
+        "bonus2": 679500.0
       },
       "build_costs": {
         "materials": [],
@@ -1772,15 +1723,214 @@
       "level": 50,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 50
         },
         {
-          "name": "Parsteel Generator A",
+          "name": "parsteel generator a",
           "level": 50
         }
-      ],
-      "rewards": []
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 15400.0,
+        "bonus2": 693000.0
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "ore",
+            "grade": 5,
+            "rarity": "common",
+            "value": 8800
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "dilithium",
+            "value": 1950000000
+          },
+          {
+            "type": "tritanium",
+            "value": 1950000000
+          }
+        ]
+      },
+      "build_time": 14906880,
+      "increased_power": 2000,
+      "level": 51,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 51
+        },
+        {
+          "name": "parsteel generator a",
+          "level": 51
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 15700.0,
+        "bonus2": 706500.0
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "ore",
+            "grade": 5,
+            "rarity": "common",
+            "value": 21900
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 3315000000
+          },
+          {
+            "type": "dilithium",
+            "value": 3315000000
+          }
+        ]
+      },
+      "build_time": 15801120,
+      "increased_power": 1500,
+      "level": 52,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 52
+        },
+        {
+          "name": "parsteel generator a",
+          "level": 52
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 16000.0,
+        "bonus2": 720000.0
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "ore",
+            "grade": 5,
+            "rarity": "common",
+            "value": 42200
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "dilithium",
+            "value": 5800000000
+          },
+          {
+            "type": "tritanium",
+            "value": 5800000000
+          }
+        ]
+      },
+      "build_time": 16748640,
+      "increased_power": 2000,
+      "level": 53,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 53
+        },
+        {
+          "name": "parsteel generator a",
+          "level": 53
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 16300.0,
+        "bonus2": 733500.0
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "ore",
+            "grade": 5,
+            "rarity": "common",
+            "value": 43100
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "dilithium",
+            "value": 8700000000
+          },
+          {
+            "type": "tritanium",
+            "value": 8700000000
+          }
+        ]
+      },
+      "build_time": 17753760,
+      "increased_power": 2000,
+      "level": 54,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 54
+        },
+        {
+          "name": "parsteel generator a",
+          "level": 54
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 19400.0,
+        "bonus2": 873000.0
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "ore",
+            "grade": 5,
+            "rarity": "common",
+            "value": 74800
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "dilithium",
+            "value": 13650000000
+          },
+          {
+            "type": "tritanium",
+            "value": 13650000000
+          }
+        ]
+      },
+      "build_time": 18819360,
+      "increased_power": 2000,
+      "level": 55,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 55
+        },
+        {
+          "name": "parsteel generator a",
+          "level": 55
+        }
+      ]
     }
   ]
 }

--- a/buildings/parsteel_generator_c.json
+++ b/buildings/parsteel_generator_c.json
@@ -2,11 +2,11 @@
   "description": "Produces Parsteel, an alloy with immense tensile strength used to build Station buildings. Upgrading Parsteel Generators increases the amount of Parsteel that is produced.",
   "bonuses": {
     "bonus1": {
-      "name": "Parsteel Production",
+      "name": "parsteel production",
       "percentage": false
     },
     "bonus2": {
-      "name": "Parsteel Storage",
+      "name": "parsteel storage",
       "percentage": false
     }
   },
@@ -14,20 +14,20 @@
   "levels": [
     {
       "bonuses": {
-        "bonus1": 90,
-        "bonus2": 45
+        "bonus1": 90.0,
+        "bonus2": 45.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 10
-          },
-          {
             "type": "tritanium",
             "value": 50
+          },
+          {
+            "type": "parsteel",
+            "value": 10
           }
         ]
       },
@@ -36,20 +36,19 @@
       "level": 1,
       "requirements": [
         {
-          "name": "Parsteel Generator A",
-          "level": 7
+          "name": "operations",
+          "level": 8
         },
         {
-          "name": "Operations",
-          "level": 8
+          "name": "parsteel generator a",
+          "level": 7
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 190,
-        "bonus2": 285
+        "bonus1": 190.0,
+        "bonus2": 285.0
       },
       "build_costs": {
         "materials": [],
@@ -70,32 +69,31 @@
       "level": 2,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 8
         },
         {
-          "name": "Parsteel Generator A",
+          "name": "parsteel generator a",
           "level": 7
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 290,
-        "bonus2": 580
+        "bonus1": 290.0,
+        "bonus2": 580.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 35
-          },
-          {
             "type": "tritanium",
             "value": 75
+          },
+          {
+            "type": "parsteel",
+            "value": 35
           }
         ]
       },
@@ -104,20 +102,19 @@
       "level": 3,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 8
         },
         {
-          "name": "Parsteel Generator A",
+          "name": "parsteel generator a",
           "level": 7
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 395,
-        "bonus2": 1190
+        "bonus1": 395.0,
+        "bonus2": 1190.0
       },
       "build_costs": {
         "materials": [],
@@ -138,32 +135,31 @@
       "level": 4,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 8
         },
         {
-          "name": "Parsteel Generator A",
+          "name": "parsteel generator a",
           "level": 7
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 495,
-        "bonus2": 1975
+        "bonus1": 495.0,
+        "bonus2": 1975.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 120
-          },
-          {
             "type": "tritanium",
             "value": 150
+          },
+          {
+            "type": "parsteel",
+            "value": 120
           }
         ]
       },
@@ -172,20 +168,19 @@
       "level": 5,
       "requirements": [
         {
-          "name": "Parsteel Generator A",
-          "level": 7
+          "name": "operations",
+          "level": 8
         },
         {
-          "name": "Operations",
-          "level": 8
+          "name": "parsteel generator a",
+          "level": 7
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 600,
-        "bonus2": 2700
+        "bonus1": 600.0,
+        "bonus2": 2700.0
       },
       "build_costs": {
         "materials": [],
@@ -206,20 +201,19 @@
       "level": 6,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 8
         },
         {
-          "name": "Parsteel Generator A",
+          "name": "parsteel generator a",
           "level": 7
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 700,
-        "bonus2": 3850
+        "bonus1": 700.0,
+        "bonus2": 3850.0
       },
       "build_costs": {
         "materials": [],
@@ -240,32 +234,31 @@
       "level": 7,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 8
         },
         {
-          "name": "Parsteel Generator A",
+          "name": "parsteel generator a",
           "level": 7
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 800,
-        "bonus2": 5200
+        "bonus1": 800.0,
+        "bonus2": 5200.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 1200
-          },
-          {
             "type": "tritanium",
             "value": 300
+          },
+          {
+            "type": "parsteel",
+            "value": 1200
           }
         ]
       },
@@ -274,32 +267,31 @@
       "level": 8,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 8
         },
         {
-          "name": "Parsteel Generator A",
+          "name": "parsteel generator a",
           "level": 8
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 900,
-        "bonus2": 6300
+        "bonus1": 900.0,
+        "bonus2": 6300.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 2500
-          },
-          {
             "type": "tritanium",
             "value": 350
+          },
+          {
+            "type": "parsteel",
+            "value": 2500
           }
         ]
       },
@@ -308,32 +300,31 @@
       "level": 9,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 9
         },
         {
-          "name": "Parsteel Generator A",
+          "name": "parsteel generator a",
           "level": 9
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 1200,
-        "bonus2": 9600
+        "bonus1": 1200.0,
+        "bonus2": 9600.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 2800
-          },
-          {
             "type": "tritanium",
             "value": 450
+          },
+          {
+            "type": "parsteel",
+            "value": 2800
           }
         ]
       },
@@ -342,20 +333,19 @@
       "level": 10,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 10
         },
         {
-          "name": "Parsteel Generator A",
+          "name": "parsteel generator a",
           "level": 10
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 1320,
-        "bonus2": 11900
+        "bonus1": 1320.0,
+        "bonus2": 11900.0
       },
       "build_costs": {
         "materials": [],
@@ -376,32 +366,31 @@
       "level": 11,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 11
         },
         {
-          "name": "Parsteel Generator A",
+          "name": "parsteel generator a",
           "level": 11
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 1450,
-        "bonus2": 15200
+        "bonus1": 1450.0,
+        "bonus2": 15200.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "tritanium",
-            "value": 138
-          },
-          {
             "type": "dilithium",
             "value": 55
+          },
+          {
+            "type": "tritanium",
+            "value": 138
           }
         ]
       },
@@ -410,20 +399,19 @@
       "level": 12,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 12
         },
         {
-          "name": "Parsteel Generator A",
+          "name": "parsteel generator a",
           "level": 12
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 1550,
-        "bonus2": 17800
+        "bonus1": 1550.0,
+        "bonus2": 17800.0
       },
       "build_costs": {
         "materials": [],
@@ -444,20 +432,19 @@
       "level": 13,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 13
         },
         {
-          "name": "Parsteel Generator A",
+          "name": "parsteel generator a",
           "level": 13
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 1675,
-        "bonus2": 21750
+        "bonus1": 1675.0,
+        "bonus2": 21750.0
       },
       "build_costs": {
         "materials": [],
@@ -478,31 +465,30 @@
       "level": 14,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 14
         },
         {
-          "name": "Parsteel Generator A",
+          "name": "parsteel generator a",
           "level": 14
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 1800,
-        "bonus2": 25250
+        "bonus1": 1800.0,
+        "bonus2": 25250.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "tritanium",
+            "type": "dilithium",
             "value": 375
           },
           {
-            "type": "dilithium",
+            "type": "tritanium",
             "value": 375
           }
         ]
@@ -512,31 +498,30 @@
       "level": 15,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 15
         },
         {
-          "name": "Parsteel Generator A",
+          "name": "parsteel generator a",
           "level": 15
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 1925,
-        "bonus2": 29000
+        "bonus1": 1925.0,
+        "bonus2": 29000.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "tritanium",
+            "type": "dilithium",
             "value": 500
           },
           {
-            "type": "dilithium",
+            "type": "tritanium",
             "value": 500
           }
         ]
@@ -546,31 +531,30 @@
       "level": 16,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 16
         },
         {
-          "name": "Parsteel Generator A",
+          "name": "parsteel generator a",
           "level": 16
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 2050,
-        "bonus2": 33750
+        "bonus1": 2050.0,
+        "bonus2": 33750.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "tritanium",
+            "type": "dilithium",
             "value": 700
           },
           {
-            "type": "dilithium",
+            "type": "tritanium",
             "value": 700
           }
         ]
@@ -580,20 +564,19 @@
       "level": 17,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 17
         },
         {
-          "name": "Parsteel Generator A",
+          "name": "parsteel generator a",
           "level": 17
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 2175,
-        "bonus2": 38000
+        "bonus1": 2175.0,
+        "bonus2": 38000.0
       },
       "build_costs": {
         "materials": [],
@@ -614,31 +597,30 @@
       "level": 18,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 18
         },
         {
-          "name": "Parsteel Generator A",
+          "name": "parsteel generator a",
           "level": 18
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 2300,
-        "bonus2": 43750
+        "bonus1": 2300.0,
+        "bonus2": 43750.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "tritanium",
+            "type": "dilithium",
             "value": 1500
           },
           {
-            "type": "dilithium",
+            "type": "tritanium",
             "value": 1500
           }
         ]
@@ -648,20 +630,19 @@
       "level": 19,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 19
         },
         {
-          "name": "Parsteel Generator A",
+          "name": "parsteel generator a",
           "level": 19
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 2825,
-        "bonus2": 56500
+        "bonus1": 2825.0,
+        "bonus2": 56500.0
       },
       "build_costs": {
         "materials": [],
@@ -682,20 +663,19 @@
       "level": 20,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 20
         },
         {
-          "name": "Parsteel Generator A",
+          "name": "parsteel generator a",
           "level": 20
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 2950,
-        "bonus2": 59000
+        "bonus1": 2950.0,
+        "bonus2": 59000.0
       },
       "build_costs": {
         "materials": [],
@@ -716,31 +696,30 @@
       "level": 21,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 21
         },
         {
-          "name": "Parsteel Generator A",
+          "name": "parsteel generator a",
           "level": 21
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 3100,
-        "bonus2": 62000
+        "bonus1": 3100.0,
+        "bonus2": 62000.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "tritanium",
+            "type": "dilithium",
             "value": 5565
           },
           {
-            "type": "dilithium",
+            "type": "tritanium",
             "value": 5565
           }
         ]
@@ -750,31 +729,30 @@
       "level": 22,
       "requirements": [
         {
-          "name": "Parsteel Generator A",
+          "name": "operations",
           "level": 22
         },
         {
-          "name": "Operations",
+          "name": "parsteel generator a",
           "level": 22
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 3225,
-        "bonus2": 64500
+        "bonus1": 3225.0,
+        "bonus2": 64500.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "tritanium",
+            "type": "dilithium",
             "value": 9158
           },
           {
-            "type": "dilithium",
+            "type": "tritanium",
             "value": 9158
           }
         ]
@@ -784,20 +762,19 @@
       "level": 23,
       "requirements": [
         {
-          "name": "Parsteel Generator A",
+          "name": "operations",
           "level": 23
         },
         {
-          "name": "Operations",
+          "name": "parsteel generator a",
           "level": 23
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 3375,
-        "bonus2": 67500
+        "bonus1": 3375.0,
+        "bonus2": 67500.0
       },
       "build_costs": {
         "materials": [],
@@ -818,31 +795,30 @@
       "level": 24,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 24
         },
         {
-          "name": "Parsteel Generator A",
+          "name": "parsteel generator a",
           "level": 24
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 4025,
-        "bonus2": 80500
+        "bonus1": 4025.0,
+        "bonus2": 80500.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "tritanium",
+            "type": "dilithium",
             "value": 23400
           },
           {
-            "type": "dilithium",
+            "type": "tritanium",
             "value": 23400
           }
         ]
@@ -852,31 +828,30 @@
       "level": 25,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 25
         },
         {
-          "name": "Parsteel Generator A",
+          "name": "parsteel generator a",
           "level": 25
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 4175,
-        "bonus2": 83500
+        "bonus1": 4175.0,
+        "bonus2": 83500.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "tritanium",
+            "type": "dilithium",
             "value": 36563
           },
           {
-            "type": "dilithium",
+            "type": "tritanium",
             "value": 36563
           }
         ]
@@ -886,20 +861,19 @@
       "level": 26,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 26
         },
         {
-          "name": "Parsteel Generator A",
+          "name": "parsteel generator a",
           "level": 26
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 4350,
-        "bonus2": 87000
+        "bonus1": 4350.0,
+        "bonus2": 87000.0
       },
       "build_costs": {
         "materials": [],
@@ -920,31 +894,30 @@
       "level": 27,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 27
         },
         {
-          "name": "Parsteel Generator A",
+          "name": "parsteel generator a",
           "level": 27
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 4500,
-        "bonus2": 90000
+        "bonus1": 4500.0,
+        "bonus2": 90000.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "tritanium",
+            "type": "dilithium",
             "value": 83700
           },
           {
-            "type": "dilithium",
+            "type": "tritanium",
             "value": 83700
           }
         ]
@@ -954,31 +927,30 @@
       "level": 28,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 28
         },
         {
-          "name": "Parsteel Generator A",
+          "name": "parsteel generator a",
           "level": 28
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 4675,
-        "bonus2": 93500
+        "bonus1": 4675.0,
+        "bonus2": 93500.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "tritanium",
+            "type": "dilithium",
             "value": 133250
           },
           {
-            "type": "dilithium",
+            "type": "tritanium",
             "value": 133250
           }
         ]
@@ -988,20 +960,19 @@
       "level": 29,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 29
         },
         {
-          "name": "Parsteel Generator A",
+          "name": "parsteel generator a",
           "level": 29
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 5400,
-        "bonus2": 108000
+        "bonus1": 5400.0,
+        "bonus2": 108000.0
       },
       "build_costs": {
         "materials": [],
@@ -1022,20 +993,19 @@
       "level": 30,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 30
         },
         {
-          "name": "Parsteel Generator A",
+          "name": "parsteel generator a",
           "level": 30
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 5600,
-        "bonus2": 112000
+        "bonus1": 5600.0,
+        "bonus2": 112000.0
       },
       "build_costs": {
         "materials": [],
@@ -1056,31 +1026,30 @@
       "level": 31,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 31
         },
         {
-          "name": "Parsteel Generator A",
+          "name": "parsteel generator a",
           "level": 31
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 5800,
-        "bonus2": 125280
+        "bonus1": 5800.0,
+        "bonus2": 125280.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "tritanium",
+            "type": "dilithium",
             "value": 445250
           },
           {
-            "type": "dilithium",
+            "type": "tritanium",
             "value": 445250
           }
         ]
@@ -1090,20 +1059,19 @@
       "level": 32,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 32
         },
         {
-          "name": "Parsteel Generator A",
+          "name": "parsteel generator a",
           "level": 32
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 6000,
-        "bonus2": 139200
+        "bonus1": 6000.0,
+        "bonus2": 139200.0
       },
       "build_costs": {
         "materials": [],
@@ -1124,31 +1092,30 @@
       "level": 33,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 33
         },
         {
-          "name": "Parsteel Generator A",
+          "name": "parsteel generator a",
           "level": 33
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 6200,
-        "bonus2": 143840
+        "bonus1": 6200.0,
+        "bonus2": 143840.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "tritanium",
+            "type": "dilithium",
             "value": 1087500
           },
           {
-            "type": "dilithium",
+            "type": "tritanium",
             "value": 1087500
           }
         ]
@@ -1158,20 +1125,19 @@
       "level": 34,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 34
         },
         {
-          "name": "Parsteel Generator A",
+          "name": "parsteel generator a",
           "level": 34
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 7000,
-        "bonus2": 173600
+        "bonus1": 7000.0,
+        "bonus2": 173600.0
       },
       "build_costs": {
         "materials": [],
@@ -1192,20 +1158,19 @@
       "level": 35,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 35
         },
         {
-          "name": "Parsteel Generator A",
+          "name": "parsteel generator a",
           "level": 35
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 7300,
-        "bonus2": 194180
+        "bonus1": 7300.0,
+        "bonus2": 194180.0
       },
       "build_costs": {
         "materials": [],
@@ -1226,20 +1191,19 @@
       "level": 36,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 36
         },
         {
-          "name": "Parsteel Generator A",
+          "name": "parsteel generator a",
           "level": 36
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 7500,
-        "bonus2": 199500
+        "bonus1": 7500.0,
+        "bonus2": 199500.0
       },
       "build_costs": {
         "materials": [],
@@ -1260,31 +1224,30 @@
       "level": 37,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 37
         },
         {
-          "name": "Parsteel Generator A",
+          "name": "parsteel generator a",
           "level": 37
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 7700,
-        "bonus2": 218680
+        "bonus1": 7700.0,
+        "bonus2": 218680.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "tritanium",
+            "type": "dilithium",
             "value": 5670000
           },
           {
-            "type": "dilithium",
+            "type": "tritanium",
             "value": 5670000
           }
         ]
@@ -1294,20 +1257,19 @@
       "level": 38,
       "requirements": [
         {
-          "name": "Parsteel Generator A",
+          "name": "operations",
           "level": 38
         },
         {
-          "name": "Operations",
+          "name": "parsteel generator a",
           "level": 38
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 7900,
-        "bonus2": 241740
+        "bonus1": 7900.0,
+        "bonus2": 241740.0
       },
       "build_costs": {
         "materials": [],
@@ -1328,31 +1290,30 @@
       "level": 39,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 39
         },
         {
-          "name": "Parsteel Generator A",
+          "name": "parsteel generator a",
           "level": 39
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 8900,
-        "bonus2": 272340
+        "bonus1": 8900.0,
+        "bonus2": 272340.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "tritanium",
+            "type": "dilithium",
             "value": 15050000
           },
           {
-            "type": "dilithium",
+            "type": "tritanium",
             "value": 15050000
           }
         ]
@@ -1362,31 +1323,30 @@
       "level": 40,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 40
         },
         {
-          "name": "Parsteel Generator A",
+          "name": "parsteel generator a",
           "level": 40
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 9100,
-        "bonus2": 300300
+        "bonus1": 9100.0,
+        "bonus2": 300300.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "tritanium",
+            "type": "dilithium",
             "value": 21500000
           },
           {
-            "type": "dilithium",
+            "type": "tritanium",
             "value": 21500000
           }
         ]
@@ -1396,20 +1356,19 @@
       "level": 41,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 41
         },
         {
-          "name": "Parsteel Generator A",
+          "name": "parsteel generator a",
           "level": 41
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 9300,
-        "bonus2": 336660
+        "bonus1": 9300.0,
+        "bonus2": 336660.0
       },
       "build_costs": {
         "materials": [],
@@ -1430,31 +1389,30 @@
       "level": 42,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 42
         },
         {
-          "name": "Parsteel Generator A",
+          "name": "parsteel generator a",
           "level": 42
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 9500,
-        "bonus2": 343900
+        "bonus1": 9500.0,
+        "bonus2": 343900.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "tritanium",
+            "type": "dilithium",
             "value": 45750000
           },
           {
-            "type": "dilithium",
+            "type": "tritanium",
             "value": 45750000
           }
         ]
@@ -1464,31 +1422,30 @@
       "level": 43,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 43
         },
         {
-          "name": "Parsteel Generator A",
+          "name": "parsteel generator a",
           "level": 43
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 9800,
-        "bonus2": 392000
+        "bonus1": 9800.0,
+        "bonus2": 392000.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "tritanium",
+            "type": "dilithium",
             "value": 68625000
           },
           {
-            "type": "dilithium",
+            "type": "tritanium",
             "value": 68625000
           }
         ]
@@ -1498,20 +1455,19 @@
       "level": 44,
       "requirements": [
         {
-          "name": "Parsteel Generator A",
+          "name": "operations",
           "level": 44
         },
         {
-          "name": "Operations",
+          "name": "parsteel generator a",
           "level": 44
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 11300,
-        "bonus2": 508500
+        "bonus1": 11300.0,
+        "bonus2": 508500.0
       },
       "build_costs": {
         "materials": [],
@@ -1532,31 +1488,30 @@
       "level": 45,
       "requirements": [
         {
-          "name": "Parsteel Generator A",
+          "name": "operations",
           "level": 45
         },
         {
-          "name": "Operations",
+          "name": "parsteel generator a",
           "level": 45
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 11600,
-        "bonus2": 522000
+        "bonus1": 11600.0,
+        "bonus2": 522000.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "tritanium",
+            "type": "dilithium",
             "value": 134062500
           },
           {
-            "type": "dilithium",
+            "type": "tritanium",
             "value": 134062500
           }
         ]
@@ -1566,31 +1521,30 @@
       "level": 46,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 46
         },
         {
-          "name": "Parsteel Generator A",
+          "name": "parsteel generator a",
           "level": 46
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 11800,
-        "bonus2": 531000
+        "bonus1": 11800.0,
+        "bonus2": 531000.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "tritanium",
+            "type": "dilithium",
             "value": 195000000
           },
           {
-            "type": "dilithium",
+            "type": "tritanium",
             "value": 195000000
           }
         ]
@@ -1600,20 +1554,19 @@
       "level": 47,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 47
         },
         {
-          "name": "Parsteel Generator A",
+          "name": "parsteel generator a",
           "level": 47
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 12100,
-        "bonus2": 544500
+        "bonus1": 12100.0,
+        "bonus2": 544500.0
       },
       "build_costs": {
         "materials": [],
@@ -1634,31 +1587,30 @@
       "level": 48,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 48
         },
         {
-          "name": "Parsteel Generator A",
+          "name": "parsteel generator a",
           "level": 48
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 12300,
-        "bonus2": 553500
+        "bonus1": 12300.0,
+        "bonus2": 553500.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "tritanium",
+            "type": "dilithium",
             "value": 525000000
           },
           {
-            "type": "dilithium",
+            "type": "tritanium",
             "value": 525000000
           }
         ]
@@ -1668,20 +1620,19 @@
       "level": 49,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 49
         },
         {
-          "name": "Parsteel Generator A",
+          "name": "parsteel generator a",
           "level": 49
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 15100,
-        "bonus2": 679500
+        "bonus1": 15100.0,
+        "bonus2": 679500.0
       },
       "build_costs": {
         "materials": [],
@@ -1702,15 +1653,179 @@
       "level": 50,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 50
         },
         {
-          "name": "Parsteel Generator A",
+          "name": "parsteel generator a",
           "level": 50
         }
-      ],
-      "rewards": []
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 15400.0,
+        "bonus2": 693000.0
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "dilithium",
+            "value": 1950000000
+          },
+          {
+            "type": "tritanium",
+            "value": 1950000000
+          }
+        ]
+      },
+      "build_time": 14906880,
+      "increased_power": 2000,
+      "level": 51,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 51
+        },
+        {
+          "name": "parsteel generator a",
+          "level": 51
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 15700.0,
+        "bonus2": 706500.0
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "dilithium",
+            "value": 3315000000
+          },
+          {
+            "type": "tritanium",
+            "value": 3315000000
+          }
+        ]
+      },
+      "build_time": 15801120,
+      "increased_power": 1500,
+      "level": 52,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 52
+        },
+        {
+          "name": "parsteel generator a",
+          "level": 52
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 16000.0,
+        "bonus2": 720000.0
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 5800000000
+          },
+          {
+            "type": "dilithium",
+            "value": 5800000000
+          }
+        ]
+      },
+      "build_time": 16748640,
+      "increased_power": 2000,
+      "level": 53,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 53
+        },
+        {
+          "name": "parsteel generator a",
+          "level": 53
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 16300.0,
+        "bonus2": 733500.0
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "dilithium",
+            "value": 8700000000
+          },
+          {
+            "type": "tritanium",
+            "value": 8700000000
+          }
+        ]
+      },
+      "build_time": 17753760,
+      "increased_power": 2000,
+      "level": 54,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 54
+        },
+        {
+          "name": "parsteel generator a",
+          "level": 54
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 19400.0,
+        "bonus2": 873000.0
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "dilithium",
+            "value": 13650000000
+          },
+          {
+            "type": "tritanium",
+            "value": 13650000000
+          }
+        ]
+      },
+      "build_time": 18819360,
+      "increased_power": 2000,
+      "level": 55,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 55
+        },
+        {
+          "name": "parsteel generator a",
+          "level": 55
+        }
+      ]
     }
   ]
 }

--- a/buildings/parsteel_generator_d.json
+++ b/buildings/parsteel_generator_d.json
@@ -2,11 +2,11 @@
   "description": "Produces Parsteel, an alloy with immense tensile strength used to build Station buildings. Upgrading Parsteel Generators increases the amount of Parsteel that is produced.",
   "bonuses": {
     "bonus1": {
-      "name": "Parsteel Production",
+      "name": "parsteel production",
       "percentage": false
     },
     "bonus2": {
-      "name": "Parsteel Storage",
+      "name": "parsteel storage",
       "percentage": false
     }
   },
@@ -14,8 +14,8 @@
   "levels": [
     {
       "bonuses": {
-        "bonus1": 90,
-        "bonus2": 45
+        "bonus1": 90.0,
+        "bonus2": 45.0
       },
       "build_costs": {
         "materials": [],
@@ -36,20 +36,19 @@
       "level": 1,
       "requirements": [
         {
-          "name": "Parsteel Generator B",
-          "level": 1
+          "name": "operations",
+          "level": 22
         },
         {
-          "name": "Operations",
-          "level": 22
+          "name": "parsteel generator b",
+          "level": 1
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 190,
-        "bonus2": 285
+        "bonus1": 190.0,
+        "bonus2": 285.0
       },
       "build_costs": {
         "materials": [],
@@ -70,20 +69,19 @@
       "level": 2,
       "requirements": [
         {
-          "name": "Parsteel Generator B",
+          "name": "operations",
           "level": 2
         },
         {
-          "name": "Operations",
+          "name": "parsteel generator b",
           "level": 2
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 290,
-        "bonus2": 580
+        "bonus1": 290.0,
+        "bonus2": 580.0
       },
       "build_costs": {
         "materials": [],
@@ -104,20 +102,19 @@
       "level": 3,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 3
         },
         {
-          "name": "Parsteel Generator B",
+          "name": "parsteel generator b",
           "level": 3
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 395,
-        "bonus2": 1190
+        "bonus1": 395.0,
+        "bonus2": 1190.0
       },
       "build_costs": {
         "materials": [],
@@ -138,20 +135,19 @@
       "level": 4,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 4
         },
         {
-          "name": "Parsteel Generator B",
+          "name": "parsteel generator b",
           "level": 4
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 495,
-        "bonus2": 1975
+        "bonus1": 495.0,
+        "bonus2": 1975.0
       },
       "build_costs": {
         "materials": [],
@@ -172,32 +168,31 @@
       "level": 5,
       "requirements": [
         {
-          "name": "Parsteel Generator B",
+          "name": "operations",
           "level": 5
         },
         {
-          "name": "Operations",
+          "name": "parsteel generator b",
           "level": 5
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 600,
-        "bonus2": 2700
+        "bonus1": 600.0,
+        "bonus2": 2700.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 350
-          },
-          {
             "type": "tritanium",
             "value": 200
+          },
+          {
+            "type": "parsteel",
+            "value": 350
           }
         ]
       },
@@ -206,32 +201,31 @@
       "level": 6,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 6
         },
         {
-          "name": "Parsteel Generator B",
+          "name": "parsteel generator b",
           "level": 6
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 700,
-        "bonus2": 3850
+        "bonus1": 700.0,
+        "bonus2": 3850.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 700
-          },
-          {
             "type": "tritanium",
             "value": 250
+          },
+          {
+            "type": "parsteel",
+            "value": 700
           }
         ]
       },
@@ -240,20 +234,19 @@
       "level": 7,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 7
         },
         {
-          "name": "Parsteel Generator B",
+          "name": "parsteel generator b",
           "level": 7
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 800,
-        "bonus2": 5200
+        "bonus1": 800.0,
+        "bonus2": 5200.0
       },
       "build_costs": {
         "materials": [],
@@ -274,32 +267,31 @@
       "level": 8,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 8
         },
         {
-          "name": "Parsteel Generator B",
+          "name": "parsteel generator b",
           "level": 8
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 900,
-        "bonus2": 6300
+        "bonus1": 900.0,
+        "bonus2": 6300.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 2500
-          },
-          {
             "type": "tritanium",
             "value": 350
+          },
+          {
+            "type": "parsteel",
+            "value": 2500
           }
         ]
       },
@@ -308,20 +300,19 @@
       "level": 9,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 9
         },
         {
-          "name": "Parsteel Generator B",
+          "name": "parsteel generator b",
           "level": 9
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 1200,
-        "bonus2": 9600
+        "bonus1": 1200.0,
+        "bonus2": 9600.0
       },
       "build_costs": {
         "materials": [],
@@ -342,32 +333,31 @@
       "level": 10,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 10
         },
         {
-          "name": "Parsteel Generator B",
+          "name": "parsteel generator b",
           "level": 10
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 1320,
-        "bonus2": 11900
+        "bonus1": 1320.0,
+        "bonus2": 11900.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "tritanium",
-            "value": 100
-          },
-          {
             "type": "dilithium",
             "value": 20
+          },
+          {
+            "type": "tritanium",
+            "value": 100
           }
         ]
       },
@@ -376,19 +366,19 @@
       "level": 11,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 11
         },
         {
-          "name": "Parsteel Generator B",
+          "name": "parsteel generator b",
           "level": 11
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 15200,
-        "bonus2": 1450
+        "bonus1": 1450.0,
+        "bonus2": 15200.0
       },
       "build_costs": {
         "materials": [],
@@ -409,19 +399,19 @@
       "level": 12,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 12
         },
         {
-          "name": "Parsteel Generator B",
+          "name": "parsteel generator b",
           "level": 12
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 1550,
-        "bonus2": 17800
+        "bonus1": 1550.0,
+        "bonus2": 17800.0
       },
       "build_costs": {
         "materials": [],
@@ -442,32 +432,31 @@
       "level": 13,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 13
         },
         {
-          "name": "Parsteel Generator B",
+          "name": "parsteel generator b",
           "level": 13
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 1675,
-        "bonus2": 21750
+        "bonus1": 1675.0,
+        "bonus2": 21750.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "tritanium",
-            "value": 275
-          },
-          {
             "type": "dilithium",
             "value": 220
+          },
+          {
+            "type": "tritanium",
+            "value": 275
           }
         ]
       },
@@ -476,30 +465,30 @@
       "level": 14,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 14
         },
         {
-          "name": "Parsteel Generator B",
+          "name": "parsteel generator b",
           "level": 14
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 25250,
-        "bonus2": 1800
+        "bonus1": 1800.0,
+        "bonus2": 25250.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "tritanium",
+            "type": "dilithium",
             "value": 375
           },
           {
-            "type": "dilithium",
+            "type": "tritanium",
             "value": 375
           }
         ]
@@ -509,19 +498,19 @@
       "level": 15,
       "requirements": [
         {
-          "name": "Parsteel Generator B",
+          "name": "operations",
           "level": 15
         },
         {
-          "name": "Operations",
+          "name": "parsteel generator b",
           "level": 15
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 1925,
-        "bonus2": 29000
+        "bonus1": 1925.0,
+        "bonus2": 29000.0
       },
       "build_costs": {
         "materials": [],
@@ -542,19 +531,19 @@
       "level": 16,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 16
         },
         {
-          "name": "Parsteel Generator B",
+          "name": "parsteel generator b",
           "level": 16
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 2050,
-        "bonus2": 33750
+        "bonus1": 2050.0,
+        "bonus2": 33750.0
       },
       "build_costs": {
         "materials": [],
@@ -575,30 +564,30 @@
       "level": 17,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 17
         },
         {
-          "name": "Parsteel Generator B",
+          "name": "parsteel generator b",
           "level": 17
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 2175,
-        "bonus2": 38000
+        "bonus1": 2175.0,
+        "bonus2": 38000.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "tritanium",
+            "type": "dilithium",
             "value": 1000
           },
           {
-            "type": "dilithium",
+            "type": "tritanium",
             "value": 1000
           }
         ]
@@ -608,30 +597,30 @@
       "level": 18,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 18
         },
         {
-          "name": "Parsteel Generator B",
+          "name": "parsteel generator b",
           "level": 18
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 2300,
-        "bonus2": 43750
+        "bonus1": 2300.0,
+        "bonus2": 43750.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "tritanium",
+            "type": "dilithium",
             "value": 1500
           },
           {
-            "type": "dilithium",
+            "type": "tritanium",
             "value": 1500
           }
         ]
@@ -641,20 +630,19 @@
       "level": 19,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 19
         },
         {
-          "name": "Parsteel Generator B",
+          "name": "parsteel generator b",
           "level": 19
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 2825,
-        "bonus2": 56500
+        "bonus1": 2825.0,
+        "bonus2": 56500.0
       },
       "build_costs": {
         "materials": [],
@@ -675,31 +663,30 @@
       "level": 20,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 20
         },
         {
-          "name": "Parsteel Generator B",
+          "name": "parsteel generator b",
           "level": 20
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 59000,
-        "bonus2": 2950
+        "bonus1": 2950.0,
+        "bonus2": 59000.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "tritanium",
+            "type": "dilithium",
             "value": 3578
           },
           {
-            "type": "dilithium",
+            "type": "tritanium",
             "value": 3578
           }
         ]
@@ -709,19 +696,19 @@
       "level": 21,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 21
         },
         {
-          "name": "Parsteel Generator B",
+          "name": "parsteel generator b",
           "level": 21
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 3100,
-        "bonus2": 62000
+        "bonus1": 3100.0,
+        "bonus2": 62000.0
       },
       "build_costs": {
         "materials": [],
@@ -742,20 +729,19 @@
       "level": 22,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 22
         },
         {
-          "name": "Parsteel Generator B",
+          "name": "parsteel generator b",
           "level": 22
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 3225,
-        "bonus2": 64500
+        "bonus1": 3225.0,
+        "bonus2": 64500.0
       },
       "build_costs": {
         "materials": [],
@@ -776,31 +762,30 @@
       "level": 23,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 23
         },
         {
-          "name": "Parsteel Generator B",
+          "name": "parsteel generator b",
           "level": 23
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 3375,
-        "bonus2": 67500
+        "bonus1": 3375.0,
+        "bonus2": 67500.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "tritanium",
+            "type": "dilithium",
             "value": 14430
           },
           {
-            "type": "dilithium",
+            "type": "tritanium",
             "value": 14430
           }
         ]
@@ -810,20 +795,19 @@
       "level": 24,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 24
         },
         {
-          "name": "Parsteel Generator B",
+          "name": "parsteel generator b",
           "level": 24
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 4025,
-        "bonus2": 80500
+        "bonus1": 4025.0,
+        "bonus2": 80500.0
       },
       "build_costs": {
         "materials": [],
@@ -844,31 +828,30 @@
       "level": 25,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 25
         },
         {
-          "name": "Parsteel Generator B",
+          "name": "parsteel generator b",
           "level": 25
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 4175,
-        "bonus2": 83500
+        "bonus1": 4175.0,
+        "bonus2": 83500.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "tritanium",
+            "type": "dilithium",
             "value": 36563
           },
           {
-            "type": "dilithium",
+            "type": "tritanium",
             "value": 36563
           }
         ]
@@ -878,20 +861,19 @@
       "level": 26,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 26
         },
         {
-          "name": "Parsteel Generator B",
+          "name": "parsteel generator b",
           "level": 26
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 4350,
-        "bonus2": 87000
+        "bonus1": 4350.0,
+        "bonus2": 87000.0
       },
       "build_costs": {
         "materials": [],
@@ -912,31 +894,30 @@
       "level": 27,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 27
         },
         {
-          "name": "Parsteel Generator B",
+          "name": "parsteel generator b",
           "level": 27
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 4500,
-        "bonus2": 90000
+        "bonus1": 4500.0,
+        "bonus2": 90000.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "tritanium",
+            "type": "dilithium",
             "value": 83700
           },
           {
-            "type": "dilithium",
+            "type": "tritanium",
             "value": 83700
           }
         ]
@@ -946,20 +927,19 @@
       "level": 28,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 28
         },
         {
-          "name": "Parsteel Generator B",
+          "name": "parsteel generator b",
           "level": 28
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 4675,
-        "bonus2": 93500
+        "bonus1": 4675.0,
+        "bonus2": 93500.0
       },
       "build_costs": {
         "materials": [],
@@ -980,20 +960,19 @@
       "level": 29,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 29
         },
         {
-          "name": "Parsteel Generator B",
+          "name": "parsteel generator b",
           "level": 29
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 5400,
-        "bonus2": 108000
+        "bonus1": 5400.0,
+        "bonus2": 108000.0
       },
       "build_costs": {
         "materials": [],
@@ -1014,31 +993,30 @@
       "level": 30,
       "requirements": [
         {
-          "name": "Parsteel Generator B",
+          "name": "operations",
           "level": 30
         },
         {
-          "name": "Operations",
+          "name": "parsteel generator b",
           "level": 30
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 5600,
-        "bonus2": 112000
+        "bonus1": 5600.0,
+        "bonus2": 112000.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "tritanium",
+            "type": "dilithium",
             "value": 308250
           },
           {
-            "type": "dilithium",
+            "type": "tritanium",
             "value": 308250
           }
         ]
@@ -1048,31 +1026,30 @@
       "level": 31,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 31
         },
         {
-          "name": "Parsteel Generator B",
+          "name": "parsteel generator b",
           "level": 31
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 5800,
-        "bonus2": 125280
+        "bonus1": 5800.0,
+        "bonus2": 125280.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "tritanium",
+            "type": "dilithium",
             "value": 445250
           },
           {
-            "type": "dilithium",
+            "type": "tritanium",
             "value": 445250
           }
         ]
@@ -1082,20 +1059,19 @@
       "level": 32,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 32
         },
         {
-          "name": "Parsteel Generator B",
+          "name": "parsteel generator b",
           "level": 32
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 6000,
-        "bonus2": 139200
+        "bonus1": 6000.0,
+        "bonus2": 139200.0
       },
       "build_costs": {
         "materials": [],
@@ -1116,20 +1092,19 @@
       "level": 33,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 33
         },
         {
-          "name": "Parsteel Generator B",
+          "name": "parsteel generator b",
           "level": 33
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 6200,
-        "bonus2": 143840
+        "bonus1": 6200.0,
+        "bonus2": 143840.0
       },
       "build_costs": {
         "materials": [],
@@ -1150,31 +1125,30 @@
       "level": 34,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 34
         },
         {
-          "name": "Parsteel Generator B",
+          "name": "parsteel generator b",
           "level": 34
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 7000,
-        "bonus2": 173600
+        "bonus1": 7000.0,
+        "bonus2": 173600.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "tritanium",
+            "type": "dilithium",
             "value": 1683000
           },
           {
-            "type": "dilithium",
+            "type": "tritanium",
             "value": 1683000
           }
         ]
@@ -1184,31 +1158,30 @@
       "level": 35,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 35
         },
         {
-          "name": "Parsteel Generator B",
+          "name": "parsteel generator b",
           "level": 35
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 7300,
-        "bonus2": 194180
+        "bonus1": 7300.0,
+        "bonus2": 194180.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "tritanium",
+            "type": "dilithium",
             "value": 2371500
           },
           {
-            "type": "dilithium",
+            "type": "tritanium",
             "value": 2371500
           }
         ]
@@ -1218,20 +1191,19 @@
       "level": 36,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 36
         },
         {
-          "name": "Parsteel Generator B",
+          "name": "parsteel generator b",
           "level": 36
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 7500,
-        "bonus2": 199500
+        "bonus1": 7500.0,
+        "bonus2": 199500.0
       },
       "build_costs": {
         "materials": [],
@@ -1252,20 +1224,19 @@
       "level": 37,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 37
         },
         {
-          "name": "Parsteel Generator B",
+          "name": "parsteel generator b",
           "level": 37
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 7700,
-        "bonus2": 218680
+        "bonus1": 7700.0,
+        "bonus2": 218680.0
       },
       "build_costs": {
         "materials": [],
@@ -1286,20 +1257,19 @@
       "level": 38,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 38
         },
         {
-          "name": "Parsteel Generator B",
+          "name": "parsteel generator b",
           "level": 38
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 7900,
-        "bonus2": 241740
+        "bonus1": 7900.0,
+        "bonus2": 241740.0
       },
       "build_costs": {
         "materials": [],
@@ -1320,20 +1290,19 @@
       "level": 39,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 39
         },
         {
-          "name": "Parsteel Generator B",
+          "name": "parsteel generator b",
           "level": 39
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 8900,
-        "bonus2": 272340
+        "bonus1": 8900.0,
+        "bonus2": 272340.0
       },
       "build_costs": {
         "materials": [],
@@ -1354,20 +1323,19 @@
       "level": 40,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 40
         },
         {
-          "name": "Parsteel Generator B",
+          "name": "parsteel generator b",
           "level": 40
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 9100,
-        "bonus2": 300300
+        "bonus1": 9100.0,
+        "bonus2": 300300.0
       },
       "build_costs": {
         "materials": [],
@@ -1388,20 +1356,19 @@
       "level": 41,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 41
         },
         {
-          "name": "Parsteel Generator B",
+          "name": "parsteel generator b",
           "level": 41
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 9300,
-        "bonus2": 336660
+        "bonus1": 9300.0,
+        "bonus2": 336660.0
       },
       "build_costs": {
         "materials": [],
@@ -1422,20 +1389,19 @@
       "level": 42,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 42
         },
         {
-          "name": "Parsteel Generator B",
+          "name": "parsteel generator b",
           "level": 42
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 9500,
-        "bonus2": 343900
+        "bonus1": 9500.0,
+        "bonus2": 343900.0
       },
       "build_costs": {
         "materials": [],
@@ -1456,20 +1422,19 @@
       "level": 43,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 43
         },
         {
-          "name": "Parsteel Generator B",
+          "name": "parsteel generator b",
           "level": 43
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 9800,
-        "bonus2": 392000
+        "bonus1": 9800.0,
+        "bonus2": 392000.0
       },
       "build_costs": {
         "materials": [],
@@ -1490,31 +1455,30 @@
       "level": 44,
       "requirements": [
         {
-          "name": "Parsteel Generator B",
+          "name": "operations",
           "level": 44
         },
         {
-          "name": "Operations",
+          "name": "parsteel generator b",
           "level": 44
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 11300,
-        "bonus2": 508500
+        "bonus1": 11300.0,
+        "bonus2": 508500.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "tritanium",
+            "type": "dilithium",
             "value": 97500000
           },
           {
-            "type": "dilithium",
+            "type": "tritanium",
             "value": 97500000
           }
         ]
@@ -1524,20 +1488,19 @@
       "level": 45,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 45
         },
         {
-          "name": "Parsteel Generator B",
+          "name": "parsteel generator b",
           "level": 45
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 11600,
-        "bonus2": 522000
+        "bonus1": 11600.0,
+        "bonus2": 522000.0
       },
       "build_costs": {
         "materials": [],
@@ -1558,31 +1521,30 @@
       "level": 46,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 46
         },
         {
-          "name": "Parsteel Generator B",
+          "name": "parsteel generator b",
           "level": 46
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 11800,
-        "bonus2": 531000
+        "bonus1": 11800.0,
+        "bonus2": 531000.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "tritanium",
+            "type": "dilithium",
             "value": 195000000
           },
           {
-            "type": "dilithium",
+            "type": "tritanium",
             "value": 195000000
           }
         ]
@@ -1592,20 +1554,19 @@
       "level": 47,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 47
         },
         {
-          "name": "Parsteel Generator B",
+          "name": "parsteel generator b",
           "level": 47
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 12100,
-        "bonus2": 544500
+        "bonus1": 12100.0,
+        "bonus2": 544500.0
       },
       "build_costs": {
         "materials": [],
@@ -1626,20 +1587,19 @@
       "level": 48,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 48
         },
         {
-          "name": "Parsteel Generator B",
+          "name": "parsteel generator b",
           "level": 48
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 12300,
-        "bonus2": 553500
+        "bonus1": 12300.0,
+        "bonus2": 553500.0
       },
       "build_costs": {
         "materials": [],
@@ -1660,20 +1620,19 @@
       "level": 49,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 49
         },
         {
-          "name": "Parsteel Generator B",
+          "name": "parsteel generator b",
           "level": 49
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 15100,
-        "bonus2": 679500
+        "bonus1": 15100.0,
+        "bonus2": 679500.0
       },
       "build_costs": {
         "materials": [],
@@ -1694,15 +1653,179 @@
       "level": 50,
       "requirements": [
         {
-          "name": "Parsteel Generator B",
+          "name": "operations",
           "level": 50
         },
         {
-          "name": "Operations",
+          "name": "parsteel generator b",
           "level": 50
         }
-      ],
-      "rewards": []
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 15400.0,
+        "bonus2": 693000.0
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 1950000000
+          },
+          {
+            "type": "dilithium",
+            "value": 1950000000
+          }
+        ]
+      },
+      "build_time": 14906880,
+      "increased_power": 2000,
+      "level": 51,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 51
+        },
+        {
+          "name": "parsteel generator b",
+          "level": 51
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 15700.0,
+        "bonus2": 706500.0
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 3315000000
+          },
+          {
+            "type": "dilithium",
+            "value": 3315000000
+          }
+        ]
+      },
+      "build_time": 15801120,
+      "increased_power": 1500,
+      "level": 52,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 52
+        },
+        {
+          "name": "parsteel generator b",
+          "level": 52
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 16000.0,
+        "bonus2": 720000.0
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 5800000000
+          },
+          {
+            "type": "dilithium",
+            "value": 5800000000
+          }
+        ]
+      },
+      "build_time": 16748640,
+      "increased_power": 2000,
+      "level": 53,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 53
+        },
+        {
+          "name": "parsteel generator b",
+          "level": 53
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 16300.0,
+        "bonus2": 733500.0
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 8700000000
+          },
+          {
+            "type": "dilithium",
+            "value": 8700000000
+          }
+        ]
+      },
+      "build_time": 17753760,
+      "increased_power": 2000,
+      "level": 54,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 54
+        },
+        {
+          "name": "parsteel generator b",
+          "level": 54
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 19400.0,
+        "bonus2": 873000.0
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "dilithium",
+            "value": 13650000000
+          },
+          {
+            "type": "tritanium",
+            "value": 13650000000
+          }
+        ]
+      },
+      "build_time": 18819360,
+      "increased_power": 2000,
+      "level": 55,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 55
+        },
+        {
+          "name": "parsteel generator b",
+          "level": 55
+        }
+      ]
     }
   ]
 }

--- a/buildings/parsteel_generator_e.json
+++ b/buildings/parsteel_generator_e.json
@@ -2,11 +2,11 @@
   "description": "Produces Parsteel, an alloy with immense tensile strength used to build Station buildings. Upgrading Parsteel Generators increases the amount of Parsteel that is produced.",
   "bonuses": {
     "bonus1": {
-      "name": "Parsteel Production",
+      "name": "parsteel production",
       "percentage": false
     },
     "bonus2": {
-      "name": "Parsteel Storage",
+      "name": "parsteel storage",
       "percentage": false
     }
   },
@@ -14,8 +14,8 @@
   "levels": [
     {
       "bonuses": {
-        "bonus1": 90,
-        "bonus2": 45
+        "bonus1": 90.0,
+        "bonus2": 45.0
       },
       "build_costs": {
         "materials": [],
@@ -36,20 +36,19 @@
       "level": 1,
       "requirements": [
         {
-          "name": "Parsteel Generator C",
-          "level": 1
+          "name": "operations",
+          "level": 32
         },
         {
-          "name": "Operations",
-          "level": 32
+          "name": "parsteel generator c",
+          "level": 1
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 190,
-        "bonus2": 285
+        "bonus1": 190.0,
+        "bonus2": 285.0
       },
       "build_costs": {
         "materials": [],
@@ -70,20 +69,19 @@
       "level": 2,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 2
         },
         {
-          "name": "Parsteel Generator C",
+          "name": "parsteel generator c",
           "level": 2
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 290,
-        "bonus2": 580
+        "bonus1": 290.0,
+        "bonus2": 580.0
       },
       "build_costs": {
         "materials": [],
@@ -104,32 +102,31 @@
       "level": 3,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 3
         },
         {
-          "name": "Parsteel Generator C",
+          "name": "parsteel generator c",
           "level": 3
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 395,
-        "bonus2": 1190
+        "bonus1": 395.0,
+        "bonus2": 1190.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 70
-          },
-          {
             "type": "tritanium",
             "value": 100
+          },
+          {
+            "type": "parsteel",
+            "value": 70
           }
         ]
       },
@@ -138,20 +135,19 @@
       "level": 4,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 4
         },
         {
-          "name": "Parsteel Generator C",
+          "name": "parsteel generator c",
           "level": 4
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 495,
-        "bonus2": 1975
+        "bonus1": 495.0,
+        "bonus2": 1975.0
       },
       "build_costs": {
         "materials": [],
@@ -172,20 +168,19 @@
       "level": 5,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 5
         },
         {
-          "name": "Parsteel Generator C",
+          "name": "parsteel generator c",
           "level": 5
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 600,
-        "bonus2": 2700
+        "bonus1": 600.0,
+        "bonus2": 2700.0
       },
       "build_costs": {
         "materials": [],
@@ -206,32 +201,31 @@
       "level": 6,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 6
         },
         {
-          "name": "Parsteel Generator C",
+          "name": "parsteel generator c",
           "level": 6
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 700,
-        "bonus2": 3850
+        "bonus1": 700.0,
+        "bonus2": 3850.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 700
-          },
-          {
             "type": "tritanium",
             "value": 250
+          },
+          {
+            "type": "parsteel",
+            "value": 700
           }
         ]
       },
@@ -240,32 +234,31 @@
       "level": 7,
       "requirements": [
         {
-          "name": "Parsteel Generator C",
+          "name": "operations",
           "level": 7
         },
         {
-          "name": "Operations",
+          "name": "parsteel generator c",
           "level": 7
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 800,
-        "bonus2": 5200
+        "bonus1": 800.0,
+        "bonus2": 5200.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 1200
-          },
-          {
             "type": "tritanium",
             "value": 300
+          },
+          {
+            "type": "parsteel",
+            "value": 1200
           }
         ]
       },
@@ -274,20 +267,19 @@
       "level": 8,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 8
         },
         {
-          "name": "Parsteel Generator C",
+          "name": "parsteel generator c",
           "level": 8
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 900,
-        "bonus2": 6300
+        "bonus1": 900.0,
+        "bonus2": 6300.0
       },
       "build_costs": {
         "materials": [],
@@ -308,32 +300,31 @@
       "level": 9,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 9
         },
         {
-          "name": "Parsteel Generator C",
+          "name": "parsteel generator c",
           "level": 9
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 1200,
-        "bonus2": 9600
+        "bonus1": 1200.0,
+        "bonus2": 9600.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 2800
-          },
-          {
             "type": "tritanium",
             "value": 450
+          },
+          {
+            "type": "parsteel",
+            "value": 2800
           }
         ]
       },
@@ -342,20 +333,19 @@
       "level": 10,
       "requirements": [
         {
-          "name": "Parsteel Generator C",
+          "name": "operations",
           "level": 10
         },
         {
-          "name": "Operations",
+          "name": "parsteel generator c",
           "level": 10
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 1320,
-        "bonus2": 11900
+        "bonus1": 1320.0,
+        "bonus2": 11900.0
       },
       "build_costs": {
         "materials": [],
@@ -376,20 +366,19 @@
       "level": 11,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 11
         },
         {
-          "name": "Parsteel Generator C",
+          "name": "parsteel generator c",
           "level": 11
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 1450,
-        "bonus2": 15200
+        "bonus1": 1450.0,
+        "bonus2": 15200.0
       },
       "build_costs": {
         "materials": [],
@@ -410,32 +399,31 @@
       "level": 12,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 12
         },
         {
-          "name": "Parsteel Generator C",
+          "name": "parsteel generator c",
           "level": 12
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 1550,
-        "bonus2": 17800
+        "bonus1": 1550.0,
+        "bonus2": 17800.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "tritanium",
-            "value": 200
-          },
-          {
             "type": "dilithium",
             "value": 120
+          },
+          {
+            "type": "tritanium",
+            "value": 200
           }
         ]
       },
@@ -444,32 +432,31 @@
       "level": 13,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 13
         },
         {
-          "name": "Parsteel Generator C",
+          "name": "parsteel generator c",
           "level": 13
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 1675,
-        "bonus2": 21750
+        "bonus1": 1675.0,
+        "bonus2": 21750.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "tritanium",
-            "value": 275
-          },
-          {
             "type": "dilithium",
             "value": 220
+          },
+          {
+            "type": "tritanium",
+            "value": 275
           }
         ]
       },
@@ -478,20 +465,19 @@
       "level": 14,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 14
         },
         {
-          "name": "Parsteel Generator C",
+          "name": "parsteel generator c",
           "level": 14
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 1800,
-        "bonus2": 25250
+        "bonus1": 1800.0,
+        "bonus2": 25250.0
       },
       "build_costs": {
         "materials": [],
@@ -512,31 +498,30 @@
       "level": 15,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 15
         },
         {
-          "name": "Parsteel Generator C",
+          "name": "parsteel generator c",
           "level": 15
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 1925,
-        "bonus2": 29000
+        "bonus1": 1925.0,
+        "bonus2": 29000.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "tritanium",
+            "type": "dilithium",
             "value": 500
           },
           {
-            "type": "dilithium",
+            "type": "tritanium",
             "value": 500
           }
         ]
@@ -546,31 +531,30 @@
       "level": 16,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 16
         },
         {
-          "name": "Parsteel Generator C",
+          "name": "parsteel generator c",
           "level": 16
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 2050,
-        "bonus2": 33750
+        "bonus1": 2050.0,
+        "bonus2": 33750.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "tritanium",
+            "type": "dilithium",
             "value": 700
           },
           {
-            "type": "dilithium",
+            "type": "tritanium",
             "value": 700
           }
         ]
@@ -580,20 +564,19 @@
       "level": 17,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 17
         },
         {
-          "name": "Parsteel Generator C",
+          "name": "parsteel generator c",
           "level": 17
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 2175,
-        "bonus2": 38000
+        "bonus1": 2175.0,
+        "bonus2": 38000.0
       },
       "build_costs": {
         "materials": [],
@@ -614,31 +597,30 @@
       "level": 18,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 18
         },
         {
-          "name": "Parsteel Generator C",
+          "name": "parsteel generator c",
           "level": 18
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 2300,
-        "bonus2": 43750
+        "bonus1": 2300.0,
+        "bonus2": 43750.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "tritanium",
+            "type": "dilithium",
             "value": 1500
           },
           {
-            "type": "dilithium",
+            "type": "tritanium",
             "value": 1500
           }
         ]
@@ -648,20 +630,19 @@
       "level": 19,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 19
         },
         {
-          "name": "Parsteel Generator C",
+          "name": "parsteel generator c",
           "level": 19
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 2825,
-        "bonus2": 56500
+        "bonus1": 2825.0,
+        "bonus2": 56500.0
       },
       "build_costs": {
         "materials": [],
@@ -682,20 +663,19 @@
       "level": 20,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 20
         },
         {
-          "name": "Parsteel Generator C",
+          "name": "parsteel generator c",
           "level": 20
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 2950,
-        "bonus2": 59000
+        "bonus1": 2950.0,
+        "bonus2": 59000.0
       },
       "build_costs": {
         "materials": [],
@@ -716,20 +696,19 @@
       "level": 21,
       "requirements": [
         {
-          "name": "Parsteel Generator C",
+          "name": "operations",
           "level": 21
         },
         {
-          "name": "Operations",
+          "name": "parsteel generator c",
           "level": 21
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 3100,
-        "bonus2": 62000
+        "bonus1": 3100.0,
+        "bonus2": 62000.0
       },
       "build_costs": {
         "materials": [],
@@ -750,20 +729,19 @@
       "level": 22,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 22
         },
         {
-          "name": "Parsteel Generator C",
+          "name": "parsteel generator c",
           "level": 22
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 3225,
-        "bonus2": 64500
+        "bonus1": 3225.0,
+        "bonus2": 64500.0
       },
       "build_costs": {
         "materials": [],
@@ -784,31 +762,30 @@
       "level": 23,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 23
         },
         {
-          "name": "Parsteel Generator C",
+          "name": "parsteel generator c",
           "level": 23
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 3375,
-        "bonus2": 67500
+        "bonus1": 3375.0,
+        "bonus2": 67500.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "tritanium",
+            "type": "dilithium",
             "value": 14430
           },
           {
-            "type": "dilithium",
+            "type": "tritanium",
             "value": 14430
           }
         ]
@@ -818,31 +795,30 @@
       "level": 24,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 24
         },
         {
-          "name": "Parsteel Generator C",
+          "name": "parsteel generator c",
           "level": 24
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 4025,
-        "bonus2": 80500
+        "bonus1": 4025.0,
+        "bonus2": 80500.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "tritanium",
+            "type": "dilithium",
             "value": 23400
           },
           {
-            "type": "dilithium",
+            "type": "tritanium",
             "value": 23400
           }
         ]
@@ -852,31 +828,30 @@
       "level": 25,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 25
         },
         {
-          "name": "Parsteel Generator C",
+          "name": "parsteel generator c",
           "level": 25
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 4175,
-        "bonus2": 83500
+        "bonus1": 4175.0,
+        "bonus2": 83500.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "tritanium",
+            "type": "dilithium",
             "value": 36563
           },
           {
-            "type": "dilithium",
+            "type": "tritanium",
             "value": 36563
           }
         ]
@@ -886,31 +861,30 @@
       "level": 26,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 26
         },
         {
-          "name": "Parsteel Generator C",
+          "name": "parsteel generator c",
           "level": 26
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 4350,
-        "bonus2": 87000
+        "bonus1": 4350.0,
+        "bonus2": 87000.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "tritanium",
+            "type": "dilithium",
             "value": 55800
           },
           {
-            "type": "dilithium",
+            "type": "tritanium",
             "value": 55800
           }
         ]
@@ -920,20 +894,19 @@
       "level": 27,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 27
         },
         {
-          "name": "Parsteel Generator C",
+          "name": "parsteel generator c",
           "level": 27
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 4500,
-        "bonus2": 90000
+        "bonus1": 4500.0,
+        "bonus2": 90000.0
       },
       "build_costs": {
         "materials": [],
@@ -954,20 +927,19 @@
       "level": 28,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 28
         },
         {
-          "name": "Parsteel Generator C",
+          "name": "parsteel generator c",
           "level": 28
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 4675,
-        "bonus2": 93500
+        "bonus1": 4675.0,
+        "bonus2": 93500.0
       },
       "build_costs": {
         "materials": [],
@@ -988,31 +960,30 @@
       "level": 29,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 29
         },
         {
-          "name": "Parsteel Generator C",
+          "name": "parsteel generator c",
           "level": 29
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 5400,
-        "bonus2": 108000
+        "bonus1": 5400.0,
+        "bonus2": 108000.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "tritanium",
+            "type": "dilithium",
             "value": 195000
           },
           {
-            "type": "dilithium",
+            "type": "tritanium",
             "value": 195000
           }
         ]
@@ -1022,20 +993,19 @@
       "level": 30,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 30
         },
         {
-          "name": "Parsteel Generator C",
+          "name": "parsteel generator c",
           "level": 30
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 5600,
-        "bonus2": 112000
+        "bonus1": 5600.0,
+        "bonus2": 112000.0
       },
       "build_costs": {
         "materials": [],
@@ -1056,31 +1026,30 @@
       "level": 31,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 31
         },
         {
-          "name": "Parsteel Generator C",
+          "name": "parsteel generator c",
           "level": 31
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 5800,
-        "bonus2": 125280
+        "bonus1": 5800.0,
+        "bonus2": 125280.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "tritanium",
+            "type": "dilithium",
             "value": 445250
           },
           {
-            "type": "dilithium",
+            "type": "tritanium",
             "value": 445250
           }
         ]
@@ -1090,20 +1059,19 @@
       "level": 32,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 32
         },
         {
-          "name": "Parsteel Generator C",
+          "name": "parsteel generator c",
           "level": 32
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 6000,
-        "bonus2": 139200
+        "bonus1": 6000.0,
+        "bonus2": 139200.0
       },
       "build_costs": {
         "materials": [],
@@ -1124,20 +1092,19 @@
       "level": 33,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 33
         },
         {
-          "name": "Parsteel Generator C",
+          "name": "parsteel generator c",
           "level": 33
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 6200,
-        "bonus2": 143840
+        "bonus1": 6200.0,
+        "bonus2": 143840.0
       },
       "build_costs": {
         "materials": [],
@@ -1158,31 +1125,30 @@
       "level": 34,
       "requirements": [
         {
-          "name": "Parsteel Generator C",
+          "name": "operations",
           "level": 34
         },
         {
-          "name": "Operations",
+          "name": "parsteel generator c",
           "level": 34
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 7000,
-        "bonus2": 173600
+        "bonus1": 7000.0,
+        "bonus2": 173600.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "tritanium",
+            "type": "dilithium",
             "value": 1683000
           },
           {
-            "type": "dilithium",
+            "type": "tritanium",
             "value": 1683000
           }
         ]
@@ -1192,31 +1158,30 @@
       "level": 35,
       "requirements": [
         {
-          "name": "Parsteel Generator C",
+          "name": "operations",
           "level": 35
         },
         {
-          "name": "Operations",
+          "name": "parsteel generator c",
           "level": 35
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 7300,
-        "bonus2": 194180
+        "bonus1": 7300.0,
+        "bonus2": 194180.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "tritanium",
+            "type": "dilithium",
             "value": 2371500
           },
           {
-            "type": "dilithium",
+            "type": "tritanium",
             "value": 2371500
           }
         ]
@@ -1226,20 +1191,19 @@
       "level": 36,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 36
         },
         {
-          "name": "Parsteel Generator C",
+          "name": "parsteel generator c",
           "level": 36
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 7500,
-        "bonus2": 199500
+        "bonus1": 7500.0,
+        "bonus2": 199500.0
       },
       "build_costs": {
         "materials": [],
@@ -1260,20 +1224,19 @@
       "level": 37,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 37
         },
         {
-          "name": "Parsteel Generator C",
+          "name": "parsteel generator c",
           "level": 37
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 7700,
-        "bonus2": 218680
+        "bonus1": 7700.0,
+        "bonus2": 218680.0
       },
       "build_costs": {
         "materials": [],
@@ -1294,20 +1257,19 @@
       "level": 38,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 38
         },
         {
-          "name": "Parsteel Generator C",
+          "name": "parsteel generator c",
           "level": 38
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 7900,
-        "bonus2": 241740
+        "bonus1": 7900.0,
+        "bonus2": 241740.0
       },
       "build_costs": {
         "materials": [],
@@ -1328,20 +1290,19 @@
       "level": 39,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 39
         },
         {
-          "name": "Parsteel Generator C",
+          "name": "parsteel generator c",
           "level": 39
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 8900,
-        "bonus2": 272340
+        "bonus1": 8900.0,
+        "bonus2": 272340.0
       },
       "build_costs": {
         "materials": [],
@@ -1362,20 +1323,19 @@
       "level": 40,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 40
         },
         {
-          "name": "Parsteel Generator C",
+          "name": "parsteel generator c",
           "level": 40
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 9100,
-        "bonus2": 300300
+        "bonus1": 9100.0,
+        "bonus2": 300300.0
       },
       "build_costs": {
         "materials": [],
@@ -1396,20 +1356,19 @@
       "level": 41,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 41
         },
         {
-          "name": "Parsteel Generator C",
+          "name": "parsteel generator c",
           "level": 41
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 9300,
-        "bonus2": 336660
+        "bonus1": 9300.0,
+        "bonus2": 336660.0
       },
       "build_costs": {
         "materials": [],
@@ -1430,20 +1389,19 @@
       "level": 42,
       "requirements": [
         {
-          "name": "Parsteel Generator C",
+          "name": "operations",
           "level": 42
         },
         {
-          "name": "Operations",
+          "name": "parsteel generator c",
           "level": 42
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 9500,
-        "bonus2": 343900
+        "bonus1": 9500.0,
+        "bonus2": 343900.0
       },
       "build_costs": {
         "materials": [],
@@ -1464,31 +1422,30 @@
       "level": 43,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 43
         },
         {
-          "name": "Parsteel Generator C",
+          "name": "parsteel generator c",
           "level": 43
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 9800,
-        "bonus2": 392000
+        "bonus1": 9800.0,
+        "bonus2": 392000.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "tritanium",
+            "type": "dilithium",
             "value": 68625000
           },
           {
-            "type": "dilithium",
+            "type": "tritanium",
             "value": 68625000
           }
         ]
@@ -1498,20 +1455,19 @@
       "level": 44,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 44
         },
         {
-          "name": "Parsteel Generator C",
+          "name": "parsteel generator c",
           "level": 44
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 11300,
-        "bonus2": 508500
+        "bonus1": 11300.0,
+        "bonus2": 508500.0
       },
       "build_costs": {
         "materials": [],
@@ -1532,20 +1488,19 @@
       "level": 45,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 45
         },
         {
-          "name": "Parsteel Generator C",
+          "name": "parsteel generator c",
           "level": 45
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 11600,
-        "bonus2": 522000
+        "bonus1": 11600.0,
+        "bonus2": 522000.0
       },
       "build_costs": {
         "materials": [],
@@ -1566,20 +1521,19 @@
       "level": 46,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 46
         },
         {
-          "name": "Parsteel Generator C",
+          "name": "parsteel generator c",
           "level": 46
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 11800,
-        "bonus2": 531000
+        "bonus1": 11800.0,
+        "bonus2": 531000.0
       },
       "build_costs": {
         "materials": [],
@@ -1600,20 +1554,19 @@
       "level": 47,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 47
         },
         {
-          "name": "Parsteel Generator C",
+          "name": "parsteel generator c",
           "level": 47
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 12100,
-        "bonus2": 544500
+        "bonus1": 12100.0,
+        "bonus2": 544500.0
       },
       "build_costs": {
         "materials": [],
@@ -1634,31 +1587,30 @@
       "level": 48,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 48
         },
         {
-          "name": "Parsteel Generator C",
+          "name": "parsteel generator c",
           "level": 48
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 12300,
-        "bonus2": 553500
+        "bonus1": 12300.0,
+        "bonus2": 553500.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "tritanium",
+            "type": "dilithium",
             "value": 525000000
           },
           {
-            "type": "dilithium",
+            "type": "tritanium",
             "value": 525000000
           }
         ]
@@ -1668,20 +1620,19 @@
       "level": 49,
       "requirements": [
         {
-          "name": "Parsteel Generator C",
+          "name": "operations",
           "level": 49
         },
         {
-          "name": "Operations",
+          "name": "parsteel generator c",
           "level": 49
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 15100,
-        "bonus2": 679500
+        "bonus1": 15100.0,
+        "bonus2": 679500.0
       },
       "build_costs": {
         "materials": [],
@@ -1702,15 +1653,179 @@
       "level": 50,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 50
         },
         {
-          "name": "Parsteel Generator C",
+          "name": "parsteel generator c",
           "level": 50
         }
-      ],
-      "rewards": []
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 15400.0,
+        "bonus2": 693000.0
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 1950000000
+          },
+          {
+            "type": "dilithium",
+            "value": 1950000000
+          }
+        ]
+      },
+      "build_time": 14906880,
+      "increased_power": 2000,
+      "level": 51,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 51
+        },
+        {
+          "name": "parsteel generator c",
+          "level": 51
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 15700.0,
+        "bonus2": 706500.0
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 3315000000
+          },
+          {
+            "type": "dilithium",
+            "value": 3315000000
+          }
+        ]
+      },
+      "build_time": 15801120,
+      "increased_power": 1500,
+      "level": 52,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 52
+        },
+        {
+          "name": "parsteel generator c",
+          "level": 52
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 16000.0,
+        "bonus2": 720000.0
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 5800000000
+          },
+          {
+            "type": "dilithium",
+            "value": 5800000000
+          }
+        ]
+      },
+      "build_time": 16748640,
+      "increased_power": 2000,
+      "level": 53,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 53
+        },
+        {
+          "name": "parsteel generator c",
+          "level": 53
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 16300.0,
+        "bonus2": 733500.0
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "dilithium",
+            "value": 8700000000
+          },
+          {
+            "type": "tritanium",
+            "value": 8700000000
+          }
+        ]
+      },
+      "build_time": 17753760,
+      "increased_power": 2000,
+      "level": 54,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 54
+        },
+        {
+          "name": "parsteel generator c",
+          "level": 54
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 19400.0,
+        "bonus2": 873000.0
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "dilithium",
+            "value": 13650000000
+          },
+          {
+            "type": "tritanium",
+            "value": 13650000000
+          }
+        ]
+      },
+      "build_time": 18819360,
+      "increased_power": 2000,
+      "level": 55,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 55
+        },
+        {
+          "name": "parsteel generator c",
+          "level": 55
+        }
+      ]
     }
   ]
 }

--- a/buildings/parsteel_generator_f.json
+++ b/buildings/parsteel_generator_f.json
@@ -2,11 +2,11 @@
   "description": "Produces Parsteel, an alloy with immense tensile strength used to build Station buildings. Upgrading Parsteel Generators increases the amount of Parsteel that is produced.",
   "bonuses": {
     "bonus1": {
-      "name": "Parsteel Production",
+      "name": "parsteel production",
       "percentage": false
     },
     "bonus2": {
-      "name": "Parsteel Storage",
+      "name": "parsteel storage",
       "percentage": false
     }
   },
@@ -14,8 +14,8 @@
   "levels": [
     {
       "bonuses": {
-        "bonus1": 90,
-        "bonus2": 45
+        "bonus1": 90.0,
+        "bonus2": 45.0
       },
       "build_costs": {
         "materials": [],
@@ -36,32 +36,31 @@
       "level": 1,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 42
         },
         {
-          "name": "Parsteel Generator D",
+          "name": "parsteel generator d",
           "level": 1
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 190,
-        "bonus2": 285
+        "bonus1": 190.0,
+        "bonus2": 285.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 20
-          },
-          {
             "type": "tritanium",
             "value": 60
+          },
+          {
+            "type": "parsteel",
+            "value": 20
           }
         ]
       },
@@ -70,32 +69,31 @@
       "level": 2,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 2
         },
         {
-          "name": "Parsteel Generator D",
+          "name": "parsteel generator d",
           "level": 2
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 290,
-        "bonus2": 580
+        "bonus1": 290.0,
+        "bonus2": 580.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 35
-          },
-          {
             "type": "tritanium",
             "value": 75
+          },
+          {
+            "type": "parsteel",
+            "value": 35
           }
         ]
       },
@@ -104,32 +102,31 @@
       "level": 3,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 3
         },
         {
-          "name": "Parsteel Generator D",
+          "name": "parsteel generator d",
           "level": 3
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 395,
-        "bonus2": 1190
+        "bonus1": 395.0,
+        "bonus2": 1190.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 70
-          },
-          {
             "type": "tritanium",
             "value": 100
+          },
+          {
+            "type": "parsteel",
+            "value": 70
           }
         ]
       },
@@ -138,32 +135,31 @@
       "level": 4,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 4
         },
         {
-          "name": "Parsteel Generator D",
+          "name": "parsteel generator d",
           "level": 4
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 495,
-        "bonus2": 1975
+        "bonus1": 495.0,
+        "bonus2": 1975.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 120
-          },
-          {
             "type": "tritanium",
             "value": 150
+          },
+          {
+            "type": "parsteel",
+            "value": 120
           }
         ]
       },
@@ -172,32 +168,31 @@
       "level": 5,
       "requirements": [
         {
-          "name": "Parsteel Generator D",
+          "name": "operations",
           "level": 5
         },
         {
-          "name": "Operations",
+          "name": "parsteel generator d",
           "level": 5
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 600,
-        "bonus2": 2700
+        "bonus1": 600.0,
+        "bonus2": 2700.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 350
-          },
-          {
             "type": "tritanium",
             "value": 200
+          },
+          {
+            "type": "parsteel",
+            "value": 350
           }
         ]
       },
@@ -206,31 +201,31 @@
       "level": 6,
       "requirements": [
         {
-          "name": "Parsteel Generator D",
+          "name": "operations",
           "level": 6
         },
         {
-          "name": "Operations",
+          "name": "parsteel generator d",
           "level": 6
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 700,
-        "bonus2": 3850
+        "bonus1": 700.0,
+        "bonus2": 3850.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 700
-          },
-          {
             "type": "tritanium",
             "value": 250
+          },
+          {
+            "type": "parsteel",
+            "value": 700
           }
         ]
       },
@@ -239,31 +234,31 @@
       "level": 7,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 7
         },
         {
-          "name": "Parsteel Generator D",
+          "name": "parsteel generator d",
           "level": 7
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 800,
-        "bonus2": 5200
+        "bonus1": 800.0,
+        "bonus2": 5200.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 1200
-          },
-          {
             "type": "tritanium",
             "value": 300
+          },
+          {
+            "type": "parsteel",
+            "value": 1200
           }
         ]
       },
@@ -272,31 +267,31 @@
       "level": 8,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 8
         },
         {
-          "name": "Parsteel Generator D",
+          "name": "parsteel generator d",
           "level": 8
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 900,
-        "bonus2": 6300
+        "bonus1": 900.0,
+        "bonus2": 6300.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 2500
-          },
-          {
             "type": "tritanium",
             "value": 350
+          },
+          {
+            "type": "parsteel",
+            "value": 2500
           }
         ]
       },
@@ -305,31 +300,31 @@
       "level": 9,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 9
         },
         {
-          "name": "Parsteel Generator D",
+          "name": "parsteel generator d",
           "level": 9
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 1200,
-        "bonus2": 9600
+        "bonus1": 1200.0,
+        "bonus2": 9600.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 2800
-          },
-          {
             "type": "tritanium",
             "value": 450
+          },
+          {
+            "type": "parsteel",
+            "value": 2800
           }
         ]
       },
@@ -338,31 +333,31 @@
       "level": 10,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 10
         },
         {
-          "name": "Parsteel Generator D",
+          "name": "parsteel generator d",
           "level": 10
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 1320,
-        "bonus2": 11900
+        "bonus1": 1320.0,
+        "bonus2": 11900.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "tritanium",
-            "value": 100
-          },
-          {
             "type": "dilithium",
             "value": 20
+          },
+          {
+            "type": "tritanium",
+            "value": 100
           }
         ]
       },
@@ -371,31 +366,31 @@
       "level": 11,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 11
         },
         {
-          "name": "Parsteel Generator D",
+          "name": "parsteel generator d",
           "level": 11
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 1450,
-        "bonus2": 15200
+        "bonus1": 1450.0,
+        "bonus2": 15200.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "tritanium",
-            "value": 138
-          },
-          {
             "type": "dilithium",
             "value": 55
+          },
+          {
+            "type": "tritanium",
+            "value": 138
           }
         ]
       },
@@ -404,31 +399,31 @@
       "level": 12,
       "requirements": [
         {
-          "name": "Parsteel Generator D",
+          "name": "operations",
           "level": 12
         },
         {
-          "name": "Operations",
+          "name": "parsteel generator d",
           "level": 12
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 1550,
-        "bonus2": 17800
+        "bonus1": 1550.0,
+        "bonus2": 17800.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "tritanium",
-            "value": 200
-          },
-          {
             "type": "dilithium",
             "value": 120
+          },
+          {
+            "type": "tritanium",
+            "value": 200
           }
         ]
       },
@@ -437,31 +432,31 @@
       "level": 13,
       "requirements": [
         {
-          "name": "Parsteel Generator D",
+          "name": "operations",
           "level": 13
         },
         {
-          "name": "Operations",
+          "name": "parsteel generator d",
           "level": 13
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 1675,
-        "bonus2": 21750
+        "bonus1": 1675.0,
+        "bonus2": 21750.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "tritanium",
-            "value": 275
-          },
-          {
             "type": "dilithium",
             "value": 220
+          },
+          {
+            "type": "tritanium",
+            "value": 275
           }
         ]
       },
@@ -470,30 +465,30 @@
       "level": 14,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 14
         },
         {
-          "name": "Parsteel Generator D",
+          "name": "parsteel generator d",
           "level": 14
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 1800,
-        "bonus2": 25250
+        "bonus1": 1800.0,
+        "bonus2": 25250.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "tritanium",
+            "type": "dilithium",
             "value": 375
           },
           {
-            "type": "dilithium",
+            "type": "tritanium",
             "value": 375
           }
         ]
@@ -503,30 +498,30 @@
       "level": 15,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 15
         },
         {
-          "name": "Parsteel Generator D",
+          "name": "parsteel generator d",
           "level": 15
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 1925,
-        "bonus2": 29000
+        "bonus1": 1925.0,
+        "bonus2": 29000.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "tritanium",
+            "type": "dilithium",
             "value": 500
           },
           {
-            "type": "dilithium",
+            "type": "tritanium",
             "value": 500
           }
         ]
@@ -536,30 +531,30 @@
       "level": 16,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 16
         },
         {
-          "name": "Parsteel Generator D",
+          "name": "parsteel generator d",
           "level": 16
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 2050,
-        "bonus2": 33750
+        "bonus1": 2050.0,
+        "bonus2": 33750.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "tritanium",
+            "type": "dilithium",
             "value": 700
           },
           {
-            "type": "dilithium",
+            "type": "tritanium",
             "value": 700
           }
         ]
@@ -569,19 +564,19 @@
       "level": 17,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 17
         },
         {
-          "name": "Parsteel Generator D",
+          "name": "parsteel generator d",
           "level": 17
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 2175,
-        "bonus2": 38000
+        "bonus1": 2175.0,
+        "bonus2": 38000.0
       },
       "build_costs": {
         "materials": [],
@@ -602,19 +597,19 @@
       "level": 18,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 18
         },
         {
-          "name": "Parsteel Generator D",
+          "name": "parsteel generator d",
           "level": 18
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 2300,
-        "bonus2": 43750
+        "bonus1": 2300.0,
+        "bonus2": 43750.0
       },
       "build_costs": {
         "materials": [],
@@ -635,19 +630,19 @@
       "level": 19,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 19
         },
         {
-          "name": "Parsteel Generator D",
+          "name": "parsteel generator d",
           "level": 19
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 2825,
-        "bonus2": 56500
+        "bonus1": 2825.0,
+        "bonus2": 56500.0
       },
       "build_costs": {
         "materials": [],
@@ -668,19 +663,19 @@
       "level": 20,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 20
         },
         {
-          "name": "Parsteel Generator D",
+          "name": "parsteel generator d",
           "level": 20
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 2950,
-        "bonus2": 59000
+        "bonus1": 2950.0,
+        "bonus2": 59000.0
       },
       "build_costs": {
         "materials": [],
@@ -701,19 +696,19 @@
       "level": 21,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 21
         },
         {
-          "name": "Parsteel Generator D",
+          "name": "parsteel generator d",
           "level": 21
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 3100,
-        "bonus2": 62000
+        "bonus1": 3100.0,
+        "bonus2": 62000.0
       },
       "build_costs": {
         "materials": [],
@@ -734,30 +729,30 @@
       "level": 22,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 22
         },
         {
-          "name": "Parsteel Generator D",
+          "name": "parsteel generator d",
           "level": 22
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 3225,
-        "bonus2": 64500
+        "bonus1": 3225.0,
+        "bonus2": 64500.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "tritanium",
+            "type": "dilithium",
             "value": 9158
           },
           {
-            "type": "dilithium",
+            "type": "tritanium",
             "value": 9158
           }
         ]
@@ -767,19 +762,19 @@
       "level": 23,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 23
         },
         {
-          "name": "Parsteel Generator D",
+          "name": "parsteel generator d",
           "level": 23
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 3375,
-        "bonus2": 67500
+        "bonus1": 3375.0,
+        "bonus2": 67500.0
       },
       "build_costs": {
         "materials": [],
@@ -800,19 +795,19 @@
       "level": 24,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 24
         },
         {
-          "name": "Parsteel Generator D",
+          "name": "parsteel generator d",
           "level": 24
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 4025,
-        "bonus2": 80500
+        "bonus1": 4025.0,
+        "bonus2": 80500.0
       },
       "build_costs": {
         "materials": [],
@@ -833,19 +828,19 @@
       "level": 25,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 25
         },
         {
-          "name": "Parsteel Generator D",
+          "name": "parsteel generator d",
           "level": 25
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 4175,
-        "bonus2": 83500
+        "bonus1": 4175.0,
+        "bonus2": 83500.0
       },
       "build_costs": {
         "materials": [],
@@ -866,19 +861,19 @@
       "level": 26,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 26
         },
         {
-          "name": "Parsteel Generator D",
+          "name": "parsteel generator d",
           "level": 26
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 4350,
-        "bonus2": 87000
+        "bonus1": 4350.0,
+        "bonus2": 87000.0
       },
       "build_costs": {
         "materials": [],
@@ -899,30 +894,30 @@
       "level": 27,
       "requirements": [
         {
-          "name": "Parsteel Generator D",
+          "name": "operations",
           "level": 27
         },
         {
-          "name": "Operations",
+          "name": "parsteel generator d",
           "level": 27
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 4500,
-        "bonus2": 90000
+        "bonus1": 4500.0,
+        "bonus2": 90000.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "tritanium",
+            "type": "dilithium",
             "value": 83700
           },
           {
-            "type": "dilithium",
+            "type": "tritanium",
             "value": 83700
           }
         ]
@@ -932,30 +927,30 @@
       "level": 28,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 28
         },
         {
-          "name": "Parsteel Generator D",
+          "name": "parsteel generator d",
           "level": 28
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 4675,
-        "bonus2": 93500
+        "bonus1": 4675.0,
+        "bonus2": 93500.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "tritanium",
+            "type": "dilithium",
             "value": 133250
           },
           {
-            "type": "dilithium",
+            "type": "tritanium",
             "value": 133250
           }
         ]
@@ -965,30 +960,30 @@
       "level": 29,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 29
         },
         {
-          "name": "Parsteel Generator D",
+          "name": "parsteel generator d",
           "level": 29
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 5400,
-        "bonus2": 108000
+        "bonus1": 5400.0,
+        "bonus2": 108000.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "tritanium",
+            "type": "dilithium",
             "value": 195000
           },
           {
-            "type": "dilithium",
+            "type": "tritanium",
             "value": 195000
           }
         ]
@@ -998,30 +993,30 @@
       "level": 30,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 30
         },
         {
-          "name": "Parsteel Generator D",
+          "name": "parsteel generator d",
           "level": 30
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 5600,
-        "bonus2": 112000
+        "bonus1": 5600.0,
+        "bonus2": 112000.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "tritanium",
+            "type": "dilithium",
             "value": 308250
           },
           {
-            "type": "dilithium",
+            "type": "tritanium",
             "value": 308250
           }
         ]
@@ -1031,19 +1026,19 @@
       "level": 31,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 31
         },
         {
-          "name": "Parsteel Generator D",
+          "name": "parsteel generator d",
           "level": 31
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 5800,
-        "bonus2": 125280
+        "bonus1": 5800.0,
+        "bonus2": 125280.0
       },
       "build_costs": {
         "materials": [],
@@ -1064,30 +1059,30 @@
       "level": 32,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 32
         },
         {
-          "name": "Parsteel Generator D",
+          "name": "parsteel generator d",
           "level": 32
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 6000,
-        "bonus2": 139200
+        "bonus1": 6000.0,
+        "bonus2": 139200.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "tritanium",
+            "type": "dilithium",
             "value": 688750
           },
           {
-            "type": "dilithium",
+            "type": "tritanium",
             "value": 688750
           }
         ]
@@ -1097,19 +1092,19 @@
       "level": 33,
       "requirements": [
         {
-          "name": "Parsteel Generator D",
+          "name": "operations",
           "level": 33
         },
         {
-          "name": "Operations",
+          "name": "parsteel generator d",
           "level": 33
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 6200,
-        "bonus2": 143840
+        "bonus1": 6200.0,
+        "bonus2": 143840.0
       },
       "build_costs": {
         "materials": [],
@@ -1130,19 +1125,19 @@
       "level": 34,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 34
         },
         {
-          "name": "Parsteel Generator D",
+          "name": "parsteel generator d",
           "level": 34
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 7000,
-        "bonus2": 173600
+        "bonus1": 7000.0,
+        "bonus2": 173600.0
       },
       "build_costs": {
         "materials": [],
@@ -1163,19 +1158,19 @@
       "level": 35,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 35
         },
         {
-          "name": "Parsteel Generator D",
+          "name": "parsteel generator d",
           "level": 35
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 7300,
-        "bonus2": 194180
+        "bonus1": 7300.0,
+        "bonus2": 194180.0
       },
       "build_costs": {
         "materials": [],
@@ -1196,19 +1191,19 @@
       "level": 36,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 36
         },
         {
-          "name": "Parsteel Generator D",
+          "name": "parsteel generator d",
           "level": 36
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 7500,
-        "bonus2": 199500
+        "bonus1": 7500.0,
+        "bonus2": 199500.0
       },
       "build_costs": {
         "materials": [],
@@ -1229,19 +1224,19 @@
       "level": 37,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 37
         },
         {
-          "name": "Parsteel Generator D",
+          "name": "parsteel generator d",
           "level": 37
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 7700,
-        "bonus2": 218680
+        "bonus1": 7700.0,
+        "bonus2": 218680.0
       },
       "build_costs": {
         "materials": [],
@@ -1262,30 +1257,30 @@
       "level": 38,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 38
         },
         {
-          "name": "Parsteel Generator D",
+          "name": "parsteel generator d",
           "level": 38
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 7900,
-        "bonus2": 241740
+        "bonus1": 7900.0,
+        "bonus2": 241740.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "tritanium",
+            "type": "dilithium",
             "value": 9675000
           },
           {
-            "type": "dilithium",
+            "type": "tritanium",
             "value": 9675000
           }
         ]
@@ -1295,30 +1290,30 @@
       "level": 39,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 39
         },
         {
-          "name": "Parsteel Generator D",
+          "name": "parsteel generator d",
           "level": 39
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 8900,
-        "bonus2": 272340
+        "bonus1": 8900.0,
+        "bonus2": 272340.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "tritanium",
+            "type": "dilithium",
             "value": 15050000
           },
           {
-            "type": "dilithium",
+            "type": "tritanium",
             "value": 15050000
           }
         ]
@@ -1328,30 +1323,30 @@
       "level": 40,
       "requirements": [
         {
-          "name": "Parsteel Generator D",
+          "name": "operations",
           "level": 40
         },
         {
-          "name": "Operations",
+          "name": "parsteel generator d",
           "level": 40
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 9100,
-        "bonus2": 300300
+        "bonus1": 9100.0,
+        "bonus2": 300300.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "tritanium",
+            "type": "dilithium",
             "value": 21500000
           },
           {
-            "type": "dilithium",
+            "type": "tritanium",
             "value": 21500000
           }
         ]
@@ -1361,19 +1356,19 @@
       "level": 41,
       "requirements": [
         {
-          "name": "Parsteel Generator D",
+          "name": "operations",
           "level": 41
         },
         {
-          "name": "Operations",
+          "name": "parsteel generator d",
           "level": 41
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 9300,
-        "bonus2": 336660
+        "bonus1": 9300.0,
+        "bonus2": 336660.0
       },
       "build_costs": {
         "materials": [],
@@ -1394,20 +1389,19 @@
       "level": 42,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 42
         },
         {
-          "name": "Parsteel Generator D",
+          "name": "parsteel generator d",
           "level": 42
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 9500,
-        "bonus2": 343900
+        "bonus1": 9500.0,
+        "bonus2": 343900.0
       },
       "build_costs": {
         "materials": [],
@@ -1428,20 +1422,19 @@
       "level": 43,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 43
         },
         {
-          "name": "Parsteel Generator D",
+          "name": "parsteel generator d",
           "level": 43
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 9800,
-        "bonus2": 392000
+        "bonus1": 9800.0,
+        "bonus2": 392000.0
       },
       "build_costs": {
         "materials": [],
@@ -1462,20 +1455,19 @@
       "level": 44,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 44
         },
         {
-          "name": "Parsteel Generator D",
+          "name": "parsteel generator d",
           "level": 44
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 11300,
-        "bonus2": 508500
+        "bonus1": 11300.0,
+        "bonus2": 508500.0
       },
       "build_costs": {
         "materials": [],
@@ -1496,20 +1488,19 @@
       "level": 45,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 45
         },
         {
-          "name": "Parsteel Generator D",
+          "name": "parsteel generator d",
           "level": 45
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 11600,
-        "bonus2": 522000
+        "bonus1": 11600.0,
+        "bonus2": 522000.0
       },
       "build_costs": {
         "materials": [],
@@ -1530,31 +1521,30 @@
       "level": 46,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 46
         },
         {
-          "name": "Parsteel Generator D",
+          "name": "parsteel generator d",
           "level": 46
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 11800,
-        "bonus2": 531000
+        "bonus1": 11800.0,
+        "bonus2": 531000.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "tritanium",
+            "type": "dilithium",
             "value": 195000000
           },
           {
-            "type": "dilithium",
+            "type": "tritanium",
             "value": 195000000
           }
         ]
@@ -1564,20 +1554,19 @@
       "level": 47,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 47
         },
         {
-          "name": "Parsteel Generator D",
+          "name": "parsteel generator d",
           "level": 47
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 12100,
-        "bonus2": 544500
+        "bonus1": 12100.0,
+        "bonus2": 544500.0
       },
       "build_costs": {
         "materials": [],
@@ -1598,31 +1587,30 @@
       "level": 48,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 48
         },
         {
-          "name": "Parsteel Generator D",
+          "name": "parsteel generator d",
           "level": 48
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 12300,
-        "bonus2": 553500
+        "bonus1": 12300.0,
+        "bonus2": 553500.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "tritanium",
+            "type": "dilithium",
             "value": 525000000
           },
           {
-            "type": "dilithium",
+            "type": "tritanium",
             "value": 525000000
           }
         ]
@@ -1632,20 +1620,19 @@
       "level": 49,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 49
         },
         {
-          "name": "Parsteel Generator D",
+          "name": "parsteel generator d",
           "level": 49
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 15100,
-        "bonus2": 679500
+        "bonus1": 15100.0,
+        "bonus2": 679500.0
       },
       "build_costs": {
         "materials": [],
@@ -1666,15 +1653,179 @@
       "level": 50,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 50
         },
         {
-          "name": "Parsteel Generator D",
+          "name": "parsteel generator d",
           "level": 50
         }
-      ],
-      "rewards": []
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 15400.0,
+        "bonus2": 693000.0
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 1950000000
+          },
+          {
+            "type": "dilithium",
+            "value": 1950000000
+          }
+        ]
+      },
+      "build_time": 14906880,
+      "increased_power": 2000,
+      "level": 51,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 51
+        },
+        {
+          "name": "parsteel generator d",
+          "level": 51
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 15700.0,
+        "bonus2": 706500.0
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "dilithium",
+            "value": 3315000000
+          },
+          {
+            "type": "tritanium",
+            "value": 3315000000
+          }
+        ]
+      },
+      "build_time": 15801120,
+      "increased_power": 1500,
+      "level": 52,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 52
+        },
+        {
+          "name": "parsteel generator d",
+          "level": 52
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 16000.0,
+        "bonus2": 720000.0
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "dilithium",
+            "value": 5800000000
+          },
+          {
+            "type": "tritanium",
+            "value": 5800000000
+          }
+        ]
+      },
+      "build_time": 16748640,
+      "increased_power": 2000,
+      "level": 53,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 53
+        },
+        {
+          "name": "parsteel generator d",
+          "level": 53
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 16300.0,
+        "bonus2": 733500.0
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "dilithium",
+            "value": 8700000000
+          },
+          {
+            "type": "tritanium",
+            "value": 8700000000
+          }
+        ]
+      },
+      "build_time": 17753760,
+      "increased_power": 2000,
+      "level": 54,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 54
+        },
+        {
+          "name": "parsteel generator d",
+          "level": 54
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 19400.0,
+        "bonus2": 873000.0
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 13650000000
+          },
+          {
+            "type": "dilithium",
+            "value": 13650000000
+          }
+        ]
+      },
+      "build_time": 18819360,
+      "increased_power": 2000,
+      "level": 55,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 55
+        },
+        {
+          "name": "parsteel generator d",
+          "level": 55
+        }
+      ]
     }
   ]
 }

--- a/buildings/parsteel_generator_g.json
+++ b/buildings/parsteel_generator_g.json
@@ -2,11 +2,11 @@
   "description": "Produces Parsteel, an alloy with immense tensile strength used to build Station buildings. Upgrading Parsteel Generators increases the amount of Parsteel that is produced.",
   "bonuses": {
     "bonus1": {
-      "name": "Parsteel Production",
+      "name": "parsteel production",
       "percentage": false
     },
     "bonus2": {
-      "name": "Parsteel Storage",
+      "name": "parsteel storage",
       "percentage": false
     }
   },
@@ -14,8 +14,8 @@
   "levels": [
     {
       "bonuses": {
-        "bonus1": 90,
-        "bonus2": 45
+        "bonus1": 90.0,
+        "bonus2": 45.0
       },
       "build_costs": {
         "materials": [],
@@ -32,20 +32,19 @@
       "level": 1,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 50
         },
         {
-          "name": "Parsteel Generator E",
+          "name": "parsteel generator e",
           "level": 1
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 190,
-        "bonus2": 285
+        "bonus1": 190.0,
+        "bonus2": 285.0
       },
       "build_costs": {
         "materials": [],
@@ -62,20 +61,19 @@
       "level": 2,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 2
         },
         {
-          "name": "Parsteel Generator E",
+          "name": "parsteel generator e",
           "level": 2
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 290,
-        "bonus2": 580
+        "bonus1": 290.0,
+        "bonus2": 580.0
       },
       "build_costs": {
         "materials": [],
@@ -92,20 +90,19 @@
       "level": 3,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 3
         },
         {
-          "name": "Parsteel Generator E",
+          "name": "parsteel generator e",
           "level": 3
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 395,
-        "bonus2": 1190
+        "bonus1": 395.0,
+        "bonus2": 1190.0
       },
       "build_costs": {
         "materials": [],
@@ -122,20 +119,19 @@
       "level": 4,
       "requirements": [
         {
-          "name": "Parsteel Generator E",
+          "name": "operations",
           "level": 4
         },
         {
-          "name": "Operations",
+          "name": "parsteel generator e",
           "level": 4
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 495,
-        "bonus2": 1975
+        "bonus1": 495.0,
+        "bonus2": 1975.0
       },
       "build_costs": {
         "materials": [],
@@ -152,20 +148,19 @@
       "level": 5,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 5
         },
         {
-          "name": "Parsteel Generator E",
+          "name": "parsteel generator e",
           "level": 5
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 600,
-        "bonus2": 2700
+        "bonus1": 600.0,
+        "bonus2": 2700.0
       },
       "build_costs": {
         "materials": [],
@@ -182,19 +177,19 @@
       "level": 6,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 6
         },
         {
-          "name": "Parsteel Generator E",
+          "name": "parsteel generator e",
           "level": 6
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 700,
-        "bonus2": 3850
+        "bonus1": 700.0,
+        "bonus2": 3850.0
       },
       "build_costs": {
         "materials": [],
@@ -215,31 +210,31 @@
       "level": 7,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 7
         },
         {
-          "name": "Parsteel Generator E",
+          "name": "parsteel generator e",
           "level": 7
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 800,
-        "bonus2": 5200
+        "bonus1": 800.0,
+        "bonus2": 5200.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 1200
-          },
-          {
             "type": "tritanium",
             "value": 15
+          },
+          {
+            "type": "parsteel",
+            "value": 1200
           }
         ]
       },
@@ -248,31 +243,31 @@
       "level": 8,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 8
         },
         {
-          "name": "Parsteel Generator E",
+          "name": "parsteel generator e",
           "level": 8
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 900,
-        "bonus2": 6300
+        "bonus1": 900.0,
+        "bonus2": 6300.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 2500
-          },
-          {
             "type": "tritanium",
             "value": 38
+          },
+          {
+            "type": "parsteel",
+            "value": 2500
           }
         ]
       },
@@ -281,19 +276,19 @@
       "level": 9,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 9
         },
         {
-          "name": "Parsteel Generator E",
+          "name": "parsteel generator e",
           "level": 9
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 1200,
-        "bonus2": 9600
+        "bonus1": 1200.0,
+        "bonus2": 9600.0
       },
       "build_costs": {
         "materials": [],
@@ -314,31 +309,31 @@
       "level": 10,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 10
         },
         {
-          "name": "Parsteel Generator E",
+          "name": "parsteel generator e",
           "level": 10
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 1320,
-        "bonus2": 11900
+        "bonus1": 1320.0,
+        "bonus2": 11900.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "tritanium",
-            "value": 100
-          },
-          {
             "type": "dilithium",
             "value": 20
+          },
+          {
+            "type": "tritanium",
+            "value": 100
           }
         ]
       },
@@ -347,31 +342,31 @@
       "level": 11,
       "requirements": [
         {
-          "name": "Parsteel Generator E",
+          "name": "operations",
           "level": 11
         },
         {
-          "name": "Operations",
+          "name": "parsteel generator e",
           "level": 11
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 1450,
-        "bonus2": 15200
+        "bonus1": 1450.0,
+        "bonus2": 15200.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "tritanium",
-            "value": 138
-          },
-          {
             "type": "dilithium",
             "value": 55
+          },
+          {
+            "type": "tritanium",
+            "value": 138
           }
         ]
       },
@@ -380,31 +375,31 @@
       "level": 12,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 12
         },
         {
-          "name": "Parsteel Generator E",
+          "name": "parsteel generator e",
           "level": 12
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 1550,
-        "bonus2": 17800
+        "bonus1": 1550.0,
+        "bonus2": 17800.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "tritanium",
-            "value": 200
-          },
-          {
             "type": "dilithium",
             "value": 120
+          },
+          {
+            "type": "tritanium",
+            "value": 200
           }
         ]
       },
@@ -413,19 +408,19 @@
       "level": 13,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 13
         },
         {
-          "name": "Parsteel Generator E",
+          "name": "parsteel generator e",
           "level": 13
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 1675,
-        "bonus2": 21750
+        "bonus1": 1675.0,
+        "bonus2": 21750.0
       },
       "build_costs": {
         "materials": [],
@@ -446,30 +441,30 @@
       "level": 14,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 14
         },
         {
-          "name": "Parsteel Generator E",
+          "name": "parsteel generator e",
           "level": 14
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 1800,
-        "bonus2": 25250
+        "bonus1": 1800.0,
+        "bonus2": 25250.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "tritanium",
+            "type": "dilithium",
             "value": 375
           },
           {
-            "type": "dilithium",
+            "type": "tritanium",
             "value": 375
           }
         ]
@@ -479,30 +474,30 @@
       "level": 15,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 15
         },
         {
-          "name": "Parsteel Generator E",
+          "name": "parsteel generator e",
           "level": 15
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 1925,
-        "bonus2": 29000
+        "bonus1": 1925.0,
+        "bonus2": 29000.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "tritanium",
+            "type": "dilithium",
             "value": 500
           },
           {
-            "type": "dilithium",
+            "type": "tritanium",
             "value": 500
           }
         ]
@@ -512,19 +507,19 @@
       "level": 16,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 16
         },
         {
-          "name": "Parsteel Generator E",
+          "name": "parsteel generator e",
           "level": 16
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 2050,
-        "bonus2": 33750
+        "bonus1": 2050.0,
+        "bonus2": 33750.0
       },
       "build_costs": {
         "materials": [],
@@ -545,19 +540,19 @@
       "level": 17,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 17
         },
         {
-          "name": "Parsteel Generator E",
+          "name": "parsteel generator e",
           "level": 17
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 2175,
-        "bonus2": 38000
+        "bonus1": 2175.0,
+        "bonus2": 38000.0
       },
       "build_costs": {
         "materials": [],
@@ -578,19 +573,19 @@
       "level": 18,
       "requirements": [
         {
-          "name": "Parsteel Generator E",
+          "name": "operations",
           "level": 18
         },
         {
-          "name": "Operations",
+          "name": "parsteel generator e",
           "level": 18
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 2300,
-        "bonus2": 43750
+        "bonus1": 2300.0,
+        "bonus2": 43750.0
       },
       "build_costs": {
         "materials": [],
@@ -611,30 +606,30 @@
       "level": 19,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 19
         },
         {
-          "name": "Parsteel Generator E",
+          "name": "parsteel generator e",
           "level": 19
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 2825,
-        "bonus2": 56500
+        "bonus1": 2825.0,
+        "bonus2": 56500.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "tritanium",
+            "type": "dilithium",
             "value": 2125
           },
           {
-            "type": "dilithium",
+            "type": "tritanium",
             "value": 2125
           }
         ]
@@ -644,30 +639,30 @@
       "level": 20,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 20
         },
         {
-          "name": "Parsteel Generator E",
+          "name": "parsteel generator e",
           "level": 20
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 2950,
-        "bonus2": 59000
+        "bonus1": 2950.0,
+        "bonus2": 59000.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "tritanium",
+            "type": "dilithium",
             "value": 3578
           },
           {
-            "type": "dilithium",
+            "type": "tritanium",
             "value": 3578
           }
         ]
@@ -677,19 +672,19 @@
       "level": 21,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 21
         },
         {
-          "name": "Parsteel Generator E",
+          "name": "parsteel generator e",
           "level": 21
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 3100,
-        "bonus2": 62000
+        "bonus1": 3100.0,
+        "bonus2": 62000.0
       },
       "build_costs": {
         "materials": [],
@@ -710,19 +705,19 @@
       "level": 22,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 22
         },
         {
-          "name": "Parsteel Generator E",
+          "name": "parsteel generator e",
           "level": 22
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 3225,
-        "bonus2": 64500
+        "bonus1": 3225.0,
+        "bonus2": 64500.0
       },
       "build_costs": {
         "materials": [],
@@ -743,30 +738,30 @@
       "level": 23,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 23
         },
         {
-          "name": "Parsteel Generator E",
+          "name": "parsteel generator e",
           "level": 23
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 3375,
-        "bonus2": 67500
+        "bonus1": 3375.0,
+        "bonus2": 67500.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "tritanium",
+            "type": "dilithium",
             "value": 14430
           },
           {
-            "type": "dilithium",
+            "type": "tritanium",
             "value": 14430
           }
         ]
@@ -776,19 +771,19 @@
       "level": 24,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 24
         },
         {
-          "name": "Parsteel Generator E",
+          "name": "parsteel generator e",
           "level": 24
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 4025,
-        "bonus2": 80500
+        "bonus1": 4025.0,
+        "bonus2": 80500.0
       },
       "build_costs": {
         "materials": [],
@@ -809,30 +804,30 @@
       "level": 25,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 25
         },
         {
-          "name": "Parsteel Generator E",
+          "name": "parsteel generator e",
           "level": 25
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 4175,
-        "bonus2": 83500
+        "bonus1": 4175.0,
+        "bonus2": 83500.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "tritanium",
+            "type": "dilithium",
             "value": 36563
           },
           {
-            "type": "dilithium",
+            "type": "tritanium",
             "value": 36563
           }
         ]
@@ -842,30 +837,30 @@
       "level": 26,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 26
         },
         {
-          "name": "Parsteel Generator E",
+          "name": "parsteel generator e",
           "level": 26
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 4350,
-        "bonus2": 87000
+        "bonus1": 4350.0,
+        "bonus2": 87000.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "tritanium",
+            "type": "dilithium",
             "value": 55800
           },
           {
-            "type": "dilithium",
+            "type": "tritanium",
             "value": 55800
           }
         ]
@@ -875,19 +870,19 @@
       "level": 27,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 27
         },
         {
-          "name": "Parsteel Generator E",
+          "name": "parsteel generator e",
           "level": 27
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 4500,
-        "bonus2": 90000
+        "bonus1": 4500.0,
+        "bonus2": 90000.0
       },
       "build_costs": {
         "materials": [],
@@ -908,19 +903,19 @@
       "level": 28,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 28
         },
         {
-          "name": "Parsteel Generator E",
+          "name": "parsteel generator e",
           "level": 28
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 4675,
-        "bonus2": 93500
+        "bonus1": 4675.0,
+        "bonus2": 93500.0
       },
       "build_costs": {
         "materials": [],
@@ -941,19 +936,19 @@
       "level": 29,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 29
         },
         {
-          "name": "Parsteel Generator E",
+          "name": "parsteel generator e",
           "level": 29
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 5400,
-        "bonus2": 108000
+        "bonus1": 5400.0,
+        "bonus2": 108000.0
       },
       "build_costs": {
         "materials": [],
@@ -974,30 +969,30 @@
       "level": 30,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 30
         },
         {
-          "name": "Parsteel Generator E",
+          "name": "parsteel generator e",
           "level": 30
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 5600,
-        "bonus2": 112000
+        "bonus1": 5600.0,
+        "bonus2": 112000.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "tritanium",
+            "type": "dilithium",
             "value": 308250
           },
           {
-            "type": "dilithium",
+            "type": "tritanium",
             "value": 308250
           }
         ]
@@ -1007,19 +1002,19 @@
       "level": 31,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 31
         },
         {
-          "name": "Parsteel Generator E",
+          "name": "parsteel generator e",
           "level": 31
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 5800,
-        "bonus2": 125280
+        "bonus1": 5800.0,
+        "bonus2": 125280.0
       },
       "build_costs": {
         "materials": [],
@@ -1040,19 +1035,19 @@
       "level": 32,
       "requirements": [
         {
-          "name": "Parsteel Generator E",
+          "name": "operations",
           "level": 32
         },
         {
-          "name": "Operations",
+          "name": "parsteel generator e",
           "level": 32
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 6000,
-        "bonus2": 139200
+        "bonus1": 6000.0,
+        "bonus2": 139200.0
       },
       "build_costs": {
         "materials": [],
@@ -1073,19 +1068,19 @@
       "level": 33,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 33
         },
         {
-          "name": "Parsteel Generator E",
+          "name": "parsteel generator e",
           "level": 33
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 6200,
-        "bonus2": 143840
+        "bonus1": 6200.0,
+        "bonus2": 143840.0
       },
       "build_costs": {
         "materials": [],
@@ -1106,19 +1101,19 @@
       "level": 34,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 34
         },
         {
-          "name": "Parsteel Generator E",
+          "name": "parsteel generator e",
           "level": 34
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 7000,
-        "bonus2": 173600
+        "bonus1": 7000.0,
+        "bonus2": 173600.0
       },
       "build_costs": {
         "materials": [],
@@ -1139,30 +1134,30 @@
       "level": 35,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 35
         },
         {
-          "name": "Parsteel Generator E",
+          "name": "parsteel generator e",
           "level": 35
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 7300,
-        "bonus2": 194180
+        "bonus1": 7300.0,
+        "bonus2": 194180.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "tritanium",
+            "type": "dilithium",
             "value": 2371500
           },
           {
-            "type": "dilithium",
+            "type": "tritanium",
             "value": 2371500
           }
         ]
@@ -1172,19 +1167,19 @@
       "level": 36,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 36
         },
         {
-          "name": "Parsteel Generator E",
+          "name": "parsteel generator e",
           "level": 36
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 7500,
-        "bonus2": 199500
+        "bonus1": 7500.0,
+        "bonus2": 199500.0
       },
       "build_costs": {
         "materials": [],
@@ -1205,19 +1200,19 @@
       "level": 37,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 37
         },
         {
-          "name": "Parsteel Generator E",
+          "name": "parsteel generator e",
           "level": 37
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 7700,
-        "bonus2": 218680
+        "bonus1": 7700.0,
+        "bonus2": 218680.0
       },
       "build_costs": {
         "materials": [],
@@ -1238,19 +1233,19 @@
       "level": 38,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 38
         },
         {
-          "name": "Parsteel Generator E",
+          "name": "parsteel generator e",
           "level": 38
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 7900,
-        "bonus2": 241740
+        "bonus1": 7900.0,
+        "bonus2": 241740.0
       },
       "build_costs": {
         "materials": [],
@@ -1271,19 +1266,19 @@
       "level": 39,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 39
         },
         {
-          "name": "Parsteel Generator E",
+          "name": "parsteel generator e",
           "level": 39
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 8900,
-        "bonus2": 272340
+        "bonus1": 8900.0,
+        "bonus2": 272340.0
       },
       "build_costs": {
         "materials": [],
@@ -1304,30 +1299,30 @@
       "level": 40,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 40
         },
         {
-          "name": "Parsteel Generator E",
+          "name": "parsteel generator e",
           "level": 40
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 9100,
-        "bonus2": 300300
+        "bonus1": 9100.0,
+        "bonus2": 300300.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "tritanium",
+            "type": "dilithium",
             "value": 21500000
           },
           {
-            "type": "dilithium",
+            "type": "tritanium",
             "value": 21500000
           }
         ]
@@ -1337,19 +1332,19 @@
       "level": 41,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 41
         },
         {
-          "name": "Parsteel Generator E",
+          "name": "parsteel generator e",
           "level": 41
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 9300,
-        "bonus2": 336660
+        "bonus1": 9300.0,
+        "bonus2": 336660.0
       },
       "build_costs": {
         "materials": [],
@@ -1370,30 +1365,30 @@
       "level": 42,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 42
         },
         {
-          "name": "Parsteel Generator E",
+          "name": "parsteel generator e",
           "level": 42
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 9500,
-        "bonus2": 343900
+        "bonus1": 9500.0,
+        "bonus2": 343900.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "tritanium",
+            "type": "dilithium",
             "value": 45750000
           },
           {
-            "type": "dilithium",
+            "type": "tritanium",
             "value": 45750000
           }
         ]
@@ -1403,19 +1398,19 @@
       "level": 43,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 43
         },
         {
-          "name": "Parsteel Generator E",
+          "name": "parsteel generator e",
           "level": 43
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 9800,
-        "bonus2": 392000
+        "bonus1": 9800.0,
+        "bonus2": 392000.0
       },
       "build_costs": {
         "materials": [],
@@ -1436,19 +1431,19 @@
       "level": 44,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 44
         },
         {
-          "name": "Parsteel Generator E",
+          "name": "parsteel generator e",
           "level": 44
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 11300,
-        "bonus2": 508500
+        "bonus1": 11300.0,
+        "bonus2": 508500.0
       },
       "build_costs": {
         "materials": [],
@@ -1469,30 +1464,30 @@
       "level": 45,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 45
         },
         {
-          "name": "Parsteel Generator E",
+          "name": "parsteel generator e",
           "level": 45
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 11600,
-        "bonus2": 522000
+        "bonus1": 11600.0,
+        "bonus2": 522000.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "tritanium",
+            "type": "dilithium",
             "value": 134062500
           },
           {
-            "type": "dilithium",
+            "type": "tritanium",
             "value": 134062500
           }
         ]
@@ -1502,19 +1497,19 @@
       "level": 46,
       "requirements": [
         {
-          "name": "Parsteel Generator E",
+          "name": "operations",
           "level": 46
         },
         {
-          "name": "Operations",
+          "name": "parsteel generator e",
           "level": 46
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 11800,
-        "bonus2": 531000
+        "bonus1": 11800.0,
+        "bonus2": 531000.0
       },
       "build_costs": {
         "materials": [],
@@ -1535,19 +1530,19 @@
       "level": 47,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 47
         },
         {
-          "name": "Parsteel Generator E",
+          "name": "parsteel generator e",
           "level": 47
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 12100,
-        "bonus2": 544500
+        "bonus1": 12100.0,
+        "bonus2": 544500.0
       },
       "build_costs": {
         "materials": [],
@@ -1568,30 +1563,30 @@
       "level": 48,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 48
         },
         {
-          "name": "Parsteel Generator E",
+          "name": "parsteel generator e",
           "level": 48
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 12300,
-        "bonus2": 553500
+        "bonus1": 12300.0,
+        "bonus2": 553500.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "tritanium",
+            "type": "dilithium",
             "value": 525000000
           },
           {
-            "type": "dilithium",
+            "type": "tritanium",
             "value": 525000000
           }
         ]
@@ -1601,30 +1596,30 @@
       "level": 49,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 49
         },
         {
-          "name": "Parsteel Generator E",
+          "name": "parsteel generator e",
           "level": 49
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 15100,
-        "bonus2": 679500
+        "bonus1": 15100.0,
+        "bonus2": 679500.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "tritanium",
+            "type": "dilithium",
             "value": 918750000
           },
           {
-            "type": "dilithium",
+            "type": "tritanium",
             "value": 918750000
           }
         ]
@@ -1634,15 +1629,179 @@
       "level": 50,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 50
         },
         {
-          "name": "Parsteel Generator E",
+          "name": "parsteel generator e",
           "level": 50
         }
-      ],
-      "rewards": []
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 15400.0,
+        "bonus2": 693000.0
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 1950000000
+          },
+          {
+            "type": "dilithium",
+            "value": 1950000000
+          }
+        ]
+      },
+      "build_time": 14906880,
+      "increased_power": 2000,
+      "level": 51,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 51
+        },
+        {
+          "name": "parsteel generator e",
+          "level": 51
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 15700.0,
+        "bonus2": 706500.0
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 3315000000
+          },
+          {
+            "type": "dilithium",
+            "value": 3315000000
+          }
+        ]
+      },
+      "build_time": 15801120,
+      "increased_power": 1500,
+      "level": 52,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 52
+        },
+        {
+          "name": "parsteel generator e",
+          "level": 52
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 16000.0,
+        "bonus2": 720000.0
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 5800000000
+          },
+          {
+            "type": "dilithium",
+            "value": 5800000000
+          }
+        ]
+      },
+      "build_time": 16748640,
+      "increased_power": 2000,
+      "level": 53,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 53
+        },
+        {
+          "name": "parsteel generator e",
+          "level": 53
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 16300.0,
+        "bonus2": 733500.0
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 8700000000
+          },
+          {
+            "type": "dilithium",
+            "value": 8700000000
+          }
+        ]
+      },
+      "build_time": 17753760,
+      "increased_power": 2000,
+      "level": 54,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 54
+        },
+        {
+          "name": "parsteel generator e",
+          "level": 54
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 19400.0,
+        "bonus2": 873000.0
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 13650000000
+          },
+          {
+            "type": "dilithium",
+            "value": 13650000000
+          }
+        ]
+      },
+      "build_time": 18819360,
+      "increased_power": 2000,
+      "level": 55,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 55
+        },
+        {
+          "name": "parsteel generator e",
+          "level": 55
+        }
+      ]
     }
   ]
 }

--- a/buildings/parsteel_generator_h.json
+++ b/buildings/parsteel_generator_h.json
@@ -2,11 +2,11 @@
   "description": "Produces Parsteel, an alloy with immense tensile strength used to build Station buildings. Upgrading Parsteel Generators increases the amount of Parsteel that is produced.",
   "bonuses": {
     "bonus1": {
-      "name": "Parsteel Production",
+      "name": "parsteel production",
       "percentage": false
     },
     "bonus2": {
-      "name": "Parsteel Storage",
+      "name": "parsteel storage",
       "percentage": false
     }
   },
@@ -14,8 +14,8 @@
   "levels": [
     {
       "bonuses": {
-        "bonus1": 90,
-        "bonus2": 45
+        "bonus1": 90.0,
+        "bonus2": 45.0
       },
       "build_costs": {
         "materials": [],
@@ -32,20 +32,19 @@
       "level": 1,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 50
         },
         {
-          "name": "Parsteel Generator F",
+          "name": "parsteel generator f",
           "level": 1
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 190,
-        "bonus2": 285
+        "bonus1": 190.0,
+        "bonus2": 285.0
       },
       "build_costs": {
         "materials": [],
@@ -62,20 +61,19 @@
       "level": 2,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 2
         },
         {
-          "name": "Parsteel Generator F",
+          "name": "parsteel generator f",
           "level": 2
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 290,
-        "bonus2": 580
+        "bonus1": 290.0,
+        "bonus2": 580.0
       },
       "build_costs": {
         "materials": [],
@@ -92,20 +90,19 @@
       "level": 3,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 3
         },
         {
-          "name": "Parsteel Generator F",
+          "name": "parsteel generator f",
           "level": 3
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 395,
-        "bonus2": 1190
+        "bonus1": 395.0,
+        "bonus2": 1190.0
       },
       "build_costs": {
         "materials": [],
@@ -122,20 +119,19 @@
       "level": 4,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 4
         },
         {
-          "name": "Parsteel Generator F",
+          "name": "parsteel generator f",
           "level": 4
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 495,
-        "bonus2": 1975
+        "bonus1": 495.0,
+        "bonus2": 1975.0
       },
       "build_costs": {
         "materials": [],
@@ -152,20 +148,19 @@
       "level": 5,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 5
         },
         {
-          "name": "Parsteel Generator F",
+          "name": "parsteel generator f",
           "level": 5
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 600,
-        "bonus2": 2700
+        "bonus1": 600.0,
+        "bonus2": 2700.0
       },
       "build_costs": {
         "materials": [],
@@ -182,19 +177,19 @@
       "level": 6,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 6
         },
         {
-          "name": "Parsteel Generator F",
+          "name": "parsteel generator f",
           "level": 6
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 700,
-        "bonus2": 3850
+        "bonus1": 700.0,
+        "bonus2": 3850.0
       },
       "build_costs": {
         "materials": [],
@@ -215,19 +210,19 @@
       "level": 7,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 7
         },
         {
-          "name": "Parsteel Generator F",
+          "name": "parsteel generator f",
           "level": 7
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 800,
-        "bonus2": 5200
+        "bonus1": 800.0,
+        "bonus2": 5200.0
       },
       "build_costs": {
         "materials": [],
@@ -248,19 +243,19 @@
       "level": 8,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 8
         },
         {
-          "name": "Parsteel Generator F",
+          "name": "parsteel generator f",
           "level": 8
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 900,
-        "bonus2": 6300
+        "bonus1": 900.0,
+        "bonus2": 6300.0
       },
       "build_costs": {
         "materials": [],
@@ -281,31 +276,31 @@
       "level": 9,
       "requirements": [
         {
-          "name": "Parsteel Generator F",
+          "name": "operations",
           "level": 9
         },
         {
-          "name": "Operations",
+          "name": "parsteel generator f",
           "level": 9
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 1200,
-        "bonus2": 9600
+        "bonus1": 1200.0,
+        "bonus2": 9600.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 2800
-          },
-          {
             "type": "tritanium",
             "value": 75
+          },
+          {
+            "type": "parsteel",
+            "value": 2800
           }
         ]
       },
@@ -314,19 +309,19 @@
       "level": 10,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 10
         },
         {
-          "name": "Parsteel Generator F",
+          "name": "parsteel generator f",
           "level": 10
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 1320,
-        "bonus2": 11900
+        "bonus1": 1320.0,
+        "bonus2": 11900.0
       },
       "build_costs": {
         "materials": [],
@@ -347,19 +342,19 @@
       "level": 11,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 11
         },
         {
-          "name": "Parsteel Generator F",
+          "name": "parsteel generator f",
           "level": 11
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 1450,
-        "bonus2": 15200
+        "bonus1": 1450.0,
+        "bonus2": 15200.0
       },
       "build_costs": {
         "materials": [],
@@ -380,19 +375,19 @@
       "level": 12,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 12
         },
         {
-          "name": "Parsteel Generator F",
+          "name": "parsteel generator f",
           "level": 12
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 1550,
-        "bonus2": 17800
+        "bonus1": 1550.0,
+        "bonus2": 17800.0
       },
       "build_costs": {
         "materials": [],
@@ -413,19 +408,19 @@
       "level": 13,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 13
         },
         {
-          "name": "Parsteel Generator F",
+          "name": "parsteel generator f",
           "level": 13
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 1675,
-        "bonus2": 21750
+        "bonus1": 1675.0,
+        "bonus2": 21750.0
       },
       "build_costs": {
         "materials": [],
@@ -446,19 +441,19 @@
       "level": 14,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 14
         },
         {
-          "name": "Parsteel Generator F",
+          "name": "parsteel generator f",
           "level": 14
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 1800,
-        "bonus2": 25250
+        "bonus1": 1800.0,
+        "bonus2": 25250.0
       },
       "build_costs": {
         "materials": [],
@@ -479,19 +474,19 @@
       "level": 15,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 15
         },
         {
-          "name": "Parsteel Generator F",
+          "name": "parsteel generator f",
           "level": 15
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 1925,
-        "bonus2": 29000
+        "bonus1": 1925.0,
+        "bonus2": 29000.0
       },
       "build_costs": {
         "materials": [],
@@ -512,30 +507,30 @@
       "level": 16,
       "requirements": [
         {
-          "name": "Parsteel Generator F",
+          "name": "operations",
           "level": 16
         },
         {
-          "name": "Operations",
+          "name": "parsteel generator f",
           "level": 16
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 2050,
-        "bonus2": 33750
+        "bonus1": 2050.0,
+        "bonus2": 33750.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "tritanium",
+            "type": "dilithium",
             "value": 700
           },
           {
-            "type": "dilithium",
+            "type": "tritanium",
             "value": 700
           }
         ]
@@ -545,19 +540,19 @@
       "level": 17,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 17
         },
         {
-          "name": "Parsteel Generator F",
+          "name": "parsteel generator f",
           "level": 17
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 2175,
-        "bonus2": 38000
+        "bonus1": 2175.0,
+        "bonus2": 38000.0
       },
       "build_costs": {
         "materials": [],
@@ -578,19 +573,19 @@
       "level": 18,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 18
         },
         {
-          "name": "Parsteel Generator F",
+          "name": "parsteel generator f",
           "level": 18
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 2300,
-        "bonus2": 43750
+        "bonus1": 2300.0,
+        "bonus2": 43750.0
       },
       "build_costs": {
         "materials": [],
@@ -611,30 +606,30 @@
       "level": 19,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 19
         },
         {
-          "name": "Parsteel Generator F",
+          "name": "parsteel generator f",
           "level": 19
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 2825,
-        "bonus2": 56500
+        "bonus1": 2825.0,
+        "bonus2": 56500.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "tritanium",
+            "type": "dilithium",
             "value": 2125
           },
           {
-            "type": "dilithium",
+            "type": "tritanium",
             "value": 2125
           }
         ]
@@ -644,19 +639,19 @@
       "level": 20,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 20
         },
         {
-          "name": "Parsteel Generator F",
+          "name": "parsteel generator f",
           "level": 20
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 2950,
-        "bonus2": 59000
+        "bonus1": 2950.0,
+        "bonus2": 59000.0
       },
       "build_costs": {
         "materials": [],
@@ -677,30 +672,30 @@
       "level": 21,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 21
         },
         {
-          "name": "Parsteel Generator F",
+          "name": "parsteel generator f",
           "level": 21
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 3100,
-        "bonus2": 62000
+        "bonus1": 3100.0,
+        "bonus2": 62000.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "tritanium",
+            "type": "dilithium",
             "value": 5565
           },
           {
-            "type": "dilithium",
+            "type": "tritanium",
             "value": 5565
           }
         ]
@@ -710,19 +705,19 @@
       "level": 22,
       "requirements": [
         {
-          "name": "Parsteel Generator F",
+          "name": "operations",
           "level": 22
         },
         {
-          "name": "Operations",
+          "name": "parsteel generator f",
           "level": 22
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 3225,
-        "bonus2": 64500
+        "bonus1": 3225.0,
+        "bonus2": 64500.0
       },
       "build_costs": {
         "materials": [],
@@ -743,19 +738,19 @@
       "level": 23,
       "requirements": [
         {
-          "name": "Parsteel Generator F",
+          "name": "operations",
           "level": 23
         },
         {
-          "name": "Operations",
+          "name": "parsteel generator f",
           "level": 23
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 3375,
-        "bonus2": 67500
+        "bonus1": 3375.0,
+        "bonus2": 67500.0
       },
       "build_costs": {
         "materials": [],
@@ -776,19 +771,19 @@
       "level": 24,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 24
         },
         {
-          "name": "Parsteel Generator F",
+          "name": "parsteel generator f",
           "level": 24
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 4025,
-        "bonus2": 80500
+        "bonus1": 4025.0,
+        "bonus2": 80500.0
       },
       "build_costs": {
         "materials": [],
@@ -809,30 +804,30 @@
       "level": 25,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 25
         },
         {
-          "name": "Parsteel Generator F",
+          "name": "parsteel generator f",
           "level": 25
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 4175,
-        "bonus2": 83500
+        "bonus1": 4175.0,
+        "bonus2": 83500.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "tritanium",
+            "type": "dilithium",
             "value": 36563
           },
           {
-            "type": "dilithium",
+            "type": "tritanium",
             "value": 36563
           }
         ]
@@ -842,19 +837,19 @@
       "level": 26,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 26
         },
         {
-          "name": "Parsteel Generator F",
+          "name": "parsteel generator f",
           "level": 26
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 4350,
-        "bonus2": 87000
+        "bonus1": 4350.0,
+        "bonus2": 87000.0
       },
       "build_costs": {
         "materials": [],
@@ -875,19 +870,19 @@
       "level": 27,
       "requirements": [
         {
-          "name": "Parsteel Generator F",
+          "name": "operations",
           "level": 27
         },
         {
-          "name": "Operations",
+          "name": "parsteel generator f",
           "level": 27
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 4500,
-        "bonus2": 90000
+        "bonus1": 4500.0,
+        "bonus2": 90000.0
       },
       "build_costs": {
         "materials": [],
@@ -908,30 +903,30 @@
       "level": 28,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 28
         },
         {
-          "name": "Parsteel Generator F",
+          "name": "parsteel generator f",
           "level": 28
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 4675,
-        "bonus2": 93500
+        "bonus1": 4675.0,
+        "bonus2": 93500.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "tritanium",
+            "type": "dilithium",
             "value": 133250
           },
           {
-            "type": "dilithium",
+            "type": "tritanium",
             "value": 133250
           }
         ]
@@ -941,19 +936,19 @@
       "level": 29,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 29
         },
         {
-          "name": "Parsteel Generator F",
+          "name": "parsteel generator f",
           "level": 29
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 5400,
-        "bonus2": 108000
+        "bonus1": 5400.0,
+        "bonus2": 108000.0
       },
       "build_costs": {
         "materials": [],
@@ -974,30 +969,30 @@
       "level": 30,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 30
         },
         {
-          "name": "Parsteel Generator F",
+          "name": "parsteel generator f",
           "level": 30
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 5600,
-        "bonus2": 112000
+        "bonus1": 5600.0,
+        "bonus2": 112000.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "tritanium",
+            "type": "dilithium",
             "value": 308250
           },
           {
-            "type": "dilithium",
+            "type": "tritanium",
             "value": 308250
           }
         ]
@@ -1007,30 +1002,30 @@
       "level": 31,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 31
         },
         {
-          "name": "Parsteel Generator F",
+          "name": "parsteel generator f",
           "level": 31
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 5800,
-        "bonus2": 125280
+        "bonus1": 5800.0,
+        "bonus2": 125280.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "tritanium",
+            "type": "dilithium",
             "value": 445250
           },
           {
-            "type": "dilithium",
+            "type": "tritanium",
             "value": 445250
           }
         ]
@@ -1040,30 +1035,30 @@
       "level": 32,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 32
         },
         {
-          "name": "Parsteel Generator F",
+          "name": "parsteel generator f",
           "level": 32
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 6000,
-        "bonus2": 139200
+        "bonus1": 6000.0,
+        "bonus2": 139200.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "tritanium",
+            "type": "dilithium",
             "value": 688750
           },
           {
-            "type": "dilithium",
+            "type": "tritanium",
             "value": 688750
           }
         ]
@@ -1073,19 +1068,19 @@
       "level": 33,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 33
         },
         {
-          "name": "Parsteel Generator F",
+          "name": "parsteel generator f",
           "level": 33
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 6200,
-        "bonus2": 143840
+        "bonus1": 6200.0,
+        "bonus2": 143840.0
       },
       "build_costs": {
         "materials": [],
@@ -1106,19 +1101,19 @@
       "level": 34,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 34
         },
         {
-          "name": "Parsteel Generator F",
+          "name": "parsteel generator f",
           "level": 34
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 7000,
-        "bonus2": 173600
+        "bonus1": 7000.0,
+        "bonus2": 173600.0
       },
       "build_costs": {
         "materials": [],
@@ -1139,30 +1134,30 @@
       "level": 35,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 35
         },
         {
-          "name": "Parsteel Generator F",
+          "name": "parsteel generator f",
           "level": 35
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 7300,
-        "bonus2": 194180
+        "bonus1": 7300.0,
+        "bonus2": 194180.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "tritanium",
+            "type": "dilithium",
             "value": 2371500
           },
           {
-            "type": "dilithium",
+            "type": "tritanium",
             "value": 2371500
           }
         ]
@@ -1172,19 +1167,19 @@
       "level": 36,
       "requirements": [
         {
-          "name": "Parsteel Generator F",
+          "name": "operations",
           "level": 36
         },
         {
-          "name": "Operations",
+          "name": "parsteel generator f",
           "level": 36
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 7500,
-        "bonus2": 199500
+        "bonus1": 7500.0,
+        "bonus2": 199500.0
       },
       "build_costs": {
         "materials": [],
@@ -1205,30 +1200,30 @@
       "level": 37,
       "requirements": [
         {
-          "name": "Parsteel Generator F",
+          "name": "operations",
           "level": 37
         },
         {
-          "name": "Operations",
+          "name": "parsteel generator f",
           "level": 37
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 7700,
-        "bonus2": 218680
+        "bonus1": 7700.0,
+        "bonus2": 218680.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "tritanium",
+            "type": "dilithium",
             "value": 5670000
           },
           {
-            "type": "dilithium",
+            "type": "tritanium",
             "value": 5670000
           }
         ]
@@ -1238,30 +1233,30 @@
       "level": 38,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 38
         },
         {
-          "name": "Parsteel Generator F",
+          "name": "parsteel generator f",
           "level": 38
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 7900,
-        "bonus2": 241740
+        "bonus1": 7900.0,
+        "bonus2": 241740.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "tritanium",
+            "type": "dilithium",
             "value": 9675000
           },
           {
-            "type": "dilithium",
+            "type": "tritanium",
             "value": 9675000
           }
         ]
@@ -1271,19 +1266,19 @@
       "level": 39,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 39
         },
         {
-          "name": "Parsteel Generator F",
+          "name": "parsteel generator f",
           "level": 39
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 8900,
-        "bonus2": 272340
+        "bonus1": 8900.0,
+        "bonus2": 272340.0
       },
       "build_costs": {
         "materials": [],
@@ -1304,30 +1299,30 @@
       "level": 40,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 40
         },
         {
-          "name": "Parsteel Generator F",
+          "name": "parsteel generator f",
           "level": 40
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 9100,
-        "bonus2": 300300
+        "bonus1": 9100.0,
+        "bonus2": 300300.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "tritanium",
+            "type": "dilithium",
             "value": 21500000
           },
           {
-            "type": "dilithium",
+            "type": "tritanium",
             "value": 21500000
           }
         ]
@@ -1337,19 +1332,19 @@
       "level": 41,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 41
         },
         {
-          "name": "Parsteel Generator F",
+          "name": "parsteel generator f",
           "level": 41
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 9300,
-        "bonus2": 336660
+        "bonus1": 9300.0,
+        "bonus2": 336660.0
       },
       "build_costs": {
         "materials": [],
@@ -1370,19 +1365,19 @@
       "level": 42,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 42
         },
         {
-          "name": "Parsteel Generator F",
+          "name": "parsteel generator f",
           "level": 42
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 9500,
-        "bonus2": 343900
+        "bonus1": 9500.0,
+        "bonus2": 343900.0
       },
       "build_costs": {
         "materials": [],
@@ -1403,19 +1398,19 @@
       "level": 43,
       "requirements": [
         {
-          "name": "Parsteel Generator F",
+          "name": "operations",
           "level": 43
         },
         {
-          "name": "Operations",
+          "name": "parsteel generator f",
           "level": 43
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 9800,
-        "bonus2": 392000
+        "bonus1": 9800.0,
+        "bonus2": 392000.0
       },
       "build_costs": {
         "materials": [],
@@ -1436,30 +1431,30 @@
       "level": 44,
       "requirements": [
         {
-          "name": "Parsteel Generator F",
+          "name": "operations",
           "level": 44
         },
         {
-          "name": "Operations",
+          "name": "parsteel generator f",
           "level": 44
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 11300,
-        "bonus2": 508500
+        "bonus1": 11300.0,
+        "bonus2": 508500.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "tritanium",
+            "type": "dilithium",
             "value": 97500000
           },
           {
-            "type": "dilithium",
+            "type": "tritanium",
             "value": 97500000
           }
         ]
@@ -1469,30 +1464,30 @@
       "level": 45,
       "requirements": [
         {
-          "name": "Parsteel Generator F",
+          "name": "operations",
           "level": 45
         },
         {
-          "name": "Operations",
+          "name": "parsteel generator f",
           "level": 45
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 11600,
-        "bonus2": 522000
+        "bonus1": 11600.0,
+        "bonus2": 522000.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "tritanium",
+            "type": "dilithium",
             "value": 134062500
           },
           {
-            "type": "dilithium",
+            "type": "tritanium",
             "value": 134062500
           }
         ]
@@ -1502,19 +1497,19 @@
       "level": 46,
       "requirements": [
         {
-          "name": "Parsteel Generator F",
+          "name": "operations",
           "level": 46
         },
         {
-          "name": "Operations",
+          "name": "parsteel generator f",
           "level": 46
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 11800,
-        "bonus2": 531000
+        "bonus1": 11800.0,
+        "bonus2": 531000.0
       },
       "build_costs": {
         "materials": [],
@@ -1535,19 +1530,19 @@
       "level": 47,
       "requirements": [
         {
-          "name": "Parsteel Generator F",
+          "name": "operations",
           "level": 47
         },
         {
-          "name": "Operations",
+          "name": "parsteel generator f",
           "level": 47
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 12100,
-        "bonus2": 544500
+        "bonus1": 12100.0,
+        "bonus2": 544500.0
       },
       "build_costs": {
         "materials": [],
@@ -1568,30 +1563,30 @@
       "level": 48,
       "requirements": [
         {
-          "name": "Parsteel Generator F",
+          "name": "operations",
           "level": 48
         },
         {
-          "name": "Operations",
+          "name": "parsteel generator f",
           "level": 48
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 12300,
-        "bonus2": 553500
+        "bonus1": 12300.0,
+        "bonus2": 553500.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "tritanium",
+            "type": "dilithium",
             "value": 525000000
           },
           {
-            "type": "dilithium",
+            "type": "tritanium",
             "value": 525000000
           }
         ]
@@ -1601,19 +1596,19 @@
       "level": 49,
       "requirements": [
         {
-          "name": "Parsteel Generator F",
+          "name": "operations",
           "level": 49
         },
         {
-          "name": "Operations",
+          "name": "parsteel generator f",
           "level": 49
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 15100,
-        "bonus2": 679500
+        "bonus1": 15100.0,
+        "bonus2": 679500.0
       },
       "build_costs": {
         "materials": [],
@@ -1634,15 +1629,179 @@
       "level": 50,
       "requirements": [
         {
-          "name": "Parsteel Generator F",
+          "name": "operations",
           "level": 50
         },
         {
-          "name": "Operations",
+          "name": "parsteel generator f",
           "level": 50
         }
-      ],
-      "rewards": []
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 15400.0,
+        "bonus2": 693000.0
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "dilithium",
+            "value": 1950000000
+          },
+          {
+            "type": "tritanium",
+            "value": 1950000000
+          }
+        ]
+      },
+      "build_time": 14906880,
+      "increased_power": 2000,
+      "level": 51,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 51
+        },
+        {
+          "name": "parsteel generator f",
+          "level": 51
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 15700.0,
+        "bonus2": 706500.0
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "dilithium",
+            "value": 3315000000
+          },
+          {
+            "type": "tritanium",
+            "value": 3315000000
+          }
+        ]
+      },
+      "build_time": 15801120,
+      "increased_power": 1500,
+      "level": 52,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 52
+        },
+        {
+          "name": "parsteel generator f",
+          "level": 52
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 16000.0,
+        "bonus2": 720000.0
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 5800000000
+          },
+          {
+            "type": "dilithium",
+            "value": 5800000000
+          }
+        ]
+      },
+      "build_time": 16748640,
+      "increased_power": 2000,
+      "level": 53,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 53
+        },
+        {
+          "name": "parsteel generator f",
+          "level": 53
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 16300.0,
+        "bonus2": 733500.0
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 8700000000
+          },
+          {
+            "type": "dilithium",
+            "value": 8700000000
+          }
+        ]
+      },
+      "build_time": 17753760,
+      "increased_power": 2000,
+      "level": 54,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 54
+        },
+        {
+          "name": "parsteel generator f",
+          "level": 54
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 19400.0,
+        "bonus2": 873000.0
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "dilithium",
+            "value": 13650000000
+          },
+          {
+            "type": "tritanium",
+            "value": 13650000000
+          }
+        ]
+      },
+      "build_time": 18819360,
+      "increased_power": 2000,
+      "level": 55,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 55
+        },
+        {
+          "name": "parsteel generator f",
+          "level": 55
+        }
+      ]
     }
   ]
 }

--- a/buildings/parsteel_vault.json
+++ b/buildings/parsteel_vault.json
@@ -2,7 +2,7 @@
   "description": "Protects the stored Parsteel from enemy attacks. Upgrade the Vault for additional security.",
   "bonuses": {
     "bonus1": {
-      "name": "Parsteel Vault Protection",
+      "name": "parsteel vault protection",
       "percentage": false
     }
   },
@@ -10,7 +10,7 @@
   "levels": [
     {
       "bonuses": {
-        "bonus1": 70000
+        "bonus1": 70000.0
       },
       "build_costs": {
         "materials": [],
@@ -31,15 +31,14 @@
       "level": 1,
       "requirements": [
         {
-          "name": "Unlock Vaults",
+          "name": "unlock vaults",
           "level": 1
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 72000
+        "bonus1": 72000.0
       },
       "build_costs": {
         "materials": [],
@@ -60,19 +59,18 @@
       "level": 2,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 2
         },
         {
-          "name": "Parsteel Generator B",
+          "name": "parsteel generator b",
           "level": 2
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 74000
+        "bonus1": 74000.0
       },
       "build_costs": {
         "materials": [],
@@ -93,31 +91,30 @@
       "level": 3,
       "requirements": [
         {
-          "name": "Parsteel Generator B",
+          "name": "operations",
           "level": 3
         },
         {
-          "name": "Operations",
+          "name": "parsteel generator b",
           "level": 3
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 77000
+        "bonus1": 77000.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 1250
-          },
-          {
             "type": "tritanium",
             "value": 50
+          },
+          {
+            "type": "parsteel",
+            "value": 1250
           }
         ]
       },
@@ -126,31 +123,30 @@
       "level": 4,
       "requirements": [
         {
-          "name": "Parsteel Generator B",
+          "name": "operations",
           "level": 4
         },
         {
-          "name": "Operations",
+          "name": "parsteel generator b",
           "level": 4
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 80000
+        "bonus1": 80000.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 1600
-          },
-          {
             "type": "tritanium",
             "value": 70
+          },
+          {
+            "type": "parsteel",
+            "value": 1600
           }
         ]
       },
@@ -159,31 +155,30 @@
       "level": 5,
       "requirements": [
         {
-          "name": "Parsteel Generator B",
+          "name": "operations",
           "level": 5
         },
         {
-          "name": "Operations",
+          "name": "parsteel generator b",
           "level": 5
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 83000
+        "bonus1": 83000.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 2000
-          },
-          {
             "type": "tritanium",
             "value": 90
+          },
+          {
+            "type": "parsteel",
+            "value": 2000
           }
         ]
       },
@@ -192,19 +187,18 @@
       "level": 6,
       "requirements": [
         {
-          "name": "Parsteel Generator B",
+          "name": "operations",
           "level": 6
         },
         {
-          "name": "Operations",
+          "name": "parsteel generator b",
           "level": 6
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 86000
+        "bonus1": 86000.0
       },
       "build_costs": {
         "materials": [],
@@ -225,31 +219,30 @@
       "level": 7,
       "requirements": [
         {
-          "name": "Parsteel Generator B",
+          "name": "operations",
           "level": 7
         },
         {
-          "name": "Operations",
+          "name": "parsteel generator b",
           "level": 7
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 90000
+        "bonus1": 90000.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 5000
-          },
-          {
             "type": "tritanium",
             "value": 150
+          },
+          {
+            "type": "parsteel",
+            "value": 5000
           }
         ]
       },
@@ -258,19 +251,18 @@
       "level": 8,
       "requirements": [
         {
-          "name": "Parsteel Generator B",
-          "level": 12
+          "name": "operations",
+          "level": 8
         },
         {
-          "name": "Operations",
-          "level": 8
+          "name": "parsteel generator b",
+          "level": 12
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 95000
+        "bonus1": 95000.0
       },
       "build_costs": {
         "materials": [],
@@ -291,19 +283,18 @@
       "level": 9,
       "requirements": [
         {
-          "name": "Parsteel Generator B",
+          "name": "operations",
           "level": 9
         },
         {
-          "name": "Operations",
+          "name": "parsteel generator b",
           "level": 9
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 100000
+        "bonus1": 100000.0
       },
       "build_costs": {
         "materials": [],
@@ -324,19 +315,18 @@
       "level": 10,
       "requirements": [
         {
-          "name": "Parsteel Generator B",
+          "name": "operations",
           "level": 10
         },
         {
-          "name": "Operations",
+          "name": "parsteel generator b",
           "level": 10
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 115000
+        "bonus1": 115000.0
       },
       "build_costs": {
         "materials": [],
@@ -357,31 +347,30 @@
       "level": 11,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 11
         },
         {
-          "name": "Parsteel Generator B",
+          "name": "parsteel generator b",
           "level": 11
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 130000
+        "bonus1": 130000.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 28050
-          },
-          {
             "type": "tritanium",
             "value": 413
+          },
+          {
+            "type": "parsteel",
+            "value": 28050
           }
         ]
       },
@@ -390,19 +379,18 @@
       "level": 12,
       "requirements": [
         {
-          "name": "Parsteel Generator B",
+          "name": "operations",
           "level": 12
         },
         {
-          "name": "Operations",
+          "name": "parsteel generator b",
           "level": 12
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 150000
+        "bonus1": 150000.0
       },
       "build_costs": {
         "materials": [],
@@ -423,19 +411,18 @@
       "level": 13,
       "requirements": [
         {
-          "name": "Parsteel Generator B",
+          "name": "operations",
           "level": 13
         },
         {
-          "name": "Operations",
+          "name": "parsteel generator b",
           "level": 13
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 170000
+        "bonus1": 170000.0
       },
       "build_costs": {
         "materials": [],
@@ -456,31 +443,30 @@
       "level": 14,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 14
         },
         {
-          "name": "Parsteel Generator B",
+          "name": "parsteel generator b",
           "level": 14
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 200000
+        "bonus1": 200000.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 76500
-          },
-          {
             "type": "tritanium",
             "value": 1125
+          },
+          {
+            "type": "parsteel",
+            "value": 76500
           }
         ]
       },
@@ -489,19 +475,18 @@
       "level": 15,
       "requirements": [
         {
-          "name": "Parsteel Generator B",
+          "name": "operations",
           "level": 15
         },
         {
-          "name": "Operations",
+          "name": "parsteel generator b",
           "level": 15
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 230000
+        "bonus1": 230000.0
       },
       "build_costs": {
         "materials": [],
@@ -522,31 +507,30 @@
       "level": 16,
       "requirements": [
         {
-          "name": "Parsteel Generator B",
+          "name": "operations",
           "level": 16
         },
         {
-          "name": "Operations",
+          "name": "parsteel generator b",
           "level": 16
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 260000
+        "bonus1": 260000.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 142800
-          },
-          {
             "type": "tritanium",
             "value": 2100
+          },
+          {
+            "type": "parsteel",
+            "value": 142800
           }
         ]
       },
@@ -555,19 +539,18 @@
       "level": 17,
       "requirements": [
         {
-          "name": "Parsteel Generator B",
+          "name": "operations",
           "level": 17
         },
         {
-          "name": "Operations",
+          "name": "parsteel generator b",
           "level": 17
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 300000
+        "bonus1": 300000.0
       },
       "build_costs": {
         "materials": [],
@@ -588,19 +571,18 @@
       "level": 18,
       "requirements": [
         {
-          "name": "Parsteel Generator B",
+          "name": "operations",
           "level": 18
         },
         {
-          "name": "Operations",
+          "name": "parsteel generator b",
           "level": 18
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 340000
+        "bonus1": 340000.0
       },
       "build_costs": {
         "materials": [],
@@ -621,23 +603,22 @@
       "level": 19,
       "requirements": [
         {
-          "name": "Parsteel Generator B",
+          "name": "operations",
           "level": 19
         },
         {
-          "name": "Operations",
+          "name": "parsteel generator b",
           "level": 19
         },
         {
-          "name": "Parsteel Warehouse",
+          "name": "parsteel warehouse",
           "level": 19
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 400000
+        "bonus1": 400000.0
       },
       "build_costs": {
         "materials": [],
@@ -658,19 +639,18 @@
       "level": 20,
       "requirements": [
         {
-          "name": "Parsteel Generator B",
+          "name": "operations",
           "level": 20
         },
         {
-          "name": "Operations",
+          "name": "parsteel generator b",
           "level": 20
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 470000
+        "bonus1": 470000.0
       },
       "build_costs": {
         "materials": [],
@@ -691,19 +671,18 @@
       "level": 21,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 21
         },
         {
-          "name": "Parsteel Generator B",
+          "name": "parsteel generator b",
           "level": 21
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 540000
+        "bonus1": 540000.0
       },
       "build_costs": {
         "materials": [],
@@ -724,31 +703,30 @@
       "level": 22,
       "requirements": [
         {
-          "name": "Parsteel Generator B",
+          "name": "operations",
           "level": 22
         },
         {
-          "name": "Operations",
+          "name": "parsteel generator b",
           "level": 22
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 620000
+        "bonus1": 620000.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 1868130
-          },
-          {
             "type": "tritanium",
             "value": 27473
+          },
+          {
+            "type": "parsteel",
+            "value": 1868130
           }
         ]
       },
@@ -757,31 +735,30 @@
       "level": 23,
       "requirements": [
         {
-          "name": "Parsteel Generator B",
+          "name": "operations",
           "level": 23
         },
         {
-          "name": "Operations",
+          "name": "parsteel generator b",
           "level": 23
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 700000
+        "bonus1": 700000.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 2943720
-          },
-          {
             "type": "tritanium",
             "value": 43290
+          },
+          {
+            "type": "parsteel",
+            "value": 2943720
           }
         ]
       },
@@ -790,33 +767,32 @@
       "level": 24,
       "requirements": [
         {
-          "name": "Parsteel Generator B",
+          "name": "operations",
           "level": 24
         },
         {
-          "name": "Operations",
+          "name": "parsteel generator b",
           "level": 24
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 800000
+        "bonus1": 800000.0
       },
       "build_costs": {
         "materials": [
           {
             "type": "ore",
             "grade": 3,
-            "rarity": "common",
-            "value": 190
+            "rarity": "uncommon",
+            "value": 2
           },
           {
             "type": "ore",
             "grade": 3,
-            "rarity": "uncommon",
-            "value": 2
+            "rarity": "common",
+            "value": 190
           }
         ],
         "others": [],
@@ -836,19 +812,18 @@
       "level": 25,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 25
         },
         {
-          "name": "Parsteel Generator B",
+          "name": "parsteel generator b",
           "level": 25
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 950000
+        "bonus1": 950000.0
       },
       "build_costs": {
         "materials": [
@@ -862,12 +837,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 7458750
-          },
-          {
             "type": "tritanium",
             "value": 109688
+          },
+          {
+            "type": "parsteel",
+            "value": 7458750
           }
         ]
       },
@@ -876,19 +851,18 @@
       "level": 26,
       "requirements": [
         {
-          "name": "Parsteel Generator B",
+          "name": "operations",
           "level": 26
         },
         {
-          "name": "Operations",
+          "name": "parsteel generator b",
           "level": 26
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 1100000
+        "bonus1": 1100000.0
       },
       "build_costs": {
         "materials": [
@@ -916,19 +890,18 @@
       "level": 27,
       "requirements": [
         {
-          "name": "Parsteel Generator B",
+          "name": "operations",
           "level": 27
         },
         {
-          "name": "Operations",
+          "name": "parsteel generator b",
           "level": 27
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 1300000
+        "bonus1": 1300000.0
       },
       "build_costs": {
         "materials": [
@@ -962,33 +935,32 @@
       "level": 28,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 28
         },
         {
-          "name": "Parsteel Generator B",
+          "name": "parsteel generator b",
           "level": 28
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 1600000
+        "bonus1": 1600000.0
       },
       "build_costs": {
         "materials": [
           {
             "type": "ore",
             "grade": 3,
-            "rarity": "common",
-            "value": 450
+            "rarity": "uncommon",
+            "value": 26
           },
           {
             "type": "ore",
             "grade": 3,
-            "rarity": "uncommon",
-            "value": 26
+            "rarity": "common",
+            "value": 450
           }
         ],
         "others": [],
@@ -1008,19 +980,18 @@
       "level": 29,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 29
         },
         {
-          "name": "Parsteel Generator B",
+          "name": "parsteel generator b",
           "level": 29
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 2000000
+        "bonus1": 2000000.0
       },
       "build_costs": {
         "materials": [
@@ -1048,19 +1019,18 @@
       "level": 30,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 30
         },
         {
-          "name": "Parsteel Generator B",
+          "name": "parsteel generator b",
           "level": 30
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 2600000
+        "bonus1": 2600000.0
       },
       "build_costs": {
         "materials": [
@@ -1074,12 +1044,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 62883000
-          },
-          {
             "type": "tritanium",
             "value": 924750
+          },
+          {
+            "type": "parsteel",
+            "value": 62883000
           }
         ]
       },
@@ -1088,19 +1058,18 @@
       "level": 31,
       "requirements": [
         {
-          "name": "Parsteel Generator B",
+          "name": "operations",
           "level": 31
         },
         {
-          "name": "Operations",
+          "name": "parsteel generator b",
           "level": 31
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 3500000
+        "bonus1": 3500000.0
       },
       "build_costs": {
         "materials": [
@@ -1128,33 +1097,32 @@
       "level": 32,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 32
         },
         {
-          "name": "Parsteel Generator B",
+          "name": "parsteel generator b",
           "level": 32
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 4800000
+        "bonus1": 4800000.0
       },
       "build_costs": {
         "materials": [
           {
             "type": "ore",
             "grade": 3,
-            "rarity": "common",
-            "value": 1000
+            "rarity": "uncommon",
+            "value": 80
           },
           {
             "type": "ore",
             "grade": 3,
-            "rarity": "uncommon",
-            "value": 80
+            "rarity": "common",
+            "value": 1000
           }
         ],
         "others": [],
@@ -1174,19 +1142,18 @@
       "level": 33,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 33
         },
         {
-          "name": "Parsteel Generator B",
+          "name": "parsteel generator b",
           "level": 33
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 6500000
+        "bonus1": 6500000.0
       },
       "build_costs": {
         "materials": [
@@ -1214,19 +1181,18 @@
       "level": 34,
       "requirements": [
         {
-          "name": "Parsteel Generator B",
+          "name": "operations",
           "level": 34
         },
         {
-          "name": "Operations",
+          "name": "parsteel generator b",
           "level": 34
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 9000000
+        "bonus1": 9000000.0
       },
       "build_costs": {
         "materials": [
@@ -1240,12 +1206,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 343332000
-          },
-          {
             "type": "tritanium",
             "value": 5049000
+          },
+          {
+            "type": "parsteel",
+            "value": 343332000
           }
         ]
       },
@@ -1254,44 +1220,43 @@
       "level": 35,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 35
         },
         {
-          "name": "Parsteel Generator B",
+          "name": "parsteel generator b",
           "level": 35
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 11800000
+        "bonus1": 11800000.0
       },
       "build_costs": {
         "materials": [
           {
             "type": "ore",
             "grade": 3,
-            "rarity": "common",
-            "value": 1600
+            "rarity": "uncommon",
+            "value": 150
           },
           {
             "type": "ore",
             "grade": 3,
-            "rarity": "uncommon",
-            "value": 150
+            "rarity": "common",
+            "value": 1600
           }
         ],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 483786000
-          },
-          {
             "type": "tritanium",
             "value": 7114500
+          },
+          {
+            "type": "parsteel",
+            "value": 483786000
           }
         ]
       },
@@ -1300,19 +1265,18 @@
       "level": 36,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 36
         },
         {
-          "name": "Parsteel Generator B",
+          "name": "parsteel generator b",
           "level": 36
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 15900000
+        "bonus1": 15900000.0
       },
       "build_costs": {
         "materials": [
@@ -1326,12 +1290,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 743580000
-          },
-          {
             "type": "tritanium",
             "value": 10935000
+          },
+          {
+            "type": "parsteel",
+            "value": 743580000
           }
         ]
       },
@@ -1340,44 +1304,43 @@
       "level": 37,
       "requirements": [
         {
-          "name": "Parsteel Generator B",
+          "name": "operations",
           "level": 37
         },
         {
-          "name": "Operations",
+          "name": "parsteel generator b",
           "level": 37
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 22850000
+        "bonus1": 22850000.0
       },
       "build_costs": {
         "materials": [
           {
             "type": "ore",
             "grade": 3,
-            "rarity": "common",
-            "value": 2100
+            "rarity": "uncommon",
+            "value": 200
           },
           {
             "type": "ore",
             "grade": 3,
-            "rarity": "uncommon",
-            "value": 200
+            "rarity": "common",
+            "value": 2100
           }
         ],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 1156680000
-          },
-          {
             "type": "tritanium",
             "value": 17010000
+          },
+          {
+            "type": "parsteel",
+            "value": 1156680000
           }
         ]
       },
@@ -1386,35 +1349,34 @@
       "level": 38,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 38
         },
         {
-          "name": "Parsteel Generator B",
+          "name": "parsteel generator b",
           "level": 38
         },
         {
-          "name": "Refinery",
+          "name": "refinery",
           "level": 37
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 33650000
+        "bonus1": 33650000.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 1973700000
-          },
-          {
             "type": "tritanium",
             "value": 29025000
+          },
+          {
+            "type": "parsteel",
+            "value": 1973700000
           }
         ]
       },
@@ -1423,23 +1385,22 @@
       "level": 39,
       "requirements": [
         {
-          "name": "Parsteel Generator B",
+          "name": "operations",
           "level": 39
         },
         {
-          "name": "Refinery",
+          "name": "parsteel generator b",
+          "level": 39
+        },
+        {
+          "name": "refinery",
           "level": 38
-        },
-        {
-          "name": "Operations",
-          "level": 39
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 47600000
+        "bonus1": 47600000.0
       },
       "build_costs": {
         "materials": [
@@ -1453,12 +1414,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 7163800000
-          },
-          {
             "type": "tritanium",
             "value": 45150000
+          },
+          {
+            "type": "parsteel",
+            "value": 7163800000
           }
         ]
       },
@@ -1467,19 +1428,18 @@
       "level": 40,
       "requirements": [
         {
-          "name": "Parsteel Generator B",
+          "name": "operations",
           "level": 40
         },
         {
-          "name": "Operations",
+          "name": "parsteel generator b",
           "level": 40
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 64600000
+        "bonus1": 64600000.0
       },
       "build_costs": {
         "materials": [
@@ -1493,12 +1453,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 7310000000
-          },
-          {
             "type": "tritanium",
             "value": 64500000
+          },
+          {
+            "type": "parsteel",
+            "value": 7310000000
           }
         ]
       },
@@ -1507,44 +1467,43 @@
       "level": 41,
       "requirements": [
         {
-          "name": "Parsteel Generator B",
+          "name": "operations",
           "level": 41
         },
         {
-          "name": "Operations",
+          "name": "parsteel generator b",
           "level": 41
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 85700000
+        "bonus1": 85700000.0
       },
       "build_costs": {
         "materials": [
           {
             "type": "ore",
             "grade": 4,
-            "rarity": "common",
-            "value": 7000
+            "rarity": "rare",
+            "value": 400
           },
           {
             "type": "ore",
             "grade": 4,
-            "rarity": "rare",
-            "value": 400
+            "rarity": "common",
+            "value": 7000
           }
         ],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 10888500000
-          },
-          {
             "type": "tritanium",
             "value": 96075000
+          },
+          {
+            "type": "parsteel",
+            "value": 10888500000
           }
         ]
       },
@@ -1553,19 +1512,18 @@
       "level": 42,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 42
         },
         {
-          "name": "Parsteel Generator B",
+          "name": "parsteel generator b",
           "level": 42
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 115600000
+        "bonus1": 115600000.0
       },
       "build_costs": {
         "materials": [
@@ -1585,12 +1543,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 15555000000
-          },
-          {
             "type": "tritanium",
             "value": 137250000
+          },
+          {
+            "type": "parsteel",
+            "value": 15555000000
           }
         ]
       },
@@ -1599,19 +1557,18 @@
       "level": 43,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 43
         },
         {
-          "name": "Parsteel Generator B",
+          "name": "parsteel generator b",
           "level": 43
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 163200000
+        "bonus1": 163200000.0
       },
       "build_costs": {
         "materials": [
@@ -1631,12 +1588,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 23332500000
-          },
-          {
             "type": "tritanium",
             "value": 205875000
+          },
+          {
+            "type": "parsteel",
+            "value": 23332500000
           }
         ]
       },
@@ -1645,19 +1602,18 @@
       "level": 44,
       "requirements": [
         {
-          "name": "Parsteel Generator B",
+          "name": "operations",
           "level": 44
         },
         {
-          "name": "Operations",
+          "name": "parsteel generator b",
           "level": 44
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 204000000
+        "bonus1": 204000000.0
       },
       "build_costs": {
         "materials": [
@@ -1671,12 +1627,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 33150000000
-          },
-          {
             "type": "tritanium",
             "value": 292500000
+          },
+          {
+            "type": "parsteel",
+            "value": 33150000000
           }
         ]
       },
@@ -1685,23 +1641,22 @@
       "level": 45,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 45
         },
         {
-          "name": "Parsteel Generator B",
+          "name": "parsteel generator b",
           "level": 45
         },
         {
-          "name": "Parsteel Warehouse",
+          "name": "parsteel warehouse",
           "level": 45
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 261800000
+        "bonus1": 261800000.0
       },
       "build_costs": {
         "materials": [
@@ -1721,12 +1676,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 45581250000
-          },
-          {
             "type": "tritanium",
             "value": 402187500
+          },
+          {
+            "type": "parsteel",
+            "value": 45581250000
           }
         ]
       },
@@ -1735,44 +1690,43 @@
       "level": 46,
       "requirements": [
         {
-          "name": "Parsteel Generator B",
+          "name": "operations",
           "level": 46
         },
         {
-          "name": "Operations",
+          "name": "parsteel generator b",
           "level": 46
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 353600000
+        "bonus1": 353600000.0
       },
       "build_costs": {
         "materials": [
           {
             "type": "ore",
             "grade": 4,
-            "rarity": "uncommon",
-            "value": 1500
+            "rarity": "rare",
+            "value": 300
           },
           {
             "type": "ore",
             "grade": 4,
-            "rarity": "rare",
-            "value": 300
+            "rarity": "uncommon",
+            "value": 1500
           }
         ],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 66300000000
-          },
-          {
             "type": "tritanium",
             "value": 585000000
+          },
+          {
+            "type": "parsteel",
+            "value": 66300000000
           }
         ]
       },
@@ -1781,23 +1735,22 @@
       "level": 47,
       "requirements": [
         {
-          "name": "Parsteel Generator B",
+          "name": "operations",
           "level": 47
         },
         {
-          "name": "Operations",
+          "name": "parsteel generator b",
           "level": 47
         },
         {
-          "name": "Parsteel Warehouse",
+          "name": "parsteel warehouse",
           "level": 47
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 489600000
+        "bonus1": 489600000.0
       },
       "build_costs": {
         "materials": [
@@ -1817,12 +1770,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 107100000000
-          },
-          {
             "type": "tritanium",
             "value": 945000000
+          },
+          {
+            "type": "parsteel",
+            "value": 107100000000
           }
         ]
       },
@@ -1831,44 +1784,43 @@
       "level": 48,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 48
         },
         {
-          "name": "Parsteel Generator B",
+          "name": "parsteel generator b",
           "level": 48
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 748000000
+        "bonus1": 748000000.0
       },
       "build_costs": {
         "materials": [
           {
             "type": "ore",
             "grade": 4,
-            "rarity": "common",
-            "value": 45000
+            "rarity": "rare",
+            "value": 4500
           },
           {
             "type": "ore",
             "grade": 4,
-            "rarity": "rare",
-            "value": 4500
+            "rarity": "common",
+            "value": 45000
           }
         ],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 178500000000
-          },
-          {
             "type": "tritanium",
             "value": 1575000000
+          },
+          {
+            "type": "parsteel",
+            "value": 178500000000
           }
         ]
       },
@@ -1877,35 +1829,34 @@
       "level": 49,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 49
         },
         {
-          "name": "Parsteel Generator B",
+          "name": "parsteel generator b",
           "level": 49
         },
         {
-          "name": "Parsteel Warehouse",
+          "name": "parsteel warehouse",
           "level": 49
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 1190000000
+        "bonus1": 1190000000.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 312375000000
-          },
-          {
             "type": "tritanium",
             "value": 2756250000
+          },
+          {
+            "type": "parsteel",
+            "value": 312375000000
           }
         ]
       },
@@ -1914,15 +1865,231 @@
       "level": 50,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 50
         },
         {
-          "name": "Parsteel Generator B",
+          "name": "parsteel generator b",
           "level": 50
         }
-      ],
-      "rewards": []
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 1768000000.0
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "ore",
+            "grade": 5,
+            "rarity": "common",
+            "value": 8100
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 5850000000
+          },
+          {
+            "type": "parsteel",
+            "value": 1558050000000
+          }
+        ]
+      },
+      "build_time": 59626080,
+      "increased_power": 7000,
+      "level": 51,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 51
+        },
+        {
+          "name": "parsteel generator b",
+          "level": 51
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 2652000000.0
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "ore",
+            "grade": 5,
+            "rarity": "common",
+            "value": 19500
+          },
+          {
+            "type": "ore",
+            "grade": 5,
+            "rarity": "uncommon",
+            "value": 3000
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 9945000000
+          },
+          {
+            "type": "parsteel",
+            "value": 2817750000000
+          }
+        ]
+      },
+      "build_time": 63204480,
+      "increased_power": 7000,
+      "level": 52,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 52
+        },
+        {
+          "name": "parsteel generator b",
+          "level": 52
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 3944000000.0
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "ore",
+            "grade": 5,
+            "rarity": "common",
+            "value": 37500
+          },
+          {
+            "type": "ore",
+            "grade": 5,
+            "rarity": "uncommon",
+            "value": 3100
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 17400000000
+          },
+          {
+            "type": "parsteel",
+            "value": 4732800000000
+          }
+        ]
+      },
+      "build_time": 66996000,
+      "increased_power": 8000,
+      "level": 53,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 53
+        },
+        {
+          "name": "parsteel generator b",
+          "level": 53
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 5916000000.0
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "ore",
+            "grade": 5,
+            "rarity": "uncommon",
+            "value": 10400
+          },
+          {
+            "type": "ore",
+            "grade": 5,
+            "rarity": "rare",
+            "value": 800
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 26100000000
+          },
+          {
+            "type": "parsteel",
+            "value": 7099200000000
+          }
+        ]
+      },
+      "build_time": 71016480,
+      "increased_power": 7000,
+      "level": 54,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 54
+        },
+        {
+          "name": "parsteel generator b",
+          "level": 54
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 8840000000.0
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "ore",
+            "grade": 5,
+            "rarity": "rare",
+            "value": 4800
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 12066600000000
+          },
+          {
+            "type": "tritanium",
+            "value": 40950000000
+          }
+        ]
+      },
+      "build_time": 75277440,
+      "increased_power": 8000,
+      "level": 55,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 55
+        },
+        {
+          "name": "parsteel generator b",
+          "level": 55
+        },
+        {
+          "name": "parsteel warehouse",
+          "level": 55
+        }
+      ]
     }
   ]
 }

--- a/buildings/parsteel_warehouse.json
+++ b/buildings/parsteel_warehouse.json
@@ -2,7 +2,7 @@
   "description": "Stores all collected Parsteel. Upgrade the Warehouse to increase the Parsteel Capacity.",
   "bonuses": {
     "bonus1": {
-      "name": "Parsteel Capacity",
+      "name": "parsteel capacity",
       "percentage": false
     }
   },
@@ -10,7 +10,7 @@
   "levels": [
     {
       "bonuses": {
-        "bonus1": 5000
+        "bonus1": 5000.0
       },
       "build_costs": {
         "materials": [],
@@ -27,19 +27,18 @@
       "level": 1,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 1
         },
         {
-          "name": "Parsteel Generator A",
+          "name": "parsteel generator a",
           "level": 1
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 6750
+        "bonus1": 6750.0
       },
       "build_costs": {
         "materials": [],
@@ -56,23 +55,22 @@
       "level": 2,
       "requirements": [
         {
-          "name": "Parsteel Generator B",
+          "name": "operations",
+          "level": 2
+        },
+        {
+          "name": "parsteel generator a",
+          "level": 2
+        },
+        {
+          "name": "parsteel generator b",
           "level": 1
-        },
-        {
-          "name": "Parsteel Generator A",
-          "level": 2
-        },
-        {
-          "name": "Operations",
-          "level": 2
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 10000
+        "bonus1": 10000.0
       },
       "build_costs": {
         "materials": [],
@@ -89,19 +87,18 @@
       "level": 3,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 3
         },
         {
-          "name": "Parsteel Generator A",
+          "name": "parsteel generator a",
           "level": 3
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 13750
+        "bonus1": 13750.0
       },
       "build_costs": {
         "materials": [],
@@ -118,19 +115,18 @@
       "level": 4,
       "requirements": [
         {
-          "name": "Parsteel Generator B",
+          "name": "operations",
           "level": 4
         },
         {
-          "name": "Operations",
+          "name": "parsteel generator b",
           "level": 4
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 21500
+        "bonus1": 21500.0
       },
       "build_costs": {
         "materials": [],
@@ -147,19 +143,18 @@
       "level": 5,
       "requirements": [
         {
-          "name": "Parsteel Generator A",
+          "name": "operations",
           "level": 5
         },
         {
-          "name": "Operations",
+          "name": "parsteel generator a",
           "level": 5
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 26000
+        "bonus1": 26000.0
       },
       "build_costs": {
         "materials": [],
@@ -176,31 +171,30 @@
       "level": 6,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 6
         },
         {
-          "name": "Parsteel Generator A",
+          "name": "parsteel generator a",
           "level": 6
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 33500
+        "bonus1": 33500.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 2000
-          },
-          {
             "type": "tritanium",
             "value": 10
+          },
+          {
+            "type": "parsteel",
+            "value": 2000
           }
         ]
       },
@@ -209,23 +203,22 @@
       "level": 7,
       "requirements": [
         {
-          "name": "Drydock B",
+          "name": "operations",
+          "level": 7
+        },
+        {
+          "name": "parsteel generator a",
+          "level": 7
+        },
+        {
+          "name": "drydock b",
           "level": 6
-        },
-        {
-          "name": "Parsteel Generator A",
-          "level": 7
-        },
-        {
-          "name": "Operations",
-          "level": 7
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 37500
+        "bonus1": 37500.0
       },
       "build_costs": {
         "materials": [],
@@ -246,31 +239,30 @@
       "level": 8,
       "requirements": [
         {
-          "name": "Parsteel Generator A",
+          "name": "operations",
           "level": 8
         },
         {
-          "name": "Operations",
+          "name": "parsteel generator a",
           "level": 8
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 39500
+        "bonus1": 39500.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 5000
-          },
-          {
             "type": "tritanium",
             "value": 75
+          },
+          {
+            "type": "parsteel",
+            "value": 5000
           }
         ]
       },
@@ -279,19 +271,18 @@
       "level": 9,
       "requirements": [
         {
-          "name": "Parsteel Generator B",
+          "name": "operations",
           "level": 9
         },
         {
-          "name": "Operations",
+          "name": "parsteel generator b",
           "level": 9
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 41500
+        "bonus1": 41500.0
       },
       "build_costs": {
         "materials": [],
@@ -312,31 +303,30 @@
       "level": 10,
       "requirements": [
         {
-          "name": "Parsteel Generator A",
+          "name": "operations",
           "level": 10
         },
         {
-          "name": "Operations",
+          "name": "parsteel generator a",
           "level": 10
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 43500
+        "bonus1": 43500.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 10200
-          },
-          {
             "type": "tritanium",
             "value": 100
+          },
+          {
+            "type": "parsteel",
+            "value": 10200
           }
         ]
       },
@@ -345,31 +335,30 @@
       "level": 11,
       "requirements": [
         {
-          "name": "Parsteel Generator A",
+          "name": "operations",
           "level": 11
         },
         {
-          "name": "Operations",
+          "name": "parsteel generator a",
           "level": 11
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 45500
+        "bonus1": 45500.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 14025
-          },
-          {
             "type": "tritanium",
             "value": 138
+          },
+          {
+            "type": "parsteel",
+            "value": 14025
           }
         ]
       },
@@ -378,31 +367,30 @@
       "level": 12,
       "requirements": [
         {
-          "name": "Parsteel Generator A",
+          "name": "operations",
           "level": 12
         },
         {
-          "name": "Operations",
+          "name": "parsteel generator a",
           "level": 12
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 48000
+        "bonus1": 48000.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 20400
-          },
-          {
             "type": "tritanium",
             "value": 200
+          },
+          {
+            "type": "parsteel",
+            "value": 20400
           }
         ]
       },
@@ -411,19 +399,18 @@
       "level": 13,
       "requirements": [
         {
-          "name": "Parsteel Generator A",
+          "name": "operations",
           "level": 13
         },
         {
-          "name": "Operations",
+          "name": "parsteel generator a",
           "level": 13
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 50500
+        "bonus1": 50500.0
       },
       "build_costs": {
         "materials": [],
@@ -444,31 +431,30 @@
       "level": 14,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 14
         },
         {
-          "name": "Parsteel Generator A",
+          "name": "parsteel generator a",
           "level": 14
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 55000
+        "bonus1": 55000.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 38250
-          },
-          {
             "type": "tritanium",
             "value": 375
+          },
+          {
+            "type": "parsteel",
+            "value": 38250
           }
         ]
       },
@@ -477,35 +463,34 @@
       "level": 15,
       "requirements": [
         {
-          "name": "Parsteel Generator A",
+          "name": "operations",
           "level": 15
         },
         {
-          "name": "Operations",
+          "name": "parsteel generator a",
           "level": 15
         },
         {
-          "name": "Parsteel Generator B",
+          "name": "parsteel generator b",
           "level": 15
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 71000
+        "bonus1": 71000.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 51000
-          },
-          {
             "type": "tritanium",
             "value": 500
+          },
+          {
+            "type": "parsteel",
+            "value": 51000
           }
         ]
       },
@@ -514,19 +499,18 @@
       "level": 16,
       "requirements": [
         {
-          "name": "Parsteel Generator A",
+          "name": "operations",
           "level": 16
         },
         {
-          "name": "Operations",
+          "name": "parsteel generator a",
           "level": 16
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 96000
+        "bonus1": 96000.0
       },
       "build_costs": {
         "materials": [
@@ -554,19 +538,18 @@
       "level": 17,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 17
         },
         {
-          "name": "Parsteel Generator A",
+          "name": "parsteel generator a",
           "level": 17
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 132000
+        "bonus1": 132000.0
       },
       "build_costs": {
         "materials": [
@@ -580,12 +563,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 102000
-          },
-          {
             "type": "tritanium",
             "value": 1000
+          },
+          {
+            "type": "parsteel",
+            "value": 102000
           }
         ]
       },
@@ -594,19 +577,18 @@
       "level": 18,
       "requirements": [
         {
-          "name": "Parsteel Generator A",
+          "name": "operations",
           "level": 18
         },
         {
-          "name": "Operations",
+          "name": "parsteel generator a",
           "level": 18
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 191000
+        "bonus1": 191000.0
       },
       "build_costs": {
         "materials": [
@@ -620,12 +602,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 153000
-          },
-          {
             "type": "tritanium",
             "value": 1500
+          },
+          {
+            "type": "parsteel",
+            "value": 153000
           }
         ]
       },
@@ -634,35 +616,34 @@
       "level": 19,
       "requirements": [
         {
-          "name": "Parsteel Generator B",
+          "name": "operations",
           "level": 19
         },
         {
-          "name": "Operations",
+          "name": "parsteel generator a",
           "level": 19
         },
         {
-          "name": "Parsteel Generator A",
+          "name": "parsteel generator b",
           "level": 19
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 260000
+        "bonus1": 260000.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 216750
-          },
-          {
             "type": "tritanium",
             "value": 2125
+          },
+          {
+            "type": "parsteel",
+            "value": 216750
           }
         ]
       },
@@ -671,31 +652,30 @@
       "level": 20,
       "requirements": [
         {
-          "name": "Parsteel Generator A",
+          "name": "operations",
           "level": 20
         },
         {
-          "name": "Operations",
+          "name": "parsteel generator a",
           "level": 20
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 395000
+        "bonus1": 395000.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 364905
-          },
-          {
             "type": "tritanium",
             "value": 3578
+          },
+          {
+            "type": "parsteel",
+            "value": 364905
           }
         ]
       },
@@ -704,31 +684,30 @@
       "level": 21,
       "requirements": [
         {
-          "name": "Parsteel Generator A",
+          "name": "operations",
           "level": 21
         },
         {
-          "name": "Operations",
+          "name": "parsteel generator a",
           "level": 21
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 585000
+        "bonus1": 585000.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 567630
-          },
-          {
             "type": "tritanium",
             "value": 5565
+          },
+          {
+            "type": "parsteel",
+            "value": 567630
           }
         ]
       },
@@ -737,31 +716,30 @@
       "level": 22,
       "requirements": [
         {
-          "name": "Parsteel Generator A",
+          "name": "operations",
           "level": 22
         },
         {
-          "name": "Operations",
+          "name": "parsteel generator a",
           "level": 22
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 880000
+        "bonus1": 880000.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 934065
-          },
-          {
             "type": "tritanium",
             "value": 9158
+          },
+          {
+            "type": "parsteel",
+            "value": 934065
           }
         ]
       },
@@ -770,19 +748,18 @@
       "level": 23,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 23
         },
         {
-          "name": "Parsteel Generator A",
+          "name": "parsteel generator a",
           "level": 23
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 1300000
+        "bonus1": 1300000.0
       },
       "build_costs": {
         "materials": [
@@ -810,19 +787,18 @@
       "level": 24,
       "requirements": [
         {
-          "name": "Parsteel Generator A",
+          "name": "operations",
           "level": 24
         },
         {
-          "name": "Operations",
+          "name": "parsteel generator a",
           "level": 24
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 1900000
+        "bonus1": 1900000.0
       },
       "build_costs": {
         "materials": [
@@ -850,19 +826,18 @@
       "level": 25,
       "requirements": [
         {
-          "name": "Parsteel Generator A",
+          "name": "operations",
           "level": 25
         },
         {
-          "name": "Operations",
+          "name": "parsteel generator a",
           "level": 25
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 2800000
+        "bonus1": 2800000.0
       },
       "build_costs": {
         "materials": [
@@ -896,19 +871,18 @@
       "level": 26,
       "requirements": [
         {
-          "name": "Parsteel Generator A",
+          "name": "operations",
           "level": 26
         },
         {
-          "name": "Operations",
+          "name": "parsteel generator a",
           "level": 26
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 3800000
+        "bonus1": 3800000.0
       },
       "build_costs": {
         "materials": [
@@ -936,19 +910,18 @@
       "level": 27,
       "requirements": [
         {
-          "name": "Parsteel Generator A",
+          "name": "operations",
           "level": 27
         },
         {
-          "name": "Operations",
+          "name": "parsteel generator a",
           "level": 27
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 5300000
+        "bonus1": 5300000.0
       },
       "build_costs": {
         "materials": [
@@ -962,12 +935,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 8537400
-          },
-          {
             "type": "tritanium",
             "value": 83700
+          },
+          {
+            "type": "parsteel",
+            "value": 8537400
           }
         ]
       },
@@ -976,33 +949,32 @@
       "level": 28,
       "requirements": [
         {
-          "name": "Parsteel Generator A",
+          "name": "operations",
           "level": 28
         },
         {
-          "name": "Operations",
+          "name": "parsteel generator a",
           "level": 28
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 7550000
+        "bonus1": 7550000.0
       },
       "build_costs": {
         "materials": [
           {
             "type": "ore",
             "grade": 3,
-            "rarity": "common",
-            "value": 450
+            "rarity": "uncommon",
+            "value": 26
           },
           {
             "type": "ore",
             "grade": 3,
-            "rarity": "uncommon",
-            "value": 26
+            "rarity": "common",
+            "value": 450
           }
         ],
         "others": [],
@@ -1022,19 +994,18 @@
       "level": 29,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 29
         },
         {
-          "name": "Parsteel Generator A",
+          "name": "parsteel generator a",
           "level": 29
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 10000000
+        "bonus1": 10000000.0
       },
       "build_costs": {
         "materials": [
@@ -1048,12 +1019,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 19890000
-          },
-          {
             "type": "tritanium",
             "value": 195000
+          },
+          {
+            "type": "parsteel",
+            "value": 19890000
           }
         ]
       },
@@ -1062,19 +1033,18 @@
       "level": 30,
       "requirements": [
         {
-          "name": "Parsteel Generator A",
+          "name": "operations",
           "level": 30
         },
         {
-          "name": "Operations",
+          "name": "parsteel generator a",
           "level": 30
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 14000000
+        "bonus1": 14000000.0
       },
       "build_costs": {
         "materials": [
@@ -1108,19 +1078,18 @@
       "level": 31,
       "requirements": [
         {
-          "name": "Parsteel Generator A",
+          "name": "operations",
           "level": 31
         },
         {
-          "name": "Operations",
+          "name": "parsteel generator a",
           "level": 31
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 18500000
+        "bonus1": 18500000.0
       },
       "build_costs": {
         "materials": [
@@ -1148,19 +1117,18 @@
       "level": 32,
       "requirements": [
         {
-          "name": "Parsteel Generator A",
+          "name": "operations",
           "level": 32
         },
         {
-          "name": "Operations",
+          "name": "parsteel generator a",
           "level": 32
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 24000000
+        "bonus1": 24000000.0
       },
       "build_costs": {
         "materials": [
@@ -1174,12 +1142,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 70252500
-          },
-          {
             "type": "tritanium",
             "value": 688750
+          },
+          {
+            "type": "parsteel",
+            "value": 70252500
           }
         ]
       },
@@ -1188,19 +1156,18 @@
       "level": 33,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 33
         },
         {
-          "name": "Parsteel Generator A",
+          "name": "parsteel generator a",
           "level": 33
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 33500000
+        "bonus1": 33500000.0
       },
       "build_costs": {
         "materials": [
@@ -1234,19 +1201,18 @@
       "level": 34,
       "requirements": [
         {
-          "name": "Parsteel Generator A",
+          "name": "operations",
           "level": 34
         },
         {
-          "name": "Operations",
+          "name": "parsteel generator a",
           "level": 34
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 43000000
+        "bonus1": 43000000.0
       },
       "build_costs": {
         "materials": [
@@ -1274,33 +1240,32 @@
       "level": 35,
       "requirements": [
         {
-          "name": "Parsteel Generator A",
+          "name": "operations",
           "level": 35
         },
         {
-          "name": "Operations",
+          "name": "parsteel generator a",
           "level": 35
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 51500000
+        "bonus1": 51500000.0
       },
       "build_costs": {
         "materials": [
           {
             "type": "ore",
             "grade": 3,
-            "rarity": "common",
-            "value": 1600
+            "rarity": "uncommon",
+            "value": 150
           },
           {
             "type": "ore",
             "grade": 3,
-            "rarity": "uncommon",
-            "value": 150
+            "rarity": "common",
+            "value": 1600
           }
         ],
         "others": [],
@@ -1320,19 +1285,18 @@
       "level": 36,
       "requirements": [
         {
-          "name": "Parsteel Generator A",
+          "name": "operations",
           "level": 36
         },
         {
-          "name": "Operations",
+          "name": "parsteel generator a",
           "level": 36
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 62000000
+        "bonus1": 62000000.0
       },
       "build_costs": {
         "materials": [
@@ -1346,12 +1310,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 371790000
-          },
-          {
             "type": "tritanium",
             "value": 3645000
+          },
+          {
+            "type": "parsteel",
+            "value": 371790000
           }
         ]
       },
@@ -1360,19 +1324,18 @@
       "level": 37,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 37
         },
         {
-          "name": "Parsteel Generator A",
+          "name": "parsteel generator a",
           "level": 37
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 76000000
+        "bonus1": 76000000.0
       },
       "build_costs": {
         "materials": [
@@ -1392,12 +1355,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 578340000
-          },
-          {
             "type": "tritanium",
             "value": 5670000
+          },
+          {
+            "type": "parsteel",
+            "value": 578340000
           }
         ]
       },
@@ -1406,19 +1369,18 @@
       "level": 38,
       "requirements": [
         {
-          "name": "Parsteel Generator A",
+          "name": "operations",
           "level": 38
         },
         {
-          "name": "Operations",
+          "name": "parsteel generator a",
           "level": 38
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 90000000
+        "bonus1": 90000000.0
       },
       "build_costs": {
         "materials": [],
@@ -1439,19 +1401,18 @@
       "level": 39,
       "requirements": [
         {
-          "name": "Parsteel Generator A",
+          "name": "operations",
           "level": 39
         },
         {
-          "name": "Operations",
+          "name": "parsteel generator a",
           "level": 39
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 94500000
+        "bonus1": 94500000.0
       },
       "build_costs": {
         "materials": [
@@ -1479,19 +1440,18 @@
       "level": 40,
       "requirements": [
         {
-          "name": "Parsteel Generator A",
+          "name": "operations",
           "level": 40
         },
         {
-          "name": "Operations",
+          "name": "parsteel generator a",
           "level": 40
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 120000000
+        "bonus1": 120000000.0
       },
       "build_costs": {
         "materials": [
@@ -1505,12 +1465,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 4386000000
-          },
-          {
             "type": "tritanium",
             "value": 21500000
+          },
+          {
+            "type": "parsteel",
+            "value": 4386000000
           }
         ]
       },
@@ -1519,19 +1479,18 @@
       "level": 41,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 41
         },
         {
-          "name": "Parsteel Generator A",
+          "name": "parsteel generator a",
           "level": 41
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 160000000
+        "bonus1": 160000000.0
       },
       "build_costs": {
         "materials": [
@@ -1565,19 +1524,18 @@
       "level": 42,
       "requirements": [
         {
-          "name": "Parsteel Generator A",
+          "name": "operations",
           "level": 42
         },
         {
-          "name": "Operations",
+          "name": "parsteel generator a",
           "level": 42
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 220000000
+        "bonus1": 220000000.0
       },
       "build_costs": {
         "materials": [
@@ -1611,44 +1569,43 @@
       "level": 43,
       "requirements": [
         {
-          "name": "Parsteel Generator A",
+          "name": "operations",
           "level": 43
         },
         {
-          "name": "Operations",
+          "name": "parsteel generator a",
           "level": 43
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 310000000
+        "bonus1": 310000000.0
       },
       "build_costs": {
         "materials": [
           {
             "type": "ore",
             "grade": 4,
-            "rarity": "uncommon",
-            "value": 2000
+            "rarity": "rare",
+            "value": 800
           },
           {
             "type": "ore",
             "grade": 4,
-            "rarity": "rare",
-            "value": 800
+            "rarity": "uncommon",
+            "value": 2000
           }
         ],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 13999500000
-          },
-          {
             "type": "tritanium",
             "value": 68625000
+          },
+          {
+            "type": "parsteel",
+            "value": 13999500000
           }
         ]
       },
@@ -1657,19 +1614,18 @@
       "level": 44,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 44
         },
         {
-          "name": "Parsteel Generator A",
+          "name": "parsteel generator a",
           "level": 44
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 390000000
+        "bonus1": 390000000.0
       },
       "build_costs": {
         "materials": [
@@ -1697,44 +1653,43 @@
       "level": 45,
       "requirements": [
         {
-          "name": "Parsteel Generator A",
+          "name": "operations",
           "level": 45
         },
         {
-          "name": "Operations",
+          "name": "parsteel generator a",
           "level": 45
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 505000000
+        "bonus1": 505000000.0
       },
       "build_costs": {
         "materials": [
           {
             "type": "ore",
             "grade": 4,
-            "rarity": "uncommon",
-            "value": 500
+            "rarity": "rare",
+            "value": 150
           },
           {
             "type": "ore",
             "grade": 4,
-            "rarity": "rare",
-            "value": 150
+            "rarity": "uncommon",
+            "value": 500
           }
         ],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 27348750000
-          },
-          {
             "type": "tritanium",
             "value": 134062500
+          },
+          {
+            "type": "parsteel",
+            "value": 27348750000
           }
         ]
       },
@@ -1743,44 +1698,43 @@
       "level": 46,
       "requirements": [
         {
-          "name": "Parsteel Generator A",
+          "name": "operations",
           "level": 46
         },
         {
-          "name": "Operations",
+          "name": "parsteel generator a",
           "level": 46
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 685000000
+        "bonus1": 685000000.0
       },
       "build_costs": {
         "materials": [
           {
             "type": "ore",
             "grade": 4,
-            "rarity": "uncommon",
-            "value": 1500
+            "rarity": "rare",
+            "value": 300
           },
           {
             "type": "ore",
             "grade": 4,
-            "rarity": "rare",
-            "value": 300
+            "rarity": "uncommon",
+            "value": 1500
           }
         ],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 39780000000
-          },
-          {
             "type": "tritanium",
             "value": 195000000
+          },
+          {
+            "type": "parsteel",
+            "value": 39780000000
           }
         ]
       },
@@ -1789,44 +1743,43 @@
       "level": 47,
       "requirements": [
         {
-          "name": "Parsteel Generator A",
+          "name": "operations",
           "level": 47
         },
         {
-          "name": "Operations",
+          "name": "parsteel generator a",
           "level": 47
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 960000000
+        "bonus1": 960000000.0
       },
       "build_costs": {
         "materials": [
           {
             "type": "ore",
             "grade": 4,
-            "rarity": "common",
-            "value": 30000
+            "rarity": "rare",
+            "value": 1200
           },
           {
             "type": "ore",
             "grade": 4,
-            "rarity": "rare",
-            "value": 1200
+            "rarity": "common",
+            "value": 30000
           }
         ],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 64260000000
-          },
-          {
             "type": "tritanium",
             "value": 315000000
+          },
+          {
+            "type": "parsteel",
+            "value": 64260000000
           }
         ]
       },
@@ -1835,33 +1788,32 @@
       "level": 48,
       "requirements": [
         {
-          "name": "Parsteel Generator A",
+          "name": "operations",
           "level": 48
         },
         {
-          "name": "Operations",
+          "name": "parsteel generator a",
           "level": 48
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 1500000000
+        "bonus1": 1500000000.0
       },
       "build_costs": {
         "materials": [
           {
             "type": "ore",
             "grade": 4,
-            "rarity": "common",
-            "value": 45000
+            "rarity": "rare",
+            "value": 4500
           },
           {
             "type": "ore",
             "grade": 4,
-            "rarity": "rare",
-            "value": 4500
+            "rarity": "common",
+            "value": 45000
           }
         ],
         "others": [],
@@ -1881,31 +1833,30 @@
       "level": 49,
       "requirements": [
         {
-          "name": "Parsteel Generator A",
+          "name": "operations",
           "level": 49
         },
         {
-          "name": "Operations",
+          "name": "parsteel generator a",
           "level": 49
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 2400000000
+        "bonus1": 2400000000.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 187425000000
-          },
-          {
             "type": "tritanium",
             "value": 918750000
+          },
+          {
+            "type": "parsteel",
+            "value": 187425000000
           }
         ]
       },
@@ -1914,15 +1865,227 @@
       "level": 50,
       "requirements": [
         {
-          "name": "Parsteel Generator A",
+          "name": "operations",
           "level": 50
         },
         {
-          "name": "Operations",
+          "name": "parsteel generator a",
           "level": 50
         }
-      ],
-      "rewards": []
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 3550000000.0
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "ore",
+            "grade": 5,
+            "rarity": "common",
+            "value": 8900
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 934830000000
+          },
+          {
+            "type": "tritanium",
+            "value": 1950000000
+          }
+        ]
+      },
+      "build_time": 37265760,
+      "increased_power": 3500,
+      "level": 51,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 51
+        },
+        {
+          "name": "parsteel generator a",
+          "level": 51
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 5300000000.0
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "ore",
+            "grade": 5,
+            "rarity": "common",
+            "value": 19500
+          },
+          {
+            "type": "ore",
+            "grade": 5,
+            "rarity": "uncommon",
+            "value": 3000
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 1690650000000
+          },
+          {
+            "type": "tritanium",
+            "value": 3315000000
+          }
+        ]
+      },
+      "build_time": 39502080,
+      "increased_power": 3500,
+      "level": 52,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 52
+        },
+        {
+          "name": "parsteel generator a",
+          "level": 52
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 7900000000.0
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "ore",
+            "grade": 5,
+            "rarity": "common",
+            "value": 37500
+          },
+          {
+            "type": "ore",
+            "grade": 5,
+            "rarity": "uncommon",
+            "value": 3100
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 5800000000
+          },
+          {
+            "type": "parsteel",
+            "value": 2839680000000
+          }
+        ]
+      },
+      "build_time": 41872320,
+      "increased_power": 4000,
+      "level": 53,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 53
+        },
+        {
+          "name": "parsteel generator a",
+          "level": 53
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 11850000000.0
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "ore",
+            "grade": 5,
+            "rarity": "rare",
+            "value": 800
+          },
+          {
+            "type": "ore",
+            "grade": 5,
+            "rarity": "uncommon",
+            "value": 10400
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 4259520000000
+          },
+          {
+            "type": "tritanium",
+            "value": 8700000000
+          }
+        ]
+      },
+      "build_time": 44385120,
+      "increased_power": 4000,
+      "level": 54,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 54
+        },
+        {
+          "name": "parsteel generator a",
+          "level": 54
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 17700000000.0
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "ore",
+            "grade": 5,
+            "rarity": "rare",
+            "value": 4800
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 13650000000
+          },
+          {
+            "type": "parsteel",
+            "value": 7239960000000
+          }
+        ]
+      },
+      "build_time": 47047680,
+      "increased_power": 4000,
+      "level": 55,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 55
+        },
+        {
+          "name": "parsteel generator a",
+          "level": 55
+        }
+      ]
     }
   ]
 }

--- a/buildings/r_d_department.json
+++ b/buildings/r_d_department.json
@@ -2,7 +2,7 @@
   "description": "The Research Lab is vital for the discovery of new technologies. Here, new Ships, buildings or supporting technologies are unlocked.",
   "bonuses": {
     "bonus1": {
-      "name": "Research Speed Bonus",
+      "name": "research speed bonus",
       "percentage": true
     }
   },
@@ -10,7 +10,7 @@
   "levels": [
     {
       "bonuses": {
-        "bonus1": 0
+        "bonus1": 0.0
       },
       "build_costs": {
         "materials": [],
@@ -27,19 +27,18 @@
       "level": 1,
       "requirements": [
         {
-          "name": "Academy",
-          "level": 1
+          "name": "operations",
+          "level": 4
         },
         {
-          "name": "Operations",
-          "level": 4
+          "name": "academy",
+          "level": 1
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 3
+        "bonus1": 0.03
       },
       "build_costs": {
         "materials": [],
@@ -56,19 +55,18 @@
       "level": 2,
       "requirements": [
         {
-          "name": "Academy",
-          "level": 2
+          "name": "operations",
+          "level": 4
         },
         {
-          "name": "Operations",
-          "level": 4
+          "name": "academy",
+          "level": 2
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 4
+        "bonus1": 0.04
       },
       "build_costs": {
         "materials": [],
@@ -85,19 +83,18 @@
       "level": 3,
       "requirements": [
         {
-          "name": "Academy",
-          "level": 3
+          "name": "operations",
+          "level": 5
         },
         {
-          "name": "Operations",
-          "level": 5
+          "name": "academy",
+          "level": 3
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 5
+        "bonus1": 0.05
       },
       "build_costs": {
         "materials": [],
@@ -114,19 +111,18 @@
       "level": 4,
       "requirements": [
         {
-          "name": "Academy",
-          "level": 4
+          "name": "operations",
+          "level": 5
         },
         {
-          "name": "Operations",
-          "level": 5
+          "name": "academy",
+          "level": 4
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 6
+        "bonus1": 0.06
       },
       "build_costs": {
         "materials": [],
@@ -143,23 +139,22 @@
       "level": 5,
       "requirements": [
         {
-          "name": "Tritanium Warehouse",
+          "name": "operations",
+          "level": 5
+        },
+        {
+          "name": "academy",
+          "level": 5
+        },
+        {
+          "name": "tritanium warehouse",
           "level": 3
-        },
-        {
-          "name": "Academy",
-          "level": 5
-        },
-        {
-          "name": "Operations",
-          "level": 5
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 8
+        "bonus1": 0.08
       },
       "build_costs": {
         "materials": [],
@@ -176,23 +171,22 @@
       "level": 6,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 6
         },
         {
-          "name": "Tritanium Warehouse",
+          "name": "academy",
+          "level": 6
+        },
+        {
+          "name": "tritanium warehouse",
           "level": 3
-        },
-        {
-          "name": "Academy",
-          "level": 6
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 9
+        "bonus1": 0.09
       },
       "build_costs": {
         "materials": [],
@@ -209,23 +203,22 @@
       "level": 7,
       "requirements": [
         {
-          "name": "Tritanium Warehouse",
+          "name": "operations",
+          "level": 7
+        },
+        {
+          "name": "academy",
+          "level": 7
+        },
+        {
+          "name": "tritanium warehouse",
           "level": 5
-        },
-        {
-          "name": "Academy",
-          "level": 7
-        },
-        {
-          "name": "Operations",
-          "level": 7
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 11
+        "bonus1": 0.11
       },
       "build_costs": {
         "materials": [],
@@ -242,19 +235,18 @@
       "level": 8,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 8
         },
         {
-          "name": "Academy",
+          "name": "academy",
           "level": 8
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 12
+        "bonus1": 0.12
       },
       "build_costs": {
         "materials": [],
@@ -271,23 +263,22 @@
       "level": 9,
       "requirements": [
         {
-          "name": "Tritanium Warehouse",
+          "name": "operations",
           "level": 9
         },
         {
-          "name": "Academy",
+          "name": "academy",
           "level": 9
         },
         {
-          "name": "Operations",
+          "name": "tritanium warehouse",
           "level": 9
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 14
+        "bonus1": 0.14
       },
       "build_costs": {
         "materials": [],
@@ -304,35 +295,34 @@
       "level": 10,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 10
         },
         {
-          "name": "Academy",
+          "name": "academy",
           "level": 10
         },
         {
-          "name": "Dilithium Generator A",
+          "name": "dilithium generator a",
           "level": 5
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 16
+        "bonus1": 0.16
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 8160
-          },
-          {
             "type": "dilithium",
             "value": 12
+          },
+          {
+            "type": "parsteel",
+            "value": 8160
           }
         ]
       },
@@ -341,19 +331,18 @@
       "level": 11,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 11
         },
         {
-          "name": "Academy",
+          "name": "academy",
           "level": 11
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 18
+        "bonus1": 0.18
       },
       "build_costs": {
         "materials": [],
@@ -374,23 +363,22 @@
       "level": 12,
       "requirements": [
         {
-          "name": "Dilithium Warehouse",
+          "name": "operations",
+          "level": 12
+        },
+        {
+          "name": "academy",
+          "level": 12
+        },
+        {
+          "name": "dilithium warehouse",
           "level": 10
-        },
-        {
-          "name": "Academy",
-          "level": 12
-        },
-        {
-          "name": "Operations",
-          "level": 12
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 20
+        "bonus1": 0.2
       },
       "build_costs": {
         "materials": [],
@@ -411,19 +399,18 @@
       "level": 13,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 13
         },
         {
-          "name": "Tritanium Warehouse",
+          "name": "tritanium warehouse",
           "level": 11
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 22
+        "bonus1": 0.22
       },
       "build_costs": {
         "materials": [],
@@ -444,23 +431,22 @@
       "level": 14,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 14
         },
         {
-          "name": "Academy",
+          "name": "academy",
           "level": 14
         },
         {
-          "name": "Dilithium Generator B",
+          "name": "dilithium generator b",
           "level": 11
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 24
+        "bonus1": 0.24
       },
       "build_costs": {
         "materials": [
@@ -488,23 +474,22 @@
       "level": 15,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 15
         },
         {
-          "name": "Academy",
+          "name": "academy",
           "level": 15
         },
         {
-          "name": "Refinery",
+          "name": "refinery",
           "level": 13
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 26
+        "bonus1": 0.26
       },
       "build_costs": {
         "materials": [
@@ -518,12 +503,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 40800
-          },
-          {
             "type": "dilithium",
             "value": 300
+          },
+          {
+            "type": "parsteel",
+            "value": 40800
           }
         ]
       },
@@ -532,23 +517,22 @@
       "level": 16,
       "requirements": [
         {
-          "name": "Defense Platform B",
+          "name": "operations",
+          "level": 16
+        },
+        {
+          "name": "academy",
+          "level": 16
+        },
+        {
+          "name": "defense platform b",
           "level": 12
-        },
-        {
-          "name": "Academy",
-          "level": 16
-        },
-        {
-          "name": "Operations",
-          "level": 16
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 29
+        "bonus1": 0.29
       },
       "build_costs": {
         "materials": [
@@ -582,23 +566,22 @@
       "level": 17,
       "requirements": [
         {
-          "name": "Tritanium Generator B",
+          "name": "operations",
           "level": 17
         },
         {
-          "name": "Operations",
+          "name": "academy",
           "level": 17
         },
         {
-          "name": "Academy",
+          "name": "tritanium generator b",
           "level": 17
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 31
+        "bonus1": 0.31
       },
       "build_costs": {
         "materials": [
@@ -632,48 +615,47 @@
       "level": 18,
       "requirements": [
         {
-          "name": "Drydock C",
+          "name": "operations",
+          "level": 18
+        },
+        {
+          "name": "academy",
+          "level": 18
+        },
+        {
+          "name": "drydock c",
           "level": 8
-        },
-        {
-          "name": "Academy",
-          "level": 18
-        },
-        {
-          "name": "Operations",
-          "level": 18
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 34
+        "bonus1": 0.34
       },
       "build_costs": {
         "materials": [
           {
             "type": "gas",
             "grade": 2,
-            "rarity": "common",
-            "value": 5000
+            "rarity": "uncommon",
+            "value": 300
           },
           {
             "type": "gas",
             "grade": 2,
-            "rarity": "uncommon",
-            "value": 300
+            "rarity": "common",
+            "value": 5000
           }
         ],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 122400
-          },
-          {
             "type": "dilithium",
             "value": 900
+          },
+          {
+            "type": "parsteel",
+            "value": 122400
           }
         ]
       },
@@ -682,23 +664,22 @@
       "level": 19,
       "requirements": [
         {
-          "name": "Defense Platform C",
+          "name": "operations",
+          "level": 19
+        },
+        {
+          "name": "academy",
+          "level": 19
+        },
+        {
+          "name": "defense platform c",
           "level": 8
-        },
-        {
-          "name": "Academy",
-          "level": 19
-        },
-        {
-          "name": "Operations",
-          "level": 19
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 36
+        "bonus1": 0.36
       },
       "build_costs": {
         "materials": [],
@@ -719,19 +700,18 @@
       "level": 20,
       "requirements": [
         {
-          "name": "Academy",
+          "name": "operations",
           "level": 20
         },
         {
-          "name": "Operations",
+          "name": "academy",
           "level": 20
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 39
+        "bonus1": 0.39
       },
       "build_costs": {
         "materials": [],
@@ -752,23 +732,22 @@
       "level": 21,
       "requirements": [
         {
-          "name": "Tritanium Warehouse",
+          "name": "operations",
           "level": 21
         },
         {
-          "name": "Academy",
+          "name": "academy",
           "level": 21
         },
         {
-          "name": "Operations",
+          "name": "tritanium warehouse",
           "level": 21
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 42
+        "bonus1": 0.42
       },
       "build_costs": {
         "materials": [],
@@ -789,19 +768,18 @@
       "level": 22,
       "requirements": [
         {
-          "name": "Academy",
+          "name": "operations",
           "level": 22
         },
         {
-          "name": "Operations",
+          "name": "academy",
           "level": 22
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 45
+        "bonus1": 0.45
       },
       "build_costs": {
         "materials": [
@@ -829,23 +807,22 @@
       "level": 23,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 23
         },
         {
-          "name": "Defense Platform A",
+          "name": "academy",
           "level": 23
         },
         {
-          "name": "Academy",
+          "name": "defense platform a",
           "level": 23
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 48
+        "bonus1": 0.48
       },
       "build_costs": {
         "materials": [
@@ -859,12 +836,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 1177488
-          },
-          {
             "type": "dilithium",
             "value": 8658
+          },
+          {
+            "type": "parsteel",
+            "value": 1177488
           }
         ]
       },
@@ -873,37 +850,36 @@
       "level": 24,
       "requirements": [
         {
-          "name": "Defense Platform B",
+          "name": "operations",
           "level": 24
         },
         {
-          "name": "Academy",
+          "name": "academy",
           "level": 24
         },
         {
-          "name": "Operations",
+          "name": "defense platform b",
           "level": 24
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 51
+        "bonus1": 0.51
       },
       "build_costs": {
         "materials": [
           {
             "type": "gas",
             "grade": 3,
-            "rarity": "common",
-            "value": 700
+            "rarity": "uncommon",
+            "value": 80
           },
           {
             "type": "gas",
             "grade": 3,
-            "rarity": "uncommon",
-            "value": 80
+            "rarity": "common",
+            "value": 700
           }
         ],
         "others": [],
@@ -923,23 +899,22 @@
       "level": 25,
       "requirements": [
         {
-          "name": "Dilithium Warehouse",
+          "name": "operations",
           "level": 25
         },
         {
-          "name": "Academy",
+          "name": "academy",
           "level": 25
         },
         {
-          "name": "Operations",
+          "name": "dilithium warehouse",
           "level": 25
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 55
+        "bonus1": 0.55
       },
       "build_costs": {
         "materials": [
@@ -973,44 +948,43 @@
       "level": 26,
       "requirements": [
         {
-          "name": "Academy",
+          "name": "operations",
           "level": 26
         },
         {
-          "name": "Operations",
+          "name": "academy",
           "level": 26
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 58
+        "bonus1": 0.58
       },
       "build_costs": {
         "materials": [
           {
             "type": "gas",
             "grade": 3,
-            "rarity": "common",
-            "value": 1000
+            "rarity": "uncommon",
+            "value": 160
           },
           {
             "type": "gas",
             "grade": 3,
-            "rarity": "uncommon",
-            "value": 160
+            "rarity": "common",
+            "value": 1000
           }
         ],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 4553280
-          },
-          {
             "type": "dilithium",
             "value": 33480
+          },
+          {
+            "type": "parsteel",
+            "value": 4553280
           }
         ]
       },
@@ -1019,37 +993,36 @@
       "level": 27,
       "requirements": [
         {
-          "name": "Refinery",
+          "name": "operations",
+          "level": 27
+        },
+        {
+          "name": "academy",
+          "level": 27
+        },
+        {
+          "name": "refinery",
           "level": 26
-        },
-        {
-          "name": "Academy",
-          "level": 27
-        },
-        {
-          "name": "Operations",
-          "level": 27
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 62
+        "bonus1": 0.62
       },
       "build_costs": {
         "materials": [
           {
             "type": "gas",
             "grade": 3,
-            "rarity": "common",
-            "value": 1200
+            "rarity": "uncommon",
+            "value": 210
           },
           {
             "type": "gas",
             "grade": 3,
-            "rarity": "uncommon",
-            "value": 210
+            "rarity": "common",
+            "value": 1200
           }
         ],
         "others": [],
@@ -1069,37 +1042,36 @@
       "level": 28,
       "requirements": [
         {
-          "name": "Defense Platform B",
+          "name": "operations",
           "level": 28
         },
         {
-          "name": "Academy",
+          "name": "academy",
           "level": 28
         },
         {
-          "name": "Operations",
+          "name": "defense platform b",
           "level": 28
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 65
+        "bonus1": 0.65
       },
       "build_costs": {
         "materials": [
           {
             "type": "gas",
             "grade": 3,
-            "rarity": "common",
-            "value": 1400
+            "rarity": "uncommon",
+            "value": 260
           },
           {
             "type": "gas",
             "grade": 3,
-            "rarity": "uncommon",
-            "value": 260
+            "rarity": "common",
+            "value": 1400
           }
         ],
         "others": [],
@@ -1119,23 +1091,22 @@
       "level": 29,
       "requirements": [
         {
-          "name": "Dilithium Vault",
+          "name": "operations",
+          "level": 29
+        },
+        {
+          "name": "academy",
+          "level": 29
+        },
+        {
+          "name": "dilithium vault",
           "level": 28
-        },
-        {
-          "name": "Academy",
-          "level": 29
-        },
-        {
-          "name": "Operations",
-          "level": 29
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 69
+        "bonus1": 0.69
       },
       "build_costs": {
         "materials": [
@@ -1169,48 +1140,47 @@
       "level": 30,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 30
         },
         {
-          "name": "Tritanium Warehouse",
+          "name": "academy",
+          "level": 30
+        },
+        {
+          "name": "tritanium warehouse",
           "level": 28
-        },
-        {
-          "name": "Academy",
-          "level": 30
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 73
+        "bonus1": 0.73
       },
       "build_costs": {
         "materials": [
           {
             "type": "gas",
             "grade": 3,
-            "rarity": "common",
-            "value": 1900
+            "rarity": "uncommon",
+            "value": 410
           },
           {
             "type": "gas",
             "grade": 3,
-            "rarity": "uncommon",
-            "value": 410
+            "rarity": "common",
+            "value": 1900
           }
         ],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 25153200
-          },
-          {
             "type": "dilithium",
             "value": 184950
+          },
+          {
+            "type": "parsteel",
+            "value": 25153200
           }
         ]
       },
@@ -1219,48 +1189,47 @@
       "level": 31,
       "requirements": [
         {
-          "name": "Defense Platform B",
+          "name": "operations",
+          "level": 31
+        },
+        {
+          "name": "academy",
+          "level": 31
+        },
+        {
+          "name": "defense platform b",
           "level": 26
-        },
-        {
-          "name": "Academy",
-          "level": 31
-        },
-        {
-          "name": "Operations",
-          "level": 31
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 77
+        "bonus1": 0.77
       },
       "build_costs": {
         "materials": [
           {
             "type": "gas",
             "grade": 3,
-            "rarity": "common",
-            "value": 2100
+            "rarity": "rare",
+            "value": 25
           },
           {
             "type": "gas",
             "grade": 3,
-            "rarity": "rare",
-            "value": 25
+            "rarity": "common",
+            "value": 2100
           }
         ],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 36332400
-          },
-          {
             "type": "dilithium",
             "value": 267150
+          },
+          {
+            "type": "parsteel",
+            "value": 36332400
           }
         ]
       },
@@ -1269,44 +1238,43 @@
       "level": 32,
       "requirements": [
         {
-          "name": "Academy",
+          "name": "operations",
           "level": 32
         },
         {
-          "name": "Operations",
+          "name": "academy",
           "level": 32
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 81
+        "bonus1": 0.81
       },
       "build_costs": {
         "materials": [
           {
             "type": "gas",
             "grade": 3,
-            "rarity": "common",
-            "value": 2400
+            "rarity": "uncommon",
+            "value": 590
           },
           {
             "type": "gas",
             "grade": 3,
-            "rarity": "uncommon",
-            "value": 590
+            "rarity": "common",
+            "value": 2400
           }
         ],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 56202000
-          },
-          {
             "type": "dilithium",
             "value": 413250
+          },
+          {
+            "type": "parsteel",
+            "value": 56202000
           }
         ]
       },
@@ -1315,19 +1283,18 @@
       "level": 33,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 33
         },
         {
-          "name": "Tritanium Vault",
+          "name": "tritanium vault",
           "level": 29
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 85
+        "bonus1": 0.85
       },
       "build_costs": {
         "materials": [
@@ -1361,44 +1328,43 @@
       "level": 34,
       "requirements": [
         {
-          "name": "Academy",
+          "name": "operations",
           "level": 34
         },
         {
-          "name": "Operations",
+          "name": "academy",
           "level": 34
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 89
+        "bonus1": 0.89
       },
       "build_costs": {
         "materials": [
           {
             "type": "gas",
             "grade": 3,
-            "rarity": "common",
-            "value": 3100
+            "rarity": "uncommon",
+            "value": 820
           },
           {
             "type": "gas",
             "grade": 3,
-            "rarity": "uncommon",
-            "value": 820
+            "rarity": "common",
+            "value": 3100
           }
         ],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 137332800
-          },
-          {
             "type": "dilithium",
             "value": 1009800
+          },
+          {
+            "type": "parsteel",
+            "value": 137332800
           }
         ]
       },
@@ -1407,19 +1373,18 @@
       "level": 35,
       "requirements": [
         {
-          "name": "Academy",
+          "name": "operations",
           "level": 35
         },
         {
-          "name": "Operations",
+          "name": "academy",
           "level": 35
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 93
+        "bonus1": 0.93
       },
       "build_costs": {
         "materials": [
@@ -1453,23 +1418,22 @@
       "level": 36,
       "requirements": [
         {
-          "name": "Defense Platform A",
+          "name": "operations",
+          "level": 36
+        },
+        {
+          "name": "academy",
+          "level": 36
+        },
+        {
+          "name": "defense platform a",
           "level": 30
-        },
-        {
-          "name": "Academy",
-          "level": 36
-        },
-        {
-          "name": "Operations",
-          "level": 36
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 98
+        "bonus1": 0.98
       },
       "build_costs": {
         "materials": [
@@ -1489,12 +1453,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 297432000
-          },
-          {
             "type": "dilithium",
             "value": 2187000
+          },
+          {
+            "type": "parsteel",
+            "value": 297432000
           }
         ]
       },
@@ -1503,37 +1467,36 @@
       "level": 37,
       "requirements": [
         {
-          "name": "Tritanium Warehouse",
+          "name": "operations",
+          "level": 37
+        },
+        {
+          "name": "academy",
+          "level": 37
+        },
+        {
+          "name": "tritanium warehouse",
           "level": 32
-        },
-        {
-          "name": "Academy",
-          "level": 37
-        },
-        {
-          "name": "Operations",
-          "level": 37
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 102
+        "bonus1": 1.02
       },
       "build_costs": {
         "materials": [
           {
             "type": "gas",
             "grade": 3,
-            "rarity": "common",
-            "value": 4300
+            "rarity": "rare",
+            "value": 200
           },
           {
             "type": "gas",
             "grade": 3,
-            "rarity": "rare",
-            "value": 200
+            "rarity": "common",
+            "value": 4300
           }
         ],
         "others": [],
@@ -1553,19 +1516,18 @@
       "level": 38,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 38
         },
         {
-          "name": "Academy",
+          "name": "academy",
           "level": 38
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 107
+        "bonus1": 1.07
       },
       "build_costs": {
         "materials": [
@@ -1599,19 +1561,18 @@
       "level": 39,
       "requirements": [
         {
-          "name": "Academy",
+          "name": "operations",
           "level": 39
         },
         {
-          "name": "Operations",
+          "name": "academy",
           "level": 39
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 111
+        "bonus1": 1.11
       },
       "build_costs": {
         "materials": [
@@ -1625,12 +1586,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 3438624000
-          },
-          {
             "type": "dilithium",
             "value": 9030000
+          },
+          {
+            "type": "parsteel",
+            "value": 3438624000
           }
         ]
       },
@@ -1639,19 +1600,18 @@
       "level": 40,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 40
         },
         {
-          "name": "Academy",
+          "name": "academy",
           "level": 40
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 116
+        "bonus1": 1.16
       },
       "build_costs": {
         "materials": [
@@ -1685,37 +1645,36 @@
       "level": 41,
       "requirements": [
         {
-          "name": "Tritanium Vault",
+          "name": "operations",
+          "level": 41
+        },
+        {
+          "name": "academy",
+          "level": 41
+        },
+        {
+          "name": "tritanium vault",
           "level": 36
-        },
-        {
-          "name": "Academy",
-          "level": 41
-        },
-        {
-          "name": "Operations",
-          "level": 41
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 121
+        "bonus1": 1.21
       },
       "build_costs": {
         "materials": [
           {
             "type": "gas",
             "grade": 4,
-            "rarity": "uncommon",
-            "value": 14500
+            "rarity": "rare",
+            "value": 4000
           },
           {
             "type": "gas",
             "grade": 4,
-            "rarity": "rare",
-            "value": 4000
+            "rarity": "uncommon",
+            "value": 14500
           }
         ],
         "others": [],
@@ -1735,48 +1694,47 @@
       "level": 42,
       "requirements": [
         {
-          "name": "Defense Platform D",
+          "name": "operations",
+          "level": 42
+        },
+        {
+          "name": "academy",
+          "level": 42
+        },
+        {
+          "name": "defense platform d",
           "level": 36
-        },
-        {
-          "name": "Academy",
-          "level": 42
-        },
-        {
-          "name": "Operations",
-          "level": 42
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 126
+        "bonus1": 1.26
       },
       "build_costs": {
         "materials": [
           {
             "type": "gas",
             "grade": 4,
-            "rarity": "uncommon",
-            "value": 16000
+            "rarity": "rare",
+            "value": 3000
           },
           {
             "type": "gas",
             "grade": 4,
-            "rarity": "rare",
-            "value": 3000
+            "rarity": "uncommon",
+            "value": 16000
           }
         ],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 7466400000
-          },
-          {
             "type": "dilithium",
             "value": 27450000
+          },
+          {
+            "type": "parsteel",
+            "value": 7466400000
           }
         ]
       },
@@ -1785,23 +1743,22 @@
       "level": 43,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 43
         },
         {
-          "name": "Academy",
+          "name": "academy",
           "level": 43
         },
         {
-          "name": "Dilithium Vault",
+          "name": "dilithium vault",
           "level": 36
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 131
+        "bonus1": 1.31
       },
       "build_costs": {
         "materials": [
@@ -1835,48 +1792,47 @@
       "level": 44,
       "requirements": [
         {
-          "name": "4\u2605 Tactical Battleships",
+          "name": "operations",
+          "level": 44
+        },
+        {
+          "name": "academy",
+          "level": 44
+        },
+        {
+          "name": "4\u2605 tactical battleships",
           "level": 1
-        },
-        {
-          "name": "Academy",
-          "level": 44
-        },
-        {
-          "name": "Operations",
-          "level": 44
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 137
+        "bonus1": 1.37
       },
       "build_costs": {
         "materials": [
           {
             "type": "gas",
             "grade": 4,
-            "rarity": "uncommon",
+            "rarity": "rare",
             "value": 8000
           },
           {
             "type": "gas",
             "grade": 4,
-            "rarity": "rare",
+            "rarity": "uncommon",
             "value": 8000
           }
         ],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 15912000000
-          },
-          {
             "type": "dilithium",
             "value": 58500000
+          },
+          {
+            "type": "parsteel",
+            "value": 15912000000
           }
         ]
       },
@@ -1885,19 +1841,18 @@
       "level": 45,
       "requirements": [
         {
-          "name": "Academy",
+          "name": "operations",
           "level": 45
         },
         {
-          "name": "Operations",
+          "name": "academy",
           "level": 45
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 143
+        "bonus1": 1.43
       },
       "build_costs": {
         "materials": [
@@ -1917,12 +1872,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 21879000000
-          },
-          {
             "type": "dilithium",
             "value": 80437500
+          },
+          {
+            "type": "parsteel",
+            "value": 21879000000
           }
         ]
       },
@@ -1931,19 +1886,18 @@
       "level": 46,
       "requirements": [
         {
-          "name": "Academy",
+          "name": "operations",
           "level": 46
         },
         {
-          "name": "Operations",
+          "name": "academy",
           "level": 46
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 149
+        "bonus1": 1.49
       },
       "build_costs": {
         "materials": [
@@ -1963,12 +1917,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 31824000000
-          },
-          {
             "type": "dilithium",
             "value": 117000000
+          },
+          {
+            "type": "parsteel",
+            "value": 31824000000
           }
         ]
       },
@@ -1977,48 +1931,47 @@
       "level": 47,
       "requirements": [
         {
-          "name": "4\u2605 Offensive Strategies",
+          "name": "operations",
+          "level": 47
+        },
+        {
+          "name": "academy",
+          "level": 47
+        },
+        {
+          "name": "4\u2605 offensive strategies",
           "level": 1
-        },
-        {
-          "name": "Academy",
-          "level": 47
-        },
-        {
-          "name": "Operations",
-          "level": 47
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 155
+        "bonus1": 1.55
       },
       "build_costs": {
         "materials": [
           {
             "type": "gas",
             "grade": 4,
-            "rarity": "uncommon",
-            "value": 12000
+            "rarity": "rare",
+            "value": 5000
           },
           {
             "type": "gas",
             "grade": 4,
-            "rarity": "rare",
-            "value": 5000
+            "rarity": "uncommon",
+            "value": 12000
           }
         ],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 51408000000
-          },
-          {
             "type": "dilithium",
             "value": 189000000
+          },
+          {
+            "type": "parsteel",
+            "value": 51408000000
           }
         ]
       },
@@ -2027,44 +1980,43 @@
       "level": 48,
       "requirements": [
         {
-          "name": "Academy",
+          "name": "operations",
           "level": 48
         },
         {
-          "name": "Operations",
+          "name": "academy",
           "level": 48
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 161
+        "bonus1": 1.61
       },
       "build_costs": {
         "materials": [
           {
             "type": "gas",
             "grade": 4,
-            "rarity": "uncommon",
-            "value": 25000
+            "rarity": "rare",
+            "value": 20000
           },
           {
             "type": "gas",
             "grade": 4,
-            "rarity": "rare",
-            "value": 20000
+            "rarity": "uncommon",
+            "value": 25000
           }
         ],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 85680000000
-          },
-          {
             "type": "dilithium",
             "value": 315000000
+          },
+          {
+            "type": "parsteel",
+            "value": 85680000000
           }
         ]
       },
@@ -2073,23 +2025,22 @@
       "level": 49,
       "requirements": [
         {
-          "name": "Tritanium Vault",
+          "name": "operations",
+          "level": 49
+        },
+        {
+          "name": "academy",
+          "level": 49
+        },
+        {
+          "name": "tritanium vault",
           "level": 43
-        },
-        {
-          "name": "Academy",
-          "level": 49
-        },
-        {
-          "name": "Operations",
-          "level": 49
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 170
+        "bonus1": 1.7
       },
       "build_costs": {
         "materials": [],
@@ -2110,15 +2061,241 @@
       "level": 50,
       "requirements": [
         {
-          "name": "Academy",
+          "name": "operations",
           "level": 50
         },
         {
-          "name": "Operations",
+          "name": "academy",
           "level": 50
         }
-      ],
-      "rewards": []
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 1.77
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "gas",
+            "grade": 5,
+            "rarity": "common",
+            "value": 20600
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "dilithium",
+            "value": 1170000000
+          },
+          {
+            "type": "parsteel",
+            "value": 747864000000
+          }
+        ]
+      },
+      "build_time": 149065920,
+      "increased_power": 5000,
+      "level": 51,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 51
+        },
+        {
+          "name": "academy",
+          "level": 51
+        },
+        {
+          "name": "tritanium vault",
+          "level": 51
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 1.84
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "gas",
+            "grade": 5,
+            "rarity": "common",
+            "value": 37500
+          },
+          {
+            "type": "gas",
+            "grade": 5,
+            "rarity": "uncommon",
+            "value": 14200
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 1352520000000
+          },
+          {
+            "type": "dilithium",
+            "value": 1989000000
+          }
+        ]
+      },
+      "build_time": 158009760,
+      "increased_power": 6000,
+      "level": 52,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 52
+        },
+        {
+          "name": "academy",
+          "level": 52
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 1.91
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "gas",
+            "grade": 5,
+            "rarity": "uncommon",
+            "value": 51000
+          },
+          {
+            "type": "gas",
+            "grade": 5,
+            "rarity": "common",
+            "value": 87700
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "dilithium",
+            "value": 3480000000
+          },
+          {
+            "type": "parsteel",
+            "value": 2271744000000
+          }
+        ]
+      },
+      "build_time": 167490720,
+      "increased_power": 5000,
+      "level": 53,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 53
+        },
+        {
+          "name": "academy",
+          "level": 53
+        },
+        {
+          "name": "dilithium vault",
+          "level": 53
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 1.98
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "gas",
+            "grade": 5,
+            "rarity": "common",
+            "value": 75600
+          },
+          {
+            "type": "gas",
+            "grade": 5,
+            "rarity": "rare",
+            "value": 11100
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "dilithium",
+            "value": 5220000000
+          },
+          {
+            "type": "parsteel",
+            "value": 3407616000000
+          }
+        ]
+      },
+      "build_time": 177540480,
+      "increased_power": 6000,
+      "level": 54,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 54
+        },
+        {
+          "name": "academy",
+          "level": 54
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 2.05
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "gas",
+            "grade": 5,
+            "rarity": "uncommon",
+            "value": 75900
+          },
+          {
+            "type": "gas",
+            "grade": 5,
+            "rarity": "rare",
+            "value": 12600
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 5791968000000
+          },
+          {
+            "type": "dilithium",
+            "value": 8190000000
+          }
+        ]
+      },
+      "build_time": 188192160,
+      "increased_power": 6000,
+      "level": 55,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 55
+        },
+        {
+          "name": "academy",
+          "level": 55
+        }
+      ]
     }
   ]
 }

--- a/buildings/refinery.json
+++ b/buildings/refinery.json
@@ -18,13 +18,13 @@
       "level": 1,
       "requirements": [
         {
-          "name": "Unlock Refinery",
+          "name": "unlock refinery",
           "level": 1
         }
       ],
       "rewards": [
         {
-          "type": "2\u2605\u00a0Raw\u00a0Crystal",
+          "type": "2\u2605 raw crystal",
           "value": 25
         }
       ]
@@ -45,17 +45,17 @@
       "level": 2,
       "requirements": [
         {
-          "name": "Shipyard",
+          "name": "operations",
           "level": 2
         },
         {
-          "name": "Operations",
+          "name": "shipyard",
           "level": 2
         }
       ],
       "rewards": [
         {
-          "type": "2\u2605\u00a0Raw\u00a0Crystal",
+          "type": "2\u2605 raw crystal",
           "value": 75
         }
       ]
@@ -76,17 +76,17 @@
       "level": 3,
       "requirements": [
         {
-          "name": "Shipyard",
+          "name": "operations",
           "level": 3
         },
         {
-          "name": "Operations",
+          "name": "shipyard",
           "level": 3
         }
       ],
       "rewards": [
         {
-          "type": "2\u2605\u00a0Raw\u00a0Crystal",
+          "type": "2\u2605 raw crystal",
           "value": 150
         }
       ]
@@ -107,17 +107,17 @@
       "level": 4,
       "requirements": [
         {
-          "name": "Shipyard",
+          "name": "operations",
           "level": 4
         },
         {
-          "name": "Operations",
+          "name": "shipyard",
           "level": 4
         }
       ],
       "rewards": [
         {
-          "type": "2\u2605\u00a0Raw\u00a0Crystal",
+          "type": "2\u2605 raw crystal",
           "value": 250
         }
       ]
@@ -138,21 +138,21 @@
       "level": 5,
       "requirements": [
         {
-          "name": "Shipyard",
+          "name": "operations",
           "level": 5
         },
         {
-          "name": "Operations",
+          "name": "shipyard",
           "level": 5
         }
       ],
       "rewards": [
         {
-          "type": "2\u2605\u00a0Raw\u00a0Gas",
+          "type": "2\u2605 raw crystal",
           "value": 400
         },
         {
-          "type": "2\u2605\u00a0Raw\u00a0Crystal",
+          "type": "2\u2605 raw gas",
           "value": 400
         }
       ]
@@ -173,21 +173,21 @@
       "level": 6,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 6
         },
         {
-          "name": "Shipyard",
+          "name": "shipyard",
           "level": 6
         }
       ],
       "rewards": [
         {
-          "type": "2\u2605\u00a0Raw\u00a0Gas",
+          "type": "2\u2605 raw crystal",
           "value": 600
         },
         {
-          "type": "2\u2605\u00a0Raw\u00a0Crystal",
+          "type": "2\u2605 raw gas",
           "value": 600
         }
       ]
@@ -208,21 +208,21 @@
       "level": 7,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 7
         },
         {
-          "name": "Shipyard",
+          "name": "shipyard",
           "level": 7
         }
       ],
       "rewards": [
         {
-          "type": "2\u2605\u00a0Raw\u00a0Gas",
+          "type": "2\u2605 raw crystal",
           "value": 850
         },
         {
-          "type": "2\u2605\u00a0Raw\u00a0Crystal",
+          "type": "2\u2605 raw gas",
           "value": 850
         }
       ]
@@ -243,21 +243,21 @@
       "level": 8,
       "requirements": [
         {
-          "name": "Shipyard",
+          "name": "operations",
           "level": 8
         },
         {
-          "name": "Operations",
+          "name": "shipyard",
           "level": 8
         }
       ],
       "rewards": [
         {
-          "type": "2\u2605\u00a0Raw\u00a0Gas",
+          "type": "2\u2605 raw crystal",
           "value": 1250
         },
         {
-          "type": "2\u2605\u00a0Raw\u00a0Crystal",
+          "type": "2\u2605 raw gas",
           "value": 1250
         }
       ]
@@ -278,21 +278,21 @@
       "level": 9,
       "requirements": [
         {
-          "name": "Shipyard",
+          "name": "operations",
           "level": 9
         },
         {
-          "name": "Operations",
+          "name": "shipyard",
           "level": 9
         }
       ],
       "rewards": [
         {
-          "type": "2\u2605\u00a0Raw\u00a0Gas",
+          "type": "2\u2605 raw crystal",
           "value": 2000
         },
         {
-          "type": "2\u2605\u00a0Raw\u00a0Crystal",
+          "type": "2\u2605 raw gas",
           "value": 2000
         }
       ]
@@ -313,25 +313,25 @@
       "level": 10,
       "requirements": [
         {
-          "name": "Shipyard",
+          "name": "operations",
           "level": 10
         },
         {
-          "name": "Operations",
+          "name": "shipyard",
           "level": 10
         }
       ],
       "rewards": [
         {
-          "type": "2\u2605\u00a0Raw\u00a0Ore",
+          "type": "2\u2605 raw crystal",
           "value": 4000
         },
         {
-          "type": "2\u2605\u00a0Raw\u00a0Crystal",
+          "type": "2\u2605 raw gas",
           "value": 4000
         },
         {
-          "type": "2\u2605\u00a0Raw\u00a0Gas",
+          "type": "2\u2605 raw ore",
           "value": 4000
         }
       ]
@@ -356,25 +356,25 @@
       "level": 11,
       "requirements": [
         {
-          "name": "Shipyard",
+          "name": "operations",
           "level": 11
         },
         {
-          "name": "Operations",
+          "name": "shipyard",
           "level": 11
         }
       ],
       "rewards": [
         {
-          "type": "2\u2605\u00a0Raw\u00a0Ore",
+          "type": "2\u2605 raw crystal",
           "value": 6000
         },
         {
-          "type": "2\u2605\u00a0Raw\u00a0Gas",
+          "type": "2\u2605 raw gas",
           "value": 6000
         },
         {
-          "type": "2\u2605\u00a0Raw\u00a0Crystal",
+          "type": "2\u2605 raw ore",
           "value": 6000
         }
       ]
@@ -385,12 +385,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 9350
-          },
-          {
             "type": "dilithium",
             "value": 66
+          },
+          {
+            "type": "parsteel",
+            "value": 9350
           }
         ]
       },
@@ -399,25 +399,25 @@
       "level": 12,
       "requirements": [
         {
-          "name": "Shipyard",
+          "name": "operations",
           "level": 12
         },
         {
-          "name": "Operations",
+          "name": "shipyard",
           "level": 12
         }
       ],
       "rewards": [
         {
-          "type": "2\u2605\u00a0Raw\u00a0Ore",
+          "type": "2\u2605 raw crystal",
           "value": 9000
         },
         {
-          "type": "2\u2605\u00a0Raw\u00a0Gas",
+          "type": "2\u2605 raw gas",
           "value": 9000
         },
         {
-          "type": "2\u2605\u00a0Raw\u00a0Crystal",
+          "type": "2\u2605 raw ore",
           "value": 9000
         }
       ]
@@ -442,25 +442,25 @@
       "level": 13,
       "requirements": [
         {
-          "name": "Shipyard",
+          "name": "operations",
           "level": 13
         },
         {
-          "name": "Operations",
+          "name": "shipyard",
           "level": 13
         }
       ],
       "rewards": [
         {
-          "type": "2\u2605\u00a0Raw\u00a0Ore",
+          "type": "2\u2605 raw crystal",
           "value": 12000
         },
         {
-          "type": "2\u2605\u00a0Raw\u00a0Gas",
+          "type": "2\u2605 raw gas",
           "value": 12000
         },
         {
-          "type": "2\u2605\u00a0Raw\u00a0Crystal",
+          "type": "2\u2605 raw ore",
           "value": 12000
         }
       ]
@@ -485,25 +485,25 @@
       "level": 14,
       "requirements": [
         {
-          "name": "Shipyard",
+          "name": "operations",
           "level": 14
         },
         {
-          "name": "Operations",
+          "name": "shipyard",
           "level": 14
         }
       ],
       "rewards": [
         {
-          "type": "2\u2605\u00a0Raw\u00a0Ore",
+          "type": "2\u2605 raw crystal",
           "value": 16000
         },
         {
-          "type": "2\u2605\u00a0Raw\u00a0Gas",
+          "type": "2\u2605 raw gas",
           "value": 16000
         },
         {
-          "type": "2\u2605\u00a0Raw\u00a0Crystal",
+          "type": "2\u2605 raw ore",
           "value": 16000
         }
       ]
@@ -528,25 +528,25 @@
       "level": 15,
       "requirements": [
         {
-          "name": "Shipyard",
+          "name": "operations",
           "level": 15
         },
         {
-          "name": "Operations",
+          "name": "shipyard",
           "level": 15
         }
       ],
       "rewards": [
         {
-          "type": "2\u2605\u00a0Raw\u00a0Gas",
+          "type": "2\u2605 raw crystal",
           "value": 20000
         },
         {
-          "type": "2\u2605\u00a0Raw\u00a0Crystal",
+          "type": "2\u2605 raw gas",
           "value": 20000
         },
         {
-          "type": "2\u2605\u00a0Raw\u00a0Ore",
+          "type": "2\u2605 raw ore",
           "value": 20000
         }
       ]
@@ -571,25 +571,25 @@
       "level": 16,
       "requirements": [
         {
-          "name": "Shipyard",
+          "name": "operations",
           "level": 16
         },
         {
-          "name": "Operations",
+          "name": "shipyard",
           "level": 16
         }
       ],
       "rewards": [
         {
-          "type": "2\u2605\u00a0Raw\u00a0Crystal",
+          "type": "2\u2605 raw crystal",
           "value": 25000
         },
         {
-          "type": "2\u2605\u00a0Raw\u00a0Ore",
+          "type": "2\u2605 raw gas",
           "value": 25000
         },
         {
-          "type": "2\u2605\u00a0Raw\u00a0Gas",
+          "type": "2\u2605 raw ore",
           "value": 25000
         }
       ]
@@ -600,12 +600,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 47600
-          },
-          {
             "type": "dilithium",
             "value": 840
+          },
+          {
+            "type": "parsteel",
+            "value": 47600
           }
         ]
       },
@@ -614,25 +614,25 @@
       "level": 17,
       "requirements": [
         {
-          "name": "Shipyard",
+          "name": "operations",
           "level": 17
         },
         {
-          "name": "Operations",
+          "name": "shipyard",
           "level": 17
         }
       ],
       "rewards": [
         {
-          "type": "2\u2605\u00a0Raw\u00a0Ore",
+          "type": "2\u2605 raw crystal",
           "value": 30000
         },
         {
-          "type": "2\u2605\u00a0Raw\u00a0Gas",
+          "type": "2\u2605 raw gas",
           "value": 30000
         },
         {
-          "type": "2\u2605\u00a0Raw\u00a0Crystal",
+          "type": "2\u2605 raw ore",
           "value": 30000
         }
       ]
@@ -643,12 +643,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 68000
-          },
-          {
             "type": "dilithium",
             "value": 1200
+          },
+          {
+            "type": "parsteel",
+            "value": 68000
           }
         ]
       },
@@ -657,25 +657,25 @@
       "level": 18,
       "requirements": [
         {
-          "name": "Shipyard",
+          "name": "operations",
           "level": 18
         },
         {
-          "name": "Operations",
+          "name": "shipyard",
           "level": 18
         }
       ],
       "rewards": [
         {
-          "type": "2\u2605\u00a0Raw\u00a0Ore",
+          "type": "2\u2605 raw crystal",
           "value": 35000
         },
         {
-          "type": "2\u2605\u00a0Raw\u00a0Gas",
+          "type": "2\u2605 raw gas",
           "value": 35000
         },
         {
-          "type": "2\u2605\u00a0Raw\u00a0Crystal",
+          "type": "2\u2605 raw ore",
           "value": 35000
         }
       ]
@@ -686,12 +686,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 102000
-          },
-          {
             "type": "dilithium",
             "value": 1800
+          },
+          {
+            "type": "parsteel",
+            "value": 102000
           }
         ]
       },
@@ -700,25 +700,25 @@
       "level": 19,
       "requirements": [
         {
-          "name": "Shipyard",
+          "name": "operations",
           "level": 19
         },
         {
-          "name": "Operations",
+          "name": "shipyard",
           "level": 19
         }
       ],
       "rewards": [
         {
-          "type": "2\u2605\u00a0Raw\u00a0Ore",
+          "type": "2\u2605 raw crystal",
           "value": 40000
         },
         {
-          "type": "2\u2605\u00a0Raw\u00a0Gas",
+          "type": "2\u2605 raw gas",
           "value": 40000
         },
         {
-          "type": "2\u2605\u00a0Raw\u00a0Crystal",
+          "type": "2\u2605 raw ore",
           "value": 40000
         }
       ]
@@ -743,30 +743,30 @@
       "level": 20,
       "requirements": [
         {
-          "name": "Parsteel Warehouse",
+          "name": "parsteel warehouse",
           "level": 19
         },
         {
-          "name": "Shipyard",
+          "name": "shipyard",
           "level": 19
         },
         {
-          "name": "Dilithium Warehouse",
+          "name": "dilithium warehouse",
           "level": 19
         }
       ],
       "rewards": [
         {
-          "type": "2\u2605\u00a0Raw\u00a0Ore",
-          "value": 45000
-        },
-        {
-          "type": "2\u2605\u00a0Raw\u00a0Gas",
-          "value": 45000
-        },
-        {
-          "type": "3\u2605\u00a0Raw\u00a0Crystal",
+          "type": "3\u2605 raw crystal",
           "value": 8000
+        },
+        {
+          "type": "2\u2605 raw gas",
+          "value": 45000
+        },
+        {
+          "type": "2\u2605 raw ore",
+          "value": 45000
         }
       ]
     },
@@ -790,25 +790,25 @@
       "level": 21,
       "requirements": [
         {
-          "name": "Shipyard",
+          "name": "operations",
           "level": 21
         },
         {
-          "name": "Operations",
+          "name": "shipyard",
           "level": 21
         }
       ],
       "rewards": [
         {
-          "type": "2\u2605\u00a0Raw\u00a0Gas",
-          "value": 50000
-        },
-        {
-          "type": "3\u2605\u00a0Raw\u00a0Crystal",
+          "type": "3\u2605 raw crystal",
           "value": 9000
         },
         {
-          "type": "2\u2605\u00a0Raw\u00a0Ore",
+          "type": "2\u2605 raw gas",
+          "value": 50000
+        },
+        {
+          "type": "2\u2605 raw ore",
           "value": 50000
         }
       ]
@@ -833,26 +833,26 @@
       "level": 22,
       "requirements": [
         {
-          "name": "Shipyard",
+          "name": "operations",
           "level": 22
         },
         {
-          "name": "Operations",
+          "name": "shipyard",
           "level": 22
         }
       ],
       "rewards": [
         {
-          "type": "2\u2605\u00a0Raw\u00a0Ore",
-          "value": 55000
-        },
-        {
-          "type": "2\u2605\u00a0Raw\u00a0Gas",
-          "value": 55000
-        },
-        {
-          "type": "3\u2605\u00a0Raw\u00a0Crystal",
+          "type": "3\u2605 raw crystal",
           "value": 10500
+        },
+        {
+          "type": "2\u2605 raw gas",
+          "value": 55000
+        },
+        {
+          "type": "2\u2605 raw ore",
+          "value": 55000
         }
       ]
     },
@@ -862,12 +862,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 622710
-          },
-          {
             "type": "dilithium",
             "value": 10989
+          },
+          {
+            "type": "parsteel",
+            "value": 622710
           }
         ]
       },
@@ -876,26 +876,26 @@
       "level": 23,
       "requirements": [
         {
-          "name": "Tritanium Warehouse",
-          "level": 22
+          "name": "operations",
+          "level": 23
         },
         {
-          "name": "Operations",
-          "level": 23
+          "name": "tritanium warehouse",
+          "level": 22
         }
       ],
       "rewards": [
         {
-          "type": "2\u2605\u00a0Raw\u00a0Ore",
+          "type": "3\u2605 raw crystal",
+          "value": 12000
+        },
+        {
+          "type": "3\u2605 raw gas",
+          "value": 12000
+        },
+        {
+          "type": "2\u2605 raw ore",
           "value": 60000
-        },
-        {
-          "type": "3\u2605\u00a0Raw\u00a0Gas",
-          "value": 12000
-        },
-        {
-          "type": "3\u2605\u00a0Raw\u00a0Crystal",
-          "value": 12000
         }
       ]
     },
@@ -919,26 +919,26 @@
       "level": 24,
       "requirements": [
         {
-          "name": "Shipyard",
+          "name": "operations",
           "level": 24
         },
         {
-          "name": "Operations",
+          "name": "shipyard",
           "level": 24
         }
       ],
       "rewards": [
         {
-          "type": "2\u2605\u00a0Raw\u00a0Ore",
+          "type": "3\u2605 raw crystal",
+          "value": 14000
+        },
+        {
+          "type": "3\u2605 raw gas",
+          "value": 14000
+        },
+        {
+          "type": "2\u2605 raw ore",
           "value": 65000
-        },
-        {
-          "type": "3\u2605\u00a0Raw\u00a0Gas",
-          "value": 14000
-        },
-        {
-          "type": "3\u2605\u00a0Raw\u00a0Crystal",
-          "value": 14000
         }
       ]
     },
@@ -955,12 +955,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 1591200
-          },
-          {
             "type": "dilithium",
             "value": 28080
+          },
+          {
+            "type": "parsteel",
+            "value": 1591200
           }
         ]
       },
@@ -969,26 +969,26 @@
       "level": 25,
       "requirements": [
         {
-          "name": "Shipyard",
+          "name": "operations",
           "level": 25
         },
         {
-          "name": "Operations",
+          "name": "shipyard",
           "level": 25
         }
       ],
       "rewards": [
         {
-          "type": "2\u2605\u00a0Raw\u00a0Ore",
+          "type": "3\u2605 raw crystal",
+          "value": 16000
+        },
+        {
+          "type": "3\u2605 raw gas",
+          "value": 16000
+        },
+        {
+          "type": "2\u2605 raw ore",
           "value": 70000
-        },
-        {
-          "type": "3\u2605\u00a0Raw\u00a0Gas",
-          "value": 16000
-        },
-        {
-          "type": "3\u2605\u00a0Raw\u00a0Crystal",
-          "value": 16000
         }
       ]
     },
@@ -998,25 +998,25 @@
           {
             "type": "ore",
             "grade": 3,
-            "rarity": "common",
-            "value": 230
+            "rarity": "uncommon",
+            "value": 5
           },
           {
             "type": "ore",
             "grade": 3,
-            "rarity": "uncommon",
-            "value": 5
+            "rarity": "common",
+            "value": 230
           }
         ],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 2486250
-          },
-          {
             "type": "dilithium",
             "value": 43875
+          },
+          {
+            "type": "parsteel",
+            "value": 2486250
           }
         ]
       },
@@ -1025,25 +1025,25 @@
       "level": 26,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 26
         },
         {
-          "name": "Shipyard",
+          "name": "shipyard",
           "level": 26
         }
       ],
       "rewards": [
         {
-          "type": "3\u2605\u00a0Raw\u00a0Ore",
+          "type": "3\u2605 raw crystal",
           "value": 18000
         },
         {
-          "type": "3\u2605\u00a0Raw\u00a0Gas",
+          "type": "3\u2605 raw gas",
           "value": 18000
         },
         {
-          "type": "3\u2605\u00a0Raw\u00a0Crystal",
+          "type": "3\u2605 raw ore",
           "value": 18000
         }
       ]
@@ -1061,12 +1061,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 3794400
-          },
-          {
             "type": "dilithium",
             "value": 66960
+          },
+          {
+            "type": "parsteel",
+            "value": 3794400
           }
         ]
       },
@@ -1075,25 +1075,25 @@
       "level": 27,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 27
         },
         {
-          "name": "Dilithium Vault",
+          "name": "dilithium vault",
           "level": 25
         }
       ],
       "rewards": [
         {
-          "type": "3\u2605\u00a0Raw\u00a0Ore",
+          "type": "3\u2605 raw crystal",
           "value": 20000
         },
         {
-          "type": "3\u2605\u00a0Raw\u00a0Crystal",
+          "type": "3\u2605 raw gas",
           "value": 20000
         },
         {
-          "type": "3\u2605\u00a0Raw\u00a0Gas",
+          "type": "3\u2605 raw ore",
           "value": 20000
         }
       ]
@@ -1117,12 +1117,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 5691600
-          },
-          {
             "type": "dilithium",
             "value": 100440
+          },
+          {
+            "type": "parsteel",
+            "value": 5691600
           }
         ]
       },
@@ -1131,25 +1131,25 @@
       "level": 28,
       "requirements": [
         {
-          "name": "Shipyard",
+          "name": "operations",
           "level": 28
         },
         {
-          "name": "Operations",
+          "name": "shipyard",
           "level": 28
         }
       ],
       "rewards": [
         {
-          "type": "3\u2605\u00a0Raw\u00a0Ore",
+          "type": "3\u2605 raw crystal",
           "value": 22000
         },
         {
-          "type": "3\u2605\u00a0Raw\u00a0Gas",
+          "type": "3\u2605 raw gas",
           "value": 22000
         },
         {
-          "type": "3\u2605\u00a0Raw\u00a0Crystal",
+          "type": "3\u2605 raw ore",
           "value": 22000
         }
       ]
@@ -1173,12 +1173,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 9061000
-          },
-          {
             "type": "dilithium",
             "value": 159900
+          },
+          {
+            "type": "parsteel",
+            "value": 9061000
           }
         ]
       },
@@ -1187,25 +1187,25 @@
       "level": 29,
       "requirements": [
         {
-          "name": "Shipyard",
+          "name": "operations",
           "level": 29
         },
         {
-          "name": "Operations",
+          "name": "shipyard",
           "level": 29
         }
       ],
       "rewards": [
         {
-          "type": "3\u2605\u00a0Raw\u00a0Ore",
+          "type": "3\u2605 raw crystal",
           "value": 24500
         },
         {
-          "type": "3\u2605\u00a0Raw\u00a0Gas",
+          "type": "3\u2605 raw gas",
           "value": 24500
         },
         {
-          "type": "3\u2605\u00a0Raw\u00a0Crystal",
+          "type": "3\u2605 raw ore",
           "value": 24500
         }
       ]
@@ -1243,25 +1243,25 @@
       "level": 30,
       "requirements": [
         {
-          "name": "Tritanium Vault",
-          "level": 27
+          "name": "operations",
+          "level": 30
         },
         {
-          "name": "Operations",
-          "level": 30
+          "name": "tritanium vault",
+          "level": 27
         }
       ],
       "rewards": [
         {
-          "type": "3\u2605\u00a0Raw\u00a0Ore",
+          "type": "3\u2605 raw crystal",
           "value": 27500
         },
         {
-          "type": "3\u2605\u00a0Raw\u00a0Gas",
+          "type": "3\u2605 raw gas",
           "value": 27500
         },
         {
-          "type": "3\u2605\u00a0Raw\u00a0Crystal",
+          "type": "3\u2605 raw ore",
           "value": 27500
         }
       ]
@@ -1293,25 +1293,25 @@
       "level": 31,
       "requirements": [
         {
-          "name": "Shipyard",
+          "name": "operations",
           "level": 31
         },
         {
-          "name": "Operations",
+          "name": "shipyard",
           "level": 31
         }
       ],
       "rewards": [
         {
-          "type": "3\u2605\u00a0Raw\u00a0Ore",
+          "type": "3\u2605 raw crystal",
           "value": 30000
         },
         {
-          "type": "3\u2605\u00a0Raw\u00a0Gas",
+          "type": "3\u2605 raw gas",
           "value": 30000
         },
         {
-          "type": "3\u2605\u00a0Raw\u00a0Crystal",
+          "type": "3\u2605 raw ore",
           "value": 30000
         }
       ]
@@ -1349,25 +1349,25 @@
       "level": 32,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 32
         },
         {
-          "name": "Shipyard",
+          "name": "shipyard",
           "level": 32
         }
       ],
       "rewards": [
         {
-          "type": "3\u2605\u00a0Raw\u00a0Ore",
+          "type": "3\u2605 raw crystal",
           "value": 32500
         },
         {
-          "type": "3\u2605\u00a0Raw\u00a0Gas",
+          "type": "3\u2605 raw gas",
           "value": 32500
         },
         {
-          "type": "3\u2605\u00a0Raw\u00a0Crystal",
+          "type": "3\u2605 raw ore",
           "value": 32500
         }
       ]
@@ -1378,25 +1378,25 @@
           {
             "type": "ore",
             "grade": 3,
-            "rarity": "common",
-            "value": 1000
+            "rarity": "uncommon",
+            "value": 80
           },
           {
             "type": "ore",
             "grade": 3,
-            "rarity": "uncommon",
-            "value": 80
+            "rarity": "common",
+            "value": 1000
           }
         ],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 46835000
-          },
-          {
             "type": "dilithium",
             "value": 826500
+          },
+          {
+            "type": "parsteel",
+            "value": 46835000
           }
         ]
       },
@@ -1405,25 +1405,25 @@
       "level": 33,
       "requirements": [
         {
-          "name": "Shipyard",
+          "name": "operations",
           "level": 33
         },
         {
-          "name": "Operations",
+          "name": "shipyard",
           "level": 33
         }
       ],
       "rewards": [
         {
-          "type": "3\u2605\u00a0Raw\u00a0Ore",
+          "type": "3\u2605 raw crystal",
           "value": 35000
         },
         {
-          "type": "3\u2605\u00a0Raw\u00a0Gas",
+          "type": "3\u2605 raw gas",
           "value": 35000
         },
         {
-          "type": "3\u2605\u00a0Raw\u00a0Crystal",
+          "type": "3\u2605 raw ore",
           "value": 35000
         }
       ]
@@ -1434,14 +1434,14 @@
           {
             "type": "ore",
             "grade": 3,
-            "rarity": "common",
-            "value": 1100
+            "rarity": "uncommon",
+            "value": 100
           },
           {
             "type": "ore",
             "grade": 3,
-            "rarity": "uncommon",
-            "value": 100
+            "rarity": "common",
+            "value": 1100
           }
         ],
         "others": [],
@@ -1461,25 +1461,25 @@
       "level": 34,
       "requirements": [
         {
-          "name": "Dilithium Vault",
-          "level": 33
+          "name": "operations",
+          "level": 34
         },
         {
-          "name": "Operations",
-          "level": 34
+          "name": "dilithium vault",
+          "level": 33
         }
       ],
       "rewards": [
         {
-          "type": "3\u2605\u00a0Raw\u00a0Ore",
+          "type": "3\u2605 raw crystal",
           "value": 37500
         },
         {
-          "type": "3\u2605\u00a0Raw\u00a0Gas",
+          "type": "3\u2605 raw gas",
           "value": 37500
         },
         {
-          "type": "3\u2605\u00a0Raw\u00a0Crystal",
+          "type": "3\u2605 raw ore",
           "value": 37500
         }
       ]
@@ -1497,12 +1497,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 114444000
-          },
-          {
             "type": "dilithium",
             "value": 2019600
+          },
+          {
+            "type": "parsteel",
+            "value": 114444000
           }
         ]
       },
@@ -1511,25 +1511,25 @@
       "level": 35,
       "requirements": [
         {
-          "name": "Shipyard",
+          "name": "operations",
           "level": 35
         },
         {
-          "name": "Operations",
+          "name": "shipyard",
           "level": 35
         }
       ],
       "rewards": [
         {
-          "type": "3\u2605\u00a0Raw\u00a0Ore",
+          "type": "3\u2605 raw crystal",
           "value": 40000
         },
         {
-          "type": "3\u2605\u00a0Raw\u00a0Gas",
+          "type": "3\u2605 raw gas",
           "value": 40000
         },
         {
-          "type": "3\u2605\u00a0Raw\u00a0Crystal",
+          "type": "3\u2605 raw ore",
           "value": 40000
         }
       ]
@@ -1540,14 +1540,14 @@
           {
             "type": "ore",
             "grade": 3,
-            "rarity": "common",
-            "value": 1600
+            "rarity": "uncommon",
+            "value": 150
           },
           {
             "type": "ore",
             "grade": 3,
-            "rarity": "uncommon",
-            "value": 150
+            "rarity": "common",
+            "value": 1600
           }
         ],
         "others": [],
@@ -1567,25 +1567,25 @@
       "level": 36,
       "requirements": [
         {
-          "name": "Shipyard",
+          "name": "operations",
           "level": 36
         },
         {
-          "name": "Operations",
+          "name": "shipyard",
           "level": 36
         }
       ],
       "rewards": [
         {
-          "type": "3\u2605\u00a0Raw\u00a0Ore",
+          "type": "3\u2605 raw crystal",
           "value": 42500
         },
         {
-          "type": "3\u2605\u00a0Raw\u00a0Gas",
+          "type": "3\u2605 raw gas",
           "value": 42500
         },
         {
-          "type": "3\u2605\u00a0Raw\u00a0Crystal",
+          "type": "3\u2605 raw ore",
           "value": 42500
         }
       ]
@@ -1623,25 +1623,25 @@
       "level": 37,
       "requirements": [
         {
-          "name": "Tritanium Warehouse",
-          "level": 36
+          "name": "operations",
+          "level": 37
         },
         {
-          "name": "Operations",
-          "level": 37
+          "name": "tritanium warehouse",
+          "level": 36
         }
       ],
       "rewards": [
         {
-          "type": "3\u2605\u00a0Raw\u00a0Ore",
+          "type": "3\u2605 raw crystal",
           "value": 45000
         },
         {
-          "type": "3\u2605\u00a0Raw\u00a0Gas",
+          "type": "3\u2605 raw gas",
           "value": 45000
         },
         {
-          "type": "3\u2605\u00a0Raw\u00a0Crystal",
+          "type": "3\u2605 raw ore",
           "value": 45000
         }
       ]
@@ -1652,14 +1652,14 @@
           {
             "type": "ore",
             "grade": 3,
-            "rarity": "common",
-            "value": 2100
+            "rarity": "uncommon",
+            "value": 200
           },
           {
             "type": "ore",
             "grade": 3,
-            "rarity": "uncommon",
-            "value": 200
+            "rarity": "common",
+            "value": 2100
           }
         ],
         "others": [],
@@ -1679,25 +1679,25 @@
       "level": 38,
       "requirements": [
         {
-          "name": "Shipyard",
+          "name": "operations",
           "level": 38
         },
         {
-          "name": "Operations",
+          "name": "shipyard",
           "level": 38
         }
       ],
       "rewards": [
         {
-          "type": "3\u2605\u00a0Raw\u00a0Crystal",
+          "type": "3\u2605 raw crystal",
           "value": 47500
         },
         {
-          "type": "3\u2605\u00a0Raw\u00a0Gas",
+          "type": "3\u2605 raw gas",
           "value": 47500
         },
         {
-          "type": "3\u2605\u00a0Raw\u00a0Ore",
+          "type": "3\u2605 raw ore",
           "value": 47500
         }
       ]
@@ -1735,25 +1735,25 @@
       "level": 39,
       "requirements": [
         {
-          "name": "Shipyard",
+          "name": "operations",
           "level": 39
         },
         {
-          "name": "Operations",
+          "name": "shipyard",
           "level": 39
         }
       ],
       "rewards": [
         {
-          "type": "3\u2605\u00a0Raw\u00a0Crystal",
+          "type": "3\u2605 raw crystal",
           "value": 50000
         },
         {
-          "type": "3\u2605\u00a0Raw\u00a0Gas",
+          "type": "3\u2605 raw gas",
           "value": 50000
         },
         {
-          "type": "3\u2605\u00a0Raw\u00a0Ore",
+          "type": "3\u2605 raw ore",
           "value": 50000
         }
       ]
@@ -1785,25 +1785,25 @@
       "level": 40,
       "requirements": [
         {
-          "name": "Dilithium Warehouse",
+          "name": "operations",
           "level": 40
         },
         {
-          "name": "Operations",
+          "name": "dilithium warehouse",
           "level": 40
         }
       ],
       "rewards": [
         {
-          "type": "4\u2605\u00a0Raw\u00a0Ore",
+          "type": "4\u2605 raw crystal",
           "value": 100000
         },
         {
-          "type": "4\u2605\u00a0Raw\u00a0Gas",
+          "type": "4\u2605 raw gas",
           "value": 100000
         },
         {
-          "type": "4\u2605\u00a0Raw\u00a0Crystal",
+          "type": "4\u2605 raw ore",
           "value": 100000
         }
       ]
@@ -1835,25 +1835,25 @@
       "level": 41,
       "requirements": [
         {
-          "name": "Shipyard",
+          "name": "operations",
           "level": 41
         },
         {
-          "name": "Operations",
+          "name": "shipyard",
           "level": 41
         }
       ],
       "rewards": [
         {
-          "type": "4\u2605\u00a0Raw\u00a0Ore",
+          "type": "4\u2605 raw crystal",
           "value": 120000
         },
         {
-          "type": "4\u2605\u00a0Raw\u00a0Gas",
+          "type": "4\u2605 raw gas",
           "value": 120000
         },
         {
-          "type": "4\u2605\u00a0Raw\u00a0Crystal",
+          "type": "4\u2605 raw ore",
           "value": 120000
         }
       ]
@@ -1885,25 +1885,25 @@
       "level": 42,
       "requirements": [
         {
-          "name": "Shipyard",
+          "name": "operations",
           "level": 42
         },
         {
-          "name": "Operations",
+          "name": "shipyard",
           "level": 42
         }
       ],
       "rewards": [
         {
-          "type": "4\u2605\u00a0Raw\u00a0Ore",
+          "type": "4\u2605 raw crystal",
           "value": 150000
         },
         {
-          "type": "4\u2605\u00a0Raw\u00a0Gas",
+          "type": "4\u2605 raw gas",
           "value": 150000
         },
         {
-          "type": "4\u2605\u00a0Raw\u00a0Crystal",
+          "type": "4\u2605 raw ore",
           "value": 150000
         }
       ]
@@ -1921,12 +1921,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 6222000000
-          },
-          {
             "type": "dilithium",
             "value": 54900000
+          },
+          {
+            "type": "parsteel",
+            "value": 6222000000
           }
         ]
       },
@@ -1935,25 +1935,25 @@
       "level": 43,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 43
         },
         {
-          "name": "Tritanium Vault",
+          "name": "tritanium vault",
           "level": 41
         }
       ],
       "rewards": [
         {
-          "type": "4\u2605\u00a0Raw\u00a0Ore",
+          "type": "4\u2605 raw crystal",
           "value": 175000
         },
         {
-          "type": "4\u2605\u00a0Raw\u00a0Gas",
+          "type": "4\u2605 raw gas",
           "value": 175000
         },
         {
-          "type": "4\u2605\u00a0Raw\u00a0Crystal",
+          "type": "4\u2605 raw ore",
           "value": 175000
         }
       ]
@@ -1985,25 +1985,25 @@
       "level": 44,
       "requirements": [
         {
-          "name": "Shipyard",
+          "name": "operations",
           "level": 44
         },
         {
-          "name": "Operations",
+          "name": "shipyard",
           "level": 44
         }
       ],
       "rewards": [
         {
-          "type": "4\u2605\u00a0Raw\u00a0Ore",
+          "type": "4\u2605 raw crystal",
           "value": 200000
         },
         {
-          "type": "4\u2605\u00a0Raw\u00a0Crystal",
+          "type": "4\u2605 raw gas",
           "value": 200000
         },
         {
-          "type": "4\u2605\u00a0Raw\u00a0Gas",
+          "type": "4\u2605 raw ore",
           "value": 200000
         }
       ]
@@ -2035,29 +2035,29 @@
       "level": 45,
       "requirements": [
         {
-          "name": "Dilithium Vault",
+          "name": "operations",
           "level": 45
         },
         {
-          "name": "Shipyard",
+          "name": "shipyard",
           "level": 45
         },
         {
-          "name": "Operations",
+          "name": "dilithium vault",
           "level": 45
         }
       ],
       "rewards": [
         {
-          "type": "4\u2605\u00a0Raw\u00a0Ore",
+          "type": "4\u2605 raw crystal",
           "value": 230000
         },
         {
-          "type": "4\u2605\u00a0Raw\u00a0Gas",
+          "type": "4\u2605 raw gas",
           "value": 230000
         },
         {
-          "type": "4\u2605\u00a0Raw\u00a0Crystal",
+          "type": "4\u2605 raw ore",
           "value": 230000
         }
       ]
@@ -2081,12 +2081,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 18232500000
-          },
-          {
             "type": "dilithium",
             "value": 160875000
+          },
+          {
+            "type": "parsteel",
+            "value": 18232500000
           }
         ]
       },
@@ -2095,25 +2095,25 @@
       "level": 46,
       "requirements": [
         {
-          "name": "Dilithium Vault",
-          "level": 45
+          "name": "operations",
+          "level": 46
         },
         {
-          "name": "Operations",
-          "level": 46
+          "name": "dilithium vault",
+          "level": 45
         }
       ],
       "rewards": [
         {
-          "type": "4\u2605\u00a0Raw\u00a0Ore",
+          "type": "4\u2605 raw crystal",
           "value": 260000
         },
         {
-          "type": "4\u2605\u00a0Raw\u00a0Gas",
+          "type": "4\u2605 raw gas",
           "value": 260000
         },
         {
-          "type": "4\u2605\u00a0Raw\u00a0Crystal",
+          "type": "4\u2605 raw ore",
           "value": 260000
         }
       ]
@@ -2137,12 +2137,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 26520000000
-          },
-          {
             "type": "dilithium",
             "value": 234000000
+          },
+          {
+            "type": "parsteel",
+            "value": 26520000000
           }
         ]
       },
@@ -2151,25 +2151,25 @@
       "level": 47,
       "requirements": [
         {
-          "name": "Shipyard",
+          "name": "operations",
           "level": 47
         },
         {
-          "name": "Operations",
+          "name": "shipyard",
           "level": 47
         }
       ],
       "rewards": [
         {
-          "type": "4\u2605\u00a0Raw\u00a0Ore",
+          "type": "4\u2605 raw crystal",
           "value": 300000
         },
         {
-          "type": "4\u2605\u00a0Raw\u00a0Gas",
+          "type": "4\u2605 raw gas",
           "value": 300000
         },
         {
-          "type": "4\u2605\u00a0Raw\u00a0Crystal",
+          "type": "4\u2605 raw ore",
           "value": 300000
         }
       ]
@@ -2193,12 +2193,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 42840000000
-          },
-          {
             "type": "dilithium",
             "value": 378000000
+          },
+          {
+            "type": "parsteel",
+            "value": 42840000000
           }
         ]
       },
@@ -2207,25 +2207,25 @@
       "level": 48,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 48
         },
         {
-          "name": "Shipyard",
+          "name": "shipyard",
           "level": 48
         }
       ],
       "rewards": [
         {
-          "type": "4\u2605\u00a0Raw\u00a0Ore",
+          "type": "4\u2605 raw crystal",
           "value": 360000
         },
         {
-          "type": "4\u2605\u00a0Raw\u00a0Gas",
+          "type": "4\u2605 raw gas",
           "value": 360000
         },
         {
-          "type": "4\u2605\u00a0Raw\u00a0Crystal",
+          "type": "4\u2605 raw ore",
           "value": 360000
         }
       ]
@@ -2236,25 +2236,25 @@
           {
             "type": "ore",
             "grade": 4,
-            "rarity": "uncommon",
-            "value": 15000
+            "rarity": "rare",
+            "value": 1000
           },
           {
             "type": "ore",
             "grade": 4,
-            "rarity": "rare",
-            "value": 1000
+            "rarity": "uncommon",
+            "value": 15000
           }
         ],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 71400000000
-          },
-          {
             "type": "dilithium",
             "value": 630000000
+          },
+          {
+            "type": "parsteel",
+            "value": 71400000000
           }
         ]
       },
@@ -2263,29 +2263,29 @@
       "level": 49,
       "requirements": [
         {
-          "name": "Dilithium Vault",
+          "name": "operations",
           "level": 49
         },
         {
-          "name": "Shipyard",
+          "name": "shipyard",
           "level": 49
         },
         {
-          "name": "Operations",
+          "name": "dilithium vault",
           "level": 49
         }
       ],
       "rewards": [
         {
-          "type": "4\u2605\u00a0Raw\u00a0Crystal",
+          "type": "4\u2605 raw crystal",
           "value": 420000
         },
         {
-          "type": "4\u2605\u00a0Raw\u00a0Gas",
+          "type": "4\u2605 raw gas",
           "value": 420000
         },
         {
-          "type": "4\u2605\u00a0Raw\u00a0Ore",
+          "type": "4\u2605 raw ore",
           "value": 420000
         }
       ]
@@ -2310,26 +2310,292 @@
       "level": 50,
       "requirements": [
         {
-          "name": "Dilithium Warehouse",
+          "name": "operations",
           "level": 50
         },
         {
-          "name": "Operations",
+          "name": "dilithium warehouse",
           "level": 50
         }
       ],
       "rewards": [
         {
-          "type": "4\u2605\u00a0Raw\u00a0Ore",
+          "type": "4\u2605 raw crystal",
           "value": 500000
         },
         {
-          "type": "4\u2605\u00a0Raw\u00a0Gas",
+          "type": "4\u2605 raw gas",
           "value": 500000
         },
         {
-          "type": "4\u2605\u00a0Raw\u00a0Crystal",
+          "type": "4\u2605 raw ore",
           "value": 500000
+        }
+      ]
+    },
+    {
+      "build_costs": {
+        "materials": [
+          {
+            "type": "ore",
+            "grade": 5,
+            "rarity": "common",
+            "value": 5600
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "dilithium",
+            "value": 2340000000
+          },
+          {
+            "type": "parsteel",
+            "value": 623220000000
+          }
+        ]
+      },
+      "build_time": 89439840,
+      "increased_power": 5000,
+      "level": 51,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 51
+        },
+        {
+          "name": "shipyard",
+          "level": 51
+        }
+      ],
+      "rewards": [
+        {
+          "type": "5\u2605 raw crystal",
+          "value": 125000
+        },
+        {
+          "type": "5\u2605 raw gas",
+          "value": 125000
+        },
+        {
+          "type": "5\u2605 raw ore",
+          "value": 125000
+        }
+      ]
+    },
+    {
+      "build_costs": {
+        "materials": [
+          {
+            "type": "ore",
+            "grade": 5,
+            "rarity": "common",
+            "value": 9800
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 1127100000000
+          },
+          {
+            "type": "dilithium",
+            "value": 3978000000
+          }
+        ]
+      },
+      "build_time": 94805280,
+      "increased_power": 6000,
+      "level": 52,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 52
+        },
+        {
+          "name": "shipyard",
+          "level": 52
+        }
+      ],
+      "rewards": [
+        {
+          "type": "5\u2605 raw crystal",
+          "value": 150000
+        },
+        {
+          "type": "5\u2605 raw gas",
+          "value": 150000
+        },
+        {
+          "type": "5\u2605 raw ore",
+          "value": 150000
+        }
+      ]
+    },
+    {
+      "build_costs": {
+        "materials": [
+          {
+            "type": "ore",
+            "grade": 5,
+            "rarity": "common",
+            "value": 18800
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "dilithium",
+            "value": 6960000000
+          },
+          {
+            "type": "parsteel",
+            "value": 1893120000000
+          }
+        ]
+      },
+      "build_time": 100494720,
+      "increased_power": 5000,
+      "level": 53,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 53
+        },
+        {
+          "name": "tritanium vault",
+          "level": 53
+        }
+      ],
+      "rewards": [
+        {
+          "type": "5\u2605 raw crystal",
+          "value": 160000
+        },
+        {
+          "type": "5\u2605 raw gas",
+          "value": 160000
+        },
+        {
+          "type": "5\u2605 raw ore",
+          "value": 160000
+        }
+      ]
+    },
+    {
+      "build_costs": {
+        "materials": [
+          {
+            "type": "ore",
+            "grade": 5,
+            "rarity": "uncommon",
+            "value": 12000
+          },
+          {
+            "type": "ore",
+            "grade": 5,
+            "rarity": "common",
+            "value": 19100
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 2839680000000
+          },
+          {
+            "type": "dilithium",
+            "value": 10440000000
+          }
+        ]
+      },
+      "build_time": 106524000,
+      "increased_power": 6000,
+      "level": 54,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 54
+        },
+        {
+          "name": "shipyard",
+          "level": 54
+        }
+      ],
+      "rewards": [
+        {
+          "type": "5\u2605 raw crystal",
+          "value": 180000
+        },
+        {
+          "type": "5\u2605 raw gas",
+          "value": 180000
+        },
+        {
+          "type": "5\u2605 raw ore",
+          "value": 180000
+        }
+      ]
+    },
+    {
+      "build_costs": {
+        "materials": [
+          {
+            "type": "ore",
+            "grade": 5,
+            "rarity": "common",
+            "value": 33300
+          },
+          {
+            "type": "ore",
+            "grade": 5,
+            "rarity": "uncommon",
+            "value": 16100
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "dilithium",
+            "value": 16380000000
+          },
+          {
+            "type": "parsteel",
+            "value": 4826640000000
+          }
+        ]
+      },
+      "build_time": 112914720,
+      "increased_power": 6000,
+      "level": 55,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 55
+        },
+        {
+          "name": "shipyard",
+          "level": 55
+        },
+        {
+          "name": "dilithium vault",
+          "level": 55
+        }
+      ],
+      "rewards": [
+        {
+          "type": "5\u2605 raw crystal",
+          "value": 200000
+        },
+        {
+          "type": "5\u2605 raw gas",
+          "value": 200000
+        },
+        {
+          "type": "5\u2605 raw ore",
+          "value": 200000
         }
       ]
     }

--- a/buildings/science_lab.json
+++ b/buildings/science_lab.json
@@ -2,11 +2,11 @@
   "description": "Shield Tech Research facility.",
   "bonuses": {
     "bonus1": {
-      "name": "Shield Deflection Bonus",
+      "name": "shield deflection bonus",
       "percentage": true
     },
     "bonus2": {
-      "name": "Explorer Shield Health Bonus",
+      "name": "explorer shield health bonus",
       "percentage": true
     }
   },
@@ -14,8 +14,8 @@
   "levels": [
     {
       "bonuses": {
-        "bonus1": 1,
-        "bonus2": 3
+        "bonus1": 0.01,
+        "bonus2": 0.03
       },
       "build_costs": {
         "materials": [
@@ -39,16 +39,15 @@
       "level": 1,
       "requirements": [
         {
-          "name": "Unlock Science Labs",
+          "name": "unlock science labs",
           "level": 1
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 2,
-        "bonus2": 6
+        "bonus1": 0.02,
+        "bonus2": 0.06
       },
       "build_costs": {
         "materials": [],
@@ -65,20 +64,19 @@
       "level": 2,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 2
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 2
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 3,
-        "bonus2": 9
+        "bonus1": 0.03,
+        "bonus2": 0.09
       },
       "build_costs": {
         "materials": [],
@@ -95,20 +93,19 @@
       "level": 3,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 3
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 3
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 4,
-        "bonus2": 12
+        "bonus1": 0.04,
+        "bonus2": 0.12
       },
       "build_costs": {
         "materials": [],
@@ -125,20 +122,19 @@
       "level": 4,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 4
         },
         {
-          "name": "R&D Department",
+          "name": "r&d department",
           "level": 4
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 5,
-        "bonus2": 15
+        "bonus1": 0.05,
+        "bonus2": 0.15
       },
       "build_costs": {
         "materials": [],
@@ -155,20 +151,19 @@
       "level": 5,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 5
         },
         {
-          "name": "R&D Department",
+          "name": "r&d department",
           "level": 5
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 6,
-        "bonus2": 18
+        "bonus1": 0.06,
+        "bonus2": 0.18
       },
       "build_costs": {
         "materials": [],
@@ -185,20 +180,19 @@
       "level": 6,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 6
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 6
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 7,
-        "bonus2": 21
+        "bonus1": 0.07,
+        "bonus2": 0.21
       },
       "build_costs": {
         "materials": [],
@@ -215,20 +209,19 @@
       "level": 7,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 7
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 7
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 8,
-        "bonus2": 24
+        "bonus1": 0.08,
+        "bonus2": 0.24
       },
       "build_costs": {
         "materials": [],
@@ -245,20 +238,19 @@
       "level": 8,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 8
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 8
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 9,
-        "bonus2": 27
+        "bonus1": 0.09,
+        "bonus2": 0.27
       },
       "build_costs": {
         "materials": [],
@@ -275,20 +267,19 @@
       "level": 9,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 9
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 9
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 10,
-        "bonus2": 30
+        "bonus1": 0.1,
+        "bonus2": 0.3
       },
       "build_costs": {
         "materials": [],
@@ -305,20 +296,19 @@
       "level": 10,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 10
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 10
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 11,
-        "bonus2": 33
+        "bonus1": 0.11,
+        "bonus2": 0.33
       },
       "build_costs": {
         "materials": [],
@@ -339,32 +329,31 @@
       "level": 11,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 11
         },
         {
-          "name": "R&D Department",
+          "name": "r&d department",
           "level": 11
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 12,
-        "bonus2": 36
+        "bonus1": 0.12,
+        "bonus2": 0.36
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 252620
-          },
-          {
             "type": "dilithium",
             "value": 33
+          },
+          {
+            "type": "parsteel",
+            "value": 252620
           }
         ]
       },
@@ -373,20 +362,19 @@
       "level": 12,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 12
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 12
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 13,
-        "bonus2": 39
+        "bonus1": 0.13,
+        "bonus2": 0.39
       },
       "build_costs": {
         "materials": [],
@@ -407,32 +395,31 @@
       "level": 13,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 13
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 13
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 14,
-        "bonus2": 42
+        "bonus1": 0.14,
+        "bonus2": 0.42
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 261970
-          },
-          {
             "type": "dilithium",
             "value": 132
+          },
+          {
+            "type": "parsteel",
+            "value": 261970
           }
         ]
       },
@@ -441,32 +428,31 @@
       "level": 14,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 14
         },
         {
-          "name": "R&D Department",
+          "name": "r&d department",
           "level": 14
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 15,
-        "bonus2": 45
+        "bonus1": 0.15,
+        "bonus2": 0.45
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 268770
-          },
-          {
             "type": "dilithium",
             "value": 225
+          },
+          {
+            "type": "parsteel",
+            "value": 268770
           }
         ]
       },
@@ -475,20 +461,19 @@
       "level": 15,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 15
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 15
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 16,
-        "bonus2": 48
+        "bonus1": 0.16,
+        "bonus2": 0.48
       },
       "build_costs": {
         "materials": [],
@@ -509,32 +494,31 @@
       "level": 16,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 16
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 16
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 17,
-        "bonus2": 51
+        "bonus1": 0.17,
+        "bonus2": 0.51
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 290870
-          },
-          {
             "type": "dilithium",
             "value": 420
+          },
+          {
+            "type": "parsteel",
+            "value": 290870
           }
         ]
       },
@@ -543,20 +527,19 @@
       "level": 17,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 17
         },
         {
-          "name": "R&D Department",
+          "name": "r&d department",
           "level": 17
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 18,
-        "bonus2": 54
+        "bonus1": 0.18,
+        "bonus2": 0.54
       },
       "build_costs": {
         "materials": [],
@@ -577,32 +560,31 @@
       "level": 18,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 18
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 18
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 19,
-        "bonus2": 57
+        "bonus1": 0.19,
+        "bonus2": 0.57
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 345270
-          },
-          {
             "type": "dilithium",
             "value": 900
+          },
+          {
+            "type": "parsteel",
+            "value": 345270
           }
         ]
       },
@@ -611,32 +593,31 @@
       "level": 19,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 19
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 19
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 20,
-        "bonus2": 60
+        "bonus1": 0.2,
+        "bonus2": 0.6
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 387770
-          },
-          {
             "type": "dilithium",
             "value": 1275
+          },
+          {
+            "type": "parsteel",
+            "value": 387770
           }
         ]
       },
@@ -645,20 +626,19 @@
       "level": 20,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 20
         },
         {
-          "name": "R&D Department",
+          "name": "r&d department",
           "level": 20
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 21,
-        "bonus2": 63
+        "bonus1": 0.21,
+        "bonus2": 0.63
       },
       "build_costs": {
         "materials": [],
@@ -679,20 +659,19 @@
       "level": 21,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 21
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 21
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 22,
-        "bonus2": 66
+        "bonus1": 0.22,
+        "bonus2": 0.66
       },
       "build_costs": {
         "materials": [],
@@ -713,20 +692,19 @@
       "level": 22,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 22
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 22
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 23,
-        "bonus2": 69
+        "bonus1": 0.23,
+        "bonus2": 0.69
       },
       "build_costs": {
         "materials": [],
@@ -747,20 +725,19 @@
       "level": 23,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 23
         },
         {
-          "name": "R&D Department",
+          "name": "r&d department",
           "level": 23
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 24,
-        "bonus2": 72
+        "bonus1": 0.24,
+        "bonus2": 0.72
       },
       "build_costs": {
         "materials": [],
@@ -781,24 +758,23 @@
       "level": 24,
       "requirements": [
         {
-          "name": "Engine Technology Lab",
+          "name": "operations",
+          "level": 24
+        },
+        {
+          "name": "r&d department",
+          "level": 24
+        },
+        {
+          "name": "engine technology lab",
           "level": 2
-        },
-        {
-          "name": "R&D Department",
-          "level": 24
-        },
-        {
-          "name": "Operations",
-          "level": 24
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 25,
-        "bonus2": 75
+        "bonus1": 0.25,
+        "bonus2": 0.75
       },
       "build_costs": {
         "materials": [
@@ -812,12 +788,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 1591200
-          },
-          {
             "type": "dilithium",
             "value": 14040
+          },
+          {
+            "type": "parsteel",
+            "value": 1591200
           }
         ]
       },
@@ -826,20 +802,19 @@
       "level": 25,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 25
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 25
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 26,
-        "bonus2": 78
+        "bonus1": 0.26,
+        "bonus2": 0.78
       },
       "build_costs": {
         "materials": [
@@ -853,12 +828,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 2486250
-          },
-          {
             "type": "dilithium",
             "value": 21938
+          },
+          {
+            "type": "parsteel",
+            "value": 2486250
           }
         ]
       },
@@ -867,20 +842,19 @@
       "level": 26,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 26
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 26
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 27,
-        "bonus2": 81
+        "bonus1": 0.27,
+        "bonus2": 0.81
       },
       "build_costs": {
         "materials": [
@@ -914,45 +888,44 @@
       "level": 27,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 27
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 27
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 28,
-        "bonus2": 84
+        "bonus1": 0.28,
+        "bonus2": 0.84
       },
       "build_costs": {
         "materials": [
           {
             "type": "gas",
             "grade": 3,
-            "rarity": "common",
-            "value": 360
+            "rarity": "uncommon",
+            "value": 18
           },
           {
             "type": "gas",
             "grade": 3,
-            "rarity": "uncommon",
-            "value": 18
+            "rarity": "common",
+            "value": 360
           }
         ],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 5691600
-          },
-          {
             "type": "dilithium",
             "value": 50220
+          },
+          {
+            "type": "parsteel",
+            "value": 5691600
           }
         ]
       },
@@ -961,20 +934,19 @@
       "level": 28,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 28
         },
         {
-          "name": "R&D Department",
+          "name": "r&d department",
           "level": 28
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 29,
-        "bonus2": 87
+        "bonus1": 0.29,
+        "bonus2": 0.87
       },
       "build_costs": {
         "materials": [
@@ -1002,45 +974,44 @@
       "level": 29,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 29
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 29
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 37,
-        "bonus2": 90
+        "bonus1": 0.37,
+        "bonus2": 0.9
       },
       "build_costs": {
         "materials": [
           {
             "type": "gas",
             "grade": 3,
-            "rarity": "common",
-            "value": 500
+            "rarity": "uncommon",
+            "value": 45
           },
           {
             "type": "gas",
             "grade": 3,
-            "rarity": "uncommon",
-            "value": 45
+            "rarity": "common",
+            "value": 500
           }
         ],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 13260000
-          },
-          {
             "type": "dilithium",
             "value": 117000
+          },
+          {
+            "type": "parsteel",
+            "value": 13260000
           }
         ]
       },
@@ -1049,34 +1020,33 @@
       "level": 30,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 30
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 30
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 38,
-        "bonus2": 93
+        "bonus1": 0.38,
+        "bonus2": 0.93
       },
       "build_costs": {
         "materials": [
           {
             "type": "gas",
             "grade": 3,
-            "rarity": "common",
-            "value": 700
+            "rarity": "uncommon",
+            "value": 65
           },
           {
             "type": "gas",
             "grade": 3,
-            "rarity": "uncommon",
-            "value": 65
+            "rarity": "common",
+            "value": 700
           }
         ],
         "others": [],
@@ -1096,24 +1066,23 @@
       "level": 31,
       "requirements": [
         {
-          "name": "Astronautics Studio",
+          "name": "operations",
           "level": 31
         },
         {
-          "name": "R&D Department",
+          "name": "r&d department",
           "level": 31
         },
         {
-          "name": "Operations",
+          "name": "astronautics studio",
           "level": 31
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 39,
-        "bonus2": 96
+        "bonus1": 0.39,
+        "bonus2": 0.96
       },
       "build_costs": {
         "materials": [
@@ -1127,12 +1096,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 30277000
-          },
-          {
             "type": "dilithium",
             "value": 267150
+          },
+          {
+            "type": "parsteel",
+            "value": 30277000
           }
         ]
       },
@@ -1141,45 +1110,44 @@
       "level": 32,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 32
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 32
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 40,
-        "bonus2": 99
+        "bonus1": 0.4,
+        "bonus2": 0.99
       },
       "build_costs": {
         "materials": [
           {
             "type": "gas",
             "grade": 3,
-            "rarity": "common",
-            "value": 1000
+            "rarity": "uncommon",
+            "value": 110
           },
           {
             "type": "gas",
             "grade": 3,
-            "rarity": "uncommon",
-            "value": 110
+            "rarity": "common",
+            "value": 1000
           }
         ],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 46835000
-          },
-          {
             "type": "dilithium",
             "value": 413250
+          },
+          {
+            "type": "parsteel",
+            "value": 46835000
           }
         ]
       },
@@ -1188,45 +1156,44 @@
       "level": 33,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 33
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 33
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 42,
-        "bonus2": 102
+        "bonus1": 0.42,
+        "bonus2": 1.02
       },
       "build_costs": {
         "materials": [
           {
             "type": "gas",
             "grade": 3,
-            "rarity": "common",
-            "value": 1100
+            "rarity": "uncommon",
+            "value": 140
           },
           {
             "type": "gas",
             "grade": 3,
-            "rarity": "uncommon",
-            "value": 140
+            "rarity": "common",
+            "value": 1100
           }
         ],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 73950000
-          },
-          {
             "type": "dilithium",
             "value": 652500
+          },
+          {
+            "type": "parsteel",
+            "value": 73950000
           }
         ]
       },
@@ -1235,20 +1202,19 @@
       "level": 34,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 34
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 34
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 44,
-        "bonus2": 105
+        "bonus1": 0.44,
+        "bonus2": 1.05
       },
       "build_costs": {
         "materials": [
@@ -1276,20 +1242,19 @@
       "level": 35,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 35
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 35
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 46,
-        "bonus2": 108
+        "bonus1": 0.46,
+        "bonus2": 1.08
       },
       "build_costs": {
         "materials": [
@@ -1309,12 +1274,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 161262000
-          },
-          {
             "type": "dilithium",
             "value": 1422900
+          },
+          {
+            "type": "parsteel",
+            "value": 161262000
           }
         ]
       },
@@ -1323,20 +1288,19 @@
       "level": 36,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 36
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 36
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 48,
-        "bonus2": 111
+        "bonus1": 0.48,
+        "bonus2": 1.11
       },
       "build_costs": {
         "materials": [
@@ -1350,12 +1314,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 247860000
-          },
-          {
             "type": "dilithium",
             "value": 2187000
+          },
+          {
+            "type": "parsteel",
+            "value": 247860000
           }
         ]
       },
@@ -1364,45 +1328,44 @@
       "level": 37,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 37
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 37
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 50,
-        "bonus2": 114
+        "bonus1": 0.5,
+        "bonus2": 1.14
       },
       "build_costs": {
         "materials": [
           {
             "type": "gas",
             "grade": 3,
-            "rarity": "common",
-            "value": 2100
+            "rarity": "uncommon",
+            "value": 310
           },
           {
             "type": "gas",
             "grade": 3,
-            "rarity": "uncommon",
-            "value": 310
+            "rarity": "common",
+            "value": 2100
           }
         ],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 385560000
-          },
-          {
             "type": "dilithium",
             "value": 3402000
+          },
+          {
+            "type": "parsteel",
+            "value": 385560000
           }
         ]
       },
@@ -1411,45 +1374,44 @@
       "level": 38,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 38
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 38
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 52,
-        "bonus2": 117
+        "bonus1": 0.52,
+        "bonus2": 1.17
       },
       "build_costs": {
         "materials": [
           {
             "type": "gas",
             "grade": 3,
-            "rarity": "common",
-            "value": 2500
+            "rarity": "uncommon",
+            "value": 360
           },
           {
             "type": "gas",
             "grade": 3,
-            "rarity": "uncommon",
-            "value": 360
+            "rarity": "common",
+            "value": 2500
           }
         ],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 657900000
-          },
-          {
             "type": "dilithium",
             "value": 5805000
+          },
+          {
+            "type": "parsteel",
+            "value": 657900000
           }
         ]
       },
@@ -1458,24 +1420,23 @@
       "level": 39,
       "requirements": [
         {
-          "name": "Astronautics Studio",
+          "name": "operations",
           "level": 39
         },
         {
-          "name": "R&D Department",
+          "name": "r&d department",
           "level": 39
         },
         {
-          "name": "Operations",
+          "name": "astronautics studio",
           "level": 39
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 54,
-        "bonus2": 120
+        "bonus1": 0.54,
+        "bonus2": 1.2
       },
       "build_costs": {
         "materials": [
@@ -1509,20 +1470,19 @@
       "level": 40,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 40
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 40
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 56,
-        "bonus2": 123
+        "bonus1": 0.56,
+        "bonus2": 1.23
       },
       "build_costs": {
         "materials": [
@@ -1556,20 +1516,19 @@
       "level": 41,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 41
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 41
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 58,
-        "bonus2": 126
+        "bonus1": 0.58,
+        "bonus2": 1.26
       },
       "build_costs": {
         "materials": [
@@ -1603,34 +1562,33 @@
       "level": 42,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 42
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 42
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 74,
-        "bonus2": 129
+        "bonus1": 0.74,
+        "bonus2": 1.29
       },
       "build_costs": {
         "materials": [
           {
             "type": "gas",
             "grade": 4,
-            "rarity": "common",
-            "value": 10000
+            "rarity": "uncommon",
+            "value": 3000
           },
           {
             "type": "gas",
             "grade": 4,
-            "rarity": "uncommon",
-            "value": 3000
+            "rarity": "common",
+            "value": 10000
           }
         ],
         "others": [],
@@ -1650,20 +1608,19 @@
       "level": 43,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 43
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 43
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 76,
-        "bonus2": 132
+        "bonus1": 0.76,
+        "bonus2": 1.32
       },
       "build_costs": {
         "materials": [
@@ -1683,12 +1640,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 9333000000
-          },
-          {
             "type": "dilithium",
             "value": 41175000
+          },
+          {
+            "type": "parsteel",
+            "value": 9333000000
           }
         ]
       },
@@ -1697,20 +1654,19 @@
       "level": 44,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 44
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 44
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 80,
-        "bonus2": 135
+        "bonus1": 0.8,
+        "bonus2": 1.35
       },
       "build_costs": {
         "materials": [
@@ -1744,45 +1700,44 @@
       "level": 45,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 45
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 45
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 84,
-        "bonus2": 138
+        "bonus1": 0.84,
+        "bonus2": 1.38
       },
       "build_costs": {
         "materials": [
           {
             "type": "gas",
             "grade": 4,
-            "rarity": "common",
-            "value": 15000
+            "rarity": "uncommon",
+            "value": 1000
           },
           {
             "type": "gas",
             "grade": 4,
-            "rarity": "uncommon",
-            "value": 1000
+            "rarity": "common",
+            "value": 15000
           }
         ],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 18232500000
-          },
-          {
             "type": "dilithium",
             "value": 80437500
+          },
+          {
+            "type": "parsteel",
+            "value": 18232500000
           }
         ]
       },
@@ -1791,34 +1746,33 @@
       "level": 46,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 46
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 46
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 88,
-        "bonus2": 141
+        "bonus1": 0.88,
+        "bonus2": 1.41
       },
       "build_costs": {
         "materials": [
           {
             "type": "gas",
             "grade": 4,
-            "rarity": "common",
-            "value": 45000
+            "rarity": "uncommon",
+            "value": 2500
           },
           {
             "type": "gas",
             "grade": 4,
-            "rarity": "uncommon",
-            "value": 2500
+            "rarity": "common",
+            "value": 45000
           }
         ],
         "others": [],
@@ -1838,20 +1792,19 @@
       "level": 47,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 47
         },
         {
-          "name": "R&D Department",
+          "name": "r&d department",
           "level": 47
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 92,
-        "bonus2": 144
+        "bonus1": 0.92,
+        "bonus2": 1.44
       },
       "build_costs": {
         "materials": [
@@ -1871,12 +1824,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 42840000000
-          },
-          {
             "type": "dilithium",
             "value": 189000000
+          },
+          {
+            "type": "parsteel",
+            "value": 42840000000
           }
         ]
       },
@@ -1885,20 +1838,19 @@
       "level": 48,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 48
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 48
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 96,
-        "bonus2": 147
+        "bonus1": 0.96,
+        "bonus2": 1.47
       },
       "build_costs": {
         "materials": [
@@ -1932,24 +1884,23 @@
       "level": 49,
       "requirements": [
         {
-          "name": "Engine Technology Lab",
+          "name": "operations",
           "level": 49
         },
         {
-          "name": "R&D Department",
+          "name": "r&d department",
           "level": 49
         },
         {
-          "name": "Operations",
+          "name": "engine technology lab",
           "level": 49
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 100,
-        "bonus2": 150
+        "bonus1": 1.0,
+        "bonus2": 1.5
       },
       "build_costs": {
         "materials": [],
@@ -1970,15 +1921,244 @@
       "level": 50,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 50
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 50
         }
-      ],
-      "rewards": []
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 1.04,
+        "bonus2": 1.53
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "gas",
+            "grade": 5,
+            "rarity": "common",
+            "value": 24700
+          },
+          {
+            "type": "gas",
+            "grade": 5,
+            "rarity": "uncommon",
+            "value": 3900
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 623220000000
+          },
+          {
+            "type": "dilithium",
+            "value": 1170000000
+          }
+        ]
+      },
+      "build_time": 44719200,
+      "increased_power": 5000,
+      "level": 51,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 51
+        },
+        {
+          "name": "r&d department",
+          "level": 51
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 1.08,
+        "bonus2": 1.56
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "gas",
+            "grade": 5,
+            "rarity": "common",
+            "value": 42800
+          },
+          {
+            "type": "gas",
+            "grade": 5,
+            "rarity": "uncommon",
+            "value": 8600
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 1127100000000
+          },
+          {
+            "type": "dilithium",
+            "value": 1989000000
+          }
+        ]
+      },
+      "build_time": 47403360,
+      "increased_power": 6000,
+      "level": 52,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 52
+        },
+        {
+          "name": "r&d department",
+          "level": 52
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 1.12,
+        "bonus2": 1.59
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "gas",
+            "grade": 5,
+            "rarity": "common",
+            "value": 102600
+          },
+          {
+            "type": "gas",
+            "grade": 5,
+            "rarity": "uncommon",
+            "value": 14900
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 1893120000000
+          },
+          {
+            "type": "dilithium",
+            "value": 3480000000
+          }
+        ]
+      },
+      "build_time": 50247360,
+      "increased_power": 5000,
+      "level": 53,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 53
+        },
+        {
+          "name": "r&d department",
+          "level": 53
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 1.16,
+        "bonus2": 1.62
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "gas",
+            "grade": 5,
+            "rarity": "uncommon",
+            "value": 18200
+          },
+          {
+            "type": "gas",
+            "grade": 5,
+            "rarity": "common",
+            "value": 87200
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 2839680000000
+          },
+          {
+            "type": "dilithium",
+            "value": 5220000000
+          }
+        ]
+      },
+      "build_time": 53261280,
+      "increased_power": 6000,
+      "level": 54,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 54
+        },
+        {
+          "name": "r&d department",
+          "level": 54
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 1.2,
+        "bonus2": 1.65
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "gas",
+            "grade": 5,
+            "rarity": "rare",
+            "value": 4300
+          },
+          {
+            "type": "gas",
+            "grade": 5,
+            "rarity": "common",
+            "value": 140000
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "dilithium",
+            "value": 8190000000
+          },
+          {
+            "type": "parsteel",
+            "value": 4826640000000
+          }
+        ]
+      },
+      "build_time": 56458080,
+      "increased_power": 6000,
+      "level": 55,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 55
+        },
+        {
+          "name": "r&d department",
+          "level": 55
+        }
+      ]
     }
   ]
 }

--- a/buildings/scrapyard.json
+++ b/buildings/scrapyard.json
@@ -2,7 +2,7 @@
   "description": "The Scrapyard lets you scrap ships for resources and materials. Upgrade to allow scrapping of more advanced ship classes, and to increase scrapping speed.",
   "bonuses": {
     "bonus1": {
-      "name": "Ship Scrapping Speed",
+      "name": "ship scrapping speed",
       "percentage": true
     }
   },
@@ -10,7 +10,7 @@
   "levels": [
     {
       "bonuses": {
-        "bonus1": 2
+        "bonus1": 0.02
       },
       "build_costs": {
         "materials": [],
@@ -27,15 +27,14 @@
       "level": 1,
       "requirements": [
         {
-          "name": "Unlock Scrapyard",
+          "name": "unlock scrapyard",
           "level": 1
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 3
+        "bonus1": 0.03
       },
       "build_costs": {
         "materials": [],
@@ -52,19 +51,18 @@
       "level": 2,
       "requirements": [
         {
-          "name": "Shipyard",
+          "name": "operations",
           "level": 2
         },
         {
-          "name": "Operations",
+          "name": "shipyard",
           "level": 2
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 5
+        "bonus1": 0.05
       },
       "build_costs": {
         "materials": [],
@@ -81,19 +79,18 @@
       "level": 3,
       "requirements": [
         {
-          "name": "Shipyard",
+          "name": "operations",
           "level": 3
         },
         {
-          "name": "Operations",
+          "name": "shipyard",
           "level": 3
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 6
+        "bonus1": 0.06
       },
       "build_costs": {
         "materials": [],
@@ -110,19 +107,18 @@
       "level": 4,
       "requirements": [
         {
-          "name": "Shipyard",
+          "name": "operations",
           "level": 4
         },
         {
-          "name": "Operations",
+          "name": "shipyard",
           "level": 4
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 8
+        "bonus1": 0.08
       },
       "build_costs": {
         "materials": [],
@@ -139,19 +135,18 @@
       "level": 5,
       "requirements": [
         {
-          "name": "Shipyard",
+          "name": "operations",
           "level": 5
         },
         {
-          "name": "Operations",
+          "name": "shipyard",
           "level": 5
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 9
+        "bonus1": 0.09
       },
       "build_costs": {
         "materials": [],
@@ -168,31 +163,30 @@
       "level": 6,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 6
         },
         {
-          "name": "Shipyard",
+          "name": "shipyard",
           "level": 6
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 11
+        "bonus1": 0.11
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 3825
-          },
-          {
             "type": "tritanium",
             "value": 19
+          },
+          {
+            "type": "parsteel",
+            "value": 3825
           }
         ]
       },
@@ -201,31 +195,30 @@
       "level": 7,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 7
         },
         {
-          "name": "Shipyard",
+          "name": "shipyard",
           "level": 7
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 12
+        "bonus1": 0.12
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 6120
-          },
-          {
             "type": "tritanium",
             "value": 60
+          },
+          {
+            "type": "parsteel",
+            "value": 6120
           }
         ]
       },
@@ -234,31 +227,30 @@
       "level": 8,
       "requirements": [
         {
-          "name": "Shipyard",
+          "name": "operations",
           "level": 8
         },
         {
-          "name": "Operations",
+          "name": "shipyard",
           "level": 8
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 14
+        "bonus1": 0.14
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 10200
-          },
-          {
             "type": "tritanium",
             "value": 150
+          },
+          {
+            "type": "parsteel",
+            "value": 10200
           }
         ]
       },
@@ -267,19 +259,18 @@
       "level": 9,
       "requirements": [
         {
-          "name": "Shipyard",
+          "name": "operations",
           "level": 9
         },
         {
-          "name": "Operations",
+          "name": "shipyard",
           "level": 9
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 15
+        "bonus1": 0.15
       },
       "build_costs": {
         "materials": [],
@@ -300,31 +291,30 @@
       "level": 10,
       "requirements": [
         {
-          "name": "Shipyard",
+          "name": "operations",
           "level": 10
         },
         {
-          "name": "Operations",
+          "name": "shipyard",
           "level": 10
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 17
+        "bonus1": 0.17
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 20400
-          },
-          {
             "type": "tritanium",
             "value": 400
+          },
+          {
+            "type": "parsteel",
+            "value": 20400
           }
         ]
       },
@@ -333,31 +323,30 @@
       "level": 11,
       "requirements": [
         {
-          "name": "Shipyard",
+          "name": "operations",
           "level": 11
         },
         {
-          "name": "Operations",
+          "name": "shipyard",
           "level": 11
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 19
+        "bonus1": 0.19
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 28050
-          },
-          {
             "type": "tritanium",
             "value": 550
+          },
+          {
+            "type": "parsteel",
+            "value": 28050
           }
         ]
       },
@@ -366,19 +355,18 @@
       "level": 12,
       "requirements": [
         {
-          "name": "Shipyard",
+          "name": "operations",
           "level": 12
         },
         {
-          "name": "Operations",
+          "name": "shipyard",
           "level": 12
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 21
+        "bonus1": 0.21
       },
       "build_costs": {
         "materials": [],
@@ -399,31 +387,30 @@
       "level": 13,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 13
         },
         {
-          "name": "Shipyard",
+          "name": "shipyard",
           "level": 13
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 23
+        "bonus1": 0.23
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 56100
-          },
-          {
             "type": "tritanium",
             "value": 1100
+          },
+          {
+            "type": "parsteel",
+            "value": 56100
           }
         ]
       },
@@ -432,31 +419,30 @@
       "level": 14,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 14
         },
         {
-          "name": "Shipyard",
+          "name": "shipyard",
           "level": 14
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 25
+        "bonus1": 0.25
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 76500
-          },
-          {
             "type": "tritanium",
             "value": 1500
+          },
+          {
+            "type": "parsteel",
+            "value": 76500
           }
         ]
       },
@@ -465,31 +451,30 @@
       "level": 15,
       "requirements": [
         {
-          "name": "Shipyard",
+          "name": "operations",
           "level": 15
         },
         {
-          "name": "Operations",
+          "name": "shipyard",
           "level": 15
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 27
+        "bonus1": 0.27
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 102000
-          },
-          {
             "type": "tritanium",
             "value": 2000
+          },
+          {
+            "type": "parsteel",
+            "value": 102000
           }
         ]
       },
@@ -498,19 +483,18 @@
       "level": 16,
       "requirements": [
         {
-          "name": "Shipyard",
+          "name": "operations",
           "level": 16
         },
         {
-          "name": "Operations",
+          "name": "shipyard",
           "level": 16
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 29
+        "bonus1": 0.29
       },
       "build_costs": {
         "materials": [],
@@ -531,31 +515,30 @@
       "level": 17,
       "requirements": [
         {
-          "name": "Shipyard",
+          "name": "operations",
           "level": 17
         },
         {
-          "name": "Operations",
+          "name": "shipyard",
           "level": 17
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 31
+        "bonus1": 0.31
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 204000
-          },
-          {
             "type": "tritanium",
             "value": 4000
+          },
+          {
+            "type": "parsteel",
+            "value": 204000
           }
         ]
       },
@@ -564,19 +547,18 @@
       "level": 18,
       "requirements": [
         {
-          "name": "Shipyard",
+          "name": "operations",
           "level": 18
         },
         {
-          "name": "Operations",
+          "name": "shipyard",
           "level": 18
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 33
+        "bonus1": 0.33
       },
       "build_costs": {
         "materials": [],
@@ -597,19 +579,18 @@
       "level": 19,
       "requirements": [
         {
-          "name": "Shipyard",
+          "name": "operations",
           "level": 19
         },
         {
-          "name": "Operations",
+          "name": "shipyard",
           "level": 19
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 35
+        "bonus1": 0.35
       },
       "build_costs": {
         "materials": [],
@@ -630,19 +611,18 @@
       "level": 20,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 20
         },
         {
-          "name": "Shipyard",
+          "name": "shipyard",
           "level": 20
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 38
+        "bonus1": 0.38
       },
       "build_costs": {
         "materials": [],
@@ -663,19 +643,18 @@
       "level": 21,
       "requirements": [
         {
-          "name": "Shipyard",
+          "name": "operations",
           "level": 21
         },
         {
-          "name": "Operations",
+          "name": "shipyard",
           "level": 21
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 40
+        "bonus1": 0.4
       },
       "build_costs": {
         "materials": [],
@@ -696,19 +675,18 @@
       "level": 22,
       "requirements": [
         {
-          "name": "Shipyard",
+          "name": "operations",
           "level": 22
         },
         {
-          "name": "Operations",
+          "name": "shipyard",
           "level": 22
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 43
+        "bonus1": 0.43
       },
       "build_costs": {
         "materials": [],
@@ -729,31 +707,30 @@
       "level": 23,
       "requirements": [
         {
-          "name": "Shipyard",
+          "name": "operations",
           "level": 23
         },
         {
-          "name": "Operations",
+          "name": "shipyard",
           "level": 23
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 45
+        "bonus1": 0.45
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 2943720
-          },
-          {
             "type": "tritanium",
             "value": 57720
+          },
+          {
+            "type": "parsteel",
+            "value": 2943720
           }
         ]
       },
@@ -762,19 +739,18 @@
       "level": 24,
       "requirements": [
         {
-          "name": "Shipyard",
+          "name": "operations",
           "level": 24
         },
         {
-          "name": "Operations",
+          "name": "shipyard",
           "level": 24
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 48
+        "bonus1": 0.48
       },
       "build_costs": {
         "materials": [],
@@ -795,31 +771,30 @@
       "level": 25,
       "requirements": [
         {
-          "name": "Shipyard",
+          "name": "operations",
           "level": 25
         },
         {
-          "name": "Operations",
+          "name": "shipyard",
           "level": 25
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 50
+        "bonus1": 0.5
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 7458750
-          },
-          {
             "type": "tritanium",
             "value": 146250
+          },
+          {
+            "type": "parsteel",
+            "value": 7458750
           }
         ]
       },
@@ -828,31 +803,30 @@
       "level": 26,
       "requirements": [
         {
-          "name": "Shipyard",
+          "name": "operations",
           "level": 26
         },
         {
-          "name": "Operations",
+          "name": "shipyard",
           "level": 26
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 53
+        "bonus1": 0.53
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 11383200
-          },
-          {
             "type": "tritanium",
             "value": 223200
+          },
+          {
+            "type": "parsteel",
+            "value": 11383200
           }
         ]
       },
@@ -861,31 +835,30 @@
       "level": 27,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 27
         },
         {
-          "name": "Shipyard",
+          "name": "shipyard",
           "level": 27
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 55
+        "bonus1": 0.55
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 17074800
-          },
-          {
             "type": "tritanium",
             "value": 334800
+          },
+          {
+            "type": "parsteel",
+            "value": 17074800
           }
         ]
       },
@@ -894,31 +867,30 @@
       "level": 28,
       "requirements": [
         {
-          "name": "Shipyard",
+          "name": "operations",
           "level": 28
         },
         {
-          "name": "Operations",
+          "name": "shipyard",
           "level": 28
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 58
+        "bonus1": 0.58
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 27183000
-          },
-          {
             "type": "tritanium",
             "value": 533000
+          },
+          {
+            "type": "parsteel",
+            "value": 27183000
           }
         ]
       },
@@ -927,31 +899,30 @@
       "level": 29,
       "requirements": [
         {
-          "name": "Shipyard",
+          "name": "operations",
           "level": 29
         },
         {
-          "name": "Operations",
+          "name": "shipyard",
           "level": 29
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 60
+        "bonus1": 0.6
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 39780000
-          },
-          {
             "type": "tritanium",
             "value": 780000
+          },
+          {
+            "type": "parsteel",
+            "value": 39780000
           }
         ]
       },
@@ -960,31 +931,30 @@
       "level": 30,
       "requirements": [
         {
-          "name": "Shipyard",
+          "name": "operations",
           "level": 30
         },
         {
-          "name": "Operations",
+          "name": "shipyard",
           "level": 30
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 63
+        "bonus1": 0.63
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 62883000
-          },
-          {
             "type": "tritanium",
             "value": 1233000
+          },
+          {
+            "type": "parsteel",
+            "value": 62883000
           }
         ]
       },
@@ -993,19 +963,18 @@
       "level": 31,
       "requirements": [
         {
-          "name": "Shipyard",
+          "name": "operations",
           "level": 31
         },
         {
-          "name": "Operations",
+          "name": "shipyard",
           "level": 31
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 66
+        "bonus1": 0.66
       },
       "build_costs": {
         "materials": [],
@@ -1026,19 +995,18 @@
       "level": 32,
       "requirements": [
         {
-          "name": "Shipyard",
+          "name": "operations",
           "level": 32
         },
         {
-          "name": "Operations",
+          "name": "shipyard",
           "level": 32
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 69
+        "bonus1": 0.69
       },
       "build_costs": {
         "materials": [],
@@ -1059,19 +1027,18 @@
       "level": 33,
       "requirements": [
         {
-          "name": "Shipyard",
+          "name": "operations",
           "level": 33
         },
         {
-          "name": "Operations",
+          "name": "shipyard",
           "level": 33
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 72
+        "bonus1": 0.72
       },
       "build_costs": {
         "materials": [],
@@ -1092,31 +1059,30 @@
       "level": 34,
       "requirements": [
         {
-          "name": "Shipyard",
+          "name": "operations",
           "level": 34
         },
         {
-          "name": "Operations",
+          "name": "shipyard",
           "level": 34
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 75
+        "bonus1": 0.75
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 343332000
-          },
-          {
             "type": "tritanium",
             "value": 6732000
+          },
+          {
+            "type": "parsteel",
+            "value": 343332000
           }
         ]
       },
@@ -1125,31 +1091,30 @@
       "level": 35,
       "requirements": [
         {
-          "name": "Shipyard",
+          "name": "operations",
           "level": 35
         },
         {
-          "name": "Operations",
+          "name": "shipyard",
           "level": 35
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 78
+        "bonus1": 0.78
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 483786000
-          },
-          {
             "type": "tritanium",
             "value": 9486000
+          },
+          {
+            "type": "parsteel",
+            "value": 483786000
           }
         ]
       },
@@ -1158,19 +1123,18 @@
       "level": 36,
       "requirements": [
         {
-          "name": "Shipyard",
+          "name": "operations",
           "level": 36
         },
         {
-          "name": "Operations",
+          "name": "shipyard",
           "level": 36
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 81
+        "bonus1": 0.81
       },
       "build_costs": {
         "materials": [],
@@ -1191,31 +1155,30 @@
       "level": 37,
       "requirements": [
         {
-          "name": "Shipyard",
+          "name": "operations",
           "level": 37
         },
         {
-          "name": "Operations",
+          "name": "shipyard",
           "level": 37
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 84
+        "bonus1": 0.84
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 1156680000
-          },
-          {
             "type": "tritanium",
             "value": 22680000
+          },
+          {
+            "type": "parsteel",
+            "value": 1156680000
           }
         ]
       },
@@ -1224,31 +1187,30 @@
       "level": 38,
       "requirements": [
         {
-          "name": "Shipyard",
+          "name": "operations",
           "level": 38
         },
         {
-          "name": "Operations",
+          "name": "shipyard",
           "level": 38
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 87
+        "bonus1": 0.87
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 1973700000
-          },
-          {
             "type": "tritanium",
             "value": 38700000
+          },
+          {
+            "type": "parsteel",
+            "value": 1973700000
           }
         ]
       },
@@ -1257,19 +1219,18 @@
       "level": 39,
       "requirements": [
         {
-          "name": "Shipyard",
+          "name": "operations",
           "level": 39
         },
         {
-          "name": "Operations",
+          "name": "shipyard",
           "level": 39
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 90
+        "bonus1": 0.9
       },
       "build_costs": {
         "materials": [
@@ -1297,19 +1258,18 @@
       "level": 40,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 40
         },
         {
-          "name": "Shipyard",
+          "name": "shipyard",
           "level": 40
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 95
+        "bonus1": 0.95
       },
       "build_costs": {
         "materials": [
@@ -1337,19 +1297,18 @@
       "level": 41,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 41
         },
         {
-          "name": "Shipyard",
+          "name": "shipyard",
           "level": 41
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 100
+        "bonus1": 1.0
       },
       "build_costs": {
         "materials": [
@@ -1363,12 +1322,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 13066200000
-          },
-          {
             "type": "tritanium",
             "value": 128100000
+          },
+          {
+            "type": "parsteel",
+            "value": 13066200000
           }
         ]
       },
@@ -1377,19 +1336,18 @@
       "level": 42,
       "requirements": [
         {
-          "name": "Shipyard",
+          "name": "operations",
           "level": 42
         },
         {
-          "name": "Operations",
+          "name": "shipyard",
           "level": 42
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 105
+        "bonus1": 1.05
       },
       "build_costs": {
         "materials": [
@@ -1417,19 +1375,18 @@
       "level": 43,
       "requirements": [
         {
-          "name": "Shipyard",
+          "name": "operations",
           "level": 43
         },
         {
-          "name": "Operations",
+          "name": "shipyard",
           "level": 43
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 110
+        "bonus1": 1.1
       },
       "build_costs": {
         "materials": [
@@ -1457,19 +1414,18 @@
       "level": 44,
       "requirements": [
         {
-          "name": "Shipyard",
+          "name": "operations",
           "level": 44
         },
         {
-          "name": "Operations",
+          "name": "shipyard",
           "level": 44
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 115
+        "bonus1": 1.15
       },
       "build_costs": {
         "materials": [
@@ -1497,19 +1453,18 @@
       "level": 45,
       "requirements": [
         {
-          "name": "Shipyard",
+          "name": "operations",
           "level": 45
         },
         {
-          "name": "Operations",
+          "name": "shipyard",
           "level": 45
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 120
+        "bonus1": 1.2
       },
       "build_costs": {
         "materials": [
@@ -1523,12 +1478,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 54697500000
-          },
-          {
             "type": "tritanium",
             "value": 536250000
+          },
+          {
+            "type": "parsteel",
+            "value": 54697500000
           }
         ]
       },
@@ -1537,19 +1492,18 @@
       "level": 46,
       "requirements": [
         {
-          "name": "Shipyard",
+          "name": "operations",
           "level": 46
         },
         {
-          "name": "Operations",
+          "name": "shipyard",
           "level": 46
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 125
+        "bonus1": 1.25
       },
       "build_costs": {
         "materials": [
@@ -1563,12 +1517,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 79560000000
-          },
-          {
             "type": "tritanium",
             "value": 780000000
+          },
+          {
+            "type": "parsteel",
+            "value": 79560000000
           }
         ]
       },
@@ -1577,19 +1531,18 @@
       "level": 47,
       "requirements": [
         {
-          "name": "Shipyard",
+          "name": "operations",
           "level": 47
         },
         {
-          "name": "Operations",
+          "name": "shipyard",
           "level": 47
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 130
+        "bonus1": 1.3
       },
       "build_costs": {
         "materials": [
@@ -1617,19 +1570,18 @@
       "level": 48,
       "requirements": [
         {
-          "name": "Shipyard",
+          "name": "operations",
           "level": 48
         },
         {
-          "name": "Operations",
+          "name": "shipyard",
           "level": 48
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 135
+        "bonus1": 1.35
       },
       "build_costs": {
         "materials": [
@@ -1643,12 +1595,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 214200000000
-          },
-          {
             "type": "tritanium",
             "value": 2100000000
+          },
+          {
+            "type": "parsteel",
+            "value": 214200000000
           }
         ]
       },
@@ -1657,31 +1609,30 @@
       "level": 49,
       "requirements": [
         {
-          "name": "Shipyard",
+          "name": "operations",
           "level": 49
         },
         {
-          "name": "Operations",
+          "name": "shipyard",
           "level": 49
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 140
+        "bonus1": 1.4
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 374850000000
-          },
-          {
             "type": "tritanium",
             "value": 3675000000
+          },
+          {
+            "type": "parsteel",
+            "value": 374850000000
           }
         ]
       },
@@ -1690,15 +1641,209 @@
       "level": 50,
       "requirements": [
         {
-          "name": "Shipyard",
+          "name": "operations",
           "level": 50
         },
         {
-          "name": "Operations",
+          "name": "shipyard",
           "level": 50
         }
-      ],
-      "rewards": []
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 1.45
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "crystal",
+            "grade": 5,
+            "rarity": "common",
+            "value": 5400
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 7800000000
+          },
+          {
+            "type": "parsteel",
+            "value": 1869660000000
+          }
+        ]
+      },
+      "build_time": 149065920,
+      "increased_power": 3500,
+      "level": 51,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 51
+        },
+        {
+          "name": "shipyard",
+          "level": 51
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 1.5
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "crystal",
+            "grade": 5,
+            "rarity": "common",
+            "value": 9400
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 13260000000
+          },
+          {
+            "type": "parsteel",
+            "value": 3381300000000
+          }
+        ]
+      },
+      "build_time": 158009760,
+      "increased_power": 3500,
+      "level": 52,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 52
+        },
+        {
+          "name": "shipyard",
+          "level": 52
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 1.55
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "crystal",
+            "grade": 5,
+            "rarity": "common",
+            "value": 10200
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 23200000000
+          },
+          {
+            "type": "parsteel",
+            "value": 5679360000000
+          }
+        ]
+      },
+      "build_time": 167490720,
+      "increased_power": 4000,
+      "level": 53,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 53
+        },
+        {
+          "name": "shipyard",
+          "level": 53
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 1.6
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "crystal",
+            "grade": 5,
+            "rarity": "common",
+            "value": 19500
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 34800000000
+          },
+          {
+            "type": "parsteel",
+            "value": 8519040000000
+          }
+        ]
+      },
+      "build_time": 177540480,
+      "increased_power": 4000,
+      "level": 54,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 54
+        },
+        {
+          "name": "shipyard",
+          "level": 54
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 1.65
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "crystal",
+            "grade": 5,
+            "rarity": "common",
+            "value": 23900
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 14479920000000
+          },
+          {
+            "type": "tritanium",
+            "value": 54600000000
+          }
+        ]
+      },
+      "build_time": 188192160,
+      "increased_power": 4000,
+      "level": 55,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 55
+        },
+        {
+          "name": "shipyard",
+          "level": 55
+        }
+      ]
     }
   ]
 }

--- a/buildings/ship_hangar.json
+++ b/buildings/ship_hangar.json
@@ -2,11 +2,11 @@
   "description": "The Ship Hangar is where extra ships are stored when they are not currently used in the active fleet. Upgrade the Hangar to increase the amount of Ships that can be owned.",
   "bonuses": {
     "bonus1": {
-      "name": "Hull Health Bonus",
+      "name": "hull health bonus",
       "percentage": true
     },
     "bonus2": {
-      "name": "Ship Inventory Slots",
+      "name": "ship inventory slots",
       "percentage": false
     }
   },
@@ -14,8 +14,8 @@
   "levels": [
     {
       "bonuses": {
-        "bonus1": 3,
-        "bonus2": 20
+        "bonus1": 0.03,
+        "bonus2": 20.0
       },
       "build_costs": {
         "materials": [],
@@ -27,16 +27,15 @@
       "level": 1,
       "requirements": [
         {
-          "name": "Unlock Ship Hangar",
+          "name": "unlock ship hangar",
           "level": 1
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 6,
-        "bonus2": 21
+        "bonus1": 0.06,
+        "bonus2": 21.0
       },
       "build_costs": {
         "materials": [],
@@ -53,24 +52,23 @@
       "level": 2,
       "requirements": [
         {
-          "name": "Unlock Ship Hangar",
-          "level": 1
+          "name": "operations",
+          "level": 2
         },
         {
-          "name": "Shipyard",
+          "name": "shipyard",
           "level": 11
         },
         {
-          "name": "Operations",
-          "level": 2
+          "name": "unlock ship hangar",
+          "level": 1
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 9,
-        "bonus2": 22
+        "bonus1": 0.09,
+        "bonus2": 22.0
       },
       "build_costs": {
         "materials": [],
@@ -87,20 +85,19 @@
       "level": 3,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 3
         },
         {
-          "name": "Shipyard",
+          "name": "shipyard",
           "level": 11
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 12,
-        "bonus2": 23
+        "bonus1": 0.12,
+        "bonus2": 23.0
       },
       "build_costs": {
         "materials": [],
@@ -117,20 +114,19 @@
       "level": 4,
       "requirements": [
         {
-          "name": "Shipyard",
-          "level": 11
+          "name": "operations",
+          "level": 4
         },
         {
-          "name": "Operations",
-          "level": 4
+          "name": "shipyard",
+          "level": 11
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 15,
-        "bonus2": 24
+        "bonus1": 0.15,
+        "bonus2": 24.0
       },
       "build_costs": {
         "materials": [],
@@ -147,20 +143,19 @@
       "level": 5,
       "requirements": [
         {
-          "name": "Shipyard",
-          "level": 11
+          "name": "operations",
+          "level": 5
         },
         {
-          "name": "Operations",
-          "level": 5
+          "name": "shipyard",
+          "level": 11
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 18,
-        "bonus2": 25
+        "bonus1": 0.18,
+        "bonus2": 25.0
       },
       "build_costs": {
         "materials": [],
@@ -177,20 +172,19 @@
       "level": 6,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 6
         },
         {
-          "name": "Shipyard",
+          "name": "shipyard",
           "level": 11
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 21,
-        "bonus2": 26
+        "bonus1": 0.21,
+        "bonus2": 26.0
       },
       "build_costs": {
         "materials": [],
@@ -211,32 +205,31 @@
       "level": 7,
       "requirements": [
         {
-          "name": "Shipyard",
-          "level": 11
+          "name": "operations",
+          "level": 7
         },
         {
-          "name": "Operations",
-          "level": 7
+          "name": "shipyard",
+          "level": 11
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 24,
-        "bonus2": 27
+        "bonus1": 0.24,
+        "bonus2": 27.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 18500
-          },
-          {
             "type": "tritanium",
             "value": 60
+          },
+          {
+            "type": "parsteel",
+            "value": 18500
           }
         ]
       },
@@ -245,20 +238,19 @@
       "level": 8,
       "requirements": [
         {
-          "name": "Shipyard",
-          "level": 11
+          "name": "operations",
+          "level": 8
         },
         {
-          "name": "Operations",
-          "level": 8
+          "name": "shipyard",
+          "level": 11
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 27,
-        "bonus2": 28
+        "bonus1": 0.27,
+        "bonus2": 28.0
       },
       "build_costs": {
         "materials": [],
@@ -279,32 +271,31 @@
       "level": 9,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 9
         },
         {
-          "name": "Shipyard",
+          "name": "shipyard",
           "level": 11
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 30,
-        "bonus2": 29
+        "bonus1": 0.3,
+        "bonus2": 29.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 19500
-          },
-          {
             "type": "tritanium",
             "value": 300
+          },
+          {
+            "type": "parsteel",
+            "value": 19500
           }
         ]
       },
@@ -313,20 +304,19 @@
       "level": 10,
       "requirements": [
         {
-          "name": "Shipyard",
-          "level": 11
+          "name": "operations",
+          "level": 10
         },
         {
-          "name": "Operations",
-          "level": 10
+          "name": "shipyard",
+          "level": 11
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 33,
-        "bonus2": 30
+        "bonus1": 0.33,
+        "bonus2": 30.0
       },
       "build_costs": {
         "materials": [],
@@ -347,32 +337,31 @@
       "level": 11,
       "requirements": [
         {
-          "name": "Shipyard",
+          "name": "operations",
           "level": 11
         },
         {
-          "name": "Operations",
+          "name": "shipyard",
           "level": 11
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 36,
-        "bonus2": 31
+        "bonus1": 0.36,
+        "bonus2": 31.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 28050
-          },
-          {
             "type": "tritanium",
             "value": 550
+          },
+          {
+            "type": "parsteel",
+            "value": 28050
           }
         ]
       },
@@ -381,32 +370,31 @@
       "level": 12,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 12
         },
         {
-          "name": "Shipyard",
+          "name": "shipyard",
           "level": 12
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 39,
-        "bonus2": 32
+        "bonus1": 0.39,
+        "bonus2": 32.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 40800
-          },
-          {
             "type": "tritanium",
             "value": 800
+          },
+          {
+            "type": "parsteel",
+            "value": 40800
           }
         ]
       },
@@ -415,32 +403,31 @@
       "level": 13,
       "requirements": [
         {
-          "name": "Shipyard",
+          "name": "operations",
           "level": 13
         },
         {
-          "name": "Operations",
+          "name": "shipyard",
           "level": 13
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 42,
-        "bonus2": 33
+        "bonus1": 0.42,
+        "bonus2": 33.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 56100
-          },
-          {
             "type": "tritanium",
             "value": 1100
+          },
+          {
+            "type": "parsteel",
+            "value": 56100
           }
         ]
       },
@@ -449,20 +436,19 @@
       "level": 14,
       "requirements": [
         {
-          "name": "Shipyard",
+          "name": "operations",
           "level": 14
         },
         {
-          "name": "Operations",
+          "name": "shipyard",
           "level": 14
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 45,
-        "bonus2": 34
+        "bonus1": 0.45,
+        "bonus2": 34.0
       },
       "build_costs": {
         "materials": [],
@@ -483,20 +469,19 @@
       "level": 15,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 15
         },
         {
-          "name": "Shipyard",
+          "name": "shipyard",
           "level": 15
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 48,
-        "bonus2": 35
+        "bonus1": 0.48,
+        "bonus2": 35.0
       },
       "build_costs": {
         "materials": [],
@@ -517,32 +502,31 @@
       "level": 16,
       "requirements": [
         {
-          "name": "Shipyard",
+          "name": "operations",
           "level": 16
         },
         {
-          "name": "Operations",
+          "name": "shipyard",
           "level": 16
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 51,
-        "bonus2": 36
+        "bonus1": 0.51,
+        "bonus2": 36.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 142800
-          },
-          {
             "type": "tritanium",
             "value": 2800
+          },
+          {
+            "type": "parsteel",
+            "value": 142800
           }
         ]
       },
@@ -551,20 +535,19 @@
       "level": 17,
       "requirements": [
         {
-          "name": "Shipyard",
+          "name": "operations",
           "level": 17
         },
         {
-          "name": "Operations",
+          "name": "shipyard",
           "level": 17
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 54,
-        "bonus2": 37
+        "bonus1": 0.54,
+        "bonus2": 37.0
       },
       "build_costs": {
         "materials": [],
@@ -585,32 +568,31 @@
       "level": 18,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 18
         },
         {
-          "name": "Shipyard",
+          "name": "shipyard",
           "level": 18
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 57,
-        "bonus2": 38
+        "bonus1": 0.57,
+        "bonus2": 38.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 306000
-          },
-          {
             "type": "tritanium",
             "value": 6000
+          },
+          {
+            "type": "parsteel",
+            "value": 306000
           }
         ]
       },
@@ -619,32 +601,31 @@
       "level": 19,
       "requirements": [
         {
-          "name": "Shipyard",
+          "name": "operations",
           "level": 19
         },
         {
-          "name": "Operations",
+          "name": "shipyard",
           "level": 19
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 60,
-        "bonus2": 39
+        "bonus1": 0.6,
+        "bonus2": 39.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 433500
-          },
-          {
             "type": "tritanium",
             "value": 8500
+          },
+          {
+            "type": "parsteel",
+            "value": 433500
           }
         ]
       },
@@ -653,32 +634,31 @@
       "level": 20,
       "requirements": [
         {
-          "name": "Shipyard",
+          "name": "operations",
           "level": 20
         },
         {
-          "name": "Operations",
+          "name": "shipyard",
           "level": 20
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 63,
-        "bonus2": 40
+        "bonus1": 0.63,
+        "bonus2": 40.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 729810
-          },
-          {
             "type": "tritanium",
             "value": 14310
+          },
+          {
+            "type": "parsteel",
+            "value": 729810
           }
         ]
       },
@@ -687,20 +667,19 @@
       "level": 21,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 21
         },
         {
-          "name": "Shipyard",
+          "name": "shipyard",
           "level": 21
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 66,
-        "bonus2": 41
+        "bonus1": 0.66,
+        "bonus2": 41.0
       },
       "build_costs": {
         "materials": [],
@@ -721,20 +700,19 @@
       "level": 22,
       "requirements": [
         {
-          "name": "Shipyard",
+          "name": "operations",
           "level": 22
         },
         {
-          "name": "Operations",
+          "name": "shipyard",
           "level": 22
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 69,
-        "bonus2": 42
+        "bonus1": 0.69,
+        "bonus2": 42.0
       },
       "build_costs": {
         "materials": [],
@@ -755,20 +733,19 @@
       "level": 23,
       "requirements": [
         {
-          "name": "Shipyard",
+          "name": "operations",
           "level": 23
         },
         {
-          "name": "Operations",
+          "name": "shipyard",
           "level": 23
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 72,
-        "bonus2": 43
+        "bonus1": 0.72,
+        "bonus2": 43.0
       },
       "build_costs": {
         "materials": [
@@ -796,20 +773,19 @@
       "level": 24,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 24
         },
         {
-          "name": "Shipyard",
+          "name": "shipyard",
           "level": 24
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 75,
-        "bonus2": 44
+        "bonus1": 0.75,
+        "bonus2": 44.0
       },
       "build_costs": {
         "materials": [
@@ -829,12 +805,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 4773600
-          },
-          {
             "type": "tritanium",
             "value": 93600
+          },
+          {
+            "type": "parsteel",
+            "value": 4773600
           }
         ]
       },
@@ -843,20 +819,19 @@
       "level": 25,
       "requirements": [
         {
-          "name": "Shipyard",
+          "name": "operations",
           "level": 25
         },
         {
-          "name": "Operations",
+          "name": "shipyard",
           "level": 25
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 78,
-        "bonus2": 45
+        "bonus1": 0.78,
+        "bonus2": 45.0
       },
       "build_costs": {
         "materials": [
@@ -890,20 +865,19 @@
       "level": 26,
       "requirements": [
         {
-          "name": "Shipyard",
+          "name": "operations",
           "level": 26
         },
         {
-          "name": "Operations",
+          "name": "shipyard",
           "level": 26
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 81,
-        "bonus2": 46
+        "bonus1": 0.81,
+        "bonus2": 46.0
       },
       "build_costs": {
         "materials": [
@@ -923,12 +897,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 11383200
-          },
-          {
             "type": "tritanium",
             "value": 223200
+          },
+          {
+            "type": "parsteel",
+            "value": 11383200
           }
         ]
       },
@@ -937,20 +911,19 @@
       "level": 27,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 27
         },
         {
-          "name": "Shipyard",
+          "name": "shipyard",
           "level": 27
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 84,
-        "bonus2": 48
+        "bonus1": 0.84,
+        "bonus2": 48.0
       },
       "build_costs": {
         "materials": [
@@ -970,12 +943,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 17074800
-          },
-          {
             "type": "tritanium",
             "value": 334800
+          },
+          {
+            "type": "parsteel",
+            "value": 17074800
           }
         ]
       },
@@ -984,20 +957,19 @@
       "level": 28,
       "requirements": [
         {
-          "name": "Shipyard",
+          "name": "operations",
           "level": 28
         },
         {
-          "name": "Operations",
+          "name": "shipyard",
           "level": 28
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 87,
-        "bonus2": 49
+        "bonus1": 0.87,
+        "bonus2": 49.0
       },
       "build_costs": {
         "materials": [
@@ -1017,12 +989,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 27183000
-          },
-          {
             "type": "tritanium",
             "value": 533000
+          },
+          {
+            "type": "parsteel",
+            "value": 27183000
           }
         ]
       },
@@ -1031,20 +1003,19 @@
       "level": 29,
       "requirements": [
         {
-          "name": "Shipyard",
+          "name": "operations",
           "level": 29
         },
         {
-          "name": "Operations",
+          "name": "shipyard",
           "level": 29
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 90,
-        "bonus2": 50
+        "bonus1": 0.9,
+        "bonus2": 50.0
       },
       "build_costs": {
         "materials": [
@@ -1078,20 +1049,19 @@
       "level": 30,
       "requirements": [
         {
-          "name": "Shipyard",
+          "name": "operations",
           "level": 30
         },
         {
-          "name": "Operations",
+          "name": "shipyard",
           "level": 30
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 93,
-        "bonus2": 51
+        "bonus1": 0.93,
+        "bonus2": 51.0
       },
       "build_costs": {
         "materials": [
@@ -1119,20 +1089,19 @@
       "level": 31,
       "requirements": [
         {
-          "name": "Shipyard",
+          "name": "operations",
           "level": 31
         },
         {
-          "name": "Operations",
+          "name": "shipyard",
           "level": 31
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 96,
-        "bonus2": 52
+        "bonus1": 0.96,
+        "bonus2": 52.0
       },
       "build_costs": {
         "materials": [
@@ -1166,34 +1135,33 @@
       "level": 32,
       "requirements": [
         {
-          "name": "Shipyard",
+          "name": "operations",
           "level": 32
         },
         {
-          "name": "Operations",
+          "name": "shipyard",
           "level": 32
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 99,
-        "bonus2": 53
+        "bonus1": 0.99,
+        "bonus2": 53.0
       },
       "build_costs": {
         "materials": [
           {
             "type": "crystal",
             "grade": 3,
-            "rarity": "common",
-            "value": 1000
+            "rarity": "uncommon",
+            "value": 110
           },
           {
             "type": "crystal",
             "grade": 3,
-            "rarity": "uncommon",
-            "value": 110
+            "rarity": "common",
+            "value": 1000
           }
         ],
         "others": [],
@@ -1213,20 +1181,19 @@
       "level": 33,
       "requirements": [
         {
-          "name": "Shipyard",
+          "name": "operations",
           "level": 33
         },
         {
-          "name": "Operations",
+          "name": "shipyard",
           "level": 33
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 102,
-        "bonus2": 54
+        "bonus1": 1.02,
+        "bonus2": 54.0
       },
       "build_costs": {
         "materials": [
@@ -1240,12 +1207,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 221850000
-          },
-          {
             "type": "tritanium",
             "value": 4350000
+          },
+          {
+            "type": "parsteel",
+            "value": 221850000
           }
         ]
       },
@@ -1254,20 +1221,19 @@
       "level": 34,
       "requirements": [
         {
-          "name": "Shipyard",
+          "name": "operations",
           "level": 34
         },
         {
-          "name": "Operations",
+          "name": "shipyard",
           "level": 34
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 105,
-        "bonus2": 55
+        "bonus1": 1.05,
+        "bonus2": 55.0
       },
       "build_costs": {
         "materials": [
@@ -1301,20 +1267,19 @@
       "level": 35,
       "requirements": [
         {
-          "name": "Shipyard",
+          "name": "operations",
           "level": 35
         },
         {
-          "name": "Operations",
+          "name": "shipyard",
           "level": 35
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 108,
-        "bonus2": 56
+        "bonus1": 1.08,
+        "bonus2": 56.0
       },
       "build_costs": {
         "materials": [
@@ -1342,20 +1307,19 @@
       "level": 36,
       "requirements": [
         {
-          "name": "Shipyard",
+          "name": "operations",
           "level": 36
         },
         {
-          "name": "Operations",
+          "name": "shipyard",
           "level": 36
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 111,
-        "bonus2": 57
+        "bonus1": 1.11,
+        "bonus2": 57.0
       },
       "build_costs": {
         "materials": [
@@ -1389,20 +1353,19 @@
       "level": 37,
       "requirements": [
         {
-          "name": "Shipyard",
+          "name": "operations",
           "level": 37
         },
         {
-          "name": "Operations",
+          "name": "shipyard",
           "level": 37
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 114,
-        "bonus2": 58
+        "bonus1": 1.14,
+        "bonus2": 58.0
       },
       "build_costs": {
         "materials": [
@@ -1422,12 +1385,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 1156680000
-          },
-          {
             "type": "tritanium",
             "value": 22680000
+          },
+          {
+            "type": "parsteel",
+            "value": 1156680000
           }
         ]
       },
@@ -1436,24 +1399,23 @@
       "level": 38,
       "requirements": [
         {
-          "name": "Defense Platform D",
+          "name": "operations",
           "level": 38
         },
         {
-          "name": "Shipyard",
+          "name": "shipyard",
           "level": 38
         },
         {
-          "name": "Operations",
+          "name": "defense platform d",
           "level": 38
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 117,
-        "bonus2": 59
+        "bonus1": 1.17,
+        "bonus2": 59.0
       },
       "build_costs": {
         "materials": [
@@ -1473,12 +1435,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 1973700000
-          },
-          {
             "type": "tritanium",
             "value": 38700000
+          },
+          {
+            "type": "parsteel",
+            "value": 1973700000
           }
         ]
       },
@@ -1487,38 +1449,37 @@
       "level": 39,
       "requirements": [
         {
-          "name": "Defense Platform D",
+          "name": "operations",
           "level": 39
         },
         {
-          "name": "Shipyard",
+          "name": "shipyard",
           "level": 39
         },
         {
-          "name": "Operations",
+          "name": "defense platform d",
           "level": 39
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 120,
-        "bonus2": 60
+        "bonus1": 1.2,
+        "bonus2": 60.0
       },
       "build_costs": {
         "materials": [
           {
             "type": "crystal",
             "grade": 4,
-            "rarity": "common",
-            "value": 10000
+            "rarity": "uncommon",
+            "value": 2500
           },
           {
             "type": "crystal",
             "grade": 4,
-            "rarity": "uncommon",
-            "value": 2500
+            "rarity": "common",
+            "value": 10000
           }
         ],
         "others": [],
@@ -1538,34 +1499,33 @@
       "level": 40,
       "requirements": [
         {
-          "name": "Shipyard",
+          "name": "operations",
           "level": 40
         },
         {
-          "name": "Operations",
+          "name": "shipyard",
           "level": 40
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 123,
-        "bonus2": 61
+        "bonus1": 1.23,
+        "bonus2": 61.0
       },
       "build_costs": {
         "materials": [
           {
             "type": "crystal",
             "grade": 4,
-            "rarity": "common",
-            "value": 15000
+            "rarity": "uncommon",
+            "value": 4000
           },
           {
             "type": "crystal",
             "grade": 4,
-            "rarity": "uncommon",
-            "value": 4000
+            "rarity": "common",
+            "value": 15000
           }
         ],
         "others": [],
@@ -1585,20 +1545,19 @@
       "level": 41,
       "requirements": [
         {
-          "name": "Shipyard",
+          "name": "operations",
           "level": 41
         },
         {
-          "name": "Operations",
+          "name": "shipyard",
           "level": 41
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 126,
-        "bonus2": 62
+        "bonus1": 1.26,
+        "bonus2": 62.0
       },
       "build_costs": {
         "materials": [
@@ -1618,12 +1577,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 13066200000
-          },
-          {
             "type": "tritanium",
             "value": 128100000
+          },
+          {
+            "type": "parsteel",
+            "value": 13066200000
           }
         ]
       },
@@ -1632,49 +1591,48 @@
       "level": 42,
       "requirements": [
         {
-          "name": "Armada Control Center",
+          "name": "operations",
+          "level": 42
+        },
+        {
+          "name": "shipyard",
+          "level": 42
+        },
+        {
+          "name": "armada control center",
           "level": 30
-        },
-        {
-          "name": "Shipyard",
-          "level": 42
-        },
-        {
-          "name": "Operations",
-          "level": 42
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 129,
-        "bonus2": 63
+        "bonus1": 1.29,
+        "bonus2": 63.0
       },
       "build_costs": {
         "materials": [
           {
             "type": "crystal",
             "grade": 4,
-            "rarity": "common",
-            "value": 20000
+            "rarity": "uncommon",
+            "value": 6000
           },
           {
             "type": "crystal",
             "grade": 4,
-            "rarity": "uncommon",
-            "value": 6000
+            "rarity": "common",
+            "value": 20000
           }
         ],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 18666000000
-          },
-          {
             "type": "tritanium",
             "value": 183000000
+          },
+          {
+            "type": "parsteel",
+            "value": 18666000000
           }
         ]
       },
@@ -1683,34 +1641,33 @@
       "level": 43,
       "requirements": [
         {
-          "name": "Shipyard",
+          "name": "operations",
           "level": 43
         },
         {
-          "name": "Operations",
+          "name": "shipyard",
           "level": 43
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 132,
-        "bonus2": 64
+        "bonus1": 1.32,
+        "bonus2": 64.0
       },
       "build_costs": {
         "materials": [
           {
             "type": "crystal",
             "grade": 4,
-            "rarity": "common",
-            "value": 35000
+            "rarity": "uncommon",
+            "value": 8000
           },
           {
             "type": "crystal",
             "grade": 4,
-            "rarity": "uncommon",
-            "value": 8000
+            "rarity": "common",
+            "value": 35000
           }
         ],
         "others": [],
@@ -1730,20 +1687,19 @@
       "level": 44,
       "requirements": [
         {
-          "name": "Shipyard",
+          "name": "operations",
           "level": 44
         },
         {
-          "name": "Operations",
+          "name": "shipyard",
           "level": 44
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 135,
-        "bonus2": 65
+        "bonus1": 1.35,
+        "bonus2": 65.0
       },
       "build_costs": {
         "materials": [
@@ -1777,20 +1733,19 @@
       "level": 45,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 45
         },
         {
-          "name": "Shipyard",
+          "name": "shipyard",
           "level": 45
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 138,
-        "bonus2": 66
+        "bonus1": 1.38,
+        "bonus2": 66.0
       },
       "build_costs": {
         "materials": [
@@ -1810,12 +1765,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 54697500000
-          },
-          {
             "type": "tritanium",
             "value": 536250000
+          },
+          {
+            "type": "parsteel",
+            "value": 54697500000
           }
         ]
       },
@@ -1824,45 +1779,44 @@
       "level": 46,
       "requirements": [
         {
-          "name": "Shipyard",
+          "name": "operations",
           "level": 46
         },
         {
-          "name": "Operations",
+          "name": "shipyard",
           "level": 46
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 141,
-        "bonus2": 67
+        "bonus1": 1.41,
+        "bonus2": 67.0
       },
       "build_costs": {
         "materials": [
           {
             "type": "crystal",
             "grade": 4,
-            "rarity": "uncommon",
-            "value": 16500
+            "rarity": "rare",
+            "value": 7500
           },
           {
             "type": "crystal",
             "grade": 4,
-            "rarity": "rare",
-            "value": 7500
+            "rarity": "uncommon",
+            "value": 16500
           }
         ],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 79560000000
-          },
-          {
             "type": "tritanium",
             "value": 780000000
+          },
+          {
+            "type": "parsteel",
+            "value": 79560000000
           }
         ]
       },
@@ -1871,20 +1825,19 @@
       "level": 47,
       "requirements": [
         {
-          "name": "Shipyard",
+          "name": "operations",
           "level": 47
         },
         {
-          "name": "Operations",
+          "name": "shipyard",
           "level": 47
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 144,
-        "bonus2": 68
+        "bonus1": 1.44,
+        "bonus2": 68.0
       },
       "build_costs": {
         "materials": [
@@ -1918,34 +1871,33 @@
       "level": 48,
       "requirements": [
         {
-          "name": "Shipyard",
+          "name": "operations",
           "level": 48
         },
         {
-          "name": "Operations",
+          "name": "shipyard",
           "level": 48
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 147,
-        "bonus2": 69
+        "bonus1": 1.47,
+        "bonus2": 69.0
       },
       "build_costs": {
         "materials": [
           {
             "type": "crystal",
             "grade": 4,
-            "rarity": "uncommon",
-            "value": 8000
+            "rarity": "rare",
+            "value": 10000
           },
           {
             "type": "crystal",
             "grade": 4,
-            "rarity": "rare",
-            "value": 10000
+            "rarity": "uncommon",
+            "value": 8000
           }
         ],
         "others": [],
@@ -1965,32 +1917,31 @@
       "level": 49,
       "requirements": [
         {
-          "name": "Shipyard",
+          "name": "operations",
           "level": 49
         },
         {
-          "name": "Operations",
+          "name": "shipyard",
           "level": 49
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 150,
-        "bonus2": 70
+        "bonus1": 1.5,
+        "bonus2": 70.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 374850000000
-          },
-          {
             "type": "tritanium",
             "value": 3675000000
+          },
+          {
+            "type": "parsteel",
+            "value": 374850000000
           }
         ]
       },
@@ -1999,15 +1950,248 @@
       "level": 50,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 50
         },
         {
-          "name": "Shipyard",
+          "name": "shipyard",
           "level": 50
         }
-      ],
-      "rewards": []
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 1.53,
+        "bonus2": 71.0
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "crystal",
+            "grade": 5,
+            "rarity": "uncommon",
+            "value": 3800
+          },
+          {
+            "type": "crystal",
+            "grade": 5,
+            "rarity": "common",
+            "value": 10800
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 1869660000000
+          },
+          {
+            "type": "tritanium",
+            "value": 7800000000
+          }
+        ]
+      },
+      "build_time": 223598880,
+      "increased_power": 2000,
+      "level": 51,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 51
+        },
+        {
+          "name": "shipyard",
+          "level": 51
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 1.56,
+        "bonus2": 72.0
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "crystal",
+            "grade": 5,
+            "rarity": "common",
+            "value": 18800
+          },
+          {
+            "type": "crystal",
+            "grade": 5,
+            "rarity": "uncommon",
+            "value": 8500
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 3381300000000
+          },
+          {
+            "type": "tritanium",
+            "value": 13260000000
+          }
+        ]
+      },
+      "build_time": 237015360,
+      "increased_power": 1500,
+      "level": 52,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 52
+        },
+        {
+          "name": "shipyard",
+          "level": 52
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 1.59,
+        "bonus2": 73.0
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "crystal",
+            "grade": 5,
+            "rarity": "uncommon",
+            "value": 31800
+          },
+          {
+            "type": "crystal",
+            "grade": 5,
+            "rarity": "common",
+            "value": 38000
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 23200000000
+          },
+          {
+            "type": "parsteel",
+            "value": 5679360000000
+          }
+        ]
+      },
+      "build_time": 251235360,
+      "increased_power": 2000,
+      "level": 53,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 53
+        },
+        {
+          "name": "shipyard",
+          "level": 53
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 1.62,
+        "bonus2": 74.0
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "crystal",
+            "grade": 5,
+            "rarity": "common",
+            "value": 46500
+          },
+          {
+            "type": "crystal",
+            "grade": 5,
+            "rarity": "rare",
+            "value": 8100
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 34800000000
+          },
+          {
+            "type": "parsteel",
+            "value": 8519040000000
+          }
+        ]
+      },
+      "build_time": 266309280,
+      "increased_power": 2000,
+      "level": 54,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 54
+        },
+        {
+          "name": "shipyard",
+          "level": 54
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 1.65,
+        "bonus2": 75.0
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "crystal",
+            "grade": 5,
+            "rarity": "rare",
+            "value": 11900
+          },
+          {
+            "type": "crystal",
+            "grade": 5,
+            "rarity": "common",
+            "value": 62200
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 14479920000000
+          },
+          {
+            "type": "tritanium",
+            "value": 54600000000
+          }
+        ]
+      },
+      "build_time": 282288960,
+      "increased_power": 2000,
+      "level": 55,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 55
+        },
+        {
+          "name": "shipyard",
+          "level": 55
+        },
+        {
+          "name": "armada control center",
+          "level": 50
+        }
+      ]
     }
   ]
 }

--- a/buildings/shipyard.json
+++ b/buildings/shipyard.json
@@ -2,11 +2,11 @@
   "description": "The Shipyard is instrumental in ship construction. Upgrade this building to get access to more ships and increase the speed of ship construction.",
   "bonuses": {
     "bonus1": {
-      "name": "Ship Construction Speed",
+      "name": "ship construction speed",
       "percentage": true
     },
     "bonus2": {
-      "name": "Tier Up Speed",
+      "name": "tier up speed",
       "percentage": true
     }
   },
@@ -14,8 +14,8 @@
   "levels": [
     {
       "bonuses": {
-        "bonus1": 0,
-        "bonus2": 0
+        "bonus1": 0.0,
+        "bonus2": 0.0
       },
       "build_costs": {
         "materials": [],
@@ -32,20 +32,19 @@
       "level": 1,
       "requirements": [
         {
-          "name": "R&D Department",
-          "level": 4
+          "name": "operations",
+          "level": 5
         },
         {
-          "name": "Operations",
-          "level": 5
+          "name": "r&d department",
+          "level": 4
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 3,
-        "bonus2": 3
+        "bonus1": 0.03,
+        "bonus2": 0.03
       },
       "build_costs": {
         "materials": [],
@@ -62,20 +61,19 @@
       "level": 2,
       "requirements": [
         {
-          "name": "R&D Department",
-          "level": 4
+          "name": "operations",
+          "level": 5
         },
         {
-          "name": "Operations",
-          "level": 5
+          "name": "r&d department",
+          "level": 4
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 4,
-        "bonus2": 4
+        "bonus1": 0.04,
+        "bonus2": 0.04
       },
       "build_costs": {
         "materials": [],
@@ -92,20 +90,19 @@
       "level": 3,
       "requirements": [
         {
-          "name": "R&D Department",
-          "level": 4
+          "name": "operations",
+          "level": 5
         },
         {
-          "name": "Operations",
-          "level": 5
+          "name": "r&d department",
+          "level": 4
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 5,
-        "bonus2": 5
+        "bonus1": 0.05,
+        "bonus2": 0.05
       },
       "build_costs": {
         "materials": [],
@@ -122,20 +119,19 @@
       "level": 4,
       "requirements": [
         {
-          "name": "R&D Department",
-          "level": 4
+          "name": "operations",
+          "level": 6
         },
         {
-          "name": "Operations",
-          "level": 6
+          "name": "r&d department",
+          "level": 4
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 6,
-        "bonus2": 6
+        "bonus1": 0.06,
+        "bonus2": 0.06
       },
       "build_costs": {
         "materials": [],
@@ -152,20 +148,19 @@
       "level": 5,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 6
         },
         {
-          "name": "R&D Department",
+          "name": "r&d department",
           "level": 5
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 8,
-        "bonus2": 8
+        "bonus1": 0.08,
+        "bonus2": 0.08
       },
       "build_costs": {
         "materials": [],
@@ -182,32 +177,31 @@
       "level": 6,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 6
         },
         {
-          "name": "R&D Department",
+          "name": "r&d department",
           "level": 6
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 9,
-        "bonus2": 9
+        "bonus1": 0.09,
+        "bonus2": 0.09
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 4500
-          },
-          {
             "type": "tritanium",
             "value": 50
+          },
+          {
+            "type": "parsteel",
+            "value": 4500
           }
         ]
       },
@@ -216,36 +210,35 @@
       "level": 7,
       "requirements": [
         {
-          "name": "Drydock A",
+          "name": "operations",
+          "level": 7
+        },
+        {
+          "name": "r&d department",
+          "level": 7
+        },
+        {
+          "name": "drydock a",
           "level": 4
-        },
-        {
-          "name": "R&D Department",
-          "level": 7
-        },
-        {
-          "name": "Operations",
-          "level": 7
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 11,
-        "bonus2": 11
+        "bonus1": 0.11,
+        "bonus2": 0.11
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 6000
-          },
-          {
             "type": "tritanium",
             "value": 100
+          },
+          {
+            "type": "parsteel",
+            "value": 6000
           }
         ]
       },
@@ -254,24 +247,23 @@
       "level": 8,
       "requirements": [
         {
-          "name": "Drydock A",
+          "name": "operations",
+          "level": 8
+        },
+        {
+          "name": "r&d department",
+          "level": 8
+        },
+        {
+          "name": "drydock a",
           "level": 6
-        },
-        {
-          "name": "R&D Department",
-          "level": 8
-        },
-        {
-          "name": "Operations",
-          "level": 8
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 12,
-        "bonus2": 12
+        "bonus1": 0.12,
+        "bonus2": 0.12
       },
       "build_costs": {
         "materials": [],
@@ -292,36 +284,35 @@
       "level": 9,
       "requirements": [
         {
-          "name": "Drydock A",
+          "name": "operations",
           "level": 9
         },
         {
-          "name": "Parsteel Warehouse",
+          "name": "parsteel warehouse",
           "level": 9
         },
         {
-          "name": "Operations",
+          "name": "drydock a",
           "level": 9
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 14,
-        "bonus2": 14
+        "bonus1": 0.14,
+        "bonus2": 0.14
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 10000
-          },
-          {
             "type": "tritanium",
             "value": 150
+          },
+          {
+            "type": "parsteel",
+            "value": 10000
           }
         ]
       },
@@ -330,20 +321,19 @@
       "level": 10,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 10
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 10
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 16,
-        "bonus2": 16
+        "bonus1": 0.16,
+        "bonus2": 0.16
       },
       "build_costs": {
         "materials": [],
@@ -364,24 +354,23 @@
       "level": 11,
       "requirements": [
         {
-          "name": "Tritanium Generator B",
+          "name": "operations",
+          "level": 11
+        },
+        {
+          "name": "r&d department",
+          "level": 11
+        },
+        {
+          "name": "tritanium generator b",
           "level": 10
-        },
-        {
-          "name": "R&D Department",
-          "level": 11
-        },
-        {
-          "name": "Operations",
-          "level": 11
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 18,
-        "bonus2": 18
+        "bonus1": 0.18,
+        "bonus2": 0.18
       },
       "build_costs": {
         "materials": [],
@@ -402,20 +391,19 @@
       "level": 12,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 12
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 12
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 20,
-        "bonus2": 20
+        "bonus1": 0.2,
+        "bonus2": 0.2
       },
       "build_costs": {
         "materials": [],
@@ -436,36 +424,35 @@
       "level": 13,
       "requirements": [
         {
-          "name": "Astronautics Studio",
+          "name": "operations",
           "level": 13
         },
         {
-          "name": "R&D Department",
+          "name": "r&d department",
           "level": 13
         },
         {
-          "name": "Operations",
+          "name": "astronautics studio",
           "level": 13
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 22,
-        "bonus2": 22
+        "bonus1": 0.22,
+        "bonus2": 0.22
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 33660
-          },
-          {
             "type": "tritanium",
             "value": 550
+          },
+          {
+            "type": "parsteel",
+            "value": 33660
           }
         ]
       },
@@ -474,24 +461,23 @@
       "level": 14,
       "requirements": [
         {
-          "name": "Tritanium Generator B",
+          "name": "operations",
           "level": 14
         },
         {
-          "name": "R&D Department",
+          "name": "r&d department",
           "level": 14
         },
         {
-          "name": "Operations",
+          "name": "tritanium generator b",
           "level": 14
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 24,
-        "bonus2": 24
+        "bonus1": 0.24,
+        "bonus2": 0.24
       },
       "build_costs": {
         "materials": [
@@ -519,24 +505,23 @@
       "level": 15,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 15
         },
         {
-          "name": "R&D Department",
+          "name": "r&d department",
           "level": 15
         },
         {
-          "name": "Dilithium Warehouse",
+          "name": "dilithium warehouse",
           "level": 12
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 26,
-        "bonus2": 26
+        "bonus1": 0.26,
+        "bonus2": 0.26
       },
       "build_costs": {
         "materials": [
@@ -564,34 +549,33 @@
       "level": 16,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 16
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 16
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 29,
-        "bonus2": 29
+        "bonus1": 0.29,
+        "bonus2": 0.29
       },
       "build_costs": {
         "materials": [
           {
             "type": "crystal",
             "grade": 2,
-            "rarity": "common",
-            "value": 200
+            "rarity": "uncommon",
+            "value": 15
           },
           {
             "type": "crystal",
             "grade": 2,
-            "rarity": "uncommon",
-            "value": 15
+            "rarity": "common",
+            "value": 200
           }
         ],
         "others": [],
@@ -611,38 +595,37 @@
       "level": 17,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 17
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 17
         },
         {
-          "name": "Tritanium Warehouse",
+          "name": "tritanium warehouse",
           "level": 17
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 31,
-        "bonus2": 31
+        "bonus1": 0.31,
+        "bonus2": 0.31
       },
       "build_costs": {
         "materials": [
           {
             "type": "crystal",
             "grade": 2,
-            "rarity": "common",
-            "value": 1000
+            "rarity": "uncommon",
+            "value": 85
           },
           {
             "type": "crystal",
             "grade": 2,
-            "rarity": "uncommon",
-            "value": 85
+            "rarity": "common",
+            "value": 1000
           }
         ],
         "others": [],
@@ -662,24 +645,23 @@
       "level": 18,
       "requirements": [
         {
-          "name": "Defense Technologies",
+          "name": "operations",
+          "level": 18
+        },
+        {
+          "name": "r&d department",
+          "level": 18
+        },
+        {
+          "name": "defense technologies",
           "level": 12
-        },
-        {
-          "name": "R&D Department",
-          "level": 18
-        },
-        {
-          "name": "Operations",
-          "level": 18
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 34,
-        "bonus2": 34
+        "bonus1": 0.34,
+        "bonus2": 0.34
       },
       "build_costs": {
         "materials": [
@@ -713,36 +695,35 @@
       "level": 19,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 19
         },
         {
-          "name": "R&D Department",
+          "name": "r&d department",
           "level": 19
         },
         {
-          "name": "Dilithium Vault",
+          "name": "dilithium vault",
           "level": 10
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 36,
-        "bonus2": 36
+        "bonus1": 0.36,
+        "bonus2": 0.36
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 260100
-          },
-          {
             "type": "tritanium",
             "value": 4250
+          },
+          {
+            "type": "parsteel",
+            "value": 260100
           }
         ]
       },
@@ -751,36 +732,35 @@
       "level": 20,
       "requirements": [
         {
-          "name": "Ship Hangar",
+          "name": "operations",
+          "level": 20
+        },
+        {
+          "name": "r&d department",
+          "level": 20
+        },
+        {
+          "name": "ship hangar",
           "level": 15
-        },
-        {
-          "name": "R&D Department",
-          "level": 20
-        },
-        {
-          "name": "Operations",
-          "level": 20
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 39,
-        "bonus2": 39
+        "bonus1": 0.39,
+        "bonus2": 0.39
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 437886
-          },
-          {
             "type": "tritanium",
             "value": 7155
+          },
+          {
+            "type": "parsteel",
+            "value": 437886
           }
         ]
       },
@@ -789,24 +769,23 @@
       "level": 21,
       "requirements": [
         {
-          "name": "Astronautics Studio",
+          "name": "operations",
           "level": 21
         },
         {
-          "name": "R&D Department",
+          "name": "r&d department",
           "level": 21
         },
         {
-          "name": "Operations",
+          "name": "astronautics studio",
           "level": 21
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 42,
-        "bonus2": 42
+        "bonus1": 0.42,
+        "bonus2": 0.42
       },
       "build_costs": {
         "materials": [],
@@ -827,24 +806,23 @@
       "level": 22,
       "requirements": [
         {
-          "name": "Dilithium Warehouse",
+          "name": "operations",
+          "level": 22
+        },
+        {
+          "name": "r&d department",
+          "level": 22
+        },
+        {
+          "name": "dilithium warehouse",
           "level": 21
-        },
-        {
-          "name": "R&D Department",
-          "level": 22
-        },
-        {
-          "name": "Operations",
-          "level": 22
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 45,
-        "bonus2": 45
+        "bonus1": 0.45,
+        "bonus2": 0.45
       },
       "build_costs": {
         "materials": [
@@ -872,24 +850,23 @@
       "level": 23,
       "requirements": [
         {
-          "name": "Refinery",
+          "name": "operations",
+          "level": 23
+        },
+        {
+          "name": "r&d department",
+          "level": 23
+        },
+        {
+          "name": "refinery",
           "level": 22
-        },
-        {
-          "name": "R&D Department",
-          "level": 23
-        },
-        {
-          "name": "Operations",
-          "level": 23
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 48,
-        "bonus2": 48
+        "bonus1": 0.48,
+        "bonus2": 0.48
       },
       "build_costs": {
         "materials": [
@@ -917,24 +894,23 @@
       "level": 24,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 24
         },
         {
-          "name": "Dilithium Vault",
+          "name": "r&d department",
           "level": 24
         },
         {
-          "name": "R&D Department",
+          "name": "dilithium vault",
           "level": 24
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 51,
-        "bonus2": 51
+        "bonus1": 0.51,
+        "bonus2": 0.51
       },
       "build_costs": {
         "materials": [
@@ -968,24 +944,23 @@
       "level": 25,
       "requirements": [
         {
-          "name": "Drydock C",
+          "name": "drydock a",
           "level": 25
         },
         {
-          "name": "Drydock B",
+          "name": "drydock b",
           "level": 25
         },
         {
-          "name": "Drydock A",
+          "name": "drydock c",
           "level": 25
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 55,
-        "bonus2": 55
+        "bonus1": 0.55,
+        "bonus2": 0.55
       },
       "build_costs": {
         "materials": [
@@ -1005,12 +980,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 4475250
-          },
-          {
             "type": "tritanium",
             "value": 73125
+          },
+          {
+            "type": "parsteel",
+            "value": 4475250
           }
         ]
       },
@@ -1019,24 +994,23 @@
       "level": 26,
       "requirements": [
         {
-          "name": "Astronautics Studio",
+          "name": "operations",
           "level": 26
         },
         {
-          "name": "R&D Department",
+          "name": "r&d department",
           "level": 26
         },
         {
-          "name": "Operations",
+          "name": "astronautics studio",
           "level": 26
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 58,
-        "bonus2": 58
+        "bonus1": 0.58,
+        "bonus2": 0.58
       },
       "build_costs": {
         "materials": [
@@ -1070,20 +1044,19 @@
       "level": 27,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 27
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 27
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 62,
-        "bonus2": 62
+        "bonus1": 0.62,
+        "bonus2": 0.62
       },
       "build_costs": {
         "materials": [
@@ -1103,12 +1076,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 10244880
-          },
-          {
             "type": "tritanium",
             "value": 167400
+          },
+          {
+            "type": "parsteel",
+            "value": 10244880
           }
         ]
       },
@@ -1117,49 +1090,48 @@
       "level": 28,
       "requirements": [
         {
-          "name": "Defense Platform A",
+          "name": "operations",
           "level": 28
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 28
         },
         {
-          "name": "R&D Department",
+          "name": "defense platform a",
           "level": 28
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 65,
-        "bonus2": 65
+        "bonus1": 0.65,
+        "bonus2": 0.65
       },
       "build_costs": {
         "materials": [
           {
             "type": "crystal",
             "grade": 3,
-            "rarity": "common",
-            "value": 1400
+            "rarity": "uncommon",
+            "value": 300
           },
           {
             "type": "crystal",
             "grade": 3,
-            "rarity": "uncommon",
-            "value": 300
+            "rarity": "common",
+            "value": 1400
           }
         ],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 16309800
-          },
-          {
             "type": "tritanium",
             "value": 266500
+          },
+          {
+            "type": "parsteel",
+            "value": 16309800
           }
         ]
       },
@@ -1168,49 +1140,48 @@
       "level": 29,
       "requirements": [
         {
-          "name": "Dilithium Vault",
+          "name": "operations",
           "level": 29
         },
         {
-          "name": "R&D Department",
+          "name": "r&d department",
           "level": 29
         },
         {
-          "name": "Operations",
+          "name": "dilithium vault",
           "level": 29
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 69,
-        "bonus2": 69
+        "bonus1": 0.69,
+        "bonus2": 0.69
       },
       "build_costs": {
         "materials": [
           {
             "type": "crystal",
             "grade": 3,
-            "rarity": "common",
-            "value": 1600
+            "rarity": "uncommon",
+            "value": 390
           },
           {
             "type": "crystal",
             "grade": 3,
-            "rarity": "uncommon",
-            "value": 390
+            "rarity": "common",
+            "value": 1600
           }
         ],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 23868000
-          },
-          {
             "type": "tritanium",
             "value": 390000
+          },
+          {
+            "type": "parsteel",
+            "value": 23868000
           }
         ]
       },
@@ -1219,38 +1190,37 @@
       "level": 30,
       "requirements": [
         {
-          "name": "Dilithium Warehouse",
+          "name": "operations",
+          "level": 30
+        },
+        {
+          "name": "r&d department",
+          "level": 30
+        },
+        {
+          "name": "dilithium warehouse",
           "level": 28
-        },
-        {
-          "name": "Operations",
-          "level": 30
-        },
-        {
-          "name": "R&D Department",
-          "level": 30
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 73,
-        "bonus2": 73
+        "bonus1": 0.73,
+        "bonus2": 0.73
       },
       "build_costs": {
         "materials": [
           {
             "type": "crystal",
             "grade": 3,
-            "rarity": "common",
-            "value": 1900
+            "rarity": "uncommon",
+            "value": 500
           },
           {
             "type": "crystal",
             "grade": 3,
-            "rarity": "uncommon",
-            "value": 500
+            "rarity": "common",
+            "value": 1900
           }
         ],
         "others": [],
@@ -1270,49 +1240,48 @@
       "level": 31,
       "requirements": [
         {
-          "name": "Foundry",
+          "name": "operations",
           "level": 31
         },
         {
-          "name": "R&D Department",
+          "name": "r&d department",
           "level": 31
         },
         {
-          "name": "Operations",
+          "name": "foundry",
           "level": 31
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 77,
-        "bonus2": 77
+        "bonus1": 0.77,
+        "bonus2": 0.77
       },
       "build_costs": {
         "materials": [
           {
             "type": "crystal",
             "grade": 3,
-            "rarity": "common",
-            "value": 2100
+            "rarity": "rare",
+            "value": 25
           },
           {
             "type": "crystal",
             "grade": 3,
-            "rarity": "rare",
-            "value": 25
+            "rarity": "common",
+            "value": 2100
           }
         ],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 54498600
-          },
-          {
             "type": "tritanium",
             "value": 890500
+          },
+          {
+            "type": "parsteel",
+            "value": 54498600
           }
         ]
       },
@@ -1321,24 +1290,23 @@
       "level": 32,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 32
         },
         {
-          "name": "Refinery",
+          "name": "r&d department",
+          "level": 32
+        },
+        {
+          "name": "refinery",
           "level": 31
-        },
-        {
-          "name": "R&D Department",
-          "level": 32
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 81,
-        "bonus2": 81
+        "bonus1": 0.81,
+        "bonus2": 0.81
       },
       "build_costs": {
         "materials": [
@@ -1372,38 +1340,37 @@
       "level": 33,
       "requirements": [
         {
-          "name": "Tritanium Vault",
+          "name": "operations",
+          "level": 33
+        },
+        {
+          "name": "r&d department",
+          "level": 33
+        },
+        {
+          "name": "tritanium vault",
           "level": 28
-        },
-        {
-          "name": "R&D Department",
-          "level": 33
-        },
-        {
-          "name": "Operations",
-          "level": 33
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 85,
-        "bonus2": 85
+        "bonus1": 0.85,
+        "bonus2": 0.85
       },
       "build_costs": {
         "materials": [
           {
             "type": "crystal",
             "grade": 3,
-            "rarity": "common",
-            "value": 2800
+            "rarity": "uncommon",
+            "value": 950
           },
           {
             "type": "crystal",
             "grade": 3,
-            "rarity": "uncommon",
-            "value": 950
+            "rarity": "common",
+            "value": 2800
           }
         ],
         "others": [],
@@ -1423,24 +1390,23 @@
       "level": 34,
       "requirements": [
         {
-          "name": "Engine Technology Lab",
+          "name": "operations",
           "level": 34
         },
         {
-          "name": "R&D Department",
+          "name": "r&d department",
           "level": 34
         },
         {
-          "name": "Operations",
+          "name": "engine technology lab",
           "level": 34
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 89,
-        "bonus2": 89
+        "bonus1": 0.89,
+        "bonus2": 0.89
       },
       "build_costs": {
         "materials": [
@@ -1460,12 +1426,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 205999200
-          },
-          {
             "type": "tritanium",
             "value": 3366000
+          },
+          {
+            "type": "parsteel",
+            "value": 205999200
           }
         ]
       },
@@ -1474,24 +1440,23 @@
       "level": 35,
       "requirements": [
         {
-          "name": "Science Lab",
+          "name": "operations",
           "level": 35
         },
         {
-          "name": "R&D Department",
+          "name": "r&d department",
           "level": 35
         },
         {
-          "name": "Operations",
+          "name": "science lab",
           "level": 35
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 93,
-        "bonus2": 93
+        "bonus1": 0.93,
+        "bonus2": 0.93
       },
       "build_costs": {
         "materials": [
@@ -1511,12 +1476,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 290271600
-          },
-          {
             "type": "tritanium",
             "value": 4743000
+          },
+          {
+            "type": "parsteel",
+            "value": 290271600
           }
         ]
       },
@@ -1525,49 +1490,48 @@
       "level": 36,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 36
         },
         {
-          "name": "R&D Department",
+          "name": "r&d department",
           "level": 36
         },
         {
-          "name": "Refinery",
+          "name": "refinery",
           "level": 35
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 98,
-        "bonus2": 98
+        "bonus1": 0.98,
+        "bonus2": 0.98
       },
       "build_costs": {
         "materials": [
           {
             "type": "crystal",
             "grade": 3,
-            "rarity": "common",
-            "value": 3900
+            "rarity": "uncommon",
+            "value": 1620
           },
           {
             "type": "crystal",
             "grade": 3,
-            "rarity": "uncommon",
-            "value": 1620
+            "rarity": "common",
+            "value": 3900
           }
         ],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 446148000
-          },
-          {
             "type": "tritanium",
             "value": 7290000
+          },
+          {
+            "type": "parsteel",
+            "value": 446148000
           }
         ]
       },
@@ -1576,20 +1540,19 @@
       "level": 37,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 37
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 37
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 102,
-        "bonus2": 102
+        "bonus1": 1.02,
+        "bonus2": 1.02
       },
       "build_costs": {
         "materials": [
@@ -1609,12 +1572,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 694008000
-          },
-          {
             "type": "tritanium",
             "value": 11340000
+          },
+          {
+            "type": "parsteel",
+            "value": 694008000
           }
         ]
       },
@@ -1623,20 +1586,19 @@
       "level": 38,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 38
         },
         {
-          "name": "R&D Department",
+          "name": "r&d department",
           "level": 38
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 107,
-        "bonus2": 107
+        "bonus1": 1.07,
+        "bonus2": 1.07
       },
       "build_costs": {
         "materials": [
@@ -1656,12 +1618,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 1184220000
-          },
-          {
             "type": "tritanium",
             "value": 19350000
+          },
+          {
+            "type": "parsteel",
+            "value": 1184220000
           }
         ]
       },
@@ -1670,24 +1632,23 @@
       "level": 39,
       "requirements": [
         {
-          "name": "Armada Control Center",
+          "name": "operations",
+          "level": 39
+        },
+        {
+          "name": "r&d department",
+          "level": 39
+        },
+        {
+          "name": "armada control center",
           "level": 10
-        },
-        {
-          "name": "R&D Department",
-          "level": 39
-        },
-        {
-          "name": "Operations",
-          "level": 39
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 111,
-        "bonus2": 111
+        "bonus1": 1.11,
+        "bonus2": 1.11
       },
       "build_costs": {
         "materials": [
@@ -1715,24 +1676,23 @@
       "level": 40,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 40
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 40
         },
         {
-          "name": "Armada Control Center",
+          "name": "armada control center",
           "level": 20
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 116,
-        "bonus2": 116
+        "bonus1": 1.16,
+        "bonus2": 1.16
       },
       "build_costs": {
         "materials": [
@@ -1766,49 +1726,48 @@
       "level": 41,
       "requirements": [
         {
-          "name": "Refinery",
+          "name": "operations",
+          "level": 41
+        },
+        {
+          "name": "r&d department",
+          "level": 41
+        },
+        {
+          "name": "refinery",
           "level": 40
-        },
-        {
-          "name": "R&D Department",
-          "level": 41
-        },
-        {
-          "name": "Operations",
-          "level": 41
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 121,
-        "bonus2": 121
+        "bonus1": 1.21,
+        "bonus2": 1.21
       },
       "build_costs": {
         "materials": [
           {
             "type": "crystal",
             "grade": 4,
-            "rarity": "uncommon",
-            "value": 8000
+            "rarity": "rare",
+            "value": 2500
           },
           {
             "type": "crystal",
             "grade": 4,
-            "rarity": "rare",
-            "value": 2500
+            "rarity": "uncommon",
+            "value": 8000
           }
         ],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 7839720000
-          },
-          {
             "type": "tritanium",
             "value": 64050000
+          },
+          {
+            "type": "parsteel",
+            "value": 7839720000
           }
         ]
       },
@@ -1817,24 +1776,23 @@
       "level": 42,
       "requirements": [
         {
-          "name": "4\u2605 Shield Modulation",
+          "name": "operations",
+          "level": 42
+        },
+        {
+          "name": "r&d department",
+          "level": 42
+        },
+        {
+          "name": "4\u2605 shield modulation",
           "level": 1
-        },
-        {
-          "name": "R&D Department",
-          "level": 42
-        },
-        {
-          "name": "Operations",
-          "level": 42
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 126,
-        "bonus2": 126
+        "bonus1": 1.26,
+        "bonus2": 1.26
       },
       "build_costs": {
         "materials": [
@@ -1868,20 +1826,19 @@
       "level": 43,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 43
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 43
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 131,
-        "bonus2": 131
+        "bonus1": 1.31,
+        "bonus2": 1.31
       },
       "build_costs": {
         "materials": [
@@ -1915,38 +1872,37 @@
       "level": 44,
       "requirements": [
         {
-          "name": "Armada Control Center",
+          "name": "operations",
+          "level": 44
+        },
+        {
+          "name": "r&d department",
+          "level": 44
+        },
+        {
+          "name": "armada control center",
           "level": 39
-        },
-        {
-          "name": "R&D Department",
-          "level": 44
-        },
-        {
-          "name": "Operations",
-          "level": 44
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 137,
-        "bonus2": 137
+        "bonus1": 1.37,
+        "bonus2": 1.37
       },
       "build_costs": {
         "materials": [
           {
             "type": "crystal",
             "grade": 4,
-            "rarity": "uncommon",
-            "value": 10000
+            "rarity": "rare",
+            "value": 5000
           },
           {
             "type": "crystal",
             "grade": 4,
-            "rarity": "rare",
-            "value": 5000
+            "rarity": "uncommon",
+            "value": 10000
           }
         ],
         "others": [],
@@ -1966,20 +1922,19 @@
       "level": 45,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 45
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 45
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 143,
-        "bonus2": 143
+        "bonus1": 1.43,
+        "bonus2": 1.43
       },
       "build_costs": {
         "materials": [
@@ -2013,24 +1968,23 @@
       "level": 46,
       "requirements": [
         {
-          "name": "Station Sabotage",
+          "name": "operations",
+          "level": 46
+        },
+        {
+          "name": "r&d department",
+          "level": 46
+        },
+        {
+          "name": "station sabotage",
           "level": 1
-        },
-        {
-          "name": "R&D Department",
-          "level": 46
-        },
-        {
-          "name": "Operations",
-          "level": 46
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 149,
-        "bonus2": 149
+        "bonus1": 1.49,
+        "bonus2": 1.49
       },
       "build_costs": {
         "materials": [
@@ -2050,12 +2004,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 47736000000
-          },
-          {
             "type": "tritanium",
             "value": 390000000
+          },
+          {
+            "type": "parsteel",
+            "value": 47736000000
           }
         ]
       },
@@ -2064,45 +2018,44 @@
       "level": 47,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 47
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 47
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 155,
-        "bonus2": 155
+        "bonus1": 1.55,
+        "bonus2": 1.55
       },
       "build_costs": {
         "materials": [
           {
             "type": "crystal",
             "grade": 4,
-            "rarity": "uncommon",
-            "value": 15000
+            "rarity": "rare",
+            "value": 4000
           },
           {
             "type": "crystal",
             "grade": 4,
-            "rarity": "rare",
-            "value": 4000
+            "rarity": "uncommon",
+            "value": 15000
           }
         ],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 77112000000
-          },
-          {
             "type": "tritanium",
             "value": 630000000
+          },
+          {
+            "type": "parsteel",
+            "value": 77112000000
           }
         ]
       },
@@ -2111,20 +2064,19 @@
       "level": 48,
       "requirements": [
         {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 48
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
           "level": 48
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 161,
-        "bonus2": 161
+        "bonus1": 1.61,
+        "bonus2": 1.61
       },
       "build_costs": {
         "materials": [
@@ -2158,24 +2110,23 @@
       "level": 49,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 49
         },
         {
-          "name": "R&D Department",
+          "name": "r&d department",
           "level": 49
         },
         {
-          "name": "Defense Technologies",
+          "name": "defense technologies",
           "level": 49
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 170,
-        "bonus2": 170
+        "bonus1": 1.7,
+        "bonus2": 1.7
       },
       "build_costs": {
         "materials": [],
@@ -2196,19 +2147,258 @@
       "level": 50,
       "requirements": [
         {
-          "name": "4\u2605 Shield Efficiency",
-          "level": 1
-        },
-        {
-          "name": "R&D Department",
+          "name": "operations",
           "level": 50
         },
         {
-          "name": "Operations",
+          "name": "r&d department",
+          "level": 50
+        },
+        {
+          "name": "4\u2605 shield efficiency",
+          "level": 1
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 1.77,
+        "bonus2": 1.77
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "crystal",
+            "grade": 5,
+            "rarity": "common",
+            "value": 20600
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 3900000000
+          },
+          {
+            "type": "parsteel",
+            "value": 1121796000000
+          }
+        ]
+      },
+      "build_time": 178879680,
+      "increased_power": 3500,
+      "level": 51,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 51
+        },
+        {
+          "name": "r&d department",
+          "level": 51
+        },
+        {
+          "name": "refinery",
           "level": 50
         }
-      ],
-      "rewards": []
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 1.84,
+        "bonus2": 1.84
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "crystal",
+            "grade": 5,
+            "rarity": "uncommon",
+            "value": 11400
+          },
+          {
+            "type": "crystal",
+            "grade": 5,
+            "rarity": "common",
+            "value": 37500
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 6630000000
+          },
+          {
+            "type": "parsteel",
+            "value": 2028780000000
+          }
+        ]
+      },
+      "build_time": 189612000,
+      "increased_power": 3500,
+      "level": 52,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 52
+        },
+        {
+          "name": "r&d department",
+          "level": 52
+        },
+        {
+          "name": "defense technologies",
+          "level": 50
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 1.91,
+        "bonus2": 1.91
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "crystal",
+            "grade": 5,
+            "rarity": "common",
+            "value": 73100
+          },
+          {
+            "type": "crystal",
+            "grade": 5,
+            "rarity": "uncommon",
+            "value": 40800
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 11600000000
+          },
+          {
+            "type": "parsteel",
+            "value": 3407616000000
+          }
+        ]
+      },
+      "build_time": 200988000,
+      "increased_power": 4000,
+      "level": 53,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 53
+        },
+        {
+          "name": "r&d department",
+          "level": 53
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 1.98,
+        "bonus2": 1.98
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "crystal",
+            "grade": 5,
+            "rarity": "uncommon",
+            "value": 36000
+          },
+          {
+            "type": "crystal",
+            "grade": 5,
+            "rarity": "rare",
+            "value": 11100
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 17400000000
+          },
+          {
+            "type": "parsteel",
+            "value": 5111424000000
+          }
+        ]
+      },
+      "build_time": 213048000,
+      "increased_power": 4000,
+      "level": 54,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 54
+        },
+        {
+          "name": "r&d department",
+          "level": 54
+        },
+        {
+          "name": "defense platform e",
+          "level": 53
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 2.05,
+        "bonus2": 2.05
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "crystal",
+            "grade": 5,
+            "rarity": "uncommon",
+            "value": 73600
+          },
+          {
+            "type": "crystal",
+            "grade": 5,
+            "rarity": "rare",
+            "value": 12600
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 27300000000
+          },
+          {
+            "type": "parsteel",
+            "value": 8687952000000
+          }
+        ]
+      },
+      "build_time": 225830880,
+      "increased_power": 4000,
+      "level": 55,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 55
+        },
+        {
+          "name": "r&d department",
+          "level": 55
+        },
+        {
+          "name": "defense platform e",
+          "level": 54
+        }
+      ]
     }
   ]
 }

--- a/buildings/shuttle_bay.json
+++ b/buildings/shuttle_bay.json
@@ -2,11 +2,11 @@
   "description": "The Shuttle Bay allows officers to be sent on Away Team Assignments.",
   "bonuses": {
     "bonus1": {
-      "name": "Weapon Damage Bonus",
+      "name": "weapon damage bonus",
       "percentage": true
     },
     "bonus2": {
-      "name": "Service Award Cost Efficiency",
+      "name": "service award cost efficiency",
       "percentage": true
     }
   },
@@ -14,8 +14,8 @@
   "levels": [
     {
       "bonuses": {
-        "bonus1": 1,
-        "bonus2": 1
+        "bonus1": 0.01,
+        "bonus2": 0.01
       },
       "build_costs": {
         "materials": [],
@@ -32,20 +32,19 @@
       "level": 1,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 8
         },
         {
-          "name": "Unlock Shuttle Bay",
+          "name": "unlock shuttle bay",
           "level": 1
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 2,
-        "bonus2": 2
+        "bonus1": 0.02,
+        "bonus2": 0.02
       },
       "build_costs": {
         "materials": [],
@@ -62,16 +61,15 @@
       "level": 2,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 8
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 3,
-        "bonus2": 3
+        "bonus1": 0.03,
+        "bonus2": 0.03
       },
       "build_costs": {
         "materials": [],
@@ -88,16 +86,15 @@
       "level": 3,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 8
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 4,
-        "bonus2": 4
+        "bonus1": 0.04,
+        "bonus2": 0.04
       },
       "build_costs": {
         "materials": [],
@@ -114,16 +111,15 @@
       "level": 4,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 8
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 5,
-        "bonus2": 5
+        "bonus1": 0.05,
+        "bonus2": 0.05
       },
       "build_costs": {
         "materials": [],
@@ -140,16 +136,15 @@
       "level": 5,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 8
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 6,
-        "bonus2": 6
+        "bonus1": 0.06,
+        "bonus2": 0.06
       },
       "build_costs": {
         "materials": [],
@@ -166,28 +161,27 @@
       "level": 6,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 8
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 7,
-        "bonus2": 7
+        "bonus1": 0.07,
+        "bonus2": 0.07
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 5950
-          },
-          {
             "type": "tritanium",
             "value": 50
+          },
+          {
+            "type": "parsteel",
+            "value": 5950
           }
         ]
       },
@@ -196,28 +190,27 @@
       "level": 7,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 8
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 8,
-        "bonus2": 8
+        "bonus1": 0.08,
+        "bonus2": 0.08
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 7950
-          },
-          {
             "type": "tritanium",
             "value": 100
+          },
+          {
+            "type": "parsteel",
+            "value": 7950
           }
         ]
       },
@@ -226,16 +219,15 @@
       "level": 8,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 8
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 9,
-        "bonus2": 9
+        "bonus1": 0.09,
+        "bonus2": 0.09
       },
       "build_costs": {
         "materials": [],
@@ -256,16 +248,15 @@
       "level": 9,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 9
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 10,
-        "bonus2": 10
+        "bonus1": 0.1,
+        "bonus2": 0.1
       },
       "build_costs": {
         "materials": [],
@@ -286,16 +277,15 @@
       "level": 10,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 10
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 11,
-        "bonus2": 11
+        "bonus1": 0.11,
+        "bonus2": 0.11
       },
       "build_costs": {
         "materials": [],
@@ -316,16 +306,15 @@
       "level": 11,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 11
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 12,
-        "bonus2": 12
+        "bonus1": 0.12,
+        "bonus2": 0.12
       },
       "build_costs": {
         "materials": [],
@@ -346,16 +335,15 @@
       "level": 12,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 12
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 13,
-        "bonus2": 13
+        "bonus1": 0.13,
+        "bonus2": 0.13
       },
       "build_costs": {
         "materials": [],
@@ -376,16 +364,15 @@
       "level": 13,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 13
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 14,
-        "bonus2": 14
+        "bonus1": 0.14,
+        "bonus2": 0.14
       },
       "build_costs": {
         "materials": [],
@@ -406,16 +393,15 @@
       "level": 14,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 14
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 15,
-        "bonus2": 15
+        "bonus1": 0.15,
+        "bonus2": 0.15
       },
       "build_costs": {
         "materials": [
@@ -443,16 +429,15 @@
       "level": 15,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 15
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 16,
-        "bonus2": 16
+        "bonus1": 0.16,
+        "bonus2": 0.16
       },
       "build_costs": {
         "materials": [
@@ -466,12 +451,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 80850
-          },
-          {
             "type": "tritanium",
             "value": 1350
+          },
+          {
+            "type": "parsteel",
+            "value": 80850
           }
         ]
       },
@@ -480,16 +465,15 @@
       "level": 16,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 16
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 17,
-        "bonus2": 17
+        "bonus1": 0.17,
+        "bonus2": 0.17
       },
       "build_costs": {
         "materials": [
@@ -503,12 +487,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 113250
-          },
-          {
             "type": "tritanium",
             "value": 1850
+          },
+          {
+            "type": "parsteel",
+            "value": 113250
           }
         ]
       },
@@ -517,16 +501,15 @@
       "level": 17,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 17
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 18,
-        "bonus2": 18
+        "bonus1": 0.18,
+        "bonus2": 0.18
       },
       "build_costs": {
         "materials": [
@@ -540,12 +523,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 161800
-          },
-          {
             "type": "tritanium",
             "value": 2650
+          },
+          {
+            "type": "parsteel",
+            "value": 161800
           }
         ]
       },
@@ -554,41 +537,40 @@
       "level": 18,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 18
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 19,
-        "bonus2": 19
+        "bonus1": 0.19,
+        "bonus2": 0.19
       },
       "build_costs": {
         "materials": [
           {
             "type": "ore",
             "grade": 2,
-            "rarity": "common",
-            "value": 840
+            "rarity": "uncommon",
+            "value": 20
           },
           {
             "type": "ore",
             "grade": 2,
-            "rarity": "uncommon",
-            "value": 20
+            "rarity": "common",
+            "value": 840
           }
         ],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 242650
-          },
-          {
             "type": "tritanium",
             "value": 4000
+          },
+          {
+            "type": "parsteel",
+            "value": 242650
           }
         ]
       },
@@ -597,16 +579,15 @@
       "level": 19,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 19
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 20,
-        "bonus2": 20
+        "bonus1": 0.2,
+        "bonus2": 0.2
       },
       "build_costs": {
         "materials": [
@@ -626,12 +607,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 343750
-          },
-          {
             "type": "tritanium",
             "value": 5600
+          },
+          {
+            "type": "parsteel",
+            "value": 343750
           }
         ]
       },
@@ -640,30 +621,29 @@
       "level": 20,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 20
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 23,
-        "bonus2": 21
+        "bonus1": 0.23,
+        "bonus2": 0.21
       },
       "build_costs": {
         "materials": [
           {
             "type": "ore",
             "grade": 2,
-            "rarity": "common",
-            "value": 1230
+            "rarity": "uncommon",
+            "value": 45
           },
           {
             "type": "ore",
             "grade": 2,
-            "rarity": "uncommon",
-            "value": 45
+            "rarity": "common",
+            "value": 1230
           }
         ],
         "others": [],
@@ -683,30 +663,29 @@
       "level": 21,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 21
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 26,
-        "bonus2": 22
+        "bonus1": 0.26,
+        "bonus2": 0.22
       },
       "build_costs": {
         "materials": [
           {
             "type": "ore",
             "grade": 2,
-            "rarity": "common",
-            "value": 1455
+            "rarity": "uncommon",
+            "value": 55
           },
           {
             "type": "ore",
             "grade": 2,
-            "rarity": "uncommon",
-            "value": 55
+            "rarity": "common",
+            "value": 1455
           }
         ],
         "others": [],
@@ -726,16 +705,15 @@
       "level": 22,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 22
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 29,
-        "bonus2": 23
+        "bonus1": 0.29,
+        "bonus2": 0.23
       },
       "build_costs": {
         "materials": [
@@ -763,16 +741,15 @@
       "level": 23,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 23
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 32,
-        "bonus2": 24
+        "bonus1": 0.32,
+        "bonus2": 0.24
       },
       "build_costs": {
         "materials": [
@@ -800,30 +777,29 @@
       "level": 24,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 24
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 35,
-        "bonus2": 25
+        "bonus1": 0.35,
+        "bonus2": 0.25
       },
       "build_costs": {
         "materials": [
           {
             "type": "ore",
             "grade": 3,
-            "rarity": "common",
-            "value": 925
+            "rarity": "uncommon",
+            "value": 120
           },
           {
             "type": "ore",
             "grade": 3,
-            "rarity": "uncommon",
-            "value": 120
+            "rarity": "common",
+            "value": 925
           }
         ],
         "others": [],
@@ -843,16 +819,15 @@
       "level": 25,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 25
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 38,
-        "bonus2": 26
+        "bonus1": 0.38,
+        "bonus2": 0.26
       },
       "build_costs": {
         "materials": [
@@ -886,16 +861,15 @@
       "level": 26,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 26
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 41,
-        "bonus2": 27
+        "bonus1": 0.41,
+        "bonus2": 0.27
       },
       "build_costs": {
         "materials": [
@@ -929,16 +903,15 @@
       "level": 27,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 27
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 44,
-        "bonus2": 28
+        "bonus1": 0.44,
+        "bonus2": 0.28
       },
       "build_costs": {
         "materials": [
@@ -972,41 +945,40 @@
       "level": 28,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 28
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 47,
-        "bonus2": 29
+        "bonus1": 0.47,
+        "bonus2": 0.29
       },
       "build_costs": {
         "materials": [
           {
             "type": "ore",
             "grade": 3,
-            "rarity": "common",
-            "value": 2000
+            "rarity": "uncommon",
+            "value": 400
           },
           {
             "type": "ore",
             "grade": 3,
-            "rarity": "uncommon",
-            "value": 400
+            "rarity": "common",
+            "value": 2000
           }
         ],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 21555000
-          },
-          {
             "type": "tritanium",
             "value": 352200
+          },
+          {
+            "type": "parsteel",
+            "value": 21555000
           }
         ]
       },
@@ -1015,16 +987,15 @@
       "level": 29,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 29
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 50,
-        "bonus2": 34
+        "bonus1": 0.5,
+        "bonus2": 0.34
       },
       "build_costs": {
         "materials": [
@@ -1058,41 +1029,40 @@
       "level": 30,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 30
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 55,
-        "bonus2": 38
+        "bonus1": 0.55,
+        "bonus2": 0.38
       },
       "build_costs": {
         "materials": [
           {
             "type": "ore",
             "grade": 3,
-            "rarity": "common",
-            "value": 3250
+            "rarity": "uncommon",
+            "value": 560
           },
           {
             "type": "ore",
             "grade": 3,
-            "rarity": "uncommon",
-            "value": 560
+            "rarity": "common",
+            "value": 3250
           }
         ],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 49863700
-          },
-          {
             "type": "tritanium",
             "value": 814750
+          },
+          {
+            "type": "parsteel",
+            "value": 49863700
           }
         ]
       },
@@ -1101,16 +1071,15 @@
       "level": 31,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 31
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 60,
-        "bonus2": 42
+        "bonus1": 0.6,
+        "bonus2": 0.42
       },
       "build_costs": {
         "materials": [
@@ -1144,41 +1113,40 @@
       "level": 32,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 32
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 65,
-        "bonus2": 46
+        "bonus1": 0.65,
+        "bonus2": 0.46
       },
       "build_costs": {
         "materials": [
           {
             "type": "ore",
             "grade": 3,
-            "rarity": "common",
-            "value": 3750
+            "rarity": "uncommon",
+            "value": 670
           },
           {
             "type": "ore",
             "grade": 3,
-            "rarity": "uncommon",
-            "value": 670
+            "rarity": "common",
+            "value": 3750
           }
         ],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 111414850
-          },
-          {
             "type": "tritanium",
             "value": 1820500
+          },
+          {
+            "type": "parsteel",
+            "value": 111414850
           }
         ]
       },
@@ -1187,41 +1155,40 @@
       "level": 33,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 33
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 70,
-        "bonus2": 50
+        "bonus1": 0.7,
+        "bonus2": 0.5
       },
       "build_costs": {
         "materials": [
           {
             "type": "ore",
             "grade": 3,
-            "rarity": "common",
-            "value": 4750
+            "rarity": "uncommon",
+            "value": 785
           },
           {
             "type": "ore",
             "grade": 3,
-            "rarity": "uncommon",
-            "value": 785
+            "rarity": "common",
+            "value": 4750
           }
         ],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 175918200
-          },
-          {
             "type": "tritanium",
             "value": 2874500
+          },
+          {
+            "type": "parsteel",
+            "value": 175918200
           }
         ]
       },
@@ -1230,16 +1197,15 @@
       "level": 34,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 34
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 75,
-        "bonus2": 54
+        "bonus1": 0.75,
+        "bonus2": 0.54
       },
       "build_costs": {
         "materials": [
@@ -1259,12 +1225,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 272248550
-          },
-          {
             "type": "tritanium",
             "value": 4448550
+          },
+          {
+            "type": "parsteel",
+            "value": 272248550
           }
         ]
       },
@@ -1273,16 +1239,15 @@
       "level": 35,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 35
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 80,
-        "bonus2": 58
+        "bonus1": 0.8,
+        "bonus2": 0.58
       },
       "build_costs": {
         "materials": [
@@ -1302,12 +1267,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 383622950
-          },
-          {
             "type": "tritanium",
             "value": 6268350
+          },
+          {
+            "type": "parsteel",
+            "value": 383622950
           }
         ]
       },
@@ -1316,16 +1281,15 @@
       "level": 36,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 36
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 85,
-        "bonus2": 62
+        "bonus1": 0.85,
+        "bonus2": 0.62
       },
       "build_costs": {
         "materials": [
@@ -1345,12 +1309,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 589629200
-          },
-          {
             "type": "tritanium",
             "value": 9634450
+          },
+          {
+            "type": "parsteel",
+            "value": 589629200
           }
         ]
       },
@@ -1359,16 +1323,15 @@
       "level": 37,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 37
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 90,
-        "bonus2": 66
+        "bonus1": 0.9,
+        "bonus2": 0.66
       },
       "build_costs": {
         "materials": [
@@ -1388,12 +1351,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 917201000
-          },
-          {
             "type": "tritanium",
             "value": 14986950
+          },
+          {
+            "type": "parsteel",
+            "value": 917201000
           }
         ]
       },
@@ -1402,16 +1365,15 @@
       "level": 38,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 38
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 95,
-        "bonus2": 70
+        "bonus1": 0.95,
+        "bonus2": 0.7
       },
       "build_costs": {
         "materials": [
@@ -1445,16 +1407,15 @@
       "level": 39,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 39
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 100,
-        "bonus2": 77
+        "bonus1": 1.0,
+        "bonus2": 0.77
       },
       "build_costs": {
         "materials": [
@@ -1482,16 +1443,15 @@
       "level": 40,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 40
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 105,
-        "bonus2": 84
+        "bonus1": 1.05,
+        "bonus2": 0.84
       },
       "build_costs": {
         "materials": [
@@ -1511,12 +1471,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 3982496500
-          },
-          {
             "type": "tritanium",
             "value": 32536750
+          },
+          {
+            "type": "parsteel",
+            "value": 3982496500
           }
         ]
       },
@@ -1525,16 +1485,15 @@
       "level": 41,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 41
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 110,
-        "bonus2": 91
+        "bonus1": 1.1,
+        "bonus2": 0.91
       },
       "build_costs": {
         "materials": [
@@ -1568,30 +1527,29 @@
       "level": 42,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 42
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 115,
-        "bonus2": 98
+        "bonus1": 1.15,
+        "bonus2": 0.98
       },
       "build_costs": {
         "materials": [
           {
             "type": "ore",
             "grade": 4,
-            "rarity": "uncommon",
-            "value": 12145
+            "rarity": "rare",
+            "value": 2785
           },
           {
             "type": "ore",
             "grade": 4,
-            "rarity": "rare",
-            "value": 2785
+            "rarity": "uncommon",
+            "value": 12145
           }
         ],
         "others": [],
@@ -1611,41 +1569,40 @@
       "level": 43,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 43
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 120,
-        "bonus2": 105
+        "bonus1": 1.2,
+        "bonus2": 1.05
       },
       "build_costs": {
         "materials": [
           {
             "type": "ore",
             "grade": 4,
-            "rarity": "uncommon",
-            "value": 13160
+            "rarity": "rare",
+            "value": 3035
           },
           {
             "type": "ore",
             "grade": 4,
-            "rarity": "rare",
-            "value": 3035
+            "rarity": "uncommon",
+            "value": 13160
           }
         ],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 12711573250
-          },
-          {
             "type": "tritanium",
             "value": 103852700
+          },
+          {
+            "type": "parsteel",
+            "value": 12711573250
           }
         ]
       },
@@ -1654,16 +1611,15 @@
       "level": 44,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 44
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 125,
-        "bonus2": 112
+        "bonus1": 1.25,
+        "bonus2": 1.12
       },
       "build_costs": {
         "materials": [
@@ -1697,16 +1653,15 @@
       "level": 45,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 45
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 130,
-        "bonus2": 119
+        "bonus1": 1.3,
+        "bonus2": 1.19
       },
       "build_costs": {
         "materials": [
@@ -1726,12 +1681,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 24832718200
-          },
-          {
             "type": "tritanium",
             "value": 202881700
+          },
+          {
+            "type": "parsteel",
+            "value": 24832718200
           }
         ]
       },
@@ -1740,16 +1695,15 @@
       "level": 46,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 46
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 135,
-        "bonus2": 126
+        "bonus1": 1.35,
+        "bonus2": 1.26
       },
       "build_costs": {
         "materials": [
@@ -1783,16 +1737,15 @@
       "level": 47,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 47
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 140,
-        "bonus2": 133
+        "bonus1": 1.4,
+        "bonus2": 1.33
       },
       "build_costs": {
         "materials": [
@@ -1812,12 +1765,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 58348204950
-          },
-          {
             "type": "tritanium",
             "value": 476701000
+          },
+          {
+            "type": "parsteel",
+            "value": 58348204950
           }
         ]
       },
@@ -1826,30 +1779,29 @@
       "level": 48,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 48
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 145,
-        "bonus2": 140
+        "bonus1": 1.45,
+        "bonus2": 1.4
       },
       "build_costs": {
         "materials": [
           {
             "type": "ore",
             "grade": 4,
-            "rarity": "uncommon",
-            "value": 19230
+            "rarity": "rare",
+            "value": 5565
           },
           {
             "type": "ore",
             "grade": 4,
-            "rarity": "rare",
-            "value": 5565
+            "rarity": "uncommon",
+            "value": 19230
           }
         ],
         "others": [],
@@ -1869,41 +1821,40 @@
       "level": 49,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 49
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 150,
-        "bonus2": 150
+        "bonus1": 1.5,
+        "bonus2": 1.5
       },
       "build_costs": {
         "materials": [
           {
             "type": "ore",
             "grade": 4,
-            "rarity": "uncommon",
-            "value": 22265
+            "rarity": "rare",
+            "value": 6075
           },
           {
             "type": "ore",
             "grade": 4,
-            "rarity": "rare",
-            "value": 6075
+            "rarity": "uncommon",
+            "value": 22265
           }
         ],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 170182264450
-          },
-          {
             "type": "tritanium",
             "value": 1390378000
+          },
+          {
+            "type": "parsteel",
+            "value": 170182264450
           }
         ]
       },
@@ -1912,11 +1863,214 @@
       "level": 50,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 50
         }
-      ],
-      "rewards": []
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 1.55,
+        "bonus2": 1.58
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "ore",
+            "grade": 5,
+            "rarity": "uncommon",
+            "value": 5400
+          },
+          {
+            "type": "ore",
+            "grade": 5,
+            "rarity": "common",
+            "value": 11400
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 3900000000
+          },
+          {
+            "type": "parsteel",
+            "value": 747864000000
+          }
+        ]
+      },
+      "build_time": 149065920,
+      "increased_power": 3500,
+      "level": 51,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 51
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 1.6,
+        "bonus2": 1.66
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "ore",
+            "grade": 5,
+            "rarity": "common",
+            "value": 19800
+          },
+          {
+            "type": "ore",
+            "grade": 5,
+            "rarity": "uncommon",
+            "value": 12000
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 1352520000000
+          },
+          {
+            "type": "tritanium",
+            "value": 6630000000
+          }
+        ]
+      },
+      "build_time": 158009760,
+      "increased_power": 3500,
+      "level": 52,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 52
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 1.65,
+        "bonus2": 1.74
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "ore",
+            "grade": 5,
+            "rarity": "uncommon",
+            "value": 33900
+          },
+          {
+            "type": "ore",
+            "grade": 5,
+            "rarity": "common",
+            "value": 38000
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 11600000000
+          },
+          {
+            "type": "parsteel",
+            "value": 2271744000000
+          }
+        ]
+      },
+      "build_time": 167490720,
+      "increased_power": 4000,
+      "level": 53,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 53
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 1.7,
+        "bonus2": 1.82
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "ore",
+            "grade": 5,
+            "rarity": "common",
+            "value": 67500
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 17400000000
+          },
+          {
+            "type": "parsteel",
+            "value": 3407616000000
+          }
+        ]
+      },
+      "build_time": 177540480,
+      "increased_power": 4000,
+      "level": 54,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 54
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 1.75,
+        "bonus2": 1.9
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "ore",
+            "grade": 5,
+            "rarity": "common",
+            "value": 67600
+          },
+          {
+            "type": "ore",
+            "grade": 5,
+            "rarity": "rare",
+            "value": 8500
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 27300000000
+          },
+          {
+            "type": "parsteel",
+            "value": 5791968000000
+          }
+        ]
+      },
+      "build_time": 188192160,
+      "increased_power": 4000,
+      "level": 55,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 55
+        }
+      ]
     }
   ]
 }

--- a/buildings/tritanium_generator_a.json
+++ b/buildings/tritanium_generator_a.json
@@ -2,11 +2,11 @@
   "description": "Produces Tritanium, an alloy many times harder than diamond, used to costruct mighty ships. Upgrading Tritanium Generators increases the amount of Tritanium that is produced.",
   "bonuses": {
     "bonus1": {
-      "name": "Tritanium Production",
+      "name": "tritanium production",
       "percentage": false
     },
     "bonus2": {
-      "name": "Tritanium Storage",
+      "name": "tritanium storage",
       "percentage": false
     }
   },
@@ -14,8 +14,8 @@
   "levels": [
     {
       "bonuses": {
-        "bonus1": 15,
-        "bonus2": 8
+        "bonus1": 15.0,
+        "bonus2": 8.0
       },
       "build_costs": {
         "materials": [],
@@ -32,16 +32,15 @@
       "level": 1,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 6
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 30,
-        "bonus2": 30
+        "bonus1": 30.0,
+        "bonus2": 30.0
       },
       "build_costs": {
         "materials": [],
@@ -58,20 +57,19 @@
       "level": 2,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 6
         },
         {
-          "name": "Tritanium Warehouse",
+          "name": "tritanium warehouse",
           "level": 1
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 45,
-        "bonus2": 68
+        "bonus1": 45.0,
+        "bonus2": 68.0
       },
       "build_costs": {
         "materials": [],
@@ -88,20 +86,19 @@
       "level": 3,
       "requirements": [
         {
-          "name": "Tritanium Warehouse",
-          "level": 1
+          "name": "operations",
+          "level": 6
         },
         {
-          "name": "Operations",
-          "level": 6
+          "name": "tritanium warehouse",
+          "level": 1
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 60,
-        "bonus2": 150
+        "bonus1": 60.0,
+        "bonus2": 150.0
       },
       "build_costs": {
         "materials": [],
@@ -118,16 +115,15 @@
       "level": 4,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 6
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 75,
-        "bonus2": 225
+        "bonus1": 75.0,
+        "bonus2": 225.0
       },
       "build_costs": {
         "materials": [],
@@ -144,16 +140,15 @@
       "level": 5,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 6
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 91,
-        "bonus2": 320
+        "bonus1": 91.0,
+        "bonus2": 320.0
       },
       "build_costs": {
         "materials": [],
@@ -170,16 +165,15 @@
       "level": 6,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 6
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 105,
-        "bonus2": 420
+        "bonus1": 105.0,
+        "bonus2": 420.0
       },
       "build_costs": {
         "materials": [],
@@ -196,16 +190,15 @@
       "level": 7,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 7
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 120,
-        "bonus2": 600
+        "bonus1": 120.0,
+        "bonus2": 600.0
       },
       "build_costs": {
         "materials": [],
@@ -222,16 +215,15 @@
       "level": 8,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 8
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 135,
-        "bonus2": 740
+        "bonus1": 135.0,
+        "bonus2": 740.0
       },
       "build_costs": {
         "materials": [],
@@ -248,16 +240,15 @@
       "level": 9,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 9
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 180,
-        "bonus2": 1080
+        "bonus1": 180.0,
+        "bonus2": 1080.0
       },
       "build_costs": {
         "materials": [],
@@ -274,28 +265,27 @@
       "level": 10,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 10
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 200,
-        "bonus2": 1400
+        "bonus1": 200.0,
+        "bonus2": 1400.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 6800
-          },
-          {
             "type": "dilithium",
             "value": 8
+          },
+          {
+            "type": "parsteel",
+            "value": 6800
           }
         ]
       },
@@ -304,28 +294,27 @@
       "level": 11,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 11
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 220,
-        "bonus2": 1650
+        "bonus1": 220.0,
+        "bonus2": 1650.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 9350
-          },
-          {
             "type": "dilithium",
             "value": 22
+          },
+          {
+            "type": "parsteel",
+            "value": 9350
           }
         ]
       },
@@ -334,28 +323,27 @@
       "level": 12,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 12
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 235,
-        "bonus2": 2000
+        "bonus1": 235.0,
+        "bonus2": 2000.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 13600
-          },
-          {
             "type": "dilithium",
             "value": 48
+          },
+          {
+            "type": "parsteel",
+            "value": 13600
           }
         ]
       },
@@ -364,16 +352,15 @@
       "level": 13,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 13
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 255,
-        "bonus2": 2300
+        "bonus1": 255.0,
+        "bonus2": 2300.0
       },
       "build_costs": {
         "materials": [],
@@ -394,28 +381,27 @@
       "level": 14,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 14
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 275,
-        "bonus2": 2750
+        "bonus1": 275.0,
+        "bonus2": 2750.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 25500
-          },
-          {
             "type": "dilithium",
             "value": 150
+          },
+          {
+            "type": "parsteel",
+            "value": 25500
           }
         ]
       },
@@ -424,16 +410,15 @@
       "level": 15,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 15
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 290,
-        "bonus2": 3200
+        "bonus1": 290.0,
+        "bonus2": 3200.0
       },
       "build_costs": {
         "materials": [],
@@ -454,16 +439,15 @@
       "level": 16,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 16
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 310,
-        "bonus2": 3575
+        "bonus1": 310.0,
+        "bonus2": 3575.0
       },
       "build_costs": {
         "materials": [],
@@ -484,16 +468,15 @@
       "level": 17,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 17
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 330,
-        "bonus2": 4125
+        "bonus1": 330.0,
+        "bonus2": 4125.0
       },
       "build_costs": {
         "materials": [],
@@ -514,16 +497,15 @@
       "level": 18,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 18
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 345,
-        "bonus2": 4475
+        "bonus1": 345.0,
+        "bonus2": 4475.0
       },
       "build_costs": {
         "materials": [],
@@ -544,16 +526,15 @@
       "level": 19,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 19
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 425,
-        "bonus2": 6000
+        "bonus1": 425.0,
+        "bonus2": 6000.0
       },
       "build_costs": {
         "materials": [],
@@ -574,16 +555,15 @@
       "level": 20,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 20
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 450,
-        "bonus2": 6300
+        "bonus1": 450.0,
+        "bonus2": 6300.0
       },
       "build_costs": {
         "materials": [],
@@ -604,16 +584,15 @@
       "level": 21,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 21
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 470,
-        "bonus2": 6600
+        "bonus1": 470.0,
+        "bonus2": 6600.0
       },
       "build_costs": {
         "materials": [],
@@ -634,28 +613,27 @@
       "level": 22,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 22
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 490,
-        "bonus2": 6900
+        "bonus1": 490.0,
+        "bonus2": 6900.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 622710
-          },
-          {
             "type": "dilithium",
             "value": 3663
+          },
+          {
+            "type": "parsteel",
+            "value": 622710
           }
         ]
       },
@@ -664,28 +642,27 @@
       "level": 23,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 23
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 510,
-        "bonus2": 7100
+        "bonus1": 510.0,
+        "bonus2": 7100.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 981240
-          },
-          {
             "type": "dilithium",
             "value": 5772
+          },
+          {
+            "type": "parsteel",
+            "value": 981240
           }
         ]
       },
@@ -694,28 +671,27 @@
       "level": 24,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 24
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 610,
-        "bonus2": 8500
+        "bonus1": 610.0,
+        "bonus2": 8500.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 1591200
-          },
-          {
             "type": "dilithium",
             "value": 9360
+          },
+          {
+            "type": "parsteel",
+            "value": 1591200
           }
         ]
       },
@@ -724,16 +700,15 @@
       "level": 25,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 25
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 640,
-        "bonus2": 9000
+        "bonus1": 640.0,
+        "bonus2": 9000.0
       },
       "build_costs": {
         "materials": [],
@@ -754,28 +729,27 @@
       "level": 26,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 26
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 660,
-        "bonus2": 9200
+        "bonus1": 660.0,
+        "bonus2": 9200.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 3794400
-          },
-          {
             "type": "dilithium",
             "value": 22320
+          },
+          {
+            "type": "parsteel",
+            "value": 3794400
           }
         ]
       },
@@ -784,28 +758,27 @@
       "level": 27,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 27
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 680,
-        "bonus2": 9500
+        "bonus1": 680.0,
+        "bonus2": 9500.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 5691600
-          },
-          {
             "type": "dilithium",
             "value": 33480
+          },
+          {
+            "type": "parsteel",
+            "value": 5691600
           }
         ]
       },
@@ -814,16 +787,15 @@
       "level": 28,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 28
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 710,
-        "bonus2": 9900
+        "bonus1": 710.0,
+        "bonus2": 9900.0
       },
       "build_costs": {
         "materials": [],
@@ -844,16 +816,15 @@
       "level": 29,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 29
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 820,
-        "bonus2": 11500
+        "bonus1": 820.0,
+        "bonus2": 11500.0
       },
       "build_costs": {
         "materials": [],
@@ -874,28 +845,27 @@
       "level": 30,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 30
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 850,
-        "bonus2": 11900
+        "bonus1": 850.0,
+        "bonus2": 11900.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 20961000
-          },
-          {
             "type": "dilithium",
             "value": 123300
+          },
+          {
+            "type": "parsteel",
+            "value": 20961000
           }
         ]
       },
@@ -904,16 +874,15 @@
       "level": 31,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 31
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 880,
-        "bonus2": 13284
+        "bonus1": 880.0,
+        "bonus2": 13284.0
       },
       "build_costs": {
         "materials": [],
@@ -934,16 +903,15 @@
       "level": 32,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 32
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 910,
-        "bonus2": 14732
+        "bonus1": 910.0,
+        "bonus2": 14732.0
       },
       "build_costs": {
         "materials": [],
@@ -964,28 +932,27 @@
       "level": 33,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 33
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 940,
-        "bonus2": 15312
+        "bonus1": 940.0,
+        "bonus2": 15312.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 73950000
-          },
-          {
             "type": "dilithium",
             "value": 435000
+          },
+          {
+            "type": "parsteel",
+            "value": 73950000
           }
         ]
       },
@@ -994,16 +961,15 @@
       "level": 34,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 34
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 1070,
-        "bonus2": 18600
+        "bonus1": 1070.0,
+        "bonus2": 18600.0
       },
       "build_costs": {
         "materials": [],
@@ -1024,28 +990,27 @@
       "level": 35,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 35
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 1100,
-        "bonus2": 20482
+        "bonus1": 1100.0,
+        "bonus2": 20482.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 161262000
-          },
-          {
             "type": "dilithium",
             "value": 948600
+          },
+          {
+            "type": "parsteel",
+            "value": 161262000
           }
         ]
       },
@@ -1054,16 +1019,15 @@
       "level": 36,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 36
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 1130,
-        "bonus2": 21014
+        "bonus1": 1130.0,
+        "bonus2": 21014.0
       },
       "build_costs": {
         "materials": [],
@@ -1084,28 +1048,27 @@
       "level": 37,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 37
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 1160,
-        "bonus2": 23004
+        "bonus1": 1160.0,
+        "bonus2": 23004.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 385560000
-          },
-          {
             "type": "dilithium",
             "value": 2268000
+          },
+          {
+            "type": "parsteel",
+            "value": 385560000
           }
         ]
       },
@@ -1114,28 +1077,27 @@
       "level": 38,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 38
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 1190,
-        "bonus2": 25551
+        "bonus1": 1190.0,
+        "bonus2": 25551.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 657900000
-          },
-          {
             "type": "dilithium",
             "value": 3870000
+          },
+          {
+            "type": "parsteel",
+            "value": 657900000
           }
         ]
       },
@@ -1144,16 +1106,15 @@
       "level": 39,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 39
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 1350,
-        "bonus2": 28917
+        "bonus1": 1350.0,
+        "bonus2": 28917.0
       },
       "build_costs": {
         "materials": [
@@ -1181,16 +1142,15 @@
       "level": 40,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 40
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 1380,
-        "bonus2": 31845
+        "bonus1": 1380.0,
+        "bonus2": 31845.0
       },
       "build_costs": {
         "materials": [
@@ -1218,16 +1178,15 @@
       "level": 41,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 41
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 1425,
-        "bonus2": 36200
+        "bonus1": 1425.0,
+        "bonus2": 36200.0
       },
       "build_costs": {
         "materials": [
@@ -1241,12 +1200,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 4355400000
-          },
-          {
             "type": "dilithium",
             "value": 12810000
+          },
+          {
+            "type": "parsteel",
+            "value": 4355400000
           }
         ]
       },
@@ -1255,16 +1214,15 @@
       "level": 42,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 42
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 1450,
-        "bonus2": 36653
+        "bonus1": 1450.0,
+        "bonus2": 36653.0
       },
       "build_costs": {
         "materials": [
@@ -1278,12 +1236,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 6222000000
-          },
-          {
             "type": "dilithium",
             "value": 18300000
+          },
+          {
+            "type": "parsteel",
+            "value": 6222000000
           }
         ]
       },
@@ -1292,16 +1250,15 @@
       "level": 43,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 43
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 1475,
-        "bonus2": 41500
+        "bonus1": 1475.0,
+        "bonus2": 41500.0
       },
       "build_costs": {
         "materials": [
@@ -1315,12 +1272,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 9333000000
-          },
-          {
             "type": "dilithium",
             "value": 27450000
+          },
+          {
+            "type": "parsteel",
+            "value": 9333000000
           }
         ]
       },
@@ -1329,16 +1286,15 @@
       "level": 44,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 44
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 1725,
-        "bonus2": 54563
+        "bonus1": 1725.0,
+        "bonus2": 54563.0
       },
       "build_costs": {
         "materials": [
@@ -1352,12 +1308,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 13260000000
-          },
-          {
             "type": "dilithium",
             "value": 39000000
+          },
+          {
+            "type": "parsteel",
+            "value": 13260000000
           }
         ]
       },
@@ -1366,41 +1322,40 @@
       "level": 45,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 45
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 1750,
-        "bonus2": 55125
+        "bonus1": 1750.0,
+        "bonus2": 55125.0
       },
       "build_costs": {
         "materials": [
           {
             "type": "ore",
             "grade": 4,
-            "rarity": "common",
-            "value": 20000
+            "rarity": "uncommon",
+            "value": 1000
           },
           {
             "type": "ore",
             "grade": 4,
-            "rarity": "uncommon",
-            "value": 1000
+            "rarity": "common",
+            "value": 20000
           }
         ],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 18232500000
-          },
-          {
             "type": "dilithium",
             "value": 53625000
+          },
+          {
+            "type": "parsteel",
+            "value": 18232500000
           }
         ]
       },
@@ -1409,16 +1364,15 @@
       "level": 46,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 46
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 1800,
-        "bonus2": 56813
+        "bonus1": 1800.0,
+        "bonus2": 56813.0
       },
       "build_costs": {
         "materials": [
@@ -1452,41 +1406,40 @@
       "level": 47,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 47
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 1850,
-        "bonus2": 58500
+        "bonus1": 1850.0,
+        "bonus2": 58500.0
       },
       "build_costs": {
         "materials": [
           {
             "type": "ore",
             "grade": 4,
-            "rarity": "common",
-            "value": 15000
+            "rarity": "uncommon",
+            "value": 6000
           },
           {
             "type": "ore",
             "grade": 4,
-            "rarity": "uncommon",
-            "value": 6000
+            "rarity": "common",
+            "value": 15000
           }
         ],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 42840000000
-          },
-          {
             "type": "dilithium",
             "value": 126000000
+          },
+          {
+            "type": "parsteel",
+            "value": 42840000000
           }
         ]
       },
@@ -1495,41 +1448,40 @@
       "level": 48,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 48
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 1875,
-        "bonus2": 59063
+        "bonus1": 1875.0,
+        "bonus2": 59063.0
       },
       "build_costs": {
         "materials": [
           {
             "type": "ore",
             "grade": 4,
-            "rarity": "common",
-            "value": 20000
+            "rarity": "uncommon",
+            "value": 13250
           },
           {
             "type": "ore",
             "grade": 4,
-            "rarity": "uncommon",
-            "value": 13250
+            "rarity": "common",
+            "value": 20000
           }
         ],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 71400000000
-          },
-          {
             "type": "dilithium",
             "value": 210000000
+          },
+          {
+            "type": "parsteel",
+            "value": 71400000000
           }
         ]
       },
@@ -1538,28 +1490,27 @@
       "level": 49,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 49
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 2300,
-        "bonus2": 72563
+        "bonus1": 2300.0,
+        "bonus2": 72563.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 124950000000
-          },
-          {
             "type": "dilithium",
             "value": 367500000
+          },
+          {
+            "type": "parsteel",
+            "value": 124950000000
           }
         ]
       },
@@ -1568,11 +1519,190 @@
       "level": 50,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 50
         }
-      ],
-      "rewards": []
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 2350.0,
+        "bonus2": 74250.0
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "ore",
+            "grade": 5,
+            "rarity": "common",
+            "value": 8800
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 623220000000
+          },
+          {
+            "type": "dilithium",
+            "value": 780000000
+          }
+        ]
+      },
+      "build_time": 29813760,
+      "increased_power": 2000,
+      "level": 51,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 51
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 2400.0,
+        "bonus2": 75375.0
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "ore",
+            "grade": 5,
+            "rarity": "common",
+            "value": 21100
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 1127100000000
+          },
+          {
+            "type": "dilithium",
+            "value": 1326000000
+          }
+        ]
+      },
+      "build_time": 31602240,
+      "increased_power": 1500,
+      "level": 52,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 52
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 2425.0,
+        "bonus2": 76500.0
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "ore",
+            "grade": 5,
+            "rarity": "common",
+            "value": 42200
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "dilithium",
+            "value": 2320000000
+          },
+          {
+            "type": "parsteel",
+            "value": 1893120000000
+          }
+        ]
+      },
+      "build_time": 33498720,
+      "increased_power": 2000,
+      "level": 53,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 53
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 2475.0,
+        "bonus2": 78188.0
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "ore",
+            "grade": 5,
+            "rarity": "common",
+            "value": 43100
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "dilithium",
+            "value": 3480000000
+          },
+          {
+            "type": "parsteel",
+            "value": 2839680000000
+          }
+        ]
+      },
+      "build_time": 35507520,
+      "increased_power": 2000,
+      "level": 54,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 54
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 2950.0,
+        "bonus2": 92813.0
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "ore",
+            "grade": 5,
+            "rarity": "common",
+            "value": 74800
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 4826640000000
+          },
+          {
+            "type": "dilithium",
+            "value": 5460000000
+          }
+        ]
+      },
+      "build_time": 37638720,
+      "increased_power": 2000,
+      "level": 55,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 55
+        }
+      ]
     }
   ]
 }

--- a/buildings/tritanium_generator_b.json
+++ b/buildings/tritanium_generator_b.json
@@ -2,11 +2,11 @@
   "description": "Produces Tritanium, an alloy many times harder than diamond, used to costruct mighty ships. Upgrading Tritanium Generators increases the amount of Tritanium that is produced.",
   "bonuses": {
     "bonus1": {
-      "name": "Tritanium Storage",
+      "name": "tritanium production",
       "percentage": false
     },
     "bonus2": {
-      "name": "Tritanium Production",
+      "name": "tritanium storage",
       "percentage": false
     }
   },
@@ -14,8 +14,8 @@
   "levels": [
     {
       "bonuses": {
-        "bonus1": 8,
-        "bonus2": 15
+        "bonus1": 15.0,
+        "bonus2": 8.0
       },
       "build_costs": {
         "materials": [],
@@ -32,19 +32,19 @@
       "level": 1,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 7
         },
         {
-          "name": "Tritanium Generator A",
+          "name": "tritanium generator a",
           "level": 1
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 30,
-        "bonus2": 30
+        "bonus1": 30.0,
+        "bonus2": 30.0
       },
       "build_costs": {
         "materials": [],
@@ -61,19 +61,19 @@
       "level": 2,
       "requirements": [
         {
-          "name": "Tritanium Generator A",
-          "level": 2
+          "name": "operations",
+          "level": 7
         },
         {
-          "name": "Operations",
-          "level": 7
+          "name": "tritanium generator a",
+          "level": 2
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 68,
-        "bonus2": 45
+        "bonus1": 45.0,
+        "bonus2": 68.0
       },
       "build_costs": {
         "materials": [],
@@ -90,19 +90,19 @@
       "level": 3,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 7
         },
         {
-          "name": "Tritanium Generator A",
+          "name": "tritanium generator a",
           "level": 3
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 150,
-        "bonus2": 60
+        "bonus1": 60.0,
+        "bonus2": 150.0
       },
       "build_costs": {
         "materials": [],
@@ -119,19 +119,19 @@
       "level": 4,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 7
         },
         {
-          "name": "Tritanium Generator A",
+          "name": "tritanium generator a",
           "level": 4
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 225,
-        "bonus2": 75
+        "bonus1": 75.0,
+        "bonus2": 225.0
       },
       "build_costs": {
         "materials": [],
@@ -148,19 +148,19 @@
       "level": 5,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 7
         },
         {
-          "name": "Tritanium Generator A",
+          "name": "tritanium generator a",
           "level": 5
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 320,
-        "bonus2": 91
+        "bonus1": 91.0,
+        "bonus2": 320.0
       },
       "build_costs": {
         "materials": [],
@@ -177,19 +177,19 @@
       "level": 6,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 7
         },
         {
-          "name": "Tritanium Generator A",
+          "name": "tritanium generator a",
           "level": 6
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 420,
-        "bonus2": 105
+        "bonus1": 105.0,
+        "bonus2": 420.0
       },
       "build_costs": {
         "materials": [],
@@ -206,20 +206,19 @@
       "level": 7,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 7
         },
         {
-          "name": "Tritanium Generator A",
+          "name": "tritanium generator a",
           "level": 7
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 600,
-        "bonus2": 120
+        "bonus1": 120.0,
+        "bonus2": 600.0
       },
       "build_costs": {
         "materials": [],
@@ -236,20 +235,19 @@
       "level": 8,
       "requirements": [
         {
-          "name": "Tritanium Generator A",
+          "name": "operations",
           "level": 8
         },
         {
-          "name": "Operations",
+          "name": "tritanium generator a",
           "level": 8
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 740,
-        "bonus2": 135
+        "bonus1": 135.0,
+        "bonus2": 740.0
       },
       "build_costs": {
         "materials": [],
@@ -266,20 +264,19 @@
       "level": 9,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 9
         },
         {
-          "name": "Tritanium Generator A",
+          "name": "tritanium generator a",
           "level": 9
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 1080,
-        "bonus2": 180
+        "bonus1": 180.0,
+        "bonus2": 1080.0
       },
       "build_costs": {
         "materials": [],
@@ -296,20 +293,19 @@
       "level": 10,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 10
         },
         {
-          "name": "Tritanium Generator A",
+          "name": "tritanium generator a",
           "level": 10
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 1400,
-        "bonus2": 200
+        "bonus1": 200.0,
+        "bonus2": 1400.0
       },
       "build_costs": {
         "materials": [],
@@ -330,32 +326,31 @@
       "level": 11,
       "requirements": [
         {
-          "name": "Tritanium Generator A",
+          "name": "operations",
           "level": 11
         },
         {
-          "name": "Operations",
+          "name": "tritanium generator a",
           "level": 11
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 1650,
-        "bonus2": 220
+        "bonus1": 220.0,
+        "bonus2": 1650.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 9350
-          },
-          {
             "type": "dilithium",
             "value": 22
+          },
+          {
+            "type": "parsteel",
+            "value": 9350
           }
         ]
       },
@@ -364,20 +359,19 @@
       "level": 12,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 12
         },
         {
-          "name": "Tritanium Generator A",
+          "name": "tritanium generator a",
           "level": 12
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 2000,
-        "bonus2": 235
+        "bonus1": 235.0,
+        "bonus2": 2000.0
       },
       "build_costs": {
         "materials": [],
@@ -398,32 +392,31 @@
       "level": 13,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 13
         },
         {
-          "name": "Tritanium Generator A",
+          "name": "tritanium generator a",
           "level": 13
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 2300,
-        "bonus2": 255
+        "bonus1": 255.0,
+        "bonus2": 2300.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 18700
-          },
-          {
             "type": "dilithium",
             "value": 88
+          },
+          {
+            "type": "parsteel",
+            "value": 18700
           }
         ]
       },
@@ -432,32 +425,31 @@
       "level": 14,
       "requirements": [
         {
-          "name": "Tritanium Generator A",
+          "name": "operations",
           "level": 14
         },
         {
-          "name": "Operations",
+          "name": "tritanium generator a",
           "level": 14
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 2750,
-        "bonus2": 275
+        "bonus1": 275.0,
+        "bonus2": 2750.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 25500
-          },
-          {
             "type": "dilithium",
             "value": 150
+          },
+          {
+            "type": "parsteel",
+            "value": 25500
           }
         ]
       },
@@ -466,32 +458,31 @@
       "level": 15,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 15
         },
         {
-          "name": "Tritanium Generator A",
+          "name": "tritanium generator a",
           "level": 15
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 3200,
-        "bonus2": 290
+        "bonus1": 290.0,
+        "bonus2": 3200.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 34000
-          },
-          {
             "type": "dilithium",
             "value": 200
+          },
+          {
+            "type": "parsteel",
+            "value": 34000
           }
         ]
       },
@@ -500,20 +491,19 @@
       "level": 16,
       "requirements": [
         {
-          "name": "Tritanium Generator A",
+          "name": "operations",
           "level": 16
         },
         {
-          "name": "Operations",
+          "name": "tritanium generator a",
           "level": 16
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 3575,
-        "bonus2": 310
+        "bonus1": 310.0,
+        "bonus2": 3575.0
       },
       "build_costs": {
         "materials": [],
@@ -534,32 +524,31 @@
       "level": 17,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 17
         },
         {
-          "name": "Tritanium Generator A",
+          "name": "tritanium generator a",
           "level": 17
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 4125,
-        "bonus2": 330
+        "bonus1": 330.0,
+        "bonus2": 4125.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 68000
-          },
-          {
             "type": "dilithium",
             "value": 400
+          },
+          {
+            "type": "parsteel",
+            "value": 68000
           }
         ]
       },
@@ -568,20 +557,19 @@
       "level": 18,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 18
         },
         {
-          "name": "Tritanium Generator A",
+          "name": "tritanium generator a",
           "level": 18
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 4475,
-        "bonus2": 345
+        "bonus1": 345.0,
+        "bonus2": 4475.0
       },
       "build_costs": {
         "materials": [],
@@ -602,20 +590,19 @@
       "level": 19,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 19
         },
         {
-          "name": "Tritanium Generator A",
+          "name": "tritanium generator a",
           "level": 19
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 6000,
-        "bonus2": 425
+        "bonus1": 425.0,
+        "bonus2": 6000.0
       },
       "build_costs": {
         "materials": [],
@@ -636,20 +623,19 @@
       "level": 20,
       "requirements": [
         {
-          "name": "Tritanium Generator A",
+          "name": "operations",
           "level": 20
         },
         {
-          "name": "Operations",
+          "name": "tritanium generator a",
           "level": 20
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 6300,
-        "bonus2": 450
+        "bonus1": 450.0,
+        "bonus2": 6300.0
       },
       "build_costs": {
         "materials": [],
@@ -670,32 +656,31 @@
       "level": 21,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 21
         },
         {
-          "name": "Tritanium Generator A",
+          "name": "tritanium generator a",
           "level": 21
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 6600,
-        "bonus2": 470
+        "bonus1": 470.0,
+        "bonus2": 6600.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 378420
-          },
-          {
             "type": "dilithium",
             "value": 2226
+          },
+          {
+            "type": "parsteel",
+            "value": 378420
           }
         ]
       },
@@ -704,20 +689,19 @@
       "level": 22,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 22
         },
         {
-          "name": "Tritanium Generator A",
+          "name": "tritanium generator a",
           "level": 22
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 6900,
-        "bonus2": 490
+        "bonus1": 490.0,
+        "bonus2": 6900.0
       },
       "build_costs": {
         "materials": [],
@@ -738,20 +722,19 @@
       "level": 23,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 23
         },
         {
-          "name": "Tritanium Generator A",
+          "name": "tritanium generator a",
           "level": 23
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 7100,
-        "bonus2": 510
+        "bonus1": 510.0,
+        "bonus2": 7100.0
       },
       "build_costs": {
         "materials": [],
@@ -772,20 +755,19 @@
       "level": 24,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 24
         },
         {
-          "name": "Tritanium Generator A",
+          "name": "tritanium generator a",
           "level": 24
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 8500,
-        "bonus2": 610
+        "bonus1": 610.0,
+        "bonus2": 8500.0
       },
       "build_costs": {
         "materials": [],
@@ -806,20 +788,19 @@
       "level": 25,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 25
         },
         {
-          "name": "Tritanium Generator A",
+          "name": "tritanium generator a",
           "level": 25
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 9000,
-        "bonus2": 640
+        "bonus1": 640.0,
+        "bonus2": 9000.0
       },
       "build_costs": {
         "materials": [],
@@ -840,32 +821,31 @@
       "level": 26,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 26
         },
         {
-          "name": "Tritanium Generator A",
+          "name": "tritanium generator a",
           "level": 26
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 9200,
-        "bonus2": 660
+        "bonus1": 660.0,
+        "bonus2": 9200.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 3794400
-          },
-          {
             "type": "dilithium",
             "value": 22320
+          },
+          {
+            "type": "parsteel",
+            "value": 3794400
           }
         ]
       },
@@ -874,20 +854,19 @@
       "level": 27,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 27
         },
         {
-          "name": "Tritanium Generator A",
+          "name": "tritanium generator a",
           "level": 27
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 9500,
-        "bonus2": 680
+        "bonus1": 680.0,
+        "bonus2": 9500.0
       },
       "build_costs": {
         "materials": [],
@@ -908,32 +887,31 @@
       "level": 28,
       "requirements": [
         {
-          "name": "Tritanium Generator A",
+          "name": "operations",
           "level": 28
         },
         {
-          "name": "Operations",
+          "name": "tritanium generator a",
           "level": 28
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 9900,
-        "bonus2": 710
+        "bonus1": 710.0,
+        "bonus2": 9900.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 9061000
-          },
-          {
             "type": "dilithium",
             "value": 53300
+          },
+          {
+            "type": "parsteel",
+            "value": 9061000
           }
         ]
       },
@@ -942,32 +920,31 @@
       "level": 29,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 29
         },
         {
-          "name": "Tritanium Generator A",
+          "name": "tritanium generator a",
           "level": 29
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 11500,
-        "bonus2": 820
+        "bonus1": 820.0,
+        "bonus2": 11500.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 13260000
-          },
-          {
             "type": "dilithium",
             "value": 78000
+          },
+          {
+            "type": "parsteel",
+            "value": 13260000
           }
         ]
       },
@@ -976,32 +953,31 @@
       "level": 30,
       "requirements": [
         {
-          "name": "Tritanium Generator A",
+          "name": "operations",
           "level": 30
         },
         {
-          "name": "Operations",
+          "name": "tritanium generator a",
           "level": 30
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 11900,
-        "bonus2": 850
+        "bonus1": 850.0,
+        "bonus2": 11900.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 20961000
-          },
-          {
             "type": "dilithium",
             "value": 123300
+          },
+          {
+            "type": "parsteel",
+            "value": 20961000
           }
         ]
       },
@@ -1010,32 +986,31 @@
       "level": 31,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 31
         },
         {
-          "name": "Tritanium Generator A",
+          "name": "tritanium generator a",
           "level": 31
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 13284,
-        "bonus2": 880
+        "bonus1": 880.0,
+        "bonus2": 13284.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 30277000
-          },
-          {
             "type": "dilithium",
             "value": 178100
+          },
+          {
+            "type": "parsteel",
+            "value": 30277000
           }
         ]
       },
@@ -1044,20 +1019,19 @@
       "level": 32,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 32
         },
         {
-          "name": "Tritanium Generator A",
+          "name": "tritanium generator a",
           "level": 32
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 14732,
-        "bonus2": 910
+        "bonus1": 910.0,
+        "bonus2": 14732.0
       },
       "build_costs": {
         "materials": [],
@@ -1078,20 +1052,19 @@
       "level": 33,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 33
         },
         {
-          "name": "Tritanium Generator A",
+          "name": "tritanium generator a",
           "level": 33
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 15312,
-        "bonus2": 940
+        "bonus1": 940.0,
+        "bonus2": 15312.0
       },
       "build_costs": {
         "materials": [],
@@ -1112,20 +1085,19 @@
       "level": 34,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 34
         },
         {
-          "name": "Tritanium Generator A",
+          "name": "tritanium generator a",
           "level": 34
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 18600,
-        "bonus2": 1070
+        "bonus1": 1070.0,
+        "bonus2": 18600.0
       },
       "build_costs": {
         "materials": [],
@@ -1146,20 +1118,19 @@
       "level": 35,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 35
         },
         {
-          "name": "Tritanium Generator A",
+          "name": "tritanium generator a",
           "level": 35
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 20482,
-        "bonus2": 1100
+        "bonus1": 1100.0,
+        "bonus2": 20482.0
       },
       "build_costs": {
         "materials": [],
@@ -1180,20 +1151,19 @@
       "level": 36,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 36
         },
         {
-          "name": "Tritanium Generator A",
+          "name": "tritanium generator a",
           "level": 36
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 21014,
-        "bonus2": 1130
+        "bonus1": 1130.0,
+        "bonus2": 21014.0
       },
       "build_costs": {
         "materials": [],
@@ -1214,32 +1184,31 @@
       "level": 37,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 37
         },
         {
-          "name": "Tritanium Generator A",
+          "name": "tritanium generator a",
           "level": 37
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 23004,
-        "bonus2": 1160
+        "bonus1": 1160.0,
+        "bonus2": 23004.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 385560000
-          },
-          {
             "type": "dilithium",
             "value": 2268000
+          },
+          {
+            "type": "parsteel",
+            "value": 385560000
           }
         ]
       },
@@ -1248,20 +1217,19 @@
       "level": 38,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 38
         },
         {
-          "name": "Tritanium Generator A",
+          "name": "tritanium generator a",
           "level": 38
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 25551,
-        "bonus2": 1190
+        "bonus1": 1190.0,
+        "bonus2": 25551.0
       },
       "build_costs": {
         "materials": [],
@@ -1282,20 +1250,19 @@
       "level": 39,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 39
         },
         {
-          "name": "Tritanium Generator A",
+          "name": "tritanium generator a",
           "level": 39
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 28917,
-        "bonus2": 1350
+        "bonus1": 1350.0,
+        "bonus2": 28917.0
       },
       "build_costs": {
         "materials": [
@@ -1323,20 +1290,19 @@
       "level": 40,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 40
         },
         {
-          "name": "Tritanium Generator A",
+          "name": "tritanium generator a",
           "level": 40
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 31845,
-        "bonus2": 1380
+        "bonus1": 1380.0,
+        "bonus2": 31845.0
       },
       "build_costs": {
         "materials": [
@@ -1364,20 +1330,19 @@
       "level": 41,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 41
         },
         {
-          "name": "Tritanium Generator A",
+          "name": "tritanium generator a",
           "level": 41
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 36200,
-        "bonus2": 1425
+        "bonus1": 1425.0,
+        "bonus2": 36200.0
       },
       "build_costs": {
         "materials": [
@@ -1405,20 +1370,19 @@
       "level": 42,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 42
         },
         {
-          "name": "Tritanium Generator A",
+          "name": "tritanium generator a",
           "level": 42
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 36653,
-        "bonus2": 1450
+        "bonus1": 1450.0,
+        "bonus2": 36653.0
       },
       "build_costs": {
         "materials": [
@@ -1432,12 +1396,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 6222000000
-          },
-          {
             "type": "dilithium",
             "value": 18300000
+          },
+          {
+            "type": "parsteel",
+            "value": 6222000000
           }
         ]
       },
@@ -1446,20 +1410,19 @@
       "level": 43,
       "requirements": [
         {
-          "name": "Tritanium Generator A",
+          "name": "operations",
           "level": 43
         },
         {
-          "name": "Operations",
+          "name": "tritanium generator a",
           "level": 43
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 41500,
-        "bonus2": 1475
+        "bonus1": 1475.0,
+        "bonus2": 41500.0
       },
       "build_costs": {
         "materials": [
@@ -1487,20 +1450,19 @@
       "level": 44,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 44
         },
         {
-          "name": "Tritanium Generator A",
+          "name": "tritanium generator a",
           "level": 44
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 54563,
-        "bonus2": 1725
+        "bonus1": 1725.0,
+        "bonus2": 54563.0
       },
       "build_costs": {
         "materials": [
@@ -1528,34 +1490,33 @@
       "level": 45,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 45
         },
         {
-          "name": "Tritanium Generator A",
+          "name": "tritanium generator a",
           "level": 45
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 55125,
-        "bonus2": 1750
+        "bonus1": 1750.0,
+        "bonus2": 55125.0
       },
       "build_costs": {
         "materials": [
           {
             "type": "ore",
             "grade": 4,
-            "rarity": "common",
-            "value": 20000
+            "rarity": "uncommon",
+            "value": 1000
           },
           {
             "type": "ore",
             "grade": 4,
-            "rarity": "uncommon",
-            "value": 1000
+            "rarity": "common",
+            "value": 20000
           }
         ],
         "others": [],
@@ -1575,20 +1536,19 @@
       "level": 46,
       "requirements": [
         {
-          "name": "Tritanium Generator A",
+          "name": "operations",
           "level": 46
         },
         {
-          "name": "Operations",
+          "name": "tritanium generator a",
           "level": 46
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 56813,
-        "bonus2": 1800
+        "bonus1": 1800.0,
+        "bonus2": 56813.0
       },
       "build_costs": {
         "materials": [
@@ -1622,20 +1582,19 @@
       "level": 47,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 47
         },
         {
-          "name": "Tritanium Generator A",
+          "name": "tritanium generator a",
           "level": 47
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 58500,
-        "bonus2": 1850
+        "bonus1": 1850.0,
+        "bonus2": 58500.0
       },
       "build_costs": {
         "materials": [
@@ -1669,20 +1628,19 @@
       "level": 48,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 48
         },
         {
-          "name": "Tritanium Generator A",
+          "name": "tritanium generator a",
           "level": 48
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 59063,
-        "bonus2": 1875
+        "bonus1": 1875.0,
+        "bonus2": 59063.0
       },
       "build_costs": {
         "materials": [
@@ -1702,12 +1660,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 71400000000
-          },
-          {
             "type": "dilithium",
             "value": 210000000
+          },
+          {
+            "type": "parsteel",
+            "value": 71400000000
           }
         ]
       },
@@ -1716,32 +1674,31 @@
       "level": 49,
       "requirements": [
         {
-          "name": "Tritanium Generator A",
+          "name": "operations",
           "level": 49
         },
         {
-          "name": "Operations",
+          "name": "tritanium generator a",
           "level": 49
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 72563,
-        "bonus2": 2300
+        "bonus1": 2300.0,
+        "bonus2": 72563.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 124950000000
-          },
-          {
             "type": "dilithium",
             "value": 367500000
+          },
+          {
+            "type": "parsteel",
+            "value": 124950000000
           }
         ]
       },
@@ -1750,15 +1707,214 @@
       "level": 50,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 50
         },
         {
-          "name": "Tritanium Generator A",
+          "name": "tritanium generator a",
           "level": 50
         }
-      ],
-      "rewards": []
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 2350.0,
+        "bonus2": 74250.0
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "ore",
+            "grade": 5,
+            "rarity": "common",
+            "value": 8800
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "dilithium",
+            "value": 780000000
+          },
+          {
+            "type": "parsteel",
+            "value": 623220000000
+          }
+        ]
+      },
+      "build_time": 29813760,
+      "increased_power": 2000,
+      "level": 51,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 51
+        },
+        {
+          "name": "tritanium generator a",
+          "level": 51
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 2400.0,
+        "bonus2": 75375.0
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "ore",
+            "grade": 5,
+            "rarity": "common",
+            "value": 21100
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 1127100000000
+          },
+          {
+            "type": "dilithium",
+            "value": 1326000000
+          }
+        ]
+      },
+      "build_time": 31602240,
+      "increased_power": 1500,
+      "level": 52,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 52
+        },
+        {
+          "name": "tritanium generator a",
+          "level": 52
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 2425.0,
+        "bonus2": 76500.0
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "ore",
+            "grade": 5,
+            "rarity": "common",
+            "value": 42200
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 1893120000000
+          },
+          {
+            "type": "dilithium",
+            "value": 2320000000
+          }
+        ]
+      },
+      "build_time": 33498720,
+      "increased_power": 2000,
+      "level": 53,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 53
+        },
+        {
+          "name": "tritanium generator a",
+          "level": 53
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 2475.0,
+        "bonus2": 78188.0
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "ore",
+            "grade": 5,
+            "rarity": "common",
+            "value": 43100
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 2839680000000
+          },
+          {
+            "type": "dilithium",
+            "value": 3480000000
+          }
+        ]
+      },
+      "build_time": 35507520,
+      "increased_power": 2000,
+      "level": 54,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 54
+        },
+        {
+          "name": "tritanium generator a",
+          "level": 54
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 2950.0,
+        "bonus2": 92813.0
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "ore",
+            "grade": 5,
+            "rarity": "common",
+            "value": 74800
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "dilithium",
+            "value": 5460000000
+          },
+          {
+            "type": "parsteel",
+            "value": 4826640000000
+          }
+        ]
+      },
+      "build_time": 37638720,
+      "increased_power": 2000,
+      "level": 55,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 55
+        },
+        {
+          "name": "tritanium generator a",
+          "level": 55
+        }
+      ]
     }
   ]
 }

--- a/buildings/tritanium_generator_c.json
+++ b/buildings/tritanium_generator_c.json
@@ -2,11 +2,11 @@
   "description": "Produces Tritanium, an alloy many times harder than diamond, used to costruct mighty ships. Upgrading Tritanium Generators increases the amount of Tritanium that is produced.",
   "bonuses": {
     "bonus1": {
-      "name": "Tritanium Production",
+      "name": "tritanium production",
       "percentage": false
     },
     "bonus2": {
-      "name": "Tritanium Storage",
+      "name": "tritanium storage",
       "percentage": false
     }
   },
@@ -14,8 +14,8 @@
   "levels": [
     {
       "bonuses": {
-        "bonus1": 15,
-        "bonus2": 8
+        "bonus1": 15.0,
+        "bonus2": 8.0
       },
       "build_costs": {
         "materials": [],
@@ -36,20 +36,19 @@
       "level": 1,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 18
         },
         {
-          "name": "Tritanium Generator A",
+          "name": "tritanium generator a",
           "level": 1
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 30,
-        "bonus2": 30
+        "bonus1": 30.0,
+        "bonus2": 30.0
       },
       "build_costs": {
         "materials": [],
@@ -70,19 +69,19 @@
       "level": 2,
       "requirements": [
         {
-          "name": "Tritanium Generator A",
+          "name": "operations",
           "level": 2
         },
         {
-          "name": "Operations",
+          "name": "tritanium generator a",
           "level": 2
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 45,
-        "bonus2": 68
+        "bonus1": 45.0,
+        "bonus2": 68.0
       },
       "build_costs": {
         "materials": [],
@@ -103,19 +102,19 @@
       "level": 3,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 3
         },
         {
-          "name": "Tritanium Generator A",
+          "name": "tritanium generator a",
           "level": 3
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 60,
-        "bonus2": 150
+        "bonus1": 60.0,
+        "bonus2": 150.0
       },
       "build_costs": {
         "materials": [],
@@ -136,19 +135,19 @@
       "level": 4,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 4
         },
         {
-          "name": "Tritanium Generator A",
+          "name": "tritanium generator a",
           "level": 4
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 75,
-        "bonus2": 225
+        "bonus1": 75.0,
+        "bonus2": 225.0
       },
       "build_costs": {
         "materials": [],
@@ -169,19 +168,19 @@
       "level": 5,
       "requirements": [
         {
-          "name": "Tritanium Generator A",
+          "name": "operations",
           "level": 5
         },
         {
-          "name": "Operations",
+          "name": "tritanium generator a",
           "level": 5
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 91,
-        "bonus2": 320
+        "bonus1": 91.0,
+        "bonus2": 320.0
       },
       "build_costs": {
         "materials": [],
@@ -202,31 +201,31 @@
       "level": 6,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 6
         },
         {
-          "name": "Tritanium Generator A",
+          "name": "tritanium generator a",
           "level": 6
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 105,
-        "bonus2": 420
+        "bonus1": 105.0,
+        "bonus2": 420.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 3500
-          },
-          {
             "type": "dilithium",
             "value": 160
+          },
+          {
+            "type": "parsteel",
+            "value": 3500
           }
         ]
       },
@@ -235,20 +234,19 @@
       "level": 7,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 7
         },
         {
-          "name": "Tritanium Generator A",
+          "name": "tritanium generator a",
           "level": 7
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 120,
-        "bonus2": 600
+        "bonus1": 120.0,
+        "bonus2": 600.0
       },
       "build_costs": {
         "materials": [],
@@ -269,32 +267,31 @@
       "level": 8,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 8
         },
         {
-          "name": "Tritanium Generator A",
+          "name": "tritanium generator a",
           "level": 8
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 135,
-        "bonus2": 740
+        "bonus1": 135.0,
+        "bonus2": 740.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 5000
-          },
-          {
             "type": "dilithium",
             "value": 80
+          },
+          {
+            "type": "parsteel",
+            "value": 5000
           }
         ]
       },
@@ -303,32 +300,31 @@
       "level": 9,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 9
         },
         {
-          "name": "Tritanium Generator A",
+          "name": "tritanium generator a",
           "level": 9
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 180,
-        "bonus2": 1080
+        "bonus1": 180.0,
+        "bonus2": 1080.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 6000
-          },
-          {
             "type": "dilithium",
             "value": 40
+          },
+          {
+            "type": "parsteel",
+            "value": 6000
           }
         ]
       },
@@ -337,20 +333,19 @@
       "level": 10,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 10
         },
         {
-          "name": "Tritanium Generator A",
+          "name": "tritanium generator a",
           "level": 10
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 200,
-        "bonus2": 1400
+        "bonus1": 200.0,
+        "bonus2": 1400.0
       },
       "build_costs": {
         "materials": [],
@@ -371,20 +366,19 @@
       "level": 11,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 11
         },
         {
-          "name": "Tritanium Generator A",
+          "name": "tritanium generator a",
           "level": 11
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 220,
-        "bonus2": 1650
+        "bonus1": 220.0,
+        "bonus2": 1650.0
       },
       "build_costs": {
         "materials": [],
@@ -405,31 +399,31 @@
       "level": 12,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 12
         },
         {
-          "name": "Tritanium Generator A",
+          "name": "tritanium generator a",
           "level": 12
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 235,
-        "bonus2": 2000
+        "bonus1": 235.0,
+        "bonus2": 2000.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 13600
-          },
-          {
             "type": "dilithium",
             "value": 48
+          },
+          {
+            "type": "parsteel",
+            "value": 13600
           }
         ]
       },
@@ -438,20 +432,19 @@
       "level": 13,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 13
         },
         {
-          "name": "Tritanium Generator A",
+          "name": "tritanium generator a",
           "level": 13
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 255,
-        "bonus2": 2300
+        "bonus1": 255.0,
+        "bonus2": 2300.0
       },
       "build_costs": {
         "materials": [],
@@ -472,20 +465,19 @@
       "level": 14,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 14
         },
         {
-          "name": "Tritanium Generator A",
+          "name": "tritanium generator a",
           "level": 14
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 275,
-        "bonus2": 2750
+        "bonus1": 275.0,
+        "bonus2": 2750.0
       },
       "build_costs": {
         "materials": [],
@@ -506,31 +498,31 @@
       "level": 15,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 15
         },
         {
-          "name": "Tritanium Generator A",
+          "name": "tritanium generator a",
           "level": 15
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 290,
-        "bonus2": 3200
+        "bonus1": 290.0,
+        "bonus2": 3200.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 34000
-          },
-          {
             "type": "dilithium",
             "value": 200
+          },
+          {
+            "type": "parsteel",
+            "value": 34000
           }
         ]
       },
@@ -539,31 +531,31 @@
       "level": 16,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 16
         },
         {
-          "name": "Tritanium Generator A",
+          "name": "tritanium generator a",
           "level": 16
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 310,
-        "bonus2": 3575
+        "bonus1": 310.0,
+        "bonus2": 3575.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 47600
-          },
-          {
             "type": "dilithium",
             "value": 280
+          },
+          {
+            "type": "parsteel",
+            "value": 47600
           }
         ]
       },
@@ -572,31 +564,31 @@
       "level": 17,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 17
         },
         {
-          "name": "Tritanium Generator A",
+          "name": "tritanium generator a",
           "level": 17
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 330,
-        "bonus2": 4125
+        "bonus1": 330.0,
+        "bonus2": 4125.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 68000
-          },
-          {
             "type": "dilithium",
             "value": 400
+          },
+          {
+            "type": "parsteel",
+            "value": 68000
           }
         ]
       },
@@ -605,32 +597,31 @@
       "level": 18,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 18
         },
         {
-          "name": "Tritanium Generator A",
+          "name": "tritanium generator a",
           "level": 18
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 345,
-        "bonus2": 4475
+        "bonus1": 345.0,
+        "bonus2": 4475.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 102000
-          },
-          {
             "type": "dilithium",
             "value": 600
+          },
+          {
+            "type": "parsteel",
+            "value": 102000
           }
         ]
       },
@@ -639,32 +630,31 @@
       "level": 19,
       "requirements": [
         {
-          "name": "Tritanium Generator A",
+          "name": "operations",
           "level": 19
         },
         {
-          "name": "Operations",
+          "name": "tritanium generator a",
           "level": 19
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 425,
-        "bonus2": 6000
+        "bonus1": 425.0,
+        "bonus2": 6000.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 144500
-          },
-          {
             "type": "dilithium",
             "value": 850
+          },
+          {
+            "type": "parsteel",
+            "value": 144500
           }
         ]
       },
@@ -673,20 +663,19 @@
       "level": 20,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 20
         },
         {
-          "name": "Tritanium Generator A",
+          "name": "tritanium generator a",
           "level": 20
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 450,
-        "bonus2": 6300
+        "bonus1": 450.0,
+        "bonus2": 6300.0
       },
       "build_costs": {
         "materials": [],
@@ -707,20 +696,19 @@
       "level": 21,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 21
         },
         {
-          "name": "Tritanium Generator A",
+          "name": "tritanium generator a",
           "level": 21
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 470,
-        "bonus2": 6600
+        "bonus1": 470.0,
+        "bonus2": 6600.0
       },
       "build_costs": {
         "materials": [],
@@ -741,20 +729,19 @@
       "level": 22,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 22
         },
         {
-          "name": "Tritanium Generator A",
+          "name": "tritanium generator a",
           "level": 22
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 490,
-        "bonus2": 6900
+        "bonus1": 490.0,
+        "bonus2": 6900.0
       },
       "build_costs": {
         "materials": [],
@@ -775,32 +762,31 @@
       "level": 23,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 23
         },
         {
-          "name": "Tritanium Generator A",
+          "name": "tritanium generator a",
           "level": 23
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 510,
-        "bonus2": 7100
+        "bonus1": 510.0,
+        "bonus2": 7100.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 981240
-          },
-          {
             "type": "dilithium",
             "value": 5772
+          },
+          {
+            "type": "parsteel",
+            "value": 981240
           }
         ]
       },
@@ -809,32 +795,31 @@
       "level": 24,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 24
         },
         {
-          "name": "Tritanium Generator A",
+          "name": "tritanium generator a",
           "level": 24
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 610,
-        "bonus2": 8500
+        "bonus1": 610.0,
+        "bonus2": 8500.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 1591200
-          },
-          {
             "type": "dilithium",
             "value": 9360
+          },
+          {
+            "type": "parsteel",
+            "value": 1591200
           }
         ]
       },
@@ -843,20 +828,19 @@
       "level": 25,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 25
         },
         {
-          "name": "Tritanium Generator A",
+          "name": "tritanium generator a",
           "level": 25
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 640,
-        "bonus2": 9000
+        "bonus1": 640.0,
+        "bonus2": 9000.0
       },
       "build_costs": {
         "materials": [],
@@ -877,32 +861,31 @@
       "level": 26,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 26
         },
         {
-          "name": "Tritanium Generator A",
+          "name": "tritanium generator a",
           "level": 26
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 660,
-        "bonus2": 9200
+        "bonus1": 660.0,
+        "bonus2": 9200.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 3794400
-          },
-          {
             "type": "dilithium",
             "value": 22320
+          },
+          {
+            "type": "parsteel",
+            "value": 3794400
           }
         ]
       },
@@ -911,20 +894,19 @@
       "level": 27,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 27
         },
         {
-          "name": "Tritanium Generator A",
+          "name": "tritanium generator a",
           "level": 27
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 680,
-        "bonus2": 9500
+        "bonus1": 680.0,
+        "bonus2": 9500.0
       },
       "build_costs": {
         "materials": [],
@@ -945,32 +927,31 @@
       "level": 28,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 28
         },
         {
-          "name": "Tritanium Generator A",
+          "name": "tritanium generator a",
           "level": 28
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 710,
-        "bonus2": 9900
+        "bonus1": 710.0,
+        "bonus2": 9900.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 9061000
-          },
-          {
             "type": "dilithium",
             "value": 53300
+          },
+          {
+            "type": "parsteel",
+            "value": 9061000
           }
         ]
       },
@@ -979,20 +960,19 @@
       "level": 29,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 29
         },
         {
-          "name": "Tritanium Generator A",
+          "name": "tritanium generator a",
           "level": 29
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 820,
-        "bonus2": 11500
+        "bonus1": 820.0,
+        "bonus2": 11500.0
       },
       "build_costs": {
         "materials": [],
@@ -1013,20 +993,19 @@
       "level": 30,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 30
         },
         {
-          "name": "Tritanium Generator A",
+          "name": "tritanium generator a",
           "level": 30
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 850,
-        "bonus2": 11900
+        "bonus1": 850.0,
+        "bonus2": 11900.0
       },
       "build_costs": {
         "materials": [],
@@ -1047,20 +1026,19 @@
       "level": 31,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 31
         },
         {
-          "name": "Tritanium Generator A",
+          "name": "tritanium generator a",
           "level": 31
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 880,
-        "bonus2": 13284
+        "bonus1": 880.0,
+        "bonus2": 13284.0
       },
       "build_costs": {
         "materials": [],
@@ -1081,20 +1059,19 @@
       "level": 32,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 32
         },
         {
-          "name": "Tritanium Generator A",
+          "name": "tritanium generator a",
           "level": 32
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 910,
-        "bonus2": 14732
+        "bonus1": 910.0,
+        "bonus2": 14732.0
       },
       "build_costs": {
         "materials": [],
@@ -1115,20 +1092,19 @@
       "level": 33,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 33
         },
         {
-          "name": "Tritanium Generator A",
+          "name": "tritanium generator a",
           "level": 33
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 940,
-        "bonus2": 15312
+        "bonus1": 940.0,
+        "bonus2": 15312.0
       },
       "build_costs": {
         "materials": [],
@@ -1149,20 +1125,19 @@
       "level": 34,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 34
         },
         {
-          "name": "Tritanium Generator A",
+          "name": "tritanium generator a",
           "level": 34
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 1070,
-        "bonus2": 18600
+        "bonus1": 1070.0,
+        "bonus2": 18600.0
       },
       "build_costs": {
         "materials": [],
@@ -1183,32 +1158,31 @@
       "level": 35,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 35
         },
         {
-          "name": "Tritanium Generator A",
+          "name": "tritanium generator a",
           "level": 35
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 1100,
-        "bonus2": 20482
+        "bonus1": 1100.0,
+        "bonus2": 20482.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 161262000
-          },
-          {
             "type": "dilithium",
             "value": 948600
+          },
+          {
+            "type": "parsteel",
+            "value": 161262000
           }
         ]
       },
@@ -1217,20 +1191,19 @@
       "level": 36,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 36
         },
         {
-          "name": "Tritanium Generator A",
+          "name": "tritanium generator a",
           "level": 36
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 1130,
-        "bonus2": 21014
+        "bonus1": 1130.0,
+        "bonus2": 21014.0
       },
       "build_costs": {
         "materials": [],
@@ -1251,20 +1224,19 @@
       "level": 37,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 37
         },
         {
-          "name": "Tritanium Generator A",
+          "name": "tritanium generator a",
           "level": 37
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 1160,
-        "bonus2": 23004
+        "bonus1": 1160.0,
+        "bonus2": 23004.0
       },
       "build_costs": {
         "materials": [],
@@ -1285,20 +1257,19 @@
       "level": 38,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 38
         },
         {
-          "name": "Tritanium Generator A",
+          "name": "tritanium generator a",
           "level": 38
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 1190,
-        "bonus2": 25551
+        "bonus1": 1190.0,
+        "bonus2": 25551.0
       },
       "build_costs": {
         "materials": [],
@@ -1319,20 +1290,19 @@
       "level": 39,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 39
         },
         {
-          "name": "Tritanium Generator A",
+          "name": "tritanium generator a",
           "level": 39
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 1350,
-        "bonus2": 28917
+        "bonus1": 1350.0,
+        "bonus2": 28917.0
       },
       "build_costs": {
         "materials": [],
@@ -1353,20 +1323,19 @@
       "level": 40,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 40
         },
         {
-          "name": "Tritanium Generator A",
+          "name": "tritanium generator a",
           "level": 40
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 1380,
-        "bonus2": 31845
+        "bonus1": 1380.0,
+        "bonus2": 31845.0
       },
       "build_costs": {
         "materials": [],
@@ -1387,32 +1356,31 @@
       "level": 41,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 41
         },
         {
-          "name": "Tritanium Generator A",
+          "name": "tritanium generator a",
           "level": 41
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 1425,
-        "bonus2": 36200
+        "bonus1": 1425.0,
+        "bonus2": 36200.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 4355400000
-          },
-          {
             "type": "dilithium",
             "value": 12810000
+          },
+          {
+            "type": "parsteel",
+            "value": 4355400000
           }
         ]
       },
@@ -1421,32 +1389,31 @@
       "level": 42,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 42
         },
         {
-          "name": "Tritanium Generator A",
+          "name": "tritanium generator a",
           "level": 42
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 1450,
-        "bonus2": 36653
+        "bonus1": 1450.0,
+        "bonus2": 36653.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 6222000000
-          },
-          {
             "type": "dilithium",
             "value": 18300000
+          },
+          {
+            "type": "parsteel",
+            "value": 6222000000
           }
         ]
       },
@@ -1455,20 +1422,19 @@
       "level": 43,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 43
         },
         {
-          "name": "Tritanium Generator A",
+          "name": "tritanium generator a",
           "level": 43
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 1475,
-        "bonus2": 41500
+        "bonus1": 1475.0,
+        "bonus2": 41500.0
       },
       "build_costs": {
         "materials": [],
@@ -1489,20 +1455,19 @@
       "level": 44,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 44
         },
         {
-          "name": "Tritanium Generator A",
+          "name": "tritanium generator a",
           "level": 44
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 1725,
-        "bonus2": 54563
+        "bonus1": 1725.0,
+        "bonus2": 54563.0
       },
       "build_costs": {
         "materials": [],
@@ -1523,32 +1488,31 @@
       "level": 45,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 45
         },
         {
-          "name": "Tritanium Generator A",
+          "name": "tritanium generator a",
           "level": 45
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 1750,
-        "bonus2": 55125
+        "bonus1": 1750.0,
+        "bonus2": 55125.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 18232500000
-          },
-          {
             "type": "dilithium",
             "value": 53625000
+          },
+          {
+            "type": "parsteel",
+            "value": 18232500000
           }
         ]
       },
@@ -1557,20 +1521,19 @@
       "level": 46,
       "requirements": [
         {
-          "name": "Tritanium Generator A",
+          "name": "operations",
           "level": 46
         },
         {
-          "name": "Operations",
+          "name": "tritanium generator a",
           "level": 46
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 1800,
-        "bonus2": 56813
+        "bonus1": 1800.0,
+        "bonus2": 56813.0
       },
       "build_costs": {
         "materials": [],
@@ -1591,20 +1554,19 @@
       "level": 47,
       "requirements": [
         {
-          "name": "Tritanium Generator A",
+          "name": "operations",
           "level": 47
         },
         {
-          "name": "Operations",
+          "name": "tritanium generator a",
           "level": 47
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 1850,
-        "bonus2": 58500
+        "bonus1": 1850.0,
+        "bonus2": 58500.0
       },
       "build_costs": {
         "materials": [],
@@ -1625,32 +1587,31 @@
       "level": 48,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 48
         },
         {
-          "name": "Tritanium Generator A",
+          "name": "tritanium generator a",
           "level": 48
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 1875,
-        "bonus2": 59063
+        "bonus1": 1875.0,
+        "bonus2": 59063.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 71400000000
-          },
-          {
             "type": "dilithium",
             "value": 210000000
+          },
+          {
+            "type": "parsteel",
+            "value": 71400000000
           }
         ]
       },
@@ -1659,20 +1620,19 @@
       "level": 49,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 49
         },
         {
-          "name": "Tritanium Generator A",
+          "name": "tritanium generator a",
           "level": 49
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 2300,
-        "bonus2": 72563
+        "bonus1": 2300.0,
+        "bonus2": 72563.0
       },
       "build_costs": {
         "materials": [],
@@ -1693,15 +1653,179 @@
       "level": 50,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 50
         },
         {
-          "name": "Tritanium Generator A",
+          "name": "tritanium generator a",
           "level": 50
         }
-      ],
-      "rewards": []
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 2350.0,
+        "bonus2": 74250.0
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 623220000000
+          },
+          {
+            "type": "dilithium",
+            "value": 780000000
+          }
+        ]
+      },
+      "build_time": 29813760,
+      "increased_power": 2000,
+      "level": 51,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 51
+        },
+        {
+          "name": "tritanium generator a",
+          "level": 51
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 2400.0,
+        "bonus2": 75375.0
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 1127100000000
+          },
+          {
+            "type": "dilithium",
+            "value": 1326000000
+          }
+        ]
+      },
+      "build_time": 31602240,
+      "increased_power": 1500,
+      "level": 52,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 52
+        },
+        {
+          "name": "tritanium generator a",
+          "level": 52
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 2425.0,
+        "bonus2": 76500.0
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 1893120000000
+          },
+          {
+            "type": "dilithium",
+            "value": 2320000000
+          }
+        ]
+      },
+      "build_time": 33498720,
+      "increased_power": 2000,
+      "level": 53,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 53
+        },
+        {
+          "name": "tritanium generator a",
+          "level": 53
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 2475.0,
+        "bonus2": 78188.0
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 2839680000000
+          },
+          {
+            "type": "dilithium",
+            "value": 3480000000
+          }
+        ]
+      },
+      "build_time": 35507520,
+      "increased_power": 2000,
+      "level": 54,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 54
+        },
+        {
+          "name": "tritanium generator a",
+          "level": 54
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 2950.0,
+        "bonus2": 92813.0
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 4826640000000
+          },
+          {
+            "type": "dilithium",
+            "value": 5460000000
+          }
+        ]
+      },
+      "build_time": 37638720,
+      "increased_power": 2000,
+      "level": 55,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 55
+        },
+        {
+          "name": "tritanium generator a",
+          "level": 55
+        }
+      ]
     }
   ]
 }

--- a/buildings/tritanium_generator_d.json
+++ b/buildings/tritanium_generator_d.json
@@ -2,11 +2,11 @@
   "description": "Produces Tritanium, an alloy many times harder than diamond, used to costruct mighty ships. Upgrading Tritanium Generators increases the amount of Tritanium that is produced.",
   "bonuses": {
     "bonus1": {
-      "name": "Tritanium Production",
+      "name": "tritanium production",
       "percentage": false
     },
     "bonus2": {
-      "name": "Tritanium Storage",
+      "name": "tritanium storage",
       "percentage": false
     }
   },
@@ -14,8 +14,8 @@
   "levels": [
     {
       "bonuses": {
-        "bonus1": 15,
-        "bonus2": 8
+        "bonus1": 15.0,
+        "bonus2": 8.0
       },
       "build_costs": {
         "materials": [],
@@ -36,20 +36,19 @@
       "level": 1,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 28
         },
         {
-          "name": "Tritanium Generator B",
+          "name": "tritanium generator b",
           "level": 1
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 30,
-        "bonus2": 30
+        "bonus1": 30.0,
+        "bonus2": 30.0
       },
       "build_costs": {
         "materials": [],
@@ -66,20 +65,19 @@
       "level": 2,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 2
         },
         {
-          "name": "Tritanium Generator B",
+          "name": "tritanium generator b",
           "level": 2
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 45,
-        "bonus2": 68
+        "bonus1": 45.0,
+        "bonus2": 68.0
       },
       "build_costs": {
         "materials": [],
@@ -96,20 +94,19 @@
       "level": 3,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 3
         },
         {
-          "name": "Tritanium Generator B",
+          "name": "tritanium generator b",
           "level": 3
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 60,
-        "bonus2": 150
+        "bonus1": 60.0,
+        "bonus2": 150.0
       },
       "build_costs": {
         "materials": [],
@@ -126,20 +123,19 @@
       "level": 4,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 4
         },
         {
-          "name": "Tritanium Generator B",
+          "name": "tritanium generator b",
           "level": 4
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 75,
-        "bonus2": 225
+        "bonus1": 75.0,
+        "bonus2": 225.0
       },
       "build_costs": {
         "materials": [],
@@ -156,20 +152,19 @@
       "level": 5,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 5
         },
         {
-          "name": "Tritanium Generator B",
+          "name": "tritanium generator b",
           "level": 5
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 91,
-        "bonus2": 320
+        "bonus1": 91.0,
+        "bonus2": 320.0
       },
       "build_costs": {
         "materials": [],
@@ -186,20 +181,19 @@
       "level": 6,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 6
         },
         {
-          "name": "Tritanium Generator B",
+          "name": "tritanium generator b",
           "level": 6
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 105,
-        "bonus2": 420
+        "bonus1": 105.0,
+        "bonus2": 420.0
       },
       "build_costs": {
         "materials": [],
@@ -216,20 +210,19 @@
       "level": 7,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 7
         },
         {
-          "name": "Tritanium Generator B",
+          "name": "tritanium generator b",
           "level": 7
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 120,
-        "bonus2": 600
+        "bonus1": 120.0,
+        "bonus2": 600.0
       },
       "build_costs": {
         "materials": [],
@@ -246,20 +239,19 @@
       "level": 8,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 8
         },
         {
-          "name": "Tritanium Generator B",
+          "name": "tritanium generator b",
           "level": 8
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 135,
-        "bonus2": 740
+        "bonus1": 135.0,
+        "bonus2": 740.0
       },
       "build_costs": {
         "materials": [],
@@ -276,20 +268,19 @@
       "level": 9,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 9
         },
         {
-          "name": "Tritanium Generator B",
+          "name": "tritanium generator b",
           "level": 9
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 180,
-        "bonus2": 1080
+        "bonus1": 180.0,
+        "bonus2": 1080.0
       },
       "build_costs": {
         "materials": [],
@@ -306,20 +297,19 @@
       "level": 10,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 10
         },
         {
-          "name": "Tritanium Generator B",
+          "name": "tritanium generator b",
           "level": 10
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 200,
-        "bonus2": 1400
+        "bonus1": 200.0,
+        "bonus2": 1400.0
       },
       "build_costs": {
         "materials": [],
@@ -340,20 +330,19 @@
       "level": 11,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 11
         },
         {
-          "name": "Tritanium Generator B",
+          "name": "tritanium generator b",
           "level": 11
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 220,
-        "bonus2": 1650
+        "bonus1": 220.0,
+        "bonus2": 1650.0
       },
       "build_costs": {
         "materials": [],
@@ -374,32 +363,31 @@
       "level": 12,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 12
         },
         {
-          "name": "Tritanium Generator B",
+          "name": "tritanium generator b",
           "level": 12
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 235,
-        "bonus2": 2000
+        "bonus1": 235.0,
+        "bonus2": 2000.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 13600
-          },
-          {
             "type": "dilithium",
             "value": 48
+          },
+          {
+            "type": "parsteel",
+            "value": 13600
           }
         ]
       },
@@ -408,32 +396,31 @@
       "level": 13,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 13
         },
         {
-          "name": "Tritanium Generator B",
+          "name": "tritanium generator b",
           "level": 13
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 255,
-        "bonus2": 2300
+        "bonus1": 255.0,
+        "bonus2": 2300.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 18700
-          },
-          {
             "type": "dilithium",
             "value": 88
+          },
+          {
+            "type": "parsteel",
+            "value": 18700
           }
         ]
       },
@@ -442,32 +429,31 @@
       "level": 14,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 14
         },
         {
-          "name": "Tritanium Generator B",
+          "name": "tritanium generator b",
           "level": 14
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 275,
-        "bonus2": 2750
+        "bonus1": 275.0,
+        "bonus2": 2750.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 25500
-          },
-          {
             "type": "dilithium",
             "value": 150
+          },
+          {
+            "type": "parsteel",
+            "value": 25500
           }
         ]
       },
@@ -476,20 +462,19 @@
       "level": 15,
       "requirements": [
         {
-          "name": "Tritanium Generator B",
+          "name": "operations",
           "level": 15
         },
         {
-          "name": "Operations",
+          "name": "tritanium generator b",
           "level": 15
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 290,
-        "bonus2": 3200
+        "bonus1": 290.0,
+        "bonus2": 3200.0
       },
       "build_costs": {
         "materials": [],
@@ -510,32 +495,31 @@
       "level": 16,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 16
         },
         {
-          "name": "Tritanium Generator B",
+          "name": "tritanium generator b",
           "level": 16
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 310,
-        "bonus2": 3575
+        "bonus1": 310.0,
+        "bonus2": 3575.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 47600
-          },
-          {
             "type": "dilithium",
             "value": 280
+          },
+          {
+            "type": "parsteel",
+            "value": 47600
           }
         ]
       },
@@ -544,32 +528,31 @@
       "level": 17,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 17
         },
         {
-          "name": "Tritanium Generator B",
+          "name": "tritanium generator b",
           "level": 17
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 330,
-        "bonus2": 4125
+        "bonus1": 330.0,
+        "bonus2": 4125.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 68000
-          },
-          {
             "type": "dilithium",
             "value": 400
+          },
+          {
+            "type": "parsteel",
+            "value": 68000
           }
         ]
       },
@@ -578,32 +561,31 @@
       "level": 18,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 18
         },
         {
-          "name": "Tritanium Generator B",
+          "name": "tritanium generator b",
           "level": 18
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 345,
-        "bonus2": 4475
+        "bonus1": 345.0,
+        "bonus2": 4475.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 102000
-          },
-          {
             "type": "dilithium",
             "value": 600
+          },
+          {
+            "type": "parsteel",
+            "value": 102000
           }
         ]
       },
@@ -612,32 +594,31 @@
       "level": 19,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 19
         },
         {
-          "name": "Tritanium Generator B",
+          "name": "tritanium generator b",
           "level": 19
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 425,
-        "bonus2": 6000
+        "bonus1": 425.0,
+        "bonus2": 6000.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 144500
-          },
-          {
             "type": "dilithium",
             "value": 850
+          },
+          {
+            "type": "parsteel",
+            "value": 144500
           }
         ]
       },
@@ -646,20 +627,19 @@
       "level": 20,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 20
         },
         {
-          "name": "Tritanium Generator B",
+          "name": "tritanium generator b",
           "level": 20
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 450,
-        "bonus2": 6300
+        "bonus1": 450.0,
+        "bonus2": 6300.0
       },
       "build_costs": {
         "materials": [],
@@ -680,32 +660,31 @@
       "level": 21,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 21
         },
         {
-          "name": "Tritanium Generator B",
+          "name": "tritanium generator b",
           "level": 21
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 470,
-        "bonus2": 6600
+        "bonus1": 470.0,
+        "bonus2": 6600.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 378420
-          },
-          {
             "type": "dilithium",
             "value": 2226
+          },
+          {
+            "type": "parsteel",
+            "value": 378420
           }
         ]
       },
@@ -714,20 +693,19 @@
       "level": 22,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 22
         },
         {
-          "name": "Tritanium Generator B",
+          "name": "tritanium generator b",
           "level": 22
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 490,
-        "bonus2": 6900
+        "bonus1": 490.0,
+        "bonus2": 6900.0
       },
       "build_costs": {
         "materials": [],
@@ -748,20 +726,19 @@
       "level": 23,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 23
         },
         {
-          "name": "Tritanium Generator B",
+          "name": "tritanium generator b",
           "level": 23
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 510,
-        "bonus2": 7100
+        "bonus1": 510.0,
+        "bonus2": 7100.0
       },
       "build_costs": {
         "materials": [],
@@ -782,20 +759,19 @@
       "level": 24,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 24
         },
         {
-          "name": "Tritanium Generator B",
+          "name": "tritanium generator b",
           "level": 24
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 610,
-        "bonus2": 8500
+        "bonus1": 610.0,
+        "bonus2": 8500.0
       },
       "build_costs": {
         "materials": [],
@@ -816,32 +792,31 @@
       "level": 25,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 25
         },
         {
-          "name": "Tritanium Generator B",
+          "name": "tritanium generator b",
           "level": 25
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 640,
-        "bonus2": 9000
+        "bonus1": 640.0,
+        "bonus2": 9000.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 2486250
-          },
-          {
             "type": "dilithium",
             "value": 14625
+          },
+          {
+            "type": "parsteel",
+            "value": 2486250
           }
         ]
       },
@@ -850,20 +825,19 @@
       "level": 26,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 26
         },
         {
-          "name": "Tritanium Generator B",
+          "name": "tritanium generator b",
           "level": 26
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 660,
-        "bonus2": 9200
+        "bonus1": 660.0,
+        "bonus2": 9200.0
       },
       "build_costs": {
         "materials": [],
@@ -884,20 +858,19 @@
       "level": 27,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 27
         },
         {
-          "name": "Tritanium Generator B",
+          "name": "tritanium generator b",
           "level": 27
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 680,
-        "bonus2": 9500
+        "bonus1": 680.0,
+        "bonus2": 9500.0
       },
       "build_costs": {
         "materials": [],
@@ -918,32 +891,31 @@
       "level": 28,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 28
         },
         {
-          "name": "Tritanium Generator B",
+          "name": "tritanium generator b",
           "level": 28
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 710,
-        "bonus2": 9900
+        "bonus1": 710.0,
+        "bonus2": 9900.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 9061000
-          },
-          {
             "type": "dilithium",
             "value": 53300
+          },
+          {
+            "type": "parsteel",
+            "value": 9061000
           }
         ]
       },
@@ -952,20 +924,19 @@
       "level": 29,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 29
         },
         {
-          "name": "Tritanium Generator B",
+          "name": "tritanium generator b",
           "level": 29
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 820,
-        "bonus2": 11500
+        "bonus1": 820.0,
+        "bonus2": 11500.0
       },
       "build_costs": {
         "materials": [],
@@ -986,32 +957,31 @@
       "level": 30,
       "requirements": [
         {
-          "name": "Tritanium Generator B",
+          "name": "operations",
           "level": 30
         },
         {
-          "name": "Operations",
+          "name": "tritanium generator b",
           "level": 30
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 850,
-        "bonus2": 11900
+        "bonus1": 850.0,
+        "bonus2": 11900.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 20961000
-          },
-          {
             "type": "dilithium",
             "value": 123300
+          },
+          {
+            "type": "parsteel",
+            "value": 20961000
           }
         ]
       },
@@ -1020,20 +990,19 @@
       "level": 31,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 31
         },
         {
-          "name": "Tritanium Generator B",
+          "name": "tritanium generator b",
           "level": 31
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 880,
-        "bonus2": 13284
+        "bonus1": 880.0,
+        "bonus2": 13284.0
       },
       "build_costs": {
         "materials": [],
@@ -1054,20 +1023,19 @@
       "level": 32,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 32
         },
         {
-          "name": "Tritanium Generator B",
+          "name": "tritanium generator b",
           "level": 32
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 910,
-        "bonus2": 14732
+        "bonus1": 910.0,
+        "bonus2": 14732.0
       },
       "build_costs": {
         "materials": [],
@@ -1088,20 +1056,19 @@
       "level": 33,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 33
         },
         {
-          "name": "Tritanium Generator B",
+          "name": "tritanium generator b",
           "level": 33
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 940,
-        "bonus2": 15312
+        "bonus1": 940.0,
+        "bonus2": 15312.0
       },
       "build_costs": {
         "materials": [],
@@ -1122,32 +1089,31 @@
       "level": 34,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 34
         },
         {
-          "name": "Tritanium Generator B",
+          "name": "tritanium generator b",
           "level": 34
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 1070,
-        "bonus2": 18600
+        "bonus1": 1070.0,
+        "bonus2": 18600.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 114444000
-          },
-          {
             "type": "dilithium",
             "value": 673200
+          },
+          {
+            "type": "parsteel",
+            "value": 114444000
           }
         ]
       },
@@ -1156,20 +1122,19 @@
       "level": 35,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 35
         },
         {
-          "name": "Tritanium Generator B",
+          "name": "tritanium generator b",
           "level": 35
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 1100,
-        "bonus2": 20482
+        "bonus1": 1100.0,
+        "bonus2": 20482.0
       },
       "build_costs": {
         "materials": [],
@@ -1190,32 +1155,31 @@
       "level": 36,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 36
         },
         {
-          "name": "Tritanium Generator B",
+          "name": "tritanium generator b",
           "level": 36
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 1130,
-        "bonus2": 21014
+        "bonus1": 1130.0,
+        "bonus2": 21014.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 247860000
-          },
-          {
             "type": "dilithium",
             "value": 1458000
+          },
+          {
+            "type": "parsteel",
+            "value": 247860000
           }
         ]
       },
@@ -1224,20 +1188,19 @@
       "level": 37,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 37
         },
         {
-          "name": "Tritanium Generator B",
+          "name": "tritanium generator b",
           "level": 37
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 1160,
-        "bonus2": 23004
+        "bonus1": 1160.0,
+        "bonus2": 23004.0
       },
       "build_costs": {
         "materials": [],
@@ -1258,32 +1221,31 @@
       "level": 38,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 38
         },
         {
-          "name": "Tritanium Generator B",
+          "name": "tritanium generator b",
           "level": 38
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 1190,
-        "bonus2": 25551
+        "bonus1": 1190.0,
+        "bonus2": 25551.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 657900000
-          },
-          {
             "type": "dilithium",
             "value": 3870000
+          },
+          {
+            "type": "parsteel",
+            "value": 657900000
           }
         ]
       },
@@ -1292,20 +1254,19 @@
       "level": 39,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 39
         },
         {
-          "name": "Tritanium Generator B",
+          "name": "tritanium generator b",
           "level": 39
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 1350,
-        "bonus2": 28917
+        "bonus1": 1350.0,
+        "bonus2": 28917.0
       },
       "build_costs": {
         "materials": [],
@@ -1326,32 +1287,31 @@
       "level": 40,
       "requirements": [
         {
-          "name": "Tritanium Generator B",
+          "name": "operations",
           "level": 40
         },
         {
-          "name": "Operations",
+          "name": "tritanium generator b",
           "level": 40
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 1380,
-        "bonus2": 31845
+        "bonus1": 1380.0,
+        "bonus2": 31845.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 2924000000
-          },
-          {
             "type": "dilithium",
             "value": 8600000
+          },
+          {
+            "type": "parsteel",
+            "value": 2924000000
           }
         ]
       },
@@ -1360,32 +1320,31 @@
       "level": 41,
       "requirements": [
         {
-          "name": "Tritanium Generator B",
+          "name": "operations",
           "level": 41
         },
         {
-          "name": "Operations",
+          "name": "tritanium generator b",
           "level": 41
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 1425,
-        "bonus2": 36200
+        "bonus1": 1425.0,
+        "bonus2": 36200.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 4355400000
-          },
-          {
             "type": "dilithium",
             "value": 12810000
+          },
+          {
+            "type": "parsteel",
+            "value": 4355400000
           }
         ]
       },
@@ -1394,32 +1353,31 @@
       "level": 42,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 42
         },
         {
-          "name": "Tritanium Generator B",
+          "name": "tritanium generator b",
           "level": 42
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 1450,
-        "bonus2": 36653
+        "bonus1": 1450.0,
+        "bonus2": 36653.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 6222000000
-          },
-          {
             "type": "dilithium",
             "value": 18300000
+          },
+          {
+            "type": "parsteel",
+            "value": 6222000000
           }
         ]
       },
@@ -1428,20 +1386,19 @@
       "level": 43,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 43
         },
         {
-          "name": "Tritanium Generator B",
+          "name": "tritanium generator b",
           "level": 43
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 1475,
-        "bonus2": 41500
+        "bonus1": 1475.0,
+        "bonus2": 41500.0
       },
       "build_costs": {
         "materials": [],
@@ -1462,32 +1419,31 @@
       "level": 44,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 44
         },
         {
-          "name": "Tritanium Generator B",
+          "name": "tritanium generator b",
           "level": 44
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 1725,
-        "bonus2": 54563
+        "bonus1": 1725.0,
+        "bonus2": 54563.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 13260000000
-          },
-          {
             "type": "dilithium",
             "value": 39000000
+          },
+          {
+            "type": "parsteel",
+            "value": 13260000000
           }
         ]
       },
@@ -1496,20 +1452,19 @@
       "level": 45,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 45
         },
         {
-          "name": "Tritanium Generator B",
+          "name": "tritanium generator b",
           "level": 45
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 1750,
-        "bonus2": 55125
+        "bonus1": 1750.0,
+        "bonus2": 55125.0
       },
       "build_costs": {
         "materials": [],
@@ -1530,32 +1485,31 @@
       "level": 46,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 46
         },
         {
-          "name": "Tritanium Generator B",
+          "name": "tritanium generator b",
           "level": 46
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 1800,
-        "bonus2": 56813
+        "bonus1": 1800.0,
+        "bonus2": 56813.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 26520000000
-          },
-          {
             "type": "dilithium",
             "value": 78000000
+          },
+          {
+            "type": "parsteel",
+            "value": 26520000000
           }
         ]
       },
@@ -1564,20 +1518,19 @@
       "level": 47,
       "requirements": [
         {
-          "name": "Tritanium Generator B",
+          "name": "operations",
           "level": 47
         },
         {
-          "name": "Operations",
+          "name": "tritanium generator b",
           "level": 47
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 1850,
-        "bonus2": 58500
+        "bonus1": 1850.0,
+        "bonus2": 58500.0
       },
       "build_costs": {
         "materials": [],
@@ -1598,20 +1551,19 @@
       "level": 48,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 48
         },
         {
-          "name": "Tritanium Generator B",
+          "name": "tritanium generator b",
           "level": 48
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 1875,
-        "bonus2": 59063
+        "bonus1": 1875.0,
+        "bonus2": 59063.0
       },
       "build_costs": {
         "materials": [],
@@ -1632,32 +1584,31 @@
       "level": 49,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 49
         },
         {
-          "name": "Tritanium Generator B",
+          "name": "tritanium generator b",
           "level": 49
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 2300,
-        "bonus2": 72563
+        "bonus1": 2300.0,
+        "bonus2": 72563.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 124950000000
-          },
-          {
             "type": "dilithium",
             "value": 367500000
+          },
+          {
+            "type": "parsteel",
+            "value": 124950000000
           }
         ]
       },
@@ -1666,15 +1617,179 @@
       "level": 50,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 50
         },
         {
-          "name": "Tritanium Generator B",
+          "name": "tritanium generator b",
           "level": 50
         }
-      ],
-      "rewards": []
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 2350.0,
+        "bonus2": 74250.0
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 623220000000
+          },
+          {
+            "type": "dilithium",
+            "value": 780000000
+          }
+        ]
+      },
+      "build_time": 29813760,
+      "increased_power": 2000,
+      "level": 51,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 51
+        },
+        {
+          "name": "tritanium generator b",
+          "level": 51
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 2400.0,
+        "bonus2": 75375.0
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "dilithium",
+            "value": 1326000000
+          },
+          {
+            "type": "parsteel",
+            "value": 1127100000000
+          }
+        ]
+      },
+      "build_time": 31602240,
+      "increased_power": 1500,
+      "level": 52,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 52
+        },
+        {
+          "name": "tritanium generator b",
+          "level": 52
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 2425.0,
+        "bonus2": 76500.0
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "dilithium",
+            "value": 2320000000
+          },
+          {
+            "type": "parsteel",
+            "value": 1893120000000
+          }
+        ]
+      },
+      "build_time": 33498720,
+      "increased_power": 2000,
+      "level": 53,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 53
+        },
+        {
+          "name": "tritanium generator b",
+          "level": 53
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 2475.0,
+        "bonus2": 78188.0
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "dilithium",
+            "value": 3480000000
+          },
+          {
+            "type": "parsteel",
+            "value": 2839680000000
+          }
+        ]
+      },
+      "build_time": 35507520,
+      "increased_power": 2000,
+      "level": 54,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 54
+        },
+        {
+          "name": "tritanium generator b",
+          "level": 54
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 2950.0,
+        "bonus2": 92813.0
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 4826640000000
+          },
+          {
+            "type": "dilithium",
+            "value": 5460000000
+          }
+        ]
+      },
+      "build_time": 37638720,
+      "increased_power": 2000,
+      "level": 55,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 55
+        },
+        {
+          "name": "tritanium generator b",
+          "level": 55
+        }
+      ]
     }
   ]
 }

--- a/buildings/tritanium_generator_e.json
+++ b/buildings/tritanium_generator_e.json
@@ -2,11 +2,11 @@
   "description": "Produces Tritanium, an alloy many times harder than diamond, used to costruct mighty ships. Upgrading Tritanium Generators increases the amount of Tritanium that is produced.",
   "bonuses": {
     "bonus1": {
-      "name": "Tritanium Production",
+      "name": "tritanium production",
       "percentage": false
     },
     "bonus2": {
-      "name": "Tritanium Storage",
+      "name": "tritanium storage",
       "percentage": false
     }
   },
@@ -14,8 +14,8 @@
   "levels": [
     {
       "bonuses": {
-        "bonus1": 15,
-        "bonus2": 8
+        "bonus1": 15.0,
+        "bonus2": 8.0
       },
       "build_costs": {
         "materials": [],
@@ -32,20 +32,19 @@
       "level": 1,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 38
         },
         {
-          "name": "Tritanium Generator C",
+          "name": "tritanium generator c",
           "level": 1
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 30,
-        "bonus2": 30
+        "bonus1": 30.0,
+        "bonus2": 30.0
       },
       "build_costs": {
         "materials": [],
@@ -62,19 +61,19 @@
       "level": 2,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 2
         },
         {
-          "name": "Tritanium Generator C",
+          "name": "tritanium generator c",
           "level": 2
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 45,
-        "bonus2": 68
+        "bonus1": 45.0,
+        "bonus2": 68.0
       },
       "build_costs": {
         "materials": [],
@@ -91,19 +90,19 @@
       "level": 3,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 3
         },
         {
-          "name": "Tritanium Generator C",
+          "name": "tritanium generator c",
           "level": 3
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 60,
-        "bonus2": 150
+        "bonus1": 60.0,
+        "bonus2": 150.0
       },
       "build_costs": {
         "materials": [],
@@ -120,19 +119,19 @@
       "level": 4,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 4
         },
         {
-          "name": "Tritanium Generator C",
+          "name": "tritanium generator c",
           "level": 4
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 75,
-        "bonus2": 225
+        "bonus1": 75.0,
+        "bonus2": 225.0
       },
       "build_costs": {
         "materials": [],
@@ -149,19 +148,19 @@
       "level": 5,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 5
         },
         {
-          "name": "Tritanium Generator C",
+          "name": "tritanium generator c",
           "level": 5
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 91,
-        "bonus2": 320
+        "bonus1": 91.0,
+        "bonus2": 320.0
       },
       "build_costs": {
         "materials": [],
@@ -178,19 +177,19 @@
       "level": 6,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 6
         },
         {
-          "name": "Tritanium Generator C",
+          "name": "tritanium generator c",
           "level": 6
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 105,
-        "bonus2": 420
+        "bonus1": 105.0,
+        "bonus2": 420.0
       },
       "build_costs": {
         "materials": [],
@@ -207,19 +206,19 @@
       "level": 7,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 7
         },
         {
-          "name": "Tritanium Generator C",
+          "name": "tritanium generator c",
           "level": 7
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 120,
-        "bonus2": 600
+        "bonus1": 120.0,
+        "bonus2": 600.0
       },
       "build_costs": {
         "materials": [],
@@ -236,19 +235,19 @@
       "level": 8,
       "requirements": [
         {
-          "name": "Tritanium Generator C",
+          "name": "operations",
           "level": 8
         },
         {
-          "name": "Operations",
+          "name": "tritanium generator c",
           "level": 8
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 135,
-        "bonus2": 740
+        "bonus1": 135.0,
+        "bonus2": 740.0
       },
       "build_costs": {
         "materials": [],
@@ -265,19 +264,19 @@
       "level": 9,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 9
         },
         {
-          "name": "Tritanium Generator C",
+          "name": "tritanium generator c",
           "level": 9
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 180,
-        "bonus2": 1080
+        "bonus1": 180.0,
+        "bonus2": 1080.0
       },
       "build_costs": {
         "materials": [],
@@ -294,31 +293,31 @@
       "level": 10,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 10
         },
         {
-          "name": "Tritanium Generator C",
+          "name": "tritanium generator c",
           "level": 10
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 200,
-        "bonus2": 1400
+        "bonus1": 200.0,
+        "bonus2": 1400.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 6800
-          },
-          {
             "type": "dilithium",
             "value": 8
+          },
+          {
+            "type": "parsteel",
+            "value": 6800
           }
         ]
       },
@@ -327,19 +326,19 @@
       "level": 11,
       "requirements": [
         {
-          "name": "Tritanium Generator C",
+          "name": "operations",
           "level": 11
         },
         {
-          "name": "Operations",
+          "name": "tritanium generator c",
           "level": 11
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 220,
-        "bonus2": 1650
+        "bonus1": 220.0,
+        "bonus2": 1650.0
       },
       "build_costs": {
         "materials": [],
@@ -360,19 +359,19 @@
       "level": 12,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 12
         },
         {
-          "name": "Tritanium Generator C",
+          "name": "tritanium generator c",
           "level": 12
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 235,
-        "bonus2": 2000
+        "bonus1": 235.0,
+        "bonus2": 2000.0
       },
       "build_costs": {
         "materials": [],
@@ -393,19 +392,19 @@
       "level": 13,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 13
         },
         {
-          "name": "Tritanium Generator C",
+          "name": "tritanium generator c",
           "level": 13
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 255,
-        "bonus2": 2300
+        "bonus1": 255.0,
+        "bonus2": 2300.0
       },
       "build_costs": {
         "materials": [],
@@ -426,19 +425,19 @@
       "level": 14,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 14
         },
         {
-          "name": "Tritanium Generator C",
+          "name": "tritanium generator c",
           "level": 14
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 275,
-        "bonus2": 2750
+        "bonus1": 275.0,
+        "bonus2": 2750.0
       },
       "build_costs": {
         "materials": [],
@@ -459,20 +458,19 @@
       "level": 15,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 15
         },
         {
-          "name": "Tritanium Generator C",
+          "name": "tritanium generator c",
           "level": 15
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 290,
-        "bonus2": 3200
+        "bonus1": 290.0,
+        "bonus2": 3200.0
       },
       "build_costs": {
         "materials": [],
@@ -493,31 +491,31 @@
       "level": 16,
       "requirements": [
         {
-          "name": "Tritanium Generator C",
+          "name": "operations",
           "level": 16
         },
         {
-          "name": "Operations",
+          "name": "tritanium generator c",
           "level": 16
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 310,
-        "bonus2": 3575
+        "bonus1": 310.0,
+        "bonus2": 3575.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 47600
-          },
-          {
             "type": "dilithium",
             "value": 280
+          },
+          {
+            "type": "parsteel",
+            "value": 47600
           }
         ]
       },
@@ -526,31 +524,31 @@
       "level": 17,
       "requirements": [
         {
-          "name": "Tritanium Generator C",
+          "name": "operations",
           "level": 17
         },
         {
-          "name": "Operations",
+          "name": "tritanium generator c",
           "level": 17
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 330,
-        "bonus2": 4125
+        "bonus1": 330.0,
+        "bonus2": 4125.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 68000
-          },
-          {
             "type": "dilithium",
             "value": 400
+          },
+          {
+            "type": "parsteel",
+            "value": 68000
           }
         ]
       },
@@ -559,19 +557,19 @@
       "level": 18,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 18
         },
         {
-          "name": "Tritanium Generator C",
+          "name": "tritanium generator c",
           "level": 18
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 345,
-        "bonus2": 4475
+        "bonus1": 345.0,
+        "bonus2": 4475.0
       },
       "build_costs": {
         "materials": [],
@@ -592,19 +590,19 @@
       "level": 19,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 19
         },
         {
-          "name": "Tritanium Generator C",
+          "name": "tritanium generator c",
           "level": 19
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 425,
-        "bonus2": 6000
+        "bonus1": 425.0,
+        "bonus2": 6000.0
       },
       "build_costs": {
         "materials": [],
@@ -625,20 +623,19 @@
       "level": 20,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 20
         },
         {
-          "name": "Tritanium Generator C",
+          "name": "tritanium generator c",
           "level": 20
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 450,
-        "bonus2": 6300
+        "bonus1": 450.0,
+        "bonus2": 6300.0
       },
       "build_costs": {
         "materials": [],
@@ -659,19 +656,19 @@
       "level": 21,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 21
         },
         {
-          "name": "Tritanium Generator C",
+          "name": "tritanium generator c",
           "level": 21
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 470,
-        "bonus2": 6600
+        "bonus1": 470.0,
+        "bonus2": 6600.0
       },
       "build_costs": {
         "materials": [],
@@ -692,31 +689,31 @@
       "level": 22,
       "requirements": [
         {
-          "name": "Tritanium Generator C",
+          "name": "operations",
           "level": 22
         },
         {
-          "name": "Operations",
+          "name": "tritanium generator c",
           "level": 22
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 490,
-        "bonus2": 6900
+        "bonus1": 490.0,
+        "bonus2": 6900.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 622710
-          },
-          {
             "type": "dilithium",
             "value": 3663
+          },
+          {
+            "type": "parsteel",
+            "value": 622710
           }
         ]
       },
@@ -725,31 +722,31 @@
       "level": 23,
       "requirements": [
         {
-          "name": "Tritanium Generator C",
+          "name": "operations",
           "level": 23
         },
         {
-          "name": "Operations",
+          "name": "tritanium generator c",
           "level": 23
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 510,
-        "bonus2": 7100
+        "bonus1": 510.0,
+        "bonus2": 7100.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 981240
-          },
-          {
             "type": "dilithium",
             "value": 5772
+          },
+          {
+            "type": "parsteel",
+            "value": 981240
           }
         ]
       },
@@ -758,20 +755,19 @@
       "level": 24,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 24
         },
         {
-          "name": "Tritanium Generator C",
+          "name": "tritanium generator c",
           "level": 24
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 610,
-        "bonus2": 8500
+        "bonus1": 610.0,
+        "bonus2": 8500.0
       },
       "build_costs": {
         "materials": [],
@@ -792,19 +788,19 @@
       "level": 25,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 25
         },
         {
-          "name": "Tritanium Generator C",
+          "name": "tritanium generator c",
           "level": 25
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 640,
-        "bonus2": 9000
+        "bonus1": 640.0,
+        "bonus2": 9000.0
       },
       "build_costs": {
         "materials": [],
@@ -825,19 +821,19 @@
       "level": 26,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 26
         },
         {
-          "name": "Tritanium Generator C",
+          "name": "tritanium generator c",
           "level": 26
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 660,
-        "bonus2": 9200
+        "bonus1": 660.0,
+        "bonus2": 9200.0
       },
       "build_costs": {
         "materials": [],
@@ -858,31 +854,31 @@
       "level": 27,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 27
         },
         {
-          "name": "Tritanium Generator C",
+          "name": "tritanium generator c",
           "level": 27
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 680,
-        "bonus2": 9500
+        "bonus1": 680.0,
+        "bonus2": 9500.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 5691600
-          },
-          {
             "type": "dilithium",
             "value": 33480
+          },
+          {
+            "type": "parsteel",
+            "value": 5691600
           }
         ]
       },
@@ -891,19 +887,19 @@
       "level": 28,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 28
         },
         {
-          "name": "Tritanium Generator C",
+          "name": "tritanium generator c",
           "level": 28
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 710,
-        "bonus2": 9900
+        "bonus1": 710.0,
+        "bonus2": 9900.0
       },
       "build_costs": {
         "materials": [],
@@ -924,31 +920,31 @@
       "level": 29,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 29
         },
         {
-          "name": "Tritanium Generator C",
+          "name": "tritanium generator c",
           "level": 29
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 820,
-        "bonus2": 11500
+        "bonus1": 820.0,
+        "bonus2": 11500.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 13260000
-          },
-          {
             "type": "dilithium",
             "value": 78000
+          },
+          {
+            "type": "parsteel",
+            "value": 13260000
           }
         ]
       },
@@ -957,31 +953,31 @@
       "level": 30,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 30
         },
         {
-          "name": "Tritanium Generator C",
+          "name": "tritanium generator c",
           "level": 30
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 850,
-        "bonus2": 11900
+        "bonus1": 850.0,
+        "bonus2": 11900.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 20961000
-          },
-          {
             "type": "dilithium",
             "value": 123300
+          },
+          {
+            "type": "parsteel",
+            "value": 20961000
           }
         ]
       },
@@ -990,19 +986,19 @@
       "level": 31,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 31
         },
         {
-          "name": "Tritanium Generator C",
+          "name": "tritanium generator c",
           "level": 31
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 880,
-        "bonus2": 13284
+        "bonus1": 880.0,
+        "bonus2": 13284.0
       },
       "build_costs": {
         "materials": [],
@@ -1023,31 +1019,31 @@
       "level": 32,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 32
         },
         {
-          "name": "Tritanium Generator C",
+          "name": "tritanium generator c",
           "level": 32
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 910,
-        "bonus2": 14732
+        "bonus1": 910.0,
+        "bonus2": 14732.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 46835000
-          },
-          {
             "type": "dilithium",
             "value": 275500
+          },
+          {
+            "type": "parsteel",
+            "value": 46835000
           }
         ]
       },
@@ -1056,31 +1052,31 @@
       "level": 33,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 33
         },
         {
-          "name": "Tritanium Generator C",
+          "name": "tritanium generator c",
           "level": 33
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 940,
-        "bonus2": 15312
+        "bonus1": 940.0,
+        "bonus2": 15312.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 73950000
-          },
-          {
             "type": "dilithium",
             "value": 435000
+          },
+          {
+            "type": "parsteel",
+            "value": 73950000
           }
         ]
       },
@@ -1089,19 +1085,19 @@
       "level": 34,
       "requirements": [
         {
-          "name": "Tritanium Generator C",
+          "name": "operations",
           "level": 34
         },
         {
-          "name": "Operations",
+          "name": "tritanium generator c",
           "level": 34
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 1070,
-        "bonus2": 18600
+        "bonus1": 1070.0,
+        "bonus2": 18600.0
       },
       "build_costs": {
         "materials": [],
@@ -1122,31 +1118,31 @@
       "level": 35,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 35
         },
         {
-          "name": "Tritanium Generator C",
+          "name": "tritanium generator c",
           "level": 35
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 1100,
-        "bonus2": 20482
+        "bonus1": 1100.0,
+        "bonus2": 20482.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 161262000
-          },
-          {
             "type": "dilithium",
             "value": 948600
+          },
+          {
+            "type": "parsteel",
+            "value": 161262000
           }
         ]
       },
@@ -1155,20 +1151,19 @@
       "level": 36,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 36
         },
         {
-          "name": "Tritanium Generator C",
+          "name": "tritanium generator c",
           "level": 36
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 1130,
-        "bonus2": 21014
+        "bonus1": 1130.0,
+        "bonus2": 21014.0
       },
       "build_costs": {
         "materials": [],
@@ -1189,31 +1184,31 @@
       "level": 37,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 37
         },
         {
-          "name": "Tritanium Generator C",
+          "name": "tritanium generator c",
           "level": 37
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 1160,
-        "bonus2": 23004
+        "bonus1": 1160.0,
+        "bonus2": 23004.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 385560000
-          },
-          {
             "type": "dilithium",
             "value": 2268000
+          },
+          {
+            "type": "parsteel",
+            "value": 385560000
           }
         ]
       },
@@ -1222,32 +1217,31 @@
       "level": 38,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 38
         },
         {
-          "name": "Tritanium Generator C",
+          "name": "tritanium generator c",
           "level": 38
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 1190,
-        "bonus2": 25551
+        "bonus1": 1190.0,
+        "bonus2": 25551.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 657900000
-          },
-          {
             "type": "dilithium",
             "value": 3870000
+          },
+          {
+            "type": "parsteel",
+            "value": 657900000
           }
         ]
       },
@@ -1256,20 +1250,19 @@
       "level": 39,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 39
         },
         {
-          "name": "Tritanium Generator C",
+          "name": "tritanium generator c",
           "level": 39
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 1350,
-        "bonus2": 28917
+        "bonus1": 1350.0,
+        "bonus2": 28917.0
       },
       "build_costs": {
         "materials": [],
@@ -1290,32 +1283,31 @@
       "level": 40,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 40
         },
         {
-          "name": "Tritanium Generator C",
+          "name": "tritanium generator c",
           "level": 40
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 1380,
-        "bonus2": 31845
+        "bonus1": 1380.0,
+        "bonus2": 31845.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 2924000000
-          },
-          {
             "type": "dilithium",
             "value": 8600000
+          },
+          {
+            "type": "parsteel",
+            "value": 2924000000
           }
         ]
       },
@@ -1324,20 +1316,19 @@
       "level": 41,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 41
         },
         {
-          "name": "Tritanium Generator C",
+          "name": "tritanium generator c",
           "level": 41
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 1425,
-        "bonus2": 36200
+        "bonus1": 1425.0,
+        "bonus2": 36200.0
       },
       "build_costs": {
         "materials": [],
@@ -1358,20 +1349,19 @@
       "level": 42,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 42
         },
         {
-          "name": "Tritanium Generator C",
+          "name": "tritanium generator c",
           "level": 42
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 1450,
-        "bonus2": 36653
+        "bonus1": 1450.0,
+        "bonus2": 36653.0
       },
       "build_costs": {
         "materials": [],
@@ -1392,20 +1382,19 @@
       "level": 43,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 43
         },
         {
-          "name": "Tritanium Generator C",
+          "name": "tritanium generator c",
           "level": 43
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 1475,
-        "bonus2": 41500
+        "bonus1": 1475.0,
+        "bonus2": 41500.0
       },
       "build_costs": {
         "materials": [],
@@ -1426,32 +1415,31 @@
       "level": 44,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 44
         },
         {
-          "name": "Tritanium Generator C",
+          "name": "tritanium generator c",
           "level": 44
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 1725,
-        "bonus2": 54563
+        "bonus1": 1725.0,
+        "bonus2": 54563.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 13260000000
-          },
-          {
             "type": "dilithium",
             "value": 39000000
+          },
+          {
+            "type": "parsteel",
+            "value": 13260000000
           }
         ]
       },
@@ -1460,32 +1448,31 @@
       "level": 45,
       "requirements": [
         {
-          "name": "Tritanium Generator C",
+          "name": "operations",
           "level": 45
         },
         {
-          "name": "Operations",
+          "name": "tritanium generator c",
           "level": 45
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 1750,
-        "bonus2": 55125
+        "bonus1": 1750.0,
+        "bonus2": 55125.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 18232500000
-          },
-          {
             "type": "dilithium",
             "value": 53625000
+          },
+          {
+            "type": "parsteel",
+            "value": 18232500000
           }
         ]
       },
@@ -1494,20 +1481,19 @@
       "level": 46,
       "requirements": [
         {
-          "name": "Tritanium Generator C",
+          "name": "operations",
           "level": 46
         },
         {
-          "name": "Operations",
+          "name": "tritanium generator c",
           "level": 46
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 1800,
-        "bonus2": 56813
+        "bonus1": 1800.0,
+        "bonus2": 56813.0
       },
       "build_costs": {
         "materials": [],
@@ -1528,20 +1514,19 @@
       "level": 47,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 47
         },
         {
-          "name": "Tritanium Generator C",
+          "name": "tritanium generator c",
           "level": 47
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 1850,
-        "bonus2": 58500
+        "bonus1": 1850.0,
+        "bonus2": 58500.0
       },
       "build_costs": {
         "materials": [],
@@ -1562,32 +1547,31 @@
       "level": 48,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 48
         },
         {
-          "name": "Tritanium Generator C",
+          "name": "tritanium generator c",
           "level": 48
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 1875,
-        "bonus2": 59063
+        "bonus1": 1875.0,
+        "bonus2": 59063.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 71400000000
-          },
-          {
             "type": "dilithium",
             "value": 210000000
+          },
+          {
+            "type": "parsteel",
+            "value": 71400000000
           }
         ]
       },
@@ -1596,32 +1580,31 @@
       "level": 49,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 49
         },
         {
-          "name": "Tritanium Generator C",
+          "name": "tritanium generator c",
           "level": 49
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 2300,
-        "bonus2": 72563
+        "bonus1": 2300.0,
+        "bonus2": 72563.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 124950000000
-          },
-          {
             "type": "dilithium",
             "value": 367500000
+          },
+          {
+            "type": "parsteel",
+            "value": 124950000000
           }
         ]
       },
@@ -1630,15 +1613,179 @@
       "level": 50,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 50
         },
         {
-          "name": "Tritanium Generator C",
+          "name": "tritanium generator c",
           "level": 50
         }
-      ],
-      "rewards": []
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 2350.0,
+        "bonus2": 74250.0
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 623220000000
+          },
+          {
+            "type": "dilithium",
+            "value": 780000000
+          }
+        ]
+      },
+      "build_time": 29813760,
+      "increased_power": 2000,
+      "level": 51,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 51
+        },
+        {
+          "name": "tritanium generator c",
+          "level": 51
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 2400.0,
+        "bonus2": 75375.0
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 1127100000000
+          },
+          {
+            "type": "dilithium",
+            "value": 1326000000
+          }
+        ]
+      },
+      "build_time": 31602240,
+      "increased_power": 1500,
+      "level": 52,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 52
+        },
+        {
+          "name": "tritanium generator c",
+          "level": 52
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 2425.0,
+        "bonus2": 76500.0
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "dilithium",
+            "value": 2320000000
+          },
+          {
+            "type": "parsteel",
+            "value": 1893120000000
+          }
+        ]
+      },
+      "build_time": 33498720,
+      "increased_power": 2000,
+      "level": 53,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 53
+        },
+        {
+          "name": "tritanium generator c",
+          "level": 53
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 2475.0,
+        "bonus2": 78188.0
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "dilithium",
+            "value": 3480000000
+          },
+          {
+            "type": "parsteel",
+            "value": 2839680000000
+          }
+        ]
+      },
+      "build_time": 35507520,
+      "increased_power": 2000,
+      "level": 54,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 54
+        },
+        {
+          "name": "tritanium generator c",
+          "level": 54
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 2950.0,
+        "bonus2": 92813.0
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "dilithium",
+            "value": 5460000000
+          },
+          {
+            "type": "parsteel",
+            "value": 4826640000000
+          }
+        ]
+      },
+      "build_time": 37638720,
+      "increased_power": 2000,
+      "level": 55,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 55
+        },
+        {
+          "name": "tritanium generator c",
+          "level": 55
+        }
+      ]
     }
   ]
 }

--- a/buildings/tritanium_generator_f.json
+++ b/buildings/tritanium_generator_f.json
@@ -2,11 +2,11 @@
   "description": "Produces Tritanium, an alloy many times harder than diamond, used to costruct mighty ships. Upgrading Tritanium Generators increases the amount of Tritanium that is produced.",
   "bonuses": {
     "bonus1": {
-      "name": "Tritanium Production",
+      "name": "tritanium production",
       "percentage": false
     },
     "bonus2": {
-      "name": "Tritanium Storage",
+      "name": "tritanium storage",
       "percentage": false
     }
   },
@@ -14,8 +14,8 @@
   "levels": [
     {
       "bonuses": {
-        "bonus1": 15,
-        "bonus2": 8
+        "bonus1": 15.0,
+        "bonus2": 8.0
       },
       "build_costs": {
         "materials": [],
@@ -32,20 +32,19 @@
       "level": 1,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 48
         },
         {
-          "name": "Tritanium Generator D",
+          "name": "tritanium generator d",
           "level": 1
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 30,
-        "bonus2": 30
+        "bonus1": 30.0,
+        "bonus2": 30.0
       },
       "build_costs": {
         "materials": [],
@@ -62,19 +61,19 @@
       "level": 2,
       "requirements": [
         {
-          "name": "Tritanium Generator D",
+          "name": "operations",
           "level": 2
         },
         {
-          "name": "Operations",
+          "name": "tritanium generator d",
           "level": 2
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 45,
-        "bonus2": 68
+        "bonus1": 45.0,
+        "bonus2": 68.0
       },
       "build_costs": {
         "materials": [],
@@ -91,19 +90,19 @@
       "level": 3,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 3
         },
         {
-          "name": "Tritanium Generator D",
+          "name": "tritanium generator d",
           "level": 3
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 60,
-        "bonus2": 150
+        "bonus1": 60.0,
+        "bonus2": 150.0
       },
       "build_costs": {
         "materials": [],
@@ -120,19 +119,19 @@
       "level": 4,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 4
         },
         {
-          "name": "Tritanium Generator D",
+          "name": "tritanium generator d",
           "level": 4
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 75,
-        "bonus2": 225
+        "bonus1": 75.0,
+        "bonus2": 225.0
       },
       "build_costs": {
         "materials": [],
@@ -149,19 +148,19 @@
       "level": 5,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 5
         },
         {
-          "name": "Tritanium Generator D",
+          "name": "tritanium generator d",
           "level": 5
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 91,
-        "bonus2": 320
+        "bonus1": 91.0,
+        "bonus2": 320.0
       },
       "build_costs": {
         "materials": [],
@@ -178,19 +177,19 @@
       "level": 6,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 6
         },
         {
-          "name": "Tritanium Generator D",
+          "name": "tritanium generator d",
           "level": 6
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 105,
-        "bonus2": 420
+        "bonus1": 105.0,
+        "bonus2": 420.0
       },
       "build_costs": {
         "materials": [],
@@ -207,19 +206,19 @@
       "level": 7,
       "requirements": [
         {
-          "name": "Tritanium Generator D",
+          "name": "operations",
           "level": 7
         },
         {
-          "name": "Operations",
+          "name": "tritanium generator d",
           "level": 7
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 120,
-        "bonus2": 600
+        "bonus1": 120.0,
+        "bonus2": 600.0
       },
       "build_costs": {
         "materials": [],
@@ -236,19 +235,19 @@
       "level": 8,
       "requirements": [
         {
-          "name": "Tritanium Generator D",
+          "name": "operations",
           "level": 8
         },
         {
-          "name": "Operations",
+          "name": "tritanium generator d",
           "level": 8
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 135,
-        "bonus2": 740
+        "bonus1": 135.0,
+        "bonus2": 740.0
       },
       "build_costs": {
         "materials": [],
@@ -265,19 +264,19 @@
       "level": 9,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 9
         },
         {
-          "name": "Tritanium Generator D",
+          "name": "tritanium generator d",
           "level": 9
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 180,
-        "bonus2": 1080
+        "bonus1": 180.0,
+        "bonus2": 1080.0
       },
       "build_costs": {
         "materials": [],
@@ -294,19 +293,19 @@
       "level": 10,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 10
         },
         {
-          "name": "Tritanium Generator D",
+          "name": "tritanium generator d",
           "level": 10
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 200,
-        "bonus2": 1400
+        "bonus1": 200.0,
+        "bonus2": 1400.0
       },
       "build_costs": {
         "materials": [],
@@ -327,31 +326,31 @@
       "level": 11,
       "requirements": [
         {
-          "name": "Tritanium Generator D",
+          "name": "operations",
           "level": 11
         },
         {
-          "name": "Operations",
+          "name": "tritanium generator d",
           "level": 11
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 220,
-        "bonus2": 1650
+        "bonus1": 220.0,
+        "bonus2": 1650.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 9350
-          },
-          {
             "type": "dilithium",
             "value": 22
+          },
+          {
+            "type": "parsteel",
+            "value": 9350
           }
         ]
       },
@@ -360,31 +359,31 @@
       "level": 12,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 12
         },
         {
-          "name": "Tritanium Generator D",
+          "name": "tritanium generator d",
           "level": 12
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 235,
-        "bonus2": 2000
+        "bonus1": 235.0,
+        "bonus2": 2000.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 13600
-          },
-          {
             "type": "dilithium",
             "value": 48
+          },
+          {
+            "type": "parsteel",
+            "value": 13600
           }
         ]
       },
@@ -393,31 +392,31 @@
       "level": 13,
       "requirements": [
         {
-          "name": "Tritanium Generator D",
+          "name": "operations",
           "level": 13
         },
         {
-          "name": "Operations",
+          "name": "tritanium generator d",
           "level": 13
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 255,
-        "bonus2": 2300
+        "bonus1": 255.0,
+        "bonus2": 2300.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 18700
-          },
-          {
             "type": "dilithium",
             "value": 88
+          },
+          {
+            "type": "parsteel",
+            "value": 18700
           }
         ]
       },
@@ -426,31 +425,31 @@
       "level": 14,
       "requirements": [
         {
-          "name": "Tritanium Generator D",
+          "name": "operations",
           "level": 14
         },
         {
-          "name": "Operations",
+          "name": "tritanium generator d",
           "level": 14
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 275,
-        "bonus2": 2750
+        "bonus1": 275.0,
+        "bonus2": 2750.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 25500
-          },
-          {
             "type": "dilithium",
             "value": 150
+          },
+          {
+            "type": "parsteel",
+            "value": 25500
           }
         ]
       },
@@ -459,19 +458,19 @@
       "level": 15,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 15
         },
         {
-          "name": "Tritanium Generator D",
+          "name": "tritanium generator d",
           "level": 15
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 290,
-        "bonus2": 3200
+        "bonus1": 290.0,
+        "bonus2": 3200.0
       },
       "build_costs": {
         "materials": [],
@@ -492,19 +491,19 @@
       "level": 16,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 16
         },
         {
-          "name": "Tritanium Generator D",
+          "name": "tritanium generator d",
           "level": 16
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 310,
-        "bonus2": 3575
+        "bonus1": 310.0,
+        "bonus2": 3575.0
       },
       "build_costs": {
         "materials": [],
@@ -525,19 +524,19 @@
       "level": 17,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 17
         },
         {
-          "name": "Tritanium Generator D",
+          "name": "tritanium generator d",
           "level": 17
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 330,
-        "bonus2": 4125
+        "bonus1": 330.0,
+        "bonus2": 4125.0
       },
       "build_costs": {
         "materials": [],
@@ -558,19 +557,19 @@
       "level": 18,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 18
         },
         {
-          "name": "Tritanium Generator D",
+          "name": "tritanium generator d",
           "level": 18
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 345,
-        "bonus2": 4475
+        "bonus1": 345.0,
+        "bonus2": 4475.0
       },
       "build_costs": {
         "materials": [],
@@ -591,31 +590,31 @@
       "level": 19,
       "requirements": [
         {
-          "name": "Tritanium Generator D",
+          "name": "operations",
           "level": 19
         },
         {
-          "name": "Operations",
+          "name": "tritanium generator d",
           "level": 19
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 425,
-        "bonus2": 6000
+        "bonus1": 425.0,
+        "bonus2": 6000.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 144500
-          },
-          {
             "type": "dilithium",
             "value": 850
+          },
+          {
+            "type": "parsteel",
+            "value": 144500
           }
         ]
       },
@@ -624,31 +623,31 @@
       "level": 20,
       "requirements": [
         {
-          "name": "Tritanium Generator D",
+          "name": "operations",
           "level": 20
         },
         {
-          "name": "Operations",
+          "name": "tritanium generator d",
           "level": 20
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 450,
-        "bonus2": 6300
+        "bonus1": 450.0,
+        "bonus2": 6300.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 243270
-          },
-          {
             "type": "dilithium",
             "value": 1431
+          },
+          {
+            "type": "parsteel",
+            "value": 243270
           }
         ]
       },
@@ -657,19 +656,19 @@
       "level": 21,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 21
         },
         {
-          "name": "Tritanium Generator D",
+          "name": "tritanium generator d",
           "level": 21
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 470,
-        "bonus2": 6600
+        "bonus1": 470.0,
+        "bonus2": 6600.0
       },
       "build_costs": {
         "materials": [],
@@ -690,31 +689,31 @@
       "level": 22,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 22
         },
         {
-          "name": "Tritanium Generator D",
+          "name": "tritanium generator d",
           "level": 22
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 490,
-        "bonus2": 6900
+        "bonus1": 490.0,
+        "bonus2": 6900.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 622710
-          },
-          {
             "type": "dilithium",
             "value": 3663
+          },
+          {
+            "type": "parsteel",
+            "value": 622710
           }
         ]
       },
@@ -723,19 +722,19 @@
       "level": 23,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 23
         },
         {
-          "name": "Tritanium Generator D",
+          "name": "tritanium generator d",
           "level": 23
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 510,
-        "bonus2": 7100
+        "bonus1": 510.0,
+        "bonus2": 7100.0
       },
       "build_costs": {
         "materials": [],
@@ -756,31 +755,31 @@
       "level": 24,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 24
         },
         {
-          "name": "Tritanium Generator D",
+          "name": "tritanium generator d",
           "level": 24
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 610,
-        "bonus2": 8500
+        "bonus1": 610.0,
+        "bonus2": 8500.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 1591200
-          },
-          {
             "type": "dilithium",
             "value": 9360
+          },
+          {
+            "type": "parsteel",
+            "value": 1591200
           }
         ]
       },
@@ -789,19 +788,19 @@
       "level": 25,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 25
         },
         {
-          "name": "Tritanium Generator D",
+          "name": "tritanium generator d",
           "level": 25
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 640,
-        "bonus2": 9000
+        "bonus1": 640.0,
+        "bonus2": 9000.0
       },
       "build_costs": {
         "materials": [],
@@ -822,19 +821,19 @@
       "level": 26,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 26
         },
         {
-          "name": "Tritanium Generator D",
+          "name": "tritanium generator d",
           "level": 26
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 660,
-        "bonus2": 9200
+        "bonus1": 660.0,
+        "bonus2": 9200.0
       },
       "build_costs": {
         "materials": [],
@@ -855,19 +854,19 @@
       "level": 27,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 27
         },
         {
-          "name": "Tritanium Generator D",
+          "name": "tritanium generator d",
           "level": 27
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 680,
-        "bonus2": 9500
+        "bonus1": 680.0,
+        "bonus2": 9500.0
       },
       "build_costs": {
         "materials": [],
@@ -888,31 +887,31 @@
       "level": 28,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 28
         },
         {
-          "name": "Tritanium Generator D",
+          "name": "tritanium generator d",
           "level": 28
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 710,
-        "bonus2": 9900
+        "bonus1": 710.0,
+        "bonus2": 9900.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 9061000
-          },
-          {
             "type": "dilithium",
             "value": 53300
+          },
+          {
+            "type": "parsteel",
+            "value": 9061000
           }
         ]
       },
@@ -921,31 +920,31 @@
       "level": 29,
       "requirements": [
         {
-          "name": "Tritanium Generator D",
+          "name": "operations",
           "level": 29
         },
         {
-          "name": "Operations",
+          "name": "tritanium generator d",
           "level": 29
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 820,
-        "bonus2": 11500
+        "bonus1": 820.0,
+        "bonus2": 11500.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 13260000
-          },
-          {
             "type": "dilithium",
             "value": 78000
+          },
+          {
+            "type": "parsteel",
+            "value": 13260000
           }
         ]
       },
@@ -954,19 +953,19 @@
       "level": 30,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 30
         },
         {
-          "name": "Tritanium Generator D",
+          "name": "tritanium generator d",
           "level": 30
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 850,
-        "bonus2": 11900
+        "bonus1": 850.0,
+        "bonus2": 11900.0
       },
       "build_costs": {
         "materials": [],
@@ -987,19 +986,19 @@
       "level": 31,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 31
         },
         {
-          "name": "Tritanium Generator D",
+          "name": "tritanium generator d",
           "level": 31
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 880,
-        "bonus2": 13284
+        "bonus1": 880.0,
+        "bonus2": 13284.0
       },
       "build_costs": {
         "materials": [],
@@ -1020,31 +1019,31 @@
       "level": 32,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 32
         },
         {
-          "name": "Tritanium Generator D",
+          "name": "tritanium generator d",
           "level": 32
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 910,
-        "bonus2": 14732
+        "bonus1": 910.0,
+        "bonus2": 14732.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 46835000
-          },
-          {
             "type": "dilithium",
             "value": 275500
+          },
+          {
+            "type": "parsteel",
+            "value": 46835000
           }
         ]
       },
@@ -1053,31 +1052,31 @@
       "level": 33,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 33
         },
         {
-          "name": "Tritanium Generator D",
+          "name": "tritanium generator d",
           "level": 33
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 940,
-        "bonus2": 15312
+        "bonus1": 940.0,
+        "bonus2": 15312.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 73950000
-          },
-          {
             "type": "dilithium",
             "value": 435000
+          },
+          {
+            "type": "parsteel",
+            "value": 73950000
           }
         ]
       },
@@ -1086,31 +1085,31 @@
       "level": 34,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 34
         },
         {
-          "name": "Tritanium Generator D",
+          "name": "tritanium generator d",
           "level": 34
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 1070,
-        "bonus2": 18600
+        "bonus1": 1070.0,
+        "bonus2": 18600.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 114444000
-          },
-          {
             "type": "dilithium",
             "value": 673200
+          },
+          {
+            "type": "parsteel",
+            "value": 114444000
           }
         ]
       },
@@ -1119,31 +1118,31 @@
       "level": 35,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 35
         },
         {
-          "name": "Tritanium Generator D",
+          "name": "tritanium generator d",
           "level": 35
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 1100,
-        "bonus2": 20482
+        "bonus1": 1100.0,
+        "bonus2": 20482.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 161262000
-          },
-          {
             "type": "dilithium",
             "value": 948600
+          },
+          {
+            "type": "parsteel",
+            "value": 161262000
           }
         ]
       },
@@ -1152,19 +1151,19 @@
       "level": 36,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 36
         },
         {
-          "name": "Tritanium Generator D",
+          "name": "tritanium generator d",
           "level": 36
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 1130,
-        "bonus2": 21014
+        "bonus1": 1130.0,
+        "bonus2": 21014.0
       },
       "build_costs": {
         "materials": [],
@@ -1185,19 +1184,19 @@
       "level": 37,
       "requirements": [
         {
-          "name": "Tritanium Generator D",
+          "name": "operations",
           "level": 37
         },
         {
-          "name": "Operations",
+          "name": "tritanium generator d",
           "level": 37
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 1160,
-        "bonus2": 23004
+        "bonus1": 1160.0,
+        "bonus2": 23004.0
       },
       "build_costs": {
         "materials": [],
@@ -1218,19 +1217,19 @@
       "level": 38,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 38
         },
         {
-          "name": "Tritanium Generator D",
+          "name": "tritanium generator d",
           "level": 38
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 1190,
-        "bonus2": 25551
+        "bonus1": 1190.0,
+        "bonus2": 25551.0
       },
       "build_costs": {
         "materials": [],
@@ -1251,19 +1250,19 @@
       "level": 39,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 39
         },
         {
-          "name": "Tritanium Generator D",
+          "name": "tritanium generator d",
           "level": 39
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 1350,
-        "bonus2": 28917
+        "bonus1": 1350.0,
+        "bonus2": 28917.0
       },
       "build_costs": {
         "materials": [],
@@ -1284,31 +1283,31 @@
       "level": 40,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 40
         },
         {
-          "name": "Tritanium Generator D",
+          "name": "tritanium generator d",
           "level": 40
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 1380,
-        "bonus2": 31845
+        "bonus1": 1380.0,
+        "bonus2": 31845.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 2924000000
-          },
-          {
             "type": "dilithium",
             "value": 8600000
+          },
+          {
+            "type": "parsteel",
+            "value": 2924000000
           }
         ]
       },
@@ -1317,31 +1316,31 @@
       "level": 41,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 41
         },
         {
-          "name": "Tritanium Generator D",
+          "name": "tritanium generator d",
           "level": 41
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 1425,
-        "bonus2": 36200
+        "bonus1": 1425.0,
+        "bonus2": 36200.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 4355400000
-          },
-          {
             "type": "dilithium",
             "value": 12810000
+          },
+          {
+            "type": "parsteel",
+            "value": 4355400000
           }
         ]
       },
@@ -1350,19 +1349,19 @@
       "level": 42,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 42
         },
         {
-          "name": "Tritanium Generator D",
+          "name": "tritanium generator d",
           "level": 42
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 1450,
-        "bonus2": 36653
+        "bonus1": 1450.0,
+        "bonus2": 36653.0
       },
       "build_costs": {
         "materials": [],
@@ -1383,31 +1382,31 @@
       "level": 43,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 43
         },
         {
-          "name": "Tritanium Generator D",
+          "name": "tritanium generator d",
           "level": 43
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 1475,
-        "bonus2": 41500
+        "bonus1": 1475.0,
+        "bonus2": 41500.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 9333000000
-          },
-          {
             "type": "dilithium",
             "value": 27450000
+          },
+          {
+            "type": "parsteel",
+            "value": 9333000000
           }
         ]
       },
@@ -1416,19 +1415,19 @@
       "level": 44,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 44
         },
         {
-          "name": "Tritanium Generator D",
+          "name": "tritanium generator d",
           "level": 44
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 1725,
-        "bonus2": 54563
+        "bonus1": 1725.0,
+        "bonus2": 54563.0
       },
       "build_costs": {
         "materials": [],
@@ -1449,19 +1448,19 @@
       "level": 45,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 45
         },
         {
-          "name": "Tritanium Generator D",
+          "name": "tritanium generator d",
           "level": 45
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 1750,
-        "bonus2": 55125
+        "bonus1": 1750.0,
+        "bonus2": 55125.0
       },
       "build_costs": {
         "materials": [],
@@ -1482,31 +1481,31 @@
       "level": 46,
       "requirements": [
         {
-          "name": "Tritanium Generator D",
+          "name": "operations",
           "level": 46
         },
         {
-          "name": "Operations",
+          "name": "tritanium generator d",
           "level": 46
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 1800,
-        "bonus2": 56813
+        "bonus1": 1800.0,
+        "bonus2": 56813.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 26520000000
-          },
-          {
             "type": "dilithium",
             "value": 78000000
+          },
+          {
+            "type": "parsteel",
+            "value": 26520000000
           }
         ]
       },
@@ -1515,19 +1514,19 @@
       "level": 47,
       "requirements": [
         {
-          "name": "Tritanium Generator D",
+          "name": "operations",
           "level": 47
         },
         {
-          "name": "Operations",
+          "name": "tritanium generator d",
           "level": 47
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 1850,
-        "bonus2": 58500
+        "bonus1": 1850.0,
+        "bonus2": 58500.0
       },
       "build_costs": {
         "materials": [],
@@ -1548,32 +1547,31 @@
       "level": 48,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 48
         },
         {
-          "name": "Tritanium Generator D",
+          "name": "tritanium generator d",
           "level": 48
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 1875,
-        "bonus2": 59063
+        "bonus1": 1875.0,
+        "bonus2": 59063.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 71400000000
-          },
-          {
             "type": "dilithium",
             "value": 210000000
+          },
+          {
+            "type": "parsteel",
+            "value": 71400000000
           }
         ]
       },
@@ -1582,32 +1580,31 @@
       "level": 49,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 49
         },
         {
-          "name": "Tritanium Generator D",
+          "name": "tritanium generator d",
           "level": 49
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 2300,
-        "bonus2": 72563
+        "bonus1": 2300.0,
+        "bonus2": 72563.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 124950000000
-          },
-          {
             "type": "dilithium",
             "value": 367500000
+          },
+          {
+            "type": "parsteel",
+            "value": 124950000000
           }
         ]
       },
@@ -1616,15 +1613,179 @@
       "level": 50,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 50
         },
         {
-          "name": "Tritanium Generator D",
+          "name": "tritanium generator d",
           "level": 50
         }
-      ],
-      "rewards": []
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 2350.0,
+        "bonus2": 74250.0
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 623220000000
+          },
+          {
+            "type": "dilithium",
+            "value": 780000000
+          }
+        ]
+      },
+      "build_time": 29813760,
+      "increased_power": 2000,
+      "level": 51,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 51
+        },
+        {
+          "name": "tritanium generator d",
+          "level": 51
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 2400.0,
+        "bonus2": 75375.0
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 1127100000000
+          },
+          {
+            "type": "dilithium",
+            "value": 1326000000
+          }
+        ]
+      },
+      "build_time": 31602240,
+      "increased_power": 1500,
+      "level": 52,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 52
+        },
+        {
+          "name": "tritanium generator d",
+          "level": 52
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 2425.0,
+        "bonus2": 76500.0
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 1893120000000
+          },
+          {
+            "type": "dilithium",
+            "value": 2320000000
+          }
+        ]
+      },
+      "build_time": 33498720,
+      "increased_power": 2000,
+      "level": 53,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 53
+        },
+        {
+          "name": "tritanium generator d",
+          "level": 53
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 2475.0,
+        "bonus2": 78188.0
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "dilithium",
+            "value": 3480000000
+          },
+          {
+            "type": "parsteel",
+            "value": 2839680000000
+          }
+        ]
+      },
+      "build_time": 35507520,
+      "increased_power": 2000,
+      "level": 54,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 54
+        },
+        {
+          "name": "tritanium generator d",
+          "level": 54
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 2950.0,
+        "bonus2": 92813.0
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 4826640000000
+          },
+          {
+            "type": "dilithium",
+            "value": 5460000000
+          }
+        ]
+      },
+      "build_time": 37638720,
+      "increased_power": 2000,
+      "level": 55,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 55
+        },
+        {
+          "name": "tritanium generator d",
+          "level": 55
+        }
+      ]
     }
   ]
 }

--- a/buildings/tritanium_generator_g.json
+++ b/buildings/tritanium_generator_g.json
@@ -2,11 +2,11 @@
   "description": "Produces Tritanium, an alloy many times harder than diamond, used to costruct mighty ships. Upgrading Tritanium Generators increases the amount of Tritanium that is produced.",
   "bonuses": {
     "bonus1": {
-      "name": "Tritanium Production",
+      "name": "tritanium production",
       "percentage": false
     },
     "bonus2": {
-      "name": "Tritanium Storage",
+      "name": "tritanium storage",
       "percentage": false
     }
   },
@@ -14,8 +14,8 @@
   "levels": [
     {
       "bonuses": {
-        "bonus1": 15,
-        "bonus2": 8
+        "bonus1": 15.0,
+        "bonus2": 8.0
       },
       "build_costs": {
         "materials": [],
@@ -32,19 +32,19 @@
       "level": 1,
       "requirements": [
         {
-          "name": "Tritanium Generator E",
-          "level": 1
+          "name": "operations",
+          "level": 50
         },
         {
-          "name": "Operations",
-          "level": 50
+          "name": "tritanium generator e",
+          "level": 1
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 30,
-        "bonus2": 30
+        "bonus1": 30.0,
+        "bonus2": 30.0
       },
       "build_costs": {
         "materials": [],
@@ -61,19 +61,19 @@
       "level": 2,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 2
         },
         {
-          "name": "Tritanium Generator E",
+          "name": "tritanium generator e",
           "level": 2
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 45,
-        "bonus2": 68
+        "bonus1": 45.0,
+        "bonus2": 68.0
       },
       "build_costs": {
         "materials": [],
@@ -90,19 +90,19 @@
       "level": 3,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 3
         },
         {
-          "name": "Tritanium Generator E",
+          "name": "tritanium generator e",
           "level": 3
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 60,
-        "bonus2": 150
+        "bonus1": 60.0,
+        "bonus2": 150.0
       },
       "build_costs": {
         "materials": [],
@@ -119,19 +119,19 @@
       "level": 4,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 4
         },
         {
-          "name": "Tritanium Generator E",
+          "name": "tritanium generator e",
           "level": 4
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 75,
-        "bonus2": 225
+        "bonus1": 75.0,
+        "bonus2": 225.0
       },
       "build_costs": {
         "materials": [],
@@ -148,19 +148,19 @@
       "level": 5,
       "requirements": [
         {
-          "name": "Tritanium Generator E",
+          "name": "operations",
           "level": 5
         },
         {
-          "name": "Operations",
+          "name": "tritanium generator e",
           "level": 5
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 91,
-        "bonus2": 320
+        "bonus1": 91.0,
+        "bonus2": 320.0
       },
       "build_costs": {
         "materials": [],
@@ -177,19 +177,19 @@
       "level": 6,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 6
         },
         {
-          "name": "Tritanium Generator E",
+          "name": "tritanium generator e",
           "level": 6
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 105,
-        "bonus2": 420
+        "bonus1": 105.0,
+        "bonus2": 420.0
       },
       "build_costs": {
         "materials": [],
@@ -206,19 +206,19 @@
       "level": 7,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 7
         },
         {
-          "name": "Tritanium Generator E",
+          "name": "tritanium generator e",
           "level": 7
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 120,
-        "bonus2": 600
+        "bonus1": 120.0,
+        "bonus2": 600.0
       },
       "build_costs": {
         "materials": [],
@@ -235,19 +235,19 @@
       "level": 8,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 8
         },
         {
-          "name": "Tritanium Generator E",
+          "name": "tritanium generator e",
           "level": 8
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 135,
-        "bonus2": 740
+        "bonus1": 135.0,
+        "bonus2": 740.0
       },
       "build_costs": {
         "materials": [],
@@ -264,19 +264,19 @@
       "level": 9,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 9
         },
         {
-          "name": "Tritanium Generator E",
+          "name": "tritanium generator e",
           "level": 9
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 180,
-        "bonus2": 1080
+        "bonus1": 180.0,
+        "bonus2": 1080.0
       },
       "build_costs": {
         "materials": [],
@@ -293,19 +293,19 @@
       "level": 10,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 10
         },
         {
-          "name": "Tritanium Generator E",
+          "name": "tritanium generator e",
           "level": 10
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 200,
-        "bonus2": 1400
+        "bonus1": 200.0,
+        "bonus2": 1400.0
       },
       "build_costs": {
         "materials": [],
@@ -326,31 +326,31 @@
       "level": 11,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 11
         },
         {
-          "name": "Tritanium Generator E",
+          "name": "tritanium generator e",
           "level": 11
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 220,
-        "bonus2": 1650
+        "bonus1": 220.0,
+        "bonus2": 1650.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 9350
-          },
-          {
             "type": "dilithium",
             "value": 22
+          },
+          {
+            "type": "parsteel",
+            "value": 9350
           }
         ]
       },
@@ -359,31 +359,31 @@
       "level": 12,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 12
         },
         {
-          "name": "Tritanium Generator E",
+          "name": "tritanium generator e",
           "level": 12
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 235,
-        "bonus2": 2000
+        "bonus1": 235.0,
+        "bonus2": 2000.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 13600
-          },
-          {
             "type": "dilithium",
             "value": 48
+          },
+          {
+            "type": "parsteel",
+            "value": 13600
           }
         ]
       },
@@ -392,19 +392,19 @@
       "level": 13,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 13
         },
         {
-          "name": "Tritanium Generator E",
+          "name": "tritanium generator e",
           "level": 13
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 255,
-        "bonus2": 2300
+        "bonus1": 255.0,
+        "bonus2": 2300.0
       },
       "build_costs": {
         "materials": [],
@@ -425,31 +425,31 @@
       "level": 14,
       "requirements": [
         {
-          "name": "Tritanium Generator E",
+          "name": "operations",
           "level": 14
         },
         {
-          "name": "Operations",
+          "name": "tritanium generator e",
           "level": 14
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 275,
-        "bonus2": 2750
+        "bonus1": 275.0,
+        "bonus2": 2750.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 25500
-          },
-          {
             "type": "dilithium",
             "value": 150
+          },
+          {
+            "type": "parsteel",
+            "value": 25500
           }
         ]
       },
@@ -458,19 +458,19 @@
       "level": 15,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 15
         },
         {
-          "name": "Tritanium Generator E",
+          "name": "tritanium generator e",
           "level": 15
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 290,
-        "bonus2": 3200
+        "bonus1": 290.0,
+        "bonus2": 3200.0
       },
       "build_costs": {
         "materials": [],
@@ -491,31 +491,31 @@
       "level": 16,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 16
         },
         {
-          "name": "Tritanium Generator E",
+          "name": "tritanium generator e",
           "level": 16
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 310,
-        "bonus2": 3575
+        "bonus1": 310.0,
+        "bonus2": 3575.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 47600
-          },
-          {
             "type": "dilithium",
             "value": 280
+          },
+          {
+            "type": "parsteel",
+            "value": 47600
           }
         ]
       },
@@ -524,31 +524,31 @@
       "level": 17,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 17
         },
         {
-          "name": "Tritanium Generator E",
+          "name": "tritanium generator e",
           "level": 17
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 330,
-        "bonus2": 4125
+        "bonus1": 330.0,
+        "bonus2": 4125.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 68000
-          },
-          {
             "type": "dilithium",
             "value": 400
+          },
+          {
+            "type": "parsteel",
+            "value": 68000
           }
         ]
       },
@@ -557,19 +557,19 @@
       "level": 18,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 18
         },
         {
-          "name": "Tritanium Generator E",
+          "name": "tritanium generator e",
           "level": 18
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 345,
-        "bonus2": 4475
+        "bonus1": 345.0,
+        "bonus2": 4475.0
       },
       "build_costs": {
         "materials": [],
@@ -590,31 +590,31 @@
       "level": 19,
       "requirements": [
         {
-          "name": "Tritanium Generator E",
+          "name": "operations",
           "level": 19
         },
         {
-          "name": "Operations",
+          "name": "tritanium generator e",
           "level": 19
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 425,
-        "bonus2": 6000
+        "bonus1": 425.0,
+        "bonus2": 6000.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 144500
-          },
-          {
             "type": "dilithium",
             "value": 850
+          },
+          {
+            "type": "parsteel",
+            "value": 144500
           }
         ]
       },
@@ -623,19 +623,19 @@
       "level": 20,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 20
         },
         {
-          "name": "Tritanium Generator E",
+          "name": "tritanium generator e",
           "level": 20
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 450,
-        "bonus2": 6300
+        "bonus1": 450.0,
+        "bonus2": 6300.0
       },
       "build_costs": {
         "materials": [],
@@ -656,31 +656,31 @@
       "level": 21,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 21
         },
         {
-          "name": "Tritanium Generator E",
+          "name": "tritanium generator e",
           "level": 21
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 470,
-        "bonus2": 6600
+        "bonus1": 470.0,
+        "bonus2": 6600.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 378420
-          },
-          {
             "type": "dilithium",
             "value": 2226
+          },
+          {
+            "type": "parsteel",
+            "value": 378420
           }
         ]
       },
@@ -689,19 +689,19 @@
       "level": 22,
       "requirements": [
         {
-          "name": "Tritanium Generator E",
+          "name": "operations",
           "level": 22
         },
         {
-          "name": "Operations",
+          "name": "tritanium generator e",
           "level": 22
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 490,
-        "bonus2": 6900
+        "bonus1": 490.0,
+        "bonus2": 6900.0
       },
       "build_costs": {
         "materials": [],
@@ -722,19 +722,19 @@
       "level": 23,
       "requirements": [
         {
-          "name": "Tritanium Generator E",
+          "name": "operations",
           "level": 23
         },
         {
-          "name": "Operations",
+          "name": "tritanium generator e",
           "level": 23
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 510,
-        "bonus2": 7100
+        "bonus1": 510.0,
+        "bonus2": 7100.0
       },
       "build_costs": {
         "materials": [],
@@ -755,31 +755,31 @@
       "level": 24,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 24
         },
         {
-          "name": "Tritanium Generator E",
+          "name": "tritanium generator e",
           "level": 24
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 610,
-        "bonus2": 8500
+        "bonus1": 610.0,
+        "bonus2": 8500.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 1591200
-          },
-          {
             "type": "dilithium",
             "value": 9360
+          },
+          {
+            "type": "parsteel",
+            "value": 1591200
           }
         ]
       },
@@ -788,19 +788,19 @@
       "level": 25,
       "requirements": [
         {
-          "name": "Tritanium Generator E",
+          "name": "operations",
           "level": 25
         },
         {
-          "name": "Operations",
+          "name": "tritanium generator e",
           "level": 25
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 640,
-        "bonus2": 9000
+        "bonus1": 640.0,
+        "bonus2": 9000.0
       },
       "build_costs": {
         "materials": [],
@@ -821,31 +821,31 @@
       "level": 26,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 26
         },
         {
-          "name": "Tritanium Generator E",
+          "name": "tritanium generator e",
           "level": 26
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 660,
-        "bonus2": 9200
+        "bonus1": 660.0,
+        "bonus2": 9200.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 3794400
-          },
-          {
             "type": "dilithium",
             "value": 22320
+          },
+          {
+            "type": "parsteel",
+            "value": 3794400
           }
         ]
       },
@@ -854,19 +854,19 @@
       "level": 27,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 27
         },
         {
-          "name": "Tritanium Generator E",
+          "name": "tritanium generator e",
           "level": 27
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 680,
-        "bonus2": 9500
+        "bonus1": 680.0,
+        "bonus2": 9500.0
       },
       "build_costs": {
         "materials": [],
@@ -887,19 +887,19 @@
       "level": 28,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 28
         },
         {
-          "name": "Tritanium Generator E",
+          "name": "tritanium generator e",
           "level": 28
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 710,
-        "bonus2": 9900
+        "bonus1": 710.0,
+        "bonus2": 9900.0
       },
       "build_costs": {
         "materials": [],
@@ -920,31 +920,31 @@
       "level": 29,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 29
         },
         {
-          "name": "Tritanium Generator E",
+          "name": "tritanium generator e",
           "level": 29
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 820,
-        "bonus2": 11500
+        "bonus1": 820.0,
+        "bonus2": 11500.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 13260000
-          },
-          {
             "type": "dilithium",
             "value": 78000
+          },
+          {
+            "type": "parsteel",
+            "value": 13260000
           }
         ]
       },
@@ -953,31 +953,31 @@
       "level": 30,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 30
         },
         {
-          "name": "Tritanium Generator E",
+          "name": "tritanium generator e",
           "level": 30
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 850,
-        "bonus2": 11900
+        "bonus1": 850.0,
+        "bonus2": 11900.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 20961000
-          },
-          {
             "type": "dilithium",
             "value": 123300
+          },
+          {
+            "type": "parsteel",
+            "value": 20961000
           }
         ]
       },
@@ -986,19 +986,19 @@
       "level": 31,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 31
         },
         {
-          "name": "Tritanium Generator E",
+          "name": "tritanium generator e",
           "level": 31
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 880,
-        "bonus2": 13284
+        "bonus1": 880.0,
+        "bonus2": 13284.0
       },
       "build_costs": {
         "materials": [],
@@ -1019,19 +1019,19 @@
       "level": 32,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 32
         },
         {
-          "name": "Tritanium Generator E",
+          "name": "tritanium generator e",
           "level": 32
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 910,
-        "bonus2": 14732
+        "bonus1": 910.0,
+        "bonus2": 14732.0
       },
       "build_costs": {
         "materials": [],
@@ -1052,19 +1052,19 @@
       "level": 33,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 33
         },
         {
-          "name": "Tritanium Generator E",
+          "name": "tritanium generator e",
           "level": 33
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 940,
-        "bonus2": 15312
+        "bonus1": 940.0,
+        "bonus2": 15312.0
       },
       "build_costs": {
         "materials": [],
@@ -1085,31 +1085,31 @@
       "level": 34,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 34
         },
         {
-          "name": "Tritanium Generator E",
+          "name": "tritanium generator e",
           "level": 34
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 1070,
-        "bonus2": 18600
+        "bonus1": 1070.0,
+        "bonus2": 18600.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 114444000
-          },
-          {
             "type": "dilithium",
             "value": 673200
+          },
+          {
+            "type": "parsteel",
+            "value": 114444000
           }
         ]
       },
@@ -1118,31 +1118,31 @@
       "level": 35,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 35
         },
         {
-          "name": "Tritanium Generator E",
+          "name": "tritanium generator e",
           "level": 35
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 1100,
-        "bonus2": 20482
+        "bonus1": 1100.0,
+        "bonus2": 20482.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 161262000
-          },
-          {
             "type": "dilithium",
             "value": 948600
+          },
+          {
+            "type": "parsteel",
+            "value": 161262000
           }
         ]
       },
@@ -1151,19 +1151,19 @@
       "level": 36,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 36
         },
         {
-          "name": "Tritanium Generator E",
+          "name": "tritanium generator e",
           "level": 36
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 1130,
-        "bonus2": 21014
+        "bonus1": 1130.0,
+        "bonus2": 21014.0
       },
       "build_costs": {
         "materials": [],
@@ -1184,31 +1184,31 @@
       "level": 37,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 37
         },
         {
-          "name": "Tritanium Generator E",
+          "name": "tritanium generator e",
           "level": 37
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 1160,
-        "bonus2": 23004
+        "bonus1": 1160.0,
+        "bonus2": 23004.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 385560000
-          },
-          {
             "type": "dilithium",
             "value": 2268000
+          },
+          {
+            "type": "parsteel",
+            "value": 385560000
           }
         ]
       },
@@ -1217,31 +1217,31 @@
       "level": 38,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 38
         },
         {
-          "name": "Tritanium Generator E",
+          "name": "tritanium generator e",
           "level": 38
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 1190,
-        "bonus2": 25551
+        "bonus1": 1190.0,
+        "bonus2": 25551.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 657900000
-          },
-          {
             "type": "dilithium",
             "value": 3870000
+          },
+          {
+            "type": "parsteel",
+            "value": 657900000
           }
         ]
       },
@@ -1250,31 +1250,31 @@
       "level": 39,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 39
         },
         {
-          "name": "Tritanium Generator E",
+          "name": "tritanium generator e",
           "level": 39
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 1350,
-        "bonus2": 28917
+        "bonus1": 1350.0,
+        "bonus2": 28917.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 2865520000
-          },
-          {
             "type": "dilithium",
             "value": 6020000
+          },
+          {
+            "type": "parsteel",
+            "value": 2865520000
           }
         ]
       },
@@ -1283,31 +1283,31 @@
       "level": 40,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 40
         },
         {
-          "name": "Tritanium Generator E",
+          "name": "tritanium generator e",
           "level": 40
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 1380,
-        "bonus2": 31845
+        "bonus1": 1380.0,
+        "bonus2": 31845.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 2924000000
-          },
-          {
             "type": "dilithium",
             "value": 8600000
+          },
+          {
+            "type": "parsteel",
+            "value": 2924000000
           }
         ]
       },
@@ -1316,31 +1316,31 @@
       "level": 41,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 41
         },
         {
-          "name": "Tritanium Generator E",
+          "name": "tritanium generator e",
           "level": 41
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 1425,
-        "bonus2": 36200
+        "bonus1": 1425.0,
+        "bonus2": 36200.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 4355400000
-          },
-          {
             "type": "dilithium",
             "value": 12810000
+          },
+          {
+            "type": "parsteel",
+            "value": 4355400000
           }
         ]
       },
@@ -1349,31 +1349,31 @@
       "level": 42,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 42
         },
         {
-          "name": "Tritanium Generator E",
+          "name": "tritanium generator e",
           "level": 42
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 1450,
-        "bonus2": 36653
+        "bonus1": 1450.0,
+        "bonus2": 36653.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 6222000000
-          },
-          {
             "type": "dilithium",
             "value": 18300000
+          },
+          {
+            "type": "parsteel",
+            "value": 6222000000
           }
         ]
       },
@@ -1382,19 +1382,19 @@
       "level": 43,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 43
         },
         {
-          "name": "Tritanium Generator E",
+          "name": "tritanium generator e",
           "level": 43
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 1475,
-        "bonus2": 41500
+        "bonus1": 1475.0,
+        "bonus2": 41500.0
       },
       "build_costs": {
         "materials": [],
@@ -1415,19 +1415,19 @@
       "level": 44,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 44
         },
         {
-          "name": "Tritanium Generator E",
+          "name": "tritanium generator e",
           "level": 44
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 1725,
-        "bonus2": 54563
+        "bonus1": 1725.0,
+        "bonus2": 54563.0
       },
       "build_costs": {
         "materials": [],
@@ -1448,31 +1448,31 @@
       "level": 45,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 45
         },
         {
-          "name": "Tritanium Generator E",
+          "name": "tritanium generator e",
           "level": 45
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 1750,
-        "bonus2": 55125
+        "bonus1": 1750.0,
+        "bonus2": 55125.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 18232500000
-          },
-          {
             "type": "dilithium",
             "value": 53625000
+          },
+          {
+            "type": "parsteel",
+            "value": 18232500000
           }
         ]
       },
@@ -1481,19 +1481,19 @@
       "level": 46,
       "requirements": [
         {
-          "name": "Tritanium Generator E",
+          "name": "operations",
           "level": 46
         },
         {
-          "name": "Operations",
+          "name": "tritanium generator e",
           "level": 46
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 1800,
-        "bonus2": 56813
+        "bonus1": 1800.0,
+        "bonus2": 56813.0
       },
       "build_costs": {
         "materials": [],
@@ -1514,19 +1514,19 @@
       "level": 47,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 47
         },
         {
-          "name": "Tritanium Generator E",
+          "name": "tritanium generator e",
           "level": 47
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 1850,
-        "bonus2": 58500
+        "bonus1": 1850.0,
+        "bonus2": 58500.0
       },
       "build_costs": {
         "materials": [],
@@ -1547,31 +1547,31 @@
       "level": 48,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 48
         },
         {
-          "name": "Tritanium Generator E",
+          "name": "tritanium generator e",
           "level": 48
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 1875,
-        "bonus2": 59063
+        "bonus1": 1875.0,
+        "bonus2": 59063.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 71400000000
-          },
-          {
             "type": "dilithium",
             "value": 210000000
+          },
+          {
+            "type": "parsteel",
+            "value": 71400000000
           }
         ]
       },
@@ -1580,31 +1580,31 @@
       "level": 49,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 49
         },
         {
-          "name": "Tritanium Generator E",
+          "name": "tritanium generator e",
           "level": 49
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 2300,
-        "bonus2": 72563
+        "bonus1": 2300.0,
+        "bonus2": 72563.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 124950000000
-          },
-          {
             "type": "dilithium",
             "value": 367500000
+          },
+          {
+            "type": "parsteel",
+            "value": 124950000000
           }
         ]
       },
@@ -1613,15 +1613,179 @@
       "level": 50,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 50
         },
         {
-          "name": "Tritanium Generator E",
+          "name": "tritanium generator e",
           "level": 50
         }
-      ],
-      "rewards": []
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 2350.0,
+        "bonus2": 74250.0
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 623220000000
+          },
+          {
+            "type": "dilithium",
+            "value": 780000000
+          }
+        ]
+      },
+      "build_time": 29813760,
+      "increased_power": 2000,
+      "level": 51,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 51
+        },
+        {
+          "name": "tritanium generator e",
+          "level": 51
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 2400.0,
+        "bonus2": 75375.0
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 1127100000000
+          },
+          {
+            "type": "dilithium",
+            "value": 1326000000
+          }
+        ]
+      },
+      "build_time": 31602240,
+      "increased_power": 1500,
+      "level": 52,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 52
+        },
+        {
+          "name": "tritanium generator e",
+          "level": 52
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 2425.0,
+        "bonus2": 76500.0
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 1893120000000
+          },
+          {
+            "type": "dilithium",
+            "value": 2320000000
+          }
+        ]
+      },
+      "build_time": 33498720,
+      "increased_power": 2000,
+      "level": 53,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 53
+        },
+        {
+          "name": "tritanium generator e",
+          "level": 53
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 2475.0,
+        "bonus2": 78188.0
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "dilithium",
+            "value": 3480000000
+          },
+          {
+            "type": "parsteel",
+            "value": 2839680000000
+          }
+        ]
+      },
+      "build_time": 35507520,
+      "increased_power": 2000,
+      "level": 54,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 54
+        },
+        {
+          "name": "tritanium generator e",
+          "level": 54
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 2950.0,
+        "bonus2": 92813.0
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 4826640000000
+          },
+          {
+            "type": "dilithium",
+            "value": 5460000000
+          }
+        ]
+      },
+      "build_time": 37638720,
+      "increased_power": 2000,
+      "level": 55,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 55
+        },
+        {
+          "name": "tritanium generator e",
+          "level": 55
+        }
+      ]
     }
   ]
 }

--- a/buildings/tritanium_generator_h.json
+++ b/buildings/tritanium_generator_h.json
@@ -2,11 +2,11 @@
   "description": "Produces Tritanium, an alloy many times harder than diamond, used to costruct mighty ships. Upgrading Tritanium Generators increases the amount of Tritanium that is produced.",
   "bonuses": {
     "bonus1": {
-      "name": "Tritanium Storage",
+      "name": "tritanium production",
       "percentage": false
     },
     "bonus2": {
-      "name": "Tritanium Production",
+      "name": "tritanium storage",
       "percentage": false
     }
   },
@@ -14,8 +14,8 @@
   "levels": [
     {
       "bonuses": {
-        "bonus1": 8,
-        "bonus2": 15
+        "bonus1": 15.0,
+        "bonus2": 8.0
       },
       "build_costs": {
         "materials": [],
@@ -32,19 +32,19 @@
       "level": 1,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 50
         },
         {
-          "name": "Tritanium Generator F",
+          "name": "tritanium generator f",
           "level": 1
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 30,
-        "bonus2": 30
+        "bonus1": 30.0,
+        "bonus2": 30.0
       },
       "build_costs": {
         "materials": [],
@@ -61,19 +61,19 @@
       "level": 2,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 2
         },
         {
-          "name": "Tritanium Generator F",
+          "name": "tritanium generator f",
           "level": 2
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 68,
-        "bonus2": 45
+        "bonus1": 45.0,
+        "bonus2": 68.0
       },
       "build_costs": {
         "materials": [],
@@ -90,19 +90,19 @@
       "level": 3,
       "requirements": [
         {
-          "name": "Tritanium Generator F",
+          "name": "operations",
           "level": 3
         },
         {
-          "name": "Operations",
+          "name": "tritanium generator f",
           "level": 3
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 150,
-        "bonus2": 60
+        "bonus1": 60.0,
+        "bonus2": 150.0
       },
       "build_costs": {
         "materials": [],
@@ -119,19 +119,19 @@
       "level": 4,
       "requirements": [
         {
-          "name": "Tritanium Generator F",
+          "name": "operations",
           "level": 4
         },
         {
-          "name": "Operations",
+          "name": "tritanium generator f",
           "level": 4
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 225,
-        "bonus2": 75
+        "bonus1": 75.0,
+        "bonus2": 225.0
       },
       "build_costs": {
         "materials": [],
@@ -148,19 +148,19 @@
       "level": 5,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 5
         },
         {
-          "name": "Tritanium Generator F",
+          "name": "tritanium generator f",
           "level": 5
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 320,
-        "bonus2": 91
+        "bonus1": 91.0,
+        "bonus2": 320.0
       },
       "build_costs": {
         "materials": [],
@@ -177,19 +177,19 @@
       "level": 6,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 6
         },
         {
-          "name": "Tritanium Generator F",
+          "name": "tritanium generator f",
           "level": 6
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 420,
-        "bonus2": 105
+        "bonus1": 105.0,
+        "bonus2": 420.0
       },
       "build_costs": {
         "materials": [],
@@ -206,19 +206,19 @@
       "level": 7,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 7
         },
         {
-          "name": "Tritanium Generator F",
+          "name": "tritanium generator f",
           "level": 7
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 600,
-        "bonus2": 120
+        "bonus1": 120.0,
+        "bonus2": 600.0
       },
       "build_costs": {
         "materials": [],
@@ -235,19 +235,19 @@
       "level": 8,
       "requirements": [
         {
-          "name": "Tritanium Generator F",
+          "name": "operations",
           "level": 8
         },
         {
-          "name": "Operations",
+          "name": "tritanium generator f",
           "level": 8
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 740,
-        "bonus2": 135
+        "bonus1": 135.0,
+        "bonus2": 740.0
       },
       "build_costs": {
         "materials": [],
@@ -264,19 +264,19 @@
       "level": 9,
       "requirements": [
         {
-          "name": "Tritanium Generator F",
+          "name": "operations",
           "level": 9
         },
         {
-          "name": "Operations",
+          "name": "tritanium generator f",
           "level": 9
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 1080,
-        "bonus2": 180
+        "bonus1": 180.0,
+        "bonus2": 1080.0
       },
       "build_costs": {
         "materials": [],
@@ -293,19 +293,19 @@
       "level": 10,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 10
         },
         {
-          "name": "Tritanium Generator F",
+          "name": "tritanium generator f",
           "level": 10
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 1400,
-        "bonus2": 200
+        "bonus1": 200.0,
+        "bonus2": 1400.0
       },
       "build_costs": {
         "materials": [],
@@ -326,19 +326,19 @@
       "level": 11,
       "requirements": [
         {
-          "name": "Tritanium Generator F",
+          "name": "operations",
           "level": 11
         },
         {
-          "name": "Operations",
+          "name": "tritanium generator f",
           "level": 11
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 1650,
-        "bonus2": 220
+        "bonus1": 220.0,
+        "bonus2": 1650.0
       },
       "build_costs": {
         "materials": [],
@@ -359,31 +359,31 @@
       "level": 12,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 12
         },
         {
-          "name": "Tritanium Generator F",
+          "name": "tritanium generator f",
           "level": 12
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 2000,
-        "bonus2": 235
+        "bonus1": 235.0,
+        "bonus2": 2000.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 13600
-          },
-          {
             "type": "dilithium",
             "value": 48
+          },
+          {
+            "type": "parsteel",
+            "value": 13600
           }
         ]
       },
@@ -392,31 +392,31 @@
       "level": 13,
       "requirements": [
         {
-          "name": "Tritanium Generator F",
+          "name": "operations",
           "level": 13
         },
         {
-          "name": "Operations",
+          "name": "tritanium generator f",
           "level": 13
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 2300,
-        "bonus2": 255
+        "bonus1": 255.0,
+        "bonus2": 2300.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 18700
-          },
-          {
             "type": "dilithium",
             "value": 88
+          },
+          {
+            "type": "parsteel",
+            "value": 18700
           }
         ]
       },
@@ -425,19 +425,19 @@
       "level": 14,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 14
         },
         {
-          "name": "Tritanium Generator F",
+          "name": "tritanium generator f",
           "level": 14
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 2750,
-        "bonus2": 275
+        "bonus1": 275.0,
+        "bonus2": 2750.0
       },
       "build_costs": {
         "materials": [],
@@ -458,31 +458,31 @@
       "level": 15,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 15
         },
         {
-          "name": "Tritanium Generator F",
+          "name": "tritanium generator f",
           "level": 15
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 3200,
-        "bonus2": 290
+        "bonus1": 290.0,
+        "bonus2": 3200.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 34000
-          },
-          {
             "type": "dilithium",
             "value": 200
+          },
+          {
+            "type": "parsteel",
+            "value": 34000
           }
         ]
       },
@@ -491,19 +491,19 @@
       "level": 16,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 16
         },
         {
-          "name": "Tritanium Generator F",
+          "name": "tritanium generator f",
           "level": 16
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 3575,
-        "bonus2": 310
+        "bonus1": 310.0,
+        "bonus2": 3575.0
       },
       "build_costs": {
         "materials": [],
@@ -524,19 +524,19 @@
       "level": 17,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 17
         },
         {
-          "name": "Tritanium Generator F",
+          "name": "tritanium generator f",
           "level": 17
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 4125,
-        "bonus2": 330
+        "bonus1": 330.0,
+        "bonus2": 4125.0
       },
       "build_costs": {
         "materials": [],
@@ -557,31 +557,31 @@
       "level": 18,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 18
         },
         {
-          "name": "Tritanium Generator F",
+          "name": "tritanium generator f",
           "level": 18
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 4475,
-        "bonus2": 345
+        "bonus1": 345.0,
+        "bonus2": 4475.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 102000
-          },
-          {
             "type": "dilithium",
             "value": 600
+          },
+          {
+            "type": "parsteel",
+            "value": 102000
           }
         ]
       },
@@ -590,19 +590,19 @@
       "level": 19,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 19
         },
         {
-          "name": "Tritanium Generator F",
+          "name": "tritanium generator f",
           "level": 19
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 6000,
-        "bonus2": 425
+        "bonus1": 425.0,
+        "bonus2": 6000.0
       },
       "build_costs": {
         "materials": [],
@@ -623,31 +623,31 @@
       "level": 20,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 20
         },
         {
-          "name": "Tritanium Generator F",
+          "name": "tritanium generator f",
           "level": 20
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 6300,
-        "bonus2": 450
+        "bonus1": 450.0,
+        "bonus2": 6300.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 243270
-          },
-          {
             "type": "dilithium",
             "value": 1431
+          },
+          {
+            "type": "parsteel",
+            "value": 243270
           }
         ]
       },
@@ -656,31 +656,31 @@
       "level": 21,
       "requirements": [
         {
-          "name": "Tritanium Generator F",
+          "name": "operations",
           "level": 21
         },
         {
-          "name": "Operations",
+          "name": "tritanium generator f",
           "level": 21
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 6600,
-        "bonus2": 470
+        "bonus1": 470.0,
+        "bonus2": 6600.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 378420
-          },
-          {
             "type": "dilithium",
             "value": 2226
+          },
+          {
+            "type": "parsteel",
+            "value": 378420
           }
         ]
       },
@@ -689,19 +689,19 @@
       "level": 22,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 22
         },
         {
-          "name": "Tritanium Generator F",
+          "name": "tritanium generator f",
           "level": 22
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 6900,
-        "bonus2": 490
+        "bonus1": 490.0,
+        "bonus2": 6900.0
       },
       "build_costs": {
         "materials": [],
@@ -722,31 +722,31 @@
       "level": 23,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 23
         },
         {
-          "name": "Tritanium Generator F",
+          "name": "tritanium generator f",
           "level": 23
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 7100,
-        "bonus2": 510
+        "bonus1": 510.0,
+        "bonus2": 7100.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 981240
-          },
-          {
             "type": "dilithium",
             "value": 5772
+          },
+          {
+            "type": "parsteel",
+            "value": 981240
           }
         ]
       },
@@ -755,31 +755,31 @@
       "level": 24,
       "requirements": [
         {
-          "name": "Tritanium Generator F",
+          "name": "operations",
           "level": 24
         },
         {
-          "name": "Operations",
+          "name": "tritanium generator f",
           "level": 24
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 8500,
-        "bonus2": 610
+        "bonus1": 610.0,
+        "bonus2": 8500.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 1591200
-          },
-          {
             "type": "dilithium",
             "value": 9360
+          },
+          {
+            "type": "parsteel",
+            "value": 1591200
           }
         ]
       },
@@ -788,31 +788,31 @@
       "level": 25,
       "requirements": [
         {
-          "name": "Tritanium Generator F",
+          "name": "operations",
           "level": 25
         },
         {
-          "name": "Operations",
+          "name": "tritanium generator f",
           "level": 25
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 9000,
-        "bonus2": 640
+        "bonus1": 640.0,
+        "bonus2": 9000.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 2486250
-          },
-          {
             "type": "dilithium",
             "value": 14625
+          },
+          {
+            "type": "parsteel",
+            "value": 2486250
           }
         ]
       },
@@ -821,19 +821,19 @@
       "level": 26,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 26
         },
         {
-          "name": "Tritanium Generator F",
+          "name": "tritanium generator f",
           "level": 26
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 9200,
-        "bonus2": 660
+        "bonus1": 660.0,
+        "bonus2": 9200.0
       },
       "build_costs": {
         "materials": [],
@@ -854,31 +854,31 @@
       "level": 27,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 27
         },
         {
-          "name": "Tritanium Generator F",
+          "name": "tritanium generator f",
           "level": 27
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 9500,
-        "bonus2": 680
+        "bonus1": 680.0,
+        "bonus2": 9500.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 5691600
-          },
-          {
             "type": "dilithium",
             "value": 33480
+          },
+          {
+            "type": "parsteel",
+            "value": 5691600
           }
         ]
       },
@@ -887,19 +887,19 @@
       "level": 28,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 28
         },
         {
-          "name": "Tritanium Generator F",
+          "name": "tritanium generator f",
           "level": 28
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 9900,
-        "bonus2": 710
+        "bonus1": 710.0,
+        "bonus2": 9900.0
       },
       "build_costs": {
         "materials": [],
@@ -920,19 +920,19 @@
       "level": 29,
       "requirements": [
         {
-          "name": "Tritanium Generator F",
+          "name": "operations",
           "level": 29
         },
         {
-          "name": "Operations",
+          "name": "tritanium generator f",
           "level": 29
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 11500,
-        "bonus2": 820
+        "bonus1": 820.0,
+        "bonus2": 11500.0
       },
       "build_costs": {
         "materials": [],
@@ -953,19 +953,19 @@
       "level": 30,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 30
         },
         {
-          "name": "Tritanium Generator F",
+          "name": "tritanium generator f",
           "level": 30
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 11900,
-        "bonus2": 850
+        "bonus1": 850.0,
+        "bonus2": 11900.0
       },
       "build_costs": {
         "materials": [],
@@ -986,19 +986,19 @@
       "level": 31,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 31
         },
         {
-          "name": "Tritanium Generator F",
+          "name": "tritanium generator f",
           "level": 31
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 13284,
-        "bonus2": 880
+        "bonus1": 880.0,
+        "bonus2": 13284.0
       },
       "build_costs": {
         "materials": [],
@@ -1019,19 +1019,19 @@
       "level": 32,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 32
         },
         {
-          "name": "Tritanium Generator F",
+          "name": "tritanium generator f",
           "level": 32
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 14732,
-        "bonus2": 910
+        "bonus1": 910.0,
+        "bonus2": 14732.0
       },
       "build_costs": {
         "materials": [],
@@ -1052,19 +1052,19 @@
       "level": 33,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 33
         },
         {
-          "name": "Tritanium Generator F",
+          "name": "tritanium generator f",
           "level": 33
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 15312,
-        "bonus2": 940
+        "bonus1": 940.0,
+        "bonus2": 15312.0
       },
       "build_costs": {
         "materials": [],
@@ -1085,31 +1085,31 @@
       "level": 34,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 34
         },
         {
-          "name": "Tritanium Generator F",
+          "name": "tritanium generator f",
           "level": 34
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 18600,
-        "bonus2": 1070
+        "bonus1": 1070.0,
+        "bonus2": 18600.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 114444000
-          },
-          {
             "type": "dilithium",
             "value": 673200
+          },
+          {
+            "type": "parsteel",
+            "value": 114444000
           }
         ]
       },
@@ -1118,31 +1118,31 @@
       "level": 35,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 35
         },
         {
-          "name": "Tritanium Generator F",
+          "name": "tritanium generator f",
           "level": 35
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 20482,
-        "bonus2": 1100
+        "bonus1": 1100.0,
+        "bonus2": 20482.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 161262000
-          },
-          {
             "type": "dilithium",
             "value": 948600
+          },
+          {
+            "type": "parsteel",
+            "value": 161262000
           }
         ]
       },
@@ -1151,19 +1151,19 @@
       "level": 36,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 36
         },
         {
-          "name": "Tritanium Generator F",
+          "name": "tritanium generator f",
           "level": 36
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 21014,
-        "bonus2": 1130
+        "bonus1": 1130.0,
+        "bonus2": 21014.0
       },
       "build_costs": {
         "materials": [],
@@ -1184,31 +1184,31 @@
       "level": 37,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 37
         },
         {
-          "name": "Tritanium Generator F",
+          "name": "tritanium generator f",
           "level": 37
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 23004,
-        "bonus2": 1160
+        "bonus1": 1160.0,
+        "bonus2": 23004.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 385560000
-          },
-          {
             "type": "dilithium",
             "value": 2268000
+          },
+          {
+            "type": "parsteel",
+            "value": 385560000
           }
         ]
       },
@@ -1217,31 +1217,31 @@
       "level": 38,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 38
         },
         {
-          "name": "Tritanium Generator F",
+          "name": "tritanium generator f",
           "level": 38
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 25551,
-        "bonus2": 1190
+        "bonus1": 1190.0,
+        "bonus2": 25551.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 657900000
-          },
-          {
             "type": "dilithium",
             "value": 3870000
+          },
+          {
+            "type": "parsteel",
+            "value": 657900000
           }
         ]
       },
@@ -1250,19 +1250,19 @@
       "level": 39,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 39
         },
         {
-          "name": "Tritanium Generator F",
+          "name": "tritanium generator f",
           "level": 39
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 28917,
-        "bonus2": 1350
+        "bonus1": 1350.0,
+        "bonus2": 28917.0
       },
       "build_costs": {
         "materials": [],
@@ -1283,19 +1283,19 @@
       "level": 40,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 40
         },
         {
-          "name": "Tritanium Generator F",
+          "name": "tritanium generator f",
           "level": 40
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 31845,
-        "bonus2": 1380
+        "bonus1": 1380.0,
+        "bonus2": 31845.0
       },
       "build_costs": {
         "materials": [],
@@ -1316,31 +1316,31 @@
       "level": 41,
       "requirements": [
         {
-          "name": "Tritanium Generator F",
+          "name": "operations",
           "level": 41
         },
         {
-          "name": "Operations",
+          "name": "tritanium generator f",
           "level": 41
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 36200,
-        "bonus2": 1425
+        "bonus1": 1425.0,
+        "bonus2": 36200.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 4355400000
-          },
-          {
             "type": "dilithium",
             "value": 12810000
+          },
+          {
+            "type": "parsteel",
+            "value": 4355400000
           }
         ]
       },
@@ -1349,19 +1349,19 @@
       "level": 42,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 42
         },
         {
-          "name": "Tritanium Generator F",
+          "name": "tritanium generator f",
           "level": 42
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 36653,
-        "bonus2": 1450
+        "bonus1": 1450.0,
+        "bonus2": 36653.0
       },
       "build_costs": {
         "materials": [],
@@ -1382,19 +1382,19 @@
       "level": 43,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 43
         },
         {
-          "name": "Tritanium Generator F",
+          "name": "tritanium generator f",
           "level": 43
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 41500,
-        "bonus2": 1475
+        "bonus1": 1475.0,
+        "bonus2": 41500.0
       },
       "build_costs": {
         "materials": [],
@@ -1415,19 +1415,19 @@
       "level": 44,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 44
         },
         {
-          "name": "Tritanium Generator F",
+          "name": "tritanium generator f",
           "level": 44
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 54563,
-        "bonus2": 1725
+        "bonus1": 1725.0,
+        "bonus2": 54563.0
       },
       "build_costs": {
         "materials": [],
@@ -1448,31 +1448,31 @@
       "level": 45,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 45
         },
         {
-          "name": "Tritanium Generator F",
+          "name": "tritanium generator f",
           "level": 45
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 55125,
-        "bonus2": 1750
+        "bonus1": 1750.0,
+        "bonus2": 55125.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 18232500000
-          },
-          {
             "type": "dilithium",
             "value": 53625000
+          },
+          {
+            "type": "parsteel",
+            "value": 18232500000
           }
         ]
       },
@@ -1481,19 +1481,19 @@
       "level": 46,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 46
         },
         {
-          "name": "Tritanium Generator F",
+          "name": "tritanium generator f",
           "level": 46
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 56813,
-        "bonus2": 1800
+        "bonus1": 1800.0,
+        "bonus2": 56813.0
       },
       "build_costs": {
         "materials": [],
@@ -1514,31 +1514,31 @@
       "level": 47,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 47
         },
         {
-          "name": "Tritanium Generator F",
+          "name": "tritanium generator f",
           "level": 47
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 58500,
-        "bonus2": 1850
+        "bonus1": 1850.0,
+        "bonus2": 58500.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 42840000000
-          },
-          {
             "type": "dilithium",
             "value": 126000000
+          },
+          {
+            "type": "parsteel",
+            "value": 42840000000
           }
         ]
       },
@@ -1547,19 +1547,19 @@
       "level": 48,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 48
         },
         {
-          "name": "Tritanium Generator F",
+          "name": "tritanium generator f",
           "level": 48
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 59063,
-        "bonus2": 1875
+        "bonus1": 1875.0,
+        "bonus2": 59063.0
       },
       "build_costs": {
         "materials": [],
@@ -1580,19 +1580,19 @@
       "level": 49,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 49
         },
         {
-          "name": "Tritanium Generator F",
+          "name": "tritanium generator f",
           "level": 49
         }
       ]
     },
     {
       "bonuses": {
-        "bonus1": 72563,
-        "bonus2": 2300
+        "bonus1": 2300.0,
+        "bonus2": 72563.0
       },
       "build_costs": {
         "materials": [],
@@ -1613,15 +1613,179 @@
       "level": 50,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 50
         },
         {
-          "name": "Tritanium Generator F",
+          "name": "tritanium generator f",
           "level": 50
         }
-      ],
-      "rewards": []
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 2350.0,
+        "bonus2": 74250.0
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 623220000000
+          },
+          {
+            "type": "dilithium",
+            "value": 780000000
+          }
+        ]
+      },
+      "build_time": 29813760,
+      "increased_power": 2000,
+      "level": 51,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 51
+        },
+        {
+          "name": "tritanium generator f",
+          "level": 51
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 2400.0,
+        "bonus2": 75375.0
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 1127100000000
+          },
+          {
+            "type": "dilithium",
+            "value": 1326000000
+          }
+        ]
+      },
+      "build_time": 31602240,
+      "increased_power": 1500,
+      "level": 52,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 52
+        },
+        {
+          "name": "tritanium generator f",
+          "level": 52
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 2425.0,
+        "bonus2": 76500.0
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 1893120000000
+          },
+          {
+            "type": "dilithium",
+            "value": 2320000000
+          }
+        ]
+      },
+      "build_time": 33498720,
+      "increased_power": 2000,
+      "level": 53,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 53
+        },
+        {
+          "name": "tritanium generator f",
+          "level": 53
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 2475.0,
+        "bonus2": 78188.0
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "dilithium",
+            "value": 3480000000
+          },
+          {
+            "type": "parsteel",
+            "value": 2839680000000
+          }
+        ]
+      },
+      "build_time": 35507520,
+      "increased_power": 2000,
+      "level": 54,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 54
+        },
+        {
+          "name": "tritanium generator f",
+          "level": 54
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 2950.0,
+        "bonus2": 92813.0
+      },
+      "build_costs": {
+        "materials": [],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 4826640000000
+          },
+          {
+            "type": "dilithium",
+            "value": 5460000000
+          }
+        ]
+      },
+      "build_time": 37638720,
+      "increased_power": 2000,
+      "level": 55,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 55
+        },
+        {
+          "name": "tritanium generator f",
+          "level": 55
+        }
+      ]
     }
   ]
 }

--- a/buildings/tritanium_vault.json
+++ b/buildings/tritanium_vault.json
@@ -2,7 +2,7 @@
   "description": "Protects the stored Tritanium from enemy attacks. Upgrade the Vault for additional security.",
   "bonuses": {
     "bonus1": {
-      "name": "Tritanium Vault Protection",
+      "name": "tritanium vault protection",
       "percentage": false
     }
   },
@@ -10,7 +10,7 @@
   "levels": [
     {
       "bonuses": {
-        "bonus1": 20000
+        "bonus1": 20000.0
       },
       "build_costs": {
         "materials": [],
@@ -31,15 +31,14 @@
       "level": 1,
       "requirements": [
         {
-          "name": "Unlock Vaults",
+          "name": "unlock vaults",
           "level": 1
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 20500
+        "bonus1": 20500.0
       },
       "build_costs": {
         "materials": [],
@@ -60,31 +59,30 @@
       "level": 2,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 2
         },
         {
-          "name": "Tritanium Generator B",
+          "name": "tritanium generator b",
           "level": 2
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 21000
+        "bonus1": 21000.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 1000
-          },
-          {
             "type": "tritanium",
             "value": 150
+          },
+          {
+            "type": "parsteel",
+            "value": 1000
           }
         ]
       },
@@ -93,31 +91,30 @@
       "level": 3,
       "requirements": [
         {
-          "name": "Tritanium Generator B",
+          "name": "parsteel vault",
           "level": 3
         },
         {
-          "name": "Parsteel Vault",
+          "name": "tritanium generator b",
           "level": 3
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 21500
+        "bonus1": 21500.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 1250
-          },
-          {
             "type": "tritanium",
             "value": 200
+          },
+          {
+            "type": "parsteel",
+            "value": 1250
           }
         ]
       },
@@ -126,31 +123,30 @@
       "level": 4,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 4
         },
         {
-          "name": "Tritanium Generator B",
+          "name": "tritanium generator b",
           "level": 4
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 22000
+        "bonus1": 22000.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 1600
-          },
-          {
             "type": "tritanium",
             "value": 250
+          },
+          {
+            "type": "parsteel",
+            "value": 1600
           }
         ]
       },
@@ -159,31 +155,30 @@
       "level": 5,
       "requirements": [
         {
-          "name": "Tritanium Generator B",
+          "name": "operations",
           "level": 5
         },
         {
-          "name": "Operations",
+          "name": "tritanium generator b",
           "level": 5
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 22500
+        "bonus1": 22500.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 2000
-          },
-          {
             "type": "tritanium",
             "value": 325
+          },
+          {
+            "type": "parsteel",
+            "value": 2000
           }
         ]
       },
@@ -192,19 +187,18 @@
       "level": 6,
       "requirements": [
         {
-          "name": "Tritanium Generator B",
+          "name": "operations",
           "level": 6
         },
         {
-          "name": "Operations",
+          "name": "tritanium generator b",
           "level": 6
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 23000
+        "bonus1": 23000.0
       },
       "build_costs": {
         "materials": [],
@@ -225,19 +219,18 @@
       "level": 7,
       "requirements": [
         {
-          "name": "Tritanium Generator B",
+          "name": "operations",
           "level": 7
         },
         {
-          "name": "Operations",
+          "name": "tritanium generator b",
           "level": 7
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 23500
+        "bonus1": 23500.0
       },
       "build_costs": {
         "materials": [],
@@ -258,19 +251,18 @@
       "level": 8,
       "requirements": [
         {
-          "name": "Tritanium Generator B",
+          "name": "operations",
           "level": 8
         },
         {
-          "name": "Operations",
+          "name": "tritanium generator b",
           "level": 8
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 24000
+        "bonus1": 24000.0
       },
       "build_costs": {
         "materials": [],
@@ -291,19 +283,18 @@
       "level": 9,
       "requirements": [
         {
-          "name": "Tritanium Generator B",
+          "name": "operations",
           "level": 9
         },
         {
-          "name": "Operations",
+          "name": "tritanium generator b",
           "level": 9
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 25000
+        "bonus1": 25000.0
       },
       "build_costs": {
         "materials": [],
@@ -324,31 +315,30 @@
       "level": 10,
       "requirements": [
         {
-          "name": "Parsteel Vault",
+          "name": "operations",
           "level": 10
         },
         {
-          "name": "Operations",
+          "name": "parsteel vault",
           "level": 10
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 27500
+        "bonus1": 27500.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 21760
-          },
-          {
             "type": "tritanium",
             "value": 1000
+          },
+          {
+            "type": "parsteel",
+            "value": 21760
           }
         ]
       },
@@ -357,31 +347,30 @@
       "level": 11,
       "requirements": [
         {
-          "name": "Tritanium Generator B",
+          "name": "operations",
           "level": 11
         },
         {
-          "name": "Operations",
+          "name": "tritanium generator b",
           "level": 11
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 30000
+        "bonus1": 30000.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 29920
-          },
-          {
             "type": "tritanium",
             "value": 1375
+          },
+          {
+            "type": "parsteel",
+            "value": 29920
           }
         ]
       },
@@ -390,19 +379,18 @@
       "level": 12,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 12
         },
         {
-          "name": "Tritanium Generator B",
+          "name": "tritanium generator b",
           "level": 12
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 33000
+        "bonus1": 33000.0
       },
       "build_costs": {
         "materials": [],
@@ -423,19 +411,18 @@
       "level": 13,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 13
         },
         {
-          "name": "Tritanium Generator B",
+          "name": "tritanium generator b",
           "level": 13
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 36000
+        "bonus1": 36000.0
       },
       "build_costs": {
         "materials": [],
@@ -456,31 +443,30 @@
       "level": 14,
       "requirements": [
         {
-          "name": "Tritanium Generator B",
+          "name": "operations",
           "level": 14
         },
         {
-          "name": "Operations",
+          "name": "tritanium generator b",
           "level": 14
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 40000
+        "bonus1": 40000.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 81600
-          },
-          {
             "type": "tritanium",
             "value": 3750
+          },
+          {
+            "type": "parsteel",
+            "value": 81600
           }
         ]
       },
@@ -489,31 +475,30 @@
       "level": 15,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 15
         },
         {
-          "name": "Tritanium Generator B",
+          "name": "tritanium generator b",
           "level": 15
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 44000
+        "bonus1": 44000.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 108800
-          },
-          {
             "type": "tritanium",
             "value": 5000
+          },
+          {
+            "type": "parsteel",
+            "value": 108800
           }
         ]
       },
@@ -522,31 +507,30 @@
       "level": 16,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 16
         },
         {
-          "name": "Tritanium Generator B",
+          "name": "tritanium generator b",
           "level": 16
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 48000
+        "bonus1": 48000.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 152320
-          },
-          {
             "type": "tritanium",
             "value": 7000
+          },
+          {
+            "type": "parsteel",
+            "value": 152320
           }
         ]
       },
@@ -555,31 +539,30 @@
       "level": 17,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 17
         },
         {
-          "name": "Tritanium Generator B",
+          "name": "tritanium generator b",
           "level": 17
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 52000
+        "bonus1": 52000.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 217600
-          },
-          {
             "type": "tritanium",
             "value": 10000
+          },
+          {
+            "type": "parsteel",
+            "value": 217600
           }
         ]
       },
@@ -588,35 +571,34 @@
       "level": 18,
       "requirements": [
         {
-          "name": "Parsteel Vault",
+          "name": "operations",
           "level": 18
         },
         {
-          "name": "Tritanium Generator B",
+          "name": "tritanium generator b",
           "level": 18
         },
         {
-          "name": "Operations",
+          "name": "parsteel vault",
           "level": 18
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 56000
+        "bonus1": 56000.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 326400
-          },
-          {
             "type": "tritanium",
             "value": 15000
+          },
+          {
+            "type": "parsteel",
+            "value": 326400
           }
         ]
       },
@@ -625,31 +607,30 @@
       "level": 19,
       "requirements": [
         {
-          "name": "Tritanium Generator B",
+          "name": "operations",
           "level": 19
         },
         {
-          "name": "Operations",
+          "name": "tritanium generator b",
           "level": 19
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 60000
+        "bonus1": 60000.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 462400
-          },
-          {
             "type": "tritanium",
             "value": 21250
+          },
+          {
+            "type": "parsteel",
+            "value": 462400
           }
         ]
       },
@@ -658,19 +639,18 @@
       "level": 20,
       "requirements": [
         {
-          "name": "Tritanium Generator B",
+          "name": "operations",
           "level": 20
         },
         {
-          "name": "Operations",
+          "name": "tritanium generator b",
           "level": 20
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 68000
+        "bonus1": 68000.0
       },
       "build_costs": {
         "materials": [],
@@ -691,19 +671,18 @@
       "level": 21,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 21
         },
         {
-          "name": "Tritanium Generator B",
+          "name": "tritanium generator b",
           "level": 21
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 78000
+        "bonus1": 78000.0
       },
       "build_costs": {
         "materials": [],
@@ -724,31 +703,30 @@
       "level": 22,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 22
         },
         {
-          "name": "Tritanium Generator B",
+          "name": "tritanium generator b",
           "level": 22
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 90000
+        "bonus1": 90000.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 1992672
-          },
-          {
             "type": "tritanium",
             "value": 91575
+          },
+          {
+            "type": "parsteel",
+            "value": 1992672
           }
         ]
       },
@@ -757,19 +735,18 @@
       "level": 23,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 23
         },
         {
-          "name": "Tritanium Generator B",
+          "name": "tritanium generator b",
           "level": 23
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 105000
+        "bonus1": 105000.0
       },
       "build_costs": {
         "materials": [],
@@ -790,37 +767,36 @@
       "level": 24,
       "requirements": [
         {
-          "name": "Parsteel Vault",
+          "name": "operations",
           "level": 24
         },
         {
-          "name": "Tritanium Generator B",
+          "name": "tritanium generator b",
           "level": 24
         },
         {
-          "name": "Operations",
+          "name": "parsteel vault",
           "level": 24
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 120000
+        "bonus1": 120000.0
       },
       "build_costs": {
         "materials": [
           {
             "type": "ore",
             "grade": 3,
-            "rarity": "common",
-            "value": 190
+            "rarity": "uncommon",
+            "value": 2
           },
           {
             "type": "ore",
             "grade": 3,
-            "rarity": "uncommon",
-            "value": 2
+            "rarity": "common",
+            "value": 190
           }
         ],
         "others": [],
@@ -840,19 +816,18 @@
       "level": 25,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 25
         },
         {
-          "name": "Tritanium Generator B",
+          "name": "tritanium generator b",
           "level": 25
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 135000
+        "bonus1": 135000.0
       },
       "build_costs": {
         "materials": [
@@ -872,12 +847,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 7956000
-          },
-          {
             "type": "tritanium",
             "value": 365625
+          },
+          {
+            "type": "parsteel",
+            "value": 7956000
           }
         ]
       },
@@ -886,44 +861,43 @@
       "level": 26,
       "requirements": [
         {
-          "name": "Tritanium Generator B",
+          "name": "operations",
           "level": 26
         },
         {
-          "name": "Operations",
+          "name": "tritanium generator b",
           "level": 26
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 155000
+        "bonus1": 155000.0
       },
       "build_costs": {
         "materials": [
           {
             "type": "ore",
             "grade": 3,
-            "rarity": "common",
-            "value": 290
+            "rarity": "uncommon",
+            "value": 10
           },
           {
             "type": "ore",
             "grade": 3,
-            "rarity": "uncommon",
-            "value": 10
+            "rarity": "common",
+            "value": 290
           }
         ],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 12142080
-          },
-          {
             "type": "tritanium",
             "value": 558000
+          },
+          {
+            "type": "parsteel",
+            "value": 12142080
           }
         ]
       },
@@ -932,19 +906,18 @@
       "level": 27,
       "requirements": [
         {
-          "name": "Tritanium Generator B",
+          "name": "operations",
           "level": 27
         },
         {
-          "name": "Operations",
+          "name": "tritanium generator b",
           "level": 27
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 180000
+        "bonus1": 180000.0
       },
       "build_costs": {
         "materials": [
@@ -972,19 +945,18 @@
       "level": 28,
       "requirements": [
         {
-          "name": "Tritanium Generator B",
+          "name": "operations",
           "level": 28
         },
         {
-          "name": "Operations",
+          "name": "tritanium generator b",
           "level": 28
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 210000
+        "bonus1": 210000.0
       },
       "build_costs": {
         "materials": [
@@ -1012,23 +984,22 @@
       "level": 29,
       "requirements": [
         {
-          "name": "Parsteel Vault",
+          "name": "operations",
           "level": 29
         },
         {
-          "name": "Tritanium Generator B",
+          "name": "tritanium generator b",
           "level": 29
         },
         {
-          "name": "Operations",
+          "name": "parsteel vault",
           "level": 29
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 250000
+        "bonus1": 250000.0
       },
       "build_costs": {
         "materials": [
@@ -1048,12 +1019,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 42432000
-          },
-          {
             "type": "tritanium",
             "value": 1950000
+          },
+          {
+            "type": "parsteel",
+            "value": 42432000
           }
         ]
       },
@@ -1062,44 +1033,43 @@
       "level": 30,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 30
         },
         {
-          "name": "Tritanium Generator B",
+          "name": "tritanium generator b",
           "level": 30
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 340000
+        "bonus1": 340000.0
       },
       "build_costs": {
         "materials": [
           {
             "type": "ore",
             "grade": 3,
-            "rarity": "common",
-            "value": 700
+            "rarity": "uncommon",
+            "value": 50
           },
           {
             "type": "ore",
             "grade": 3,
-            "rarity": "uncommon",
-            "value": 50
+            "rarity": "common",
+            "value": 700
           }
         ],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 67075200
-          },
-          {
             "type": "tritanium",
             "value": 3082500
+          },
+          {
+            "type": "parsteel",
+            "value": 67075200
           }
         ]
       },
@@ -1108,19 +1078,18 @@
       "level": 31,
       "requirements": [
         {
-          "name": "Tritanium Generator B",
+          "name": "operations",
           "level": 31
         },
         {
-          "name": "Operations",
+          "name": "tritanium generator b",
           "level": 31
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 460000
+        "bonus1": 460000.0
       },
       "build_costs": {
         "materials": [
@@ -1140,12 +1109,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 96886400
-          },
-          {
             "type": "tritanium",
             "value": 4452500
+          },
+          {
+            "type": "parsteel",
+            "value": 96886400
           }
         ]
       },
@@ -1154,19 +1123,18 @@
       "level": 32,
       "requirements": [
         {
-          "name": "Tritanium Generator B",
+          "name": "operations",
           "level": 32
         },
         {
-          "name": "Operations",
+          "name": "tritanium generator b",
           "level": 32
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 630000
+        "bonus1": 630000.0
       },
       "build_costs": {
         "materials": [
@@ -1180,12 +1148,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 149872000
-          },
-          {
             "type": "tritanium",
             "value": 6887500
+          },
+          {
+            "type": "parsteel",
+            "value": 149872000
           }
         ]
       },
@@ -1194,19 +1162,18 @@
       "level": 33,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 33
         },
         {
-          "name": "Tritanium Generator B",
+          "name": "tritanium generator b",
           "level": 33
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 800000
+        "bonus1": 800000.0
       },
       "build_costs": {
         "materials": [
@@ -1220,12 +1187,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 236640000
-          },
-          {
             "type": "tritanium",
             "value": 10875000
+          },
+          {
+            "type": "parsteel",
+            "value": 236640000
           }
         ]
       },
@@ -1234,44 +1201,43 @@
       "level": 34,
       "requirements": [
         {
-          "name": "Tritanium Generator B",
+          "name": "operations",
           "level": 34
         },
         {
-          "name": "Operations",
+          "name": "tritanium generator b",
           "level": 34
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 1100000
+        "bonus1": 1100000.0
       },
       "build_costs": {
         "materials": [
           {
             "type": "ore",
             "grade": 3,
-            "rarity": "common",
-            "value": 1300
+            "rarity": "uncommon",
+            "value": 120
           },
           {
             "type": "ore",
             "grade": 3,
-            "rarity": "uncommon",
-            "value": 120
+            "rarity": "common",
+            "value": 1300
           }
         ],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 366220800
-          },
-          {
             "type": "tritanium",
             "value": 16830000
+          },
+          {
+            "type": "parsteel",
+            "value": 366220800
           }
         ]
       },
@@ -1280,19 +1246,18 @@
       "level": 35,
       "requirements": [
         {
-          "name": "Tritanium Generator B",
+          "name": "operations",
           "level": 35
         },
         {
-          "name": "Operations",
+          "name": "tritanium generator b",
           "level": 35
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 1430000
+        "bonus1": 1430000.0
       },
       "build_costs": {
         "materials": [
@@ -1306,12 +1271,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 516038400
-          },
-          {
             "type": "tritanium",
             "value": 23715000
+          },
+          {
+            "type": "parsteel",
+            "value": 516038400
           }
         ]
       },
@@ -1320,19 +1285,18 @@
       "level": 36,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 36
         },
         {
-          "name": "Tritanium Generator B",
+          "name": "tritanium generator b",
           "level": 36
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 1890000
+        "bonus1": 1890000.0
       },
       "build_costs": {
         "materials": [
@@ -1360,19 +1324,18 @@
       "level": 37,
       "requirements": [
         {
-          "name": "Tritanium Generator B",
+          "name": "operations",
           "level": 37
         },
         {
-          "name": "Operations",
+          "name": "tritanium generator b",
           "level": 37
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 2660000
+        "bonus1": 2660000.0
       },
       "build_costs": {
         "materials": [
@@ -1406,35 +1369,34 @@
       "level": 38,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 38
         },
         {
-          "name": "Tritanium Generator B",
+          "name": "tritanium generator b",
           "level": 38
         },
         {
-          "name": "Parsteel Vault",
+          "name": "parsteel vault",
           "level": 38
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 3830000
+        "bonus1": 3830000.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 2105280000
-          },
-          {
             "type": "tritanium",
             "value": 96750000
+          },
+          {
+            "type": "parsteel",
+            "value": 2105280000
           }
         ]
       },
@@ -1443,19 +1405,18 @@
       "level": 39,
       "requirements": [
         {
-          "name": "Tritanium Generator B",
+          "name": "operations",
           "level": 39
         },
         {
-          "name": "Operations",
+          "name": "tritanium generator b",
           "level": 39
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 5250000
+        "bonus1": 5250000.0
       },
       "build_costs": {
         "materials": [
@@ -1469,12 +1430,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 9169664000
-          },
-          {
             "type": "tritanium",
             "value": 150500000
+          },
+          {
+            "type": "parsteel",
+            "value": 9169664000
           }
         ]
       },
@@ -1483,19 +1444,18 @@
       "level": 40,
       "requirements": [
         {
-          "name": "Tritanium Generator B",
+          "name": "operations",
           "level": 40
         },
         {
-          "name": "Operations",
+          "name": "tritanium generator b",
           "level": 40
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 7130000
+        "bonus1": 7130000.0
       },
       "build_costs": {
         "materials": [
@@ -1509,12 +1469,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 9356800000
-          },
-          {
             "type": "tritanium",
             "value": 215000000
+          },
+          {
+            "type": "parsteel",
+            "value": 9356800000
           }
         ]
       },
@@ -1523,33 +1483,32 @@
       "level": 41,
       "requirements": [
         {
-          "name": "Tritanium Generator B",
+          "name": "operations",
           "level": 41
         },
         {
-          "name": "Operations",
+          "name": "tritanium generator b",
           "level": 41
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 9450000
+        "bonus1": 9450000.0
       },
       "build_costs": {
         "materials": [
           {
             "type": "ore",
             "grade": 4,
-            "rarity": "common",
-            "value": 7000
+            "rarity": "rare",
+            "value": 400
           },
           {
             "type": "ore",
             "grade": 4,
-            "rarity": "rare",
-            "value": 400
+            "rarity": "common",
+            "value": 7000
           }
         ],
         "others": [],
@@ -1569,19 +1528,18 @@
       "level": 42,
       "requirements": [
         {
-          "name": "Tritanium Generator B",
+          "name": "operations",
           "level": 42
         },
         {
-          "name": "Operations",
+          "name": "tritanium generator b",
           "level": 42
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 12750000
+        "bonus1": 12750000.0
       },
       "build_costs": {
         "materials": [
@@ -1615,19 +1573,18 @@
       "level": 43,
       "requirements": [
         {
-          "name": "Tritanium Generator B",
+          "name": "operations",
           "level": 43
         },
         {
-          "name": "Operations",
+          "name": "tritanium generator b",
           "level": 43
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 18000000
+        "bonus1": 18000000.0
       },
       "build_costs": {
         "materials": [
@@ -1647,12 +1604,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 29865600000
-          },
-          {
             "type": "tritanium",
             "value": 686250000
+          },
+          {
+            "type": "parsteel",
+            "value": 29865600000
           }
         ]
       },
@@ -1661,19 +1618,18 @@
       "level": 44,
       "requirements": [
         {
-          "name": "Tritanium Generator B",
+          "name": "operations",
           "level": 44
         },
         {
-          "name": "Operations",
+          "name": "tritanium generator b",
           "level": 44
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 22500000
+        "bonus1": 22500000.0
       },
       "build_costs": {
         "materials": [
@@ -1701,23 +1657,22 @@
       "level": 45,
       "requirements": [
         {
-          "name": "Tritanium Warehouse",
+          "name": "operations",
           "level": 45
         },
         {
-          "name": "Tritanium Generator B",
+          "name": "tritanium generator b",
           "level": 45
         },
         {
-          "name": "Operations",
+          "name": "tritanium warehouse",
           "level": 45
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 28900000
+        "bonus1": 28900000.0
       },
       "build_costs": {
         "materials": [
@@ -1737,12 +1692,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 58344000000
-          },
-          {
             "type": "tritanium",
             "value": 1340625000
+          },
+          {
+            "type": "parsteel",
+            "value": 58344000000
           }
         ]
       },
@@ -1751,33 +1706,32 @@
       "level": 46,
       "requirements": [
         {
-          "name": "Tritanium Generator B",
+          "name": "operations",
           "level": 46
         },
         {
-          "name": "Operations",
+          "name": "tritanium generator b",
           "level": 46
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 39000000
+        "bonus1": 39000000.0
       },
       "build_costs": {
         "materials": [
           {
             "type": "ore",
             "grade": 4,
-            "rarity": "uncommon",
-            "value": 2000
+            "rarity": "rare",
+            "value": 400
           },
           {
             "type": "ore",
             "grade": 4,
-            "rarity": "rare",
-            "value": 400
+            "rarity": "uncommon",
+            "value": 2000
           }
         ],
         "others": [],
@@ -1797,37 +1751,36 @@
       "level": 47,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 47
         },
         {
-          "name": "Tritanium Generator B",
+          "name": "tritanium generator b",
           "level": 47
         },
         {
-          "name": "Tritanium Warehouse",
+          "name": "tritanium warehouse",
           "level": 47
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 54000000
+        "bonus1": 54000000.0
       },
       "build_costs": {
         "materials": [
           {
             "type": "ore",
             "grade": 4,
-            "rarity": "common",
-            "value": 30000
+            "rarity": "rare",
+            "value": 1200
           },
           {
             "type": "ore",
             "grade": 4,
-            "rarity": "rare",
-            "value": 1200
+            "rarity": "common",
+            "value": 30000
           }
         ],
         "others": [],
@@ -1847,19 +1800,18 @@
       "level": 48,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 48
         },
         {
-          "name": "Tritanium Generator B",
+          "name": "tritanium generator b",
           "level": 48
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 82500000
+        "bonus1": 82500000.0
       },
       "build_costs": {
         "materials": [
@@ -1879,12 +1831,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 228480000000
-          },
-          {
             "type": "tritanium",
             "value": 5250000000
+          },
+          {
+            "type": "parsteel",
+            "value": 228480000000
           }
         ]
       },
@@ -1893,35 +1845,34 @@
       "level": 49,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 49
         },
         {
-          "name": "Tritanium Warehouse",
+          "name": "tritanium generator b",
           "level": 49
         },
         {
-          "name": "Tritanium Generator B",
+          "name": "tritanium warehouse",
           "level": 49
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 131300000
+        "bonus1": 131300000.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 399840000000
-          },
-          {
             "type": "tritanium",
             "value": 9187500000
+          },
+          {
+            "type": "parsteel",
+            "value": 399840000000
           }
         ]
       },
@@ -1930,15 +1881,235 @@
       "level": 50,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 50
         },
         {
-          "name": "Tritanium Generator B",
+          "name": "tritanium generator b",
           "level": 50
         }
-      ],
-      "rewards": []
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 195000000.0
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "ore",
+            "grade": 5,
+            "rarity": "common",
+            "value": 8100
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 19500000000
+          },
+          {
+            "type": "parsteel",
+            "value": 1994304000000
+          }
+        ]
+      },
+      "build_time": 89439840,
+      "increased_power": 7000,
+      "level": 51,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 51
+        },
+        {
+          "name": "tritanium generator b",
+          "level": 51
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 292500000.0
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "ore",
+            "grade": 5,
+            "rarity": "common",
+            "value": 18800
+          },
+          {
+            "type": "ore",
+            "grade": 5,
+            "rarity": "uncommon",
+            "value": 2800
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 33150000000
+          },
+          {
+            "type": "parsteel",
+            "value": 3606720000000
+          }
+        ]
+      },
+      "build_time": 94805280,
+      "increased_power": 7000,
+      "level": 52,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 52
+        },
+        {
+          "name": "tritanium generator b",
+          "level": 52
+        },
+        {
+          "name": "tritanium warehouse",
+          "level": 52
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 435000000.0
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "ore",
+            "grade": 5,
+            "rarity": "common",
+            "value": 37500
+          },
+          {
+            "type": "ore",
+            "grade": 5,
+            "rarity": "uncommon",
+            "value": 3100
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 6057984000000
+          },
+          {
+            "type": "tritanium",
+            "value": 58000000000
+          }
+        ]
+      },
+      "build_time": 100494720,
+      "increased_power": 8000,
+      "level": 53,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 53
+        },
+        {
+          "name": "tritanium generator b",
+          "level": 53
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 652500000.0
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "ore",
+            "grade": 5,
+            "rarity": "uncommon",
+            "value": 10400
+          },
+          {
+            "type": "ore",
+            "grade": 5,
+            "rarity": "rare",
+            "value": 800
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 9086976000000
+          },
+          {
+            "type": "tritanium",
+            "value": 87000000000
+          }
+        ]
+      },
+      "build_time": 106524000,
+      "increased_power": 7000,
+      "level": 54,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 54
+        },
+        {
+          "name": "tritanium generator b",
+          "level": 54
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 975000000.0
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "ore",
+            "grade": 5,
+            "rarity": "rare",
+            "value": 4800
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 136500000000
+          },
+          {
+            "type": "parsteel",
+            "value": 15445248000000
+          }
+        ]
+      },
+      "build_time": 112914720,
+      "increased_power": 8000,
+      "level": 55,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 55
+        },
+        {
+          "name": "tritanium generator b",
+          "level": 55
+        },
+        {
+          "name": "tritanium warehouse",
+          "level": 55
+        }
+      ]
     }
   ]
 }

--- a/buildings/tritanium_warehouse.json
+++ b/buildings/tritanium_warehouse.json
@@ -2,7 +2,7 @@
   "description": "Stores all collected Tritanium. Upgrade the Warehouse to increase the Tritanium Capacity.",
   "bonuses": {
     "bonus1": {
-      "name": "Tritanium Capacity",
+      "name": "tritanium capacity",
       "percentage": false
     }
   },
@@ -10,7 +10,7 @@
   "levels": [
     {
       "bonuses": {
-        "bonus1": 1000
+        "bonus1": 1000.0
       },
       "build_costs": {
         "materials": [],
@@ -27,19 +27,18 @@
       "level": 1,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 6
         },
         {
-          "name": "Tritanium Generator A",
+          "name": "tritanium generator a",
           "level": 1
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 1350
+        "bonus1": 1350.0
       },
       "build_costs": {
         "materials": [],
@@ -56,19 +55,18 @@
       "level": 2,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 6
         },
         {
-          "name": "Tritanium Generator A",
+          "name": "tritanium generator a",
           "level": 3
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 2000
+        "bonus1": 2000.0
       },
       "build_costs": {
         "materials": [],
@@ -85,19 +83,18 @@
       "level": 3,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 6
         },
         {
-          "name": "Tritanium Generator A",
+          "name": "tritanium generator a",
           "level": 3
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 2800
+        "bonus1": 2800.0
       },
       "build_costs": {
         "materials": [],
@@ -114,19 +111,18 @@
       "level": 4,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 6
         },
         {
-          "name": "Tritanium Generator A",
+          "name": "tritanium generator a",
           "level": 4
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 4400
+        "bonus1": 4400.0
       },
       "build_costs": {
         "materials": [],
@@ -143,19 +139,18 @@
       "level": 5,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 6
         },
         {
-          "name": "Tritanium Generator A",
+          "name": "tritanium generator a",
           "level": 5
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 5500
+        "bonus1": 5500.0
       },
       "build_costs": {
         "materials": [],
@@ -172,19 +167,18 @@
       "level": 6,
       "requirements": [
         {
-          "name": "Tritanium Generator A",
+          "name": "operations",
           "level": 6
         },
         {
-          "name": "Operations",
+          "name": "tritanium generator a",
           "level": 6
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 7250
+        "bonus1": 7250.0
       },
       "build_costs": {
         "materials": [],
@@ -205,31 +199,30 @@
       "level": 7,
       "requirements": [
         {
-          "name": "Tritanium Generator A",
+          "name": "operations",
           "level": 7
         },
         {
-          "name": "Operations",
+          "name": "tritanium generator a",
           "level": 7
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 8500
+        "bonus1": 8500.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 2600
-          },
-          {
             "type": "tritanium",
             "value": 80
+          },
+          {
+            "type": "parsteel",
+            "value": 2600
           }
         ]
       },
@@ -238,19 +231,18 @@
       "level": 8,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 8
         },
         {
-          "name": "Tritanium Generator A",
+          "name": "tritanium generator a",
           "level": 8
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 9000
+        "bonus1": 9000.0
       },
       "build_costs": {
         "materials": [],
@@ -271,19 +263,18 @@
       "level": 9,
       "requirements": [
         {
-          "name": "Tritanium Generator B",
+          "name": "tritanium generator b",
           "level": 9
         },
         {
-          "name": "Tritanium Generator A",
+          "name": "tritanium generator a",
           "level": 9
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 9750
+        "bonus1": 9750.0
       },
       "build_costs": {
         "materials": [],
@@ -304,31 +295,30 @@
       "level": 10,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 10
         },
         {
-          "name": "Tritanium Generator A",
+          "name": "tritanium generator a",
           "level": 10
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 10250
+        "bonus1": 10250.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 5440
-          },
-          {
             "type": "tritanium",
             "value": 1800
+          },
+          {
+            "type": "parsteel",
+            "value": 5440
           }
         ]
       },
@@ -337,31 +327,30 @@
       "level": 11,
       "requirements": [
         {
-          "name": "Tritanium Generator A",
+          "name": "operations",
           "level": 11
         },
         {
-          "name": "Operations",
+          "name": "tritanium generator a",
           "level": 11
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 10750
+        "bonus1": 10750.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 7480
-          },
-          {
             "type": "tritanium",
             "value": 2475
+          },
+          {
+            "type": "parsteel",
+            "value": 7480
           }
         ]
       },
@@ -370,19 +359,18 @@
       "level": 12,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 12
         },
         {
-          "name": "Tritanium Generator A",
+          "name": "tritanium generator a",
           "level": 12
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 13500
+        "bonus1": 13500.0
       },
       "build_costs": {
         "materials": [],
@@ -403,31 +391,30 @@
       "level": 13,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 13
         },
         {
-          "name": "Tritanium Generator A",
+          "name": "tritanium generator a",
           "level": 13
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 17500
+        "bonus1": 17500.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 14960
-          },
-          {
             "type": "tritanium",
             "value": 4950
+          },
+          {
+            "type": "parsteel",
+            "value": 14960
           }
         ]
       },
@@ -436,31 +423,30 @@
       "level": 14,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 14
         },
         {
-          "name": "Tritanium Generator A",
+          "name": "tritanium generator a",
           "level": 14
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 22500
+        "bonus1": 22500.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 20400
-          },
-          {
             "type": "tritanium",
             "value": 6750
+          },
+          {
+            "type": "parsteel",
+            "value": 20400
           }
         ]
       },
@@ -469,31 +455,30 @@
       "level": 15,
       "requirements": [
         {
-          "name": "Tritanium Generator A",
+          "name": "operations",
           "level": 15
         },
         {
-          "name": "Operations",
+          "name": "tritanium generator a",
           "level": 15
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 28000
+        "bonus1": 28000.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 27200
-          },
-          {
             "type": "tritanium",
             "value": 9000
+          },
+          {
+            "type": "parsteel",
+            "value": 27200
           }
         ]
       },
@@ -502,19 +487,18 @@
       "level": 16,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 16
         },
         {
-          "name": "Tritanium Generator A",
+          "name": "tritanium generator a",
           "level": 16
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 36500
+        "bonus1": 36500.0
       },
       "build_costs": {
         "materials": [
@@ -542,19 +526,18 @@
       "level": 17,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 17
         },
         {
-          "name": "Tritanium Generator A",
+          "name": "tritanium generator a",
           "level": 17
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 48000
+        "bonus1": 48000.0
       },
       "build_costs": {
         "materials": [
@@ -568,12 +551,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 54400
-          },
-          {
             "type": "tritanium",
             "value": 18000
+          },
+          {
+            "type": "parsteel",
+            "value": 54400
           }
         ]
       },
@@ -582,19 +565,18 @@
       "level": 18,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 18
         },
         {
-          "name": "Tritanium Generator A",
+          "name": "tritanium generator a",
           "level": 18
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 66000
+        "bonus1": 66000.0
       },
       "build_costs": {
         "materials": [
@@ -622,19 +604,18 @@
       "level": 19,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 19
         },
         {
-          "name": "Tritanium Generator B",
+          "name": "tritanium generator b",
           "level": 19
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 85000
+        "bonus1": 85000.0
       },
       "build_costs": {
         "materials": [],
@@ -655,19 +636,18 @@
       "level": 20,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 20
         },
         {
-          "name": "Tritanium Generator A",
+          "name": "tritanium generator a",
           "level": 20
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 128000
+        "bonus1": 128000.0
       },
       "build_costs": {
         "materials": [],
@@ -688,19 +668,18 @@
       "level": 21,
       "requirements": [
         {
-          "name": "Tritanium Generator A",
+          "name": "operations",
           "level": 21
         },
         {
-          "name": "Operations",
+          "name": "tritanium generator a",
           "level": 21
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 200000
+        "bonus1": 200000.0
       },
       "build_costs": {
         "materials": [],
@@ -721,31 +700,30 @@
       "level": 22,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 22
         },
         {
-          "name": "Tritanium Generator A",
+          "name": "tritanium generator a",
           "level": 22
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 340000
+        "bonus1": 340000.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 498168
-          },
-          {
             "type": "tritanium",
             "value": 164835
+          },
+          {
+            "type": "parsteel",
+            "value": 498168
           }
         ]
       },
@@ -754,19 +732,18 @@
       "level": 23,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 23
         },
         {
-          "name": "Tritanium Generator A",
+          "name": "tritanium generator a",
           "level": 23
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 490000
+        "bonus1": 490000.0
       },
       "build_costs": {
         "materials": [
@@ -780,12 +757,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 784992
-          },
-          {
             "type": "tritanium",
             "value": 259740
+          },
+          {
+            "type": "parsteel",
+            "value": 784992
           }
         ]
       },
@@ -794,19 +771,18 @@
       "level": 24,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 24
         },
         {
-          "name": "Tritanium Generator A",
+          "name": "tritanium generator a",
           "level": 24
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 770000
+        "bonus1": 770000.0
       },
       "build_costs": {
         "materials": [
@@ -834,23 +810,22 @@
       "level": 25,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 25
         },
         {
-          "name": "Tritanium Generator A",
+          "name": "tritanium generator a",
           "level": 25
         },
         {
-          "name": "Parsteel Warehouse",
+          "name": "parsteel warehouse",
           "level": 25
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 880000
+        "bonus1": 880000.0
       },
       "build_costs": {
         "materials": [
@@ -864,12 +839,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 1989000
-          },
-          {
             "type": "tritanium",
             "value": 658125
+          },
+          {
+            "type": "parsteel",
+            "value": 1989000
           }
         ]
       },
@@ -878,44 +853,43 @@
       "level": 26,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 26
         },
         {
-          "name": "Tritanium Generator A",
+          "name": "tritanium generator a",
           "level": 26
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 1150000
+        "bonus1": 1150000.0
       },
       "build_costs": {
         "materials": [
           {
             "type": "ore",
             "grade": 3,
-            "rarity": "common",
-            "value": 290
+            "rarity": "uncommon",
+            "value": 10
           },
           {
             "type": "ore",
             "grade": 3,
-            "rarity": "uncommon",
-            "value": 10
+            "rarity": "common",
+            "value": 290
           }
         ],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 3035520
-          },
-          {
             "type": "tritanium",
             "value": 1004400
+          },
+          {
+            "type": "parsteel",
+            "value": 3035520
           }
         ]
       },
@@ -924,19 +898,18 @@
       "level": 27,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 27
         },
         {
-          "name": "Tritanium Generator A",
+          "name": "tritanium generator a",
           "level": 27
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 1600000
+        "bonus1": 1600000.0
       },
       "build_costs": {
         "materials": [
@@ -964,19 +937,18 @@
       "level": 28,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 28
         },
         {
-          "name": "Tritanium Generator A",
+          "name": "tritanium generator a",
           "level": 28
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 2250000
+        "bonus1": 2250000.0
       },
       "build_costs": {
         "materials": [
@@ -990,12 +962,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 7248800
-          },
-          {
             "type": "tritanium",
             "value": 2398500
+          },
+          {
+            "type": "parsteel",
+            "value": 7248800
           }
         ]
       },
@@ -1004,19 +976,18 @@
       "level": 29,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 29
         },
         {
-          "name": "Tritanium Generator A",
+          "name": "tritanium generator a",
           "level": 29
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 3000000
+        "bonus1": 3000000.0
       },
       "build_costs": {
         "materials": [
@@ -1030,12 +1001,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 10608000
-          },
-          {
             "type": "tritanium",
             "value": 3510000
+          },
+          {
+            "type": "parsteel",
+            "value": 10608000
           }
         ]
       },
@@ -1044,33 +1015,32 @@
       "level": 30,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 30
         },
         {
-          "name": "Tritanium Generator A",
+          "name": "tritanium generator a",
           "level": 30
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 4100000
+        "bonus1": 4100000.0
       },
       "build_costs": {
         "materials": [
           {
             "type": "ore",
             "grade": 3,
-            "rarity": "common",
-            "value": 700
+            "rarity": "uncommon",
+            "value": 50
           },
           {
             "type": "ore",
             "grade": 3,
-            "rarity": "uncommon",
-            "value": 50
+            "rarity": "common",
+            "value": 700
           }
         ],
         "others": [],
@@ -1090,19 +1060,18 @@
       "level": 31,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 31
         },
         {
-          "name": "Tritanium Generator A",
+          "name": "tritanium generator a",
           "level": 31
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 5300000
+        "bonus1": 5300000.0
       },
       "build_costs": {
         "materials": [
@@ -1116,12 +1085,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 24221600
-          },
-          {
             "type": "tritanium",
             "value": 8014500
+          },
+          {
+            "type": "parsteel",
+            "value": 24221600
           }
         ]
       },
@@ -1130,19 +1099,18 @@
       "level": 32,
       "requirements": [
         {
-          "name": "Tritanium Generator A",
+          "name": "operations",
           "level": 32
         },
         {
-          "name": "Operations",
+          "name": "tritanium generator a",
           "level": 32
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 6850000
+        "bonus1": 6850000.0
       },
       "build_costs": {
         "materials": [
@@ -1170,19 +1138,18 @@
       "level": 33,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 33
         },
         {
-          "name": "Tritanium Generator A",
+          "name": "tritanium generator a",
           "level": 33
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 9450000
+        "bonus1": 9450000.0
       },
       "build_costs": {
         "materials": [
@@ -1216,19 +1183,18 @@
       "level": 34,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 34
         },
         {
-          "name": "Tritanium Generator A",
+          "name": "tritanium generator a",
           "level": 34
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 12000000
+        "bonus1": 12000000.0
       },
       "build_costs": {
         "materials": [
@@ -1248,12 +1214,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 91555200
-          },
-          {
             "type": "tritanium",
             "value": 30294000
+          },
+          {
+            "type": "parsteel",
+            "value": 91555200
           }
         ]
       },
@@ -1262,19 +1228,18 @@
       "level": 35,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 35
         },
         {
-          "name": "Tritanium Generator A",
+          "name": "tritanium generator a",
           "level": 35
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 14000000
+        "bonus1": 14000000.0
       },
       "build_costs": {
         "materials": [
@@ -1288,12 +1253,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 129009600
-          },
-          {
             "type": "tritanium",
             "value": 42687000
+          },
+          {
+            "type": "parsteel",
+            "value": 129009600
           }
         ]
       },
@@ -1302,33 +1267,32 @@
       "level": 36,
       "requirements": [
         {
-          "name": "Tritanium Generator A",
+          "name": "operations",
           "level": 36
         },
         {
-          "name": "Operations",
+          "name": "tritanium generator a",
           "level": 36
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 16000000
+        "bonus1": 16000000.0
       },
       "build_costs": {
         "materials": [
           {
             "type": "ore",
             "grade": 3,
-            "rarity": "common",
-            "value": 1800
+            "rarity": "uncommon",
+            "value": 170
           },
           {
             "type": "ore",
             "grade": 3,
-            "rarity": "uncommon",
-            "value": 170
+            "rarity": "common",
+            "value": 1800
           }
         ],
         "others": [],
@@ -1348,33 +1312,32 @@
       "level": 37,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 37
         },
         {
-          "name": "Tritanium Generator A",
+          "name": "tritanium generator a",
           "level": 37
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 18000000
+        "bonus1": 18000000.0
       },
       "build_costs": {
         "materials": [
           {
             "type": "ore",
             "grade": 3,
-            "rarity": "common",
-            "value": 2100
+            "rarity": "uncommon",
+            "value": 200
           },
           {
             "type": "ore",
             "grade": 3,
-            "rarity": "uncommon",
-            "value": 200
+            "rarity": "common",
+            "value": 2100
           }
         ],
         "others": [],
@@ -1394,35 +1357,34 @@
       "level": 38,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 38
         },
         {
-          "name": "Tritanium Generator A",
+          "name": "tritanium generator a",
           "level": 38
         },
         {
-          "name": "Parsteel Warehouse",
+          "name": "parsteel warehouse",
           "level": 38
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 19500000
+        "bonus1": 19500000.0
       },
       "build_costs": {
         "materials": [],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 526320000
-          },
-          {
             "type": "tritanium",
             "value": 174150000
+          },
+          {
+            "type": "parsteel",
+            "value": 526320000
           }
         ]
       },
@@ -1431,19 +1393,18 @@
       "level": 39,
       "requirements": [
         {
-          "name": "Tritanium Generator A",
+          "name": "operations",
           "level": 39
         },
         {
-          "name": "Operations",
+          "name": "tritanium generator a",
           "level": 39
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 20500000
+        "bonus1": 20500000.0
       },
       "build_costs": {
         "materials": [
@@ -1457,12 +1418,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 2292416000
-          },
-          {
             "type": "tritanium",
             "value": 270900000
+          },
+          {
+            "type": "parsteel",
+            "value": 2292416000
           }
         ]
       },
@@ -1471,19 +1432,18 @@
       "level": 40,
       "requirements": [
         {
-          "name": "Tritanium Generator A",
+          "name": "operations",
           "level": 40
         },
         {
-          "name": "Operations",
+          "name": "tritanium generator a",
           "level": 40
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 21500000
+        "bonus1": 21500000.0
       },
       "build_costs": {
         "materials": [
@@ -1497,12 +1457,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 2339200000
-          },
-          {
             "type": "tritanium",
             "value": 387000000
+          },
+          {
+            "type": "parsteel",
+            "value": 2339200000
           }
         ]
       },
@@ -1511,19 +1471,18 @@
       "level": 41,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 41
         },
         {
-          "name": "Tritanium Generator A",
+          "name": "tritanium generator a",
           "level": 41
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 24000000
+        "bonus1": 24000000.0
       },
       "build_costs": {
         "materials": [
@@ -1543,12 +1502,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 3484320000
-          },
-          {
             "type": "tritanium",
             "value": 576450000
+          },
+          {
+            "type": "parsteel",
+            "value": 3484320000
           }
         ]
       },
@@ -1557,19 +1516,18 @@
       "level": 42,
       "requirements": [
         {
-          "name": "Tritanium Generator A",
+          "name": "operations",
           "level": 42
         },
         {
-          "name": "Operations",
+          "name": "tritanium generator a",
           "level": 42
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 32500000
+        "bonus1": 32500000.0
       },
       "build_costs": {
         "materials": [
@@ -1589,12 +1547,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 4977600000
-          },
-          {
             "type": "tritanium",
             "value": 823500000
+          },
+          {
+            "type": "parsteel",
+            "value": 4977600000
           }
         ]
       },
@@ -1603,33 +1561,32 @@
       "level": 43,
       "requirements": [
         {
-          "name": "Tritanium Generator A",
+          "name": "operations",
           "level": 43
         },
         {
-          "name": "Operations",
+          "name": "tritanium generator a",
           "level": 43
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 46000000
+        "bonus1": 46000000.0
       },
       "build_costs": {
         "materials": [
           {
             "type": "ore",
             "grade": 4,
-            "rarity": "uncommon",
-            "value": 2000
+            "rarity": "rare",
+            "value": 800
           },
           {
             "type": "ore",
             "grade": 4,
-            "rarity": "rare",
-            "value": 800
+            "rarity": "uncommon",
+            "value": 2000
           }
         ],
         "others": [],
@@ -1649,19 +1606,18 @@
       "level": 44,
       "requirements": [
         {
-          "name": "Tritanium Generator A",
+          "name": "operations",
           "level": 44
         },
         {
-          "name": "Operations",
+          "name": "tritanium generator a",
           "level": 44
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 57500000
+        "bonus1": 57500000.0
       },
       "build_costs": {
         "materials": [
@@ -1689,23 +1645,22 @@
       "level": 45,
       "requirements": [
         {
-          "name": "Parsteel Vault",
+          "name": "operations",
           "level": 45
         },
         {
-          "name": "Tritanium Generator A",
+          "name": "tritanium generator a",
           "level": 45
         },
         {
-          "name": "Operations",
+          "name": "parsteel vault",
           "level": 45
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 74500000
+        "bonus1": 74500000.0
       },
       "build_costs": {
         "materials": [
@@ -1725,12 +1680,12 @@
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 14586000000
-          },
-          {
             "type": "tritanium",
             "value": 2413125000
+          },
+          {
+            "type": "parsteel",
+            "value": 14586000000
           }
         ]
       },
@@ -1739,33 +1694,32 @@
       "level": 46,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 46
         },
         {
-          "name": "Tritanium Generator A",
+          "name": "tritanium generator a",
           "level": 46
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 100000000
+        "bonus1": 100000000.0
       },
       "build_costs": {
         "materials": [
           {
             "type": "ore",
             "grade": 4,
-            "rarity": "uncommon",
-            "value": 2000
+            "rarity": "rare",
+            "value": 400
           },
           {
             "type": "ore",
             "grade": 4,
-            "rarity": "rare",
-            "value": 400
+            "rarity": "uncommon",
+            "value": 2000
           }
         ],
         "others": [],
@@ -1785,48 +1739,47 @@
       "level": 47,
       "requirements": [
         {
-          "name": "Tritanium Generator A",
+          "name": "operations",
           "level": 47
         },
         {
-          "name": "Operations",
+          "name": "tritanium generator a",
           "level": 47
         },
         {
-          "name": "Parsteel Vault",
+          "name": "parsteel vault",
           "level": 47
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 140000000
+        "bonus1": 140000000.0
       },
       "build_costs": {
         "materials": [
           {
             "type": "ore",
             "grade": 4,
-            "rarity": "common",
-            "value": 30000
+            "rarity": "rare",
+            "value": 1200
           },
           {
             "type": "ore",
             "grade": 4,
-            "rarity": "rare",
-            "value": 1200
+            "rarity": "common",
+            "value": 30000
           }
         ],
         "others": [],
         "resources": [
           {
-            "type": "parsteel",
-            "value": 34272000000
-          },
-          {
             "type": "tritanium",
             "value": 5670000000
+          },
+          {
+            "type": "parsteel",
+            "value": 34272000000
           }
         ]
       },
@@ -1835,33 +1788,32 @@
       "level": 48,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 48
         },
         {
-          "name": "Tritanium Generator A",
+          "name": "tritanium generator a",
           "level": 48
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 220000000
+        "bonus1": 220000000.0
       },
       "build_costs": {
         "materials": [
           {
             "type": "ore",
             "grade": 4,
-            "rarity": "common",
-            "value": 45000
+            "rarity": "rare",
+            "value": 4500
           },
           {
             "type": "ore",
             "grade": 4,
-            "rarity": "rare",
-            "value": 4500
+            "rarity": "common",
+            "value": 45000
           }
         ],
         "others": [],
@@ -1881,23 +1833,22 @@
       "level": 49,
       "requirements": [
         {
-          "name": "Tritanium Generator A",
+          "name": "operations",
           "level": 49
         },
         {
-          "name": "Operations",
+          "name": "tritanium generator a",
           "level": 49
         },
         {
-          "name": "Parsteel Vault",
+          "name": "parsteel vault",
           "level": 49
         }
-      ],
-      "rewards": []
+      ]
     },
     {
       "bonuses": {
-        "bonus1": 350000000
+        "bonus1": 350000000.0
       },
       "build_costs": {
         "materials": [],
@@ -1918,15 +1869,231 @@
       "level": 50,
       "requirements": [
         {
-          "name": "Operations",
+          "name": "operations",
           "level": 50
         },
         {
-          "name": "Tritanium Generator A",
+          "name": "tritanium generator a",
           "level": 50
         }
-      ],
-      "rewards": []
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 520000000.0
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "ore",
+            "grade": 5,
+            "rarity": "common",
+            "value": 8500
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 35100000000
+          },
+          {
+            "type": "parsteel",
+            "value": 498576000000
+          }
+        ]
+      },
+      "build_time": 67079520,
+      "increased_power": 3500,
+      "level": 51,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 51
+        },
+        {
+          "name": "tritanium generator a",
+          "level": 51
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 780000000.0
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "ore",
+            "grade": 5,
+            "rarity": "common",
+            "value": 18800
+          },
+          {
+            "type": "ore",
+            "grade": 5,
+            "rarity": "uncommon",
+            "value": 2800
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 59670000000
+          },
+          {
+            "type": "parsteel",
+            "value": 901680000000
+          }
+        ]
+      },
+      "build_time": 71104320,
+      "increased_power": 3500,
+      "level": 52,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 52
+        },
+        {
+          "name": "tritanium generator a",
+          "level": 52
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 1150000000.0
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "ore",
+            "grade": 5,
+            "rarity": "uncommon",
+            "value": 3100
+          },
+          {
+            "type": "ore",
+            "grade": 5,
+            "rarity": "common",
+            "value": 37500
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "parsteel",
+            "value": 1514496000000
+          },
+          {
+            "type": "tritanium",
+            "value": 104400000000
+          }
+        ]
+      },
+      "build_time": 75371040,
+      "increased_power": 4000,
+      "level": 53,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 53
+        },
+        {
+          "name": "tritanium generator a",
+          "level": 53
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 1750000000.0
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "ore",
+            "grade": 5,
+            "rarity": "rare",
+            "value": 800
+          },
+          {
+            "type": "ore",
+            "grade": 5,
+            "rarity": "uncommon",
+            "value": 10400
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 156600000000
+          },
+          {
+            "type": "parsteel",
+            "value": 2271744000000
+          }
+        ]
+      },
+      "build_time": 79892640,
+      "increased_power": 4000,
+      "level": 54,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 54
+        },
+        {
+          "name": "tritanium generator a",
+          "level": 54
+        }
+      ]
+    },
+    {
+      "bonuses": {
+        "bonus1": 2600000000.0
+      },
+      "build_costs": {
+        "materials": [
+          {
+            "type": "ore",
+            "grade": 5,
+            "rarity": "rare",
+            "value": 4800
+          }
+        ],
+        "others": [],
+        "resources": [
+          {
+            "type": "tritanium",
+            "value": 245700000000
+          },
+          {
+            "type": "parsteel",
+            "value": 3861312000000
+          }
+        ]
+      },
+      "build_time": 84686400,
+      "increased_power": 4000,
+      "level": 55,
+      "requirements": [
+        {
+          "name": "operations",
+          "level": 55
+        },
+        {
+          "name": "tritanium generator a",
+          "level": 55
+        },
+        {
+          "name": "parsteel vault",
+          "level": 55
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
# Patch 35
- Add building data for level 51 to 55

# Adds
- Add weapon info and stats for defense platforms
Note: For new levels 51- 55, min and max damage is swapped due to incorrect Scopely data which had min damage bigger than max damage. Should be checked later when it is possible fixed.

# Fixes
- Change file name for Exocomp Factory for inconsistent hyphen
- Update wrong resource values
- Update wrong bonuses

# Consistency improvement
- Set all bonuses as floating-point notation instead of mix
- Change requirements and rewards to lowercase
- Set requirements, rewards in consistent order across same buildings and levels if possible
- Set bonus order as in game
- Remove empty rewards field to make it consistent with newer buildings and other data

Side note: bot update will follow regarding improvements