### PR TITLE
G5 Ships - Temp name fix

### DIFF
--- a/ships/corvus.json
+++ b/ships/corvus.json
@@ -23,7 +23,7 @@
     "percentage": true
   },
   "ship_class": "explorer",
-  "ship_name": "Corvus",
+  "ship_name": "corvus",
   "tiers": [
     {
       "build_time": 12960000,

--- a/ships/nova.json
+++ b/ships/nova.json
@@ -23,7 +23,7 @@
     "percentage": true
   },
   "ship_class": "survey",
-  "ship_name": "Nova",
+  "ship_name": "nova",
   "tiers": [
     {
       "build_time": 7344000,

--- a/ships/uss_northcutt.json
+++ b/ships/uss_northcutt.json
@@ -23,7 +23,7 @@
     "percentage": true
   },
   "ship_class": "interceptor",
-  "ship_name": "USS Northcutt",
+  "ship_name": "uss northcutt",
   "tiers": [
     {
       "build_time": 12960000,

--- a/ships/vor_cha.json
+++ b/ships/vor_cha.json
@@ -23,7 +23,7 @@
     "percentage": false
   },
   "ship_class": "battleship",
-  "ship_name": "Vor'Cha",
+  "ship_name": "vor'cha",
   "tiers": [
     {
       "build_time": 12960000,


### PR DESCRIPTION
Temporary fix until ships are reparsed with Engineering 2.0